### PR TITLE
feat: enhance confirm failure artifact capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Default tool-owned state home (profiles, DB, artifacts):
 
 - `~/.linkedin-assistant/linkedin-owa-agentools`
 - Override with `LINKEDIN_ASSISTANT_HOME=/custom/path`
+- Confirm-failure trace size cap: `LINKEDIN_ASSISTANT_CONFIRM_TRACE_MAX_BYTES` (defaults to `26214400`)
 
 ## CLI Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2663,6 +2663,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -4623,6 +4629,7 @@
       "version": "0.1.0",
       "dependencies": {
         "better-sqlite3": "^11.9.0",
+        "fflate": "^0.8.2",
         "playwright-core": "^1.50.1",
         "proper-lockfile": "^4.1.2"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^11.9.0",
+    "fflate": "^0.8.2",
     "playwright-core": "^1.50.1",
     "proper-lockfile": "^4.1.2"
   },

--- a/packages/core/src/__tests__/confirmArtifacts.test.ts
+++ b/packages/core/src/__tests__/confirmArtifacts.test.ts
@@ -1,0 +1,210 @@
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { BrowserContext, Page } from "playwright-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { strToU8, unzipSync, zipSync } from "fflate";
+import { ArtifactHelpers } from "../artifacts.js";
+import { executeConfirmActionWithArtifacts } from "../confirmArtifacts.js";
+import type { ConfirmFailureArtifactConfig, ConfigPaths } from "../config.js";
+import { ensureConfigPaths, resolveConfigPaths } from "../config.js";
+import { LinkedInAssistantError, asLinkedInAssistantError } from "../errors.js";
+
+interface TestRuntime {
+  artifacts: ArtifactHelpers;
+  confirmFailureArtifacts: ConfirmFailureArtifactConfig;
+  logger: {
+    log: ReturnType<typeof vi.fn>;
+  };
+}
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const tempDir = tempDirs.pop();
+    if (!tempDir) {
+      continue;
+    }
+
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+function createTestRuntime(traceMaxBytes: number): TestRuntime {
+  const baseDir = mkdtempSync(path.join(tmpdir(), "linkedin-confirm-artifacts-"));
+  tempDirs.push(baseDir);
+  const paths: ConfigPaths = resolveConfigPaths(baseDir);
+  ensureConfigPaths(paths);
+
+  return {
+    artifacts: new ArtifactHelpers(paths, "run-test"),
+    confirmFailureArtifacts: {
+      traceMaxBytes
+    },
+    logger: {
+      log: vi.fn()
+    }
+  };
+}
+
+function createTraceArchive(): Uint8Array {
+  return zipSync(
+    {
+      "trace.trace": strToU8(JSON.stringify({ events: [{ type: "before" }] })),
+      "trace.network": strToU8(JSON.stringify({ requests: [] })),
+      "resources/large-resource.txt": new Uint8Array(8_192).fill(65)
+    },
+    { level: 0 }
+  );
+}
+
+function createContext(traceArchive: Uint8Array, accessibilityTree: unknown): BrowserContext {
+  const cdpSession = {
+    send: vi.fn(async () => accessibilityTree),
+    detach: vi.fn(async () => undefined)
+  };
+
+  return {
+    tracing: {
+      start: vi.fn(async () => undefined),
+      stop: vi.fn(async (options?: { path?: string }) => {
+        if (options?.path) {
+          writeFileSync(options.path, Buffer.from(traceArchive));
+        }
+      })
+    },
+    newCDPSession: vi.fn(async () => cdpSession)
+  } as unknown as BrowserContext;
+}
+
+function createPage(context: BrowserContext, currentUrl: string): Page {
+  return {
+    screenshot: vi.fn(async (options?: { path?: string }) => {
+      if (options?.path) {
+        writeFileSync(options.path, Buffer.from("png"));
+      }
+    }),
+    content: vi.fn(async () => "<html><body><main>Failure snapshot</main></body></html>"),
+    context: vi.fn(() => context),
+    url: vi.fn(() => currentUrl)
+  } as unknown as Page;
+}
+
+describe("executeConfirmActionWithArtifacts", () => {
+  it("captures screenshot, DOM, accessibility, and a capped trace on failure", async () => {
+    const runtime = createTestRuntime(600);
+    const traceArchive = createTraceArchive();
+    const context = createContext(traceArchive, {
+      nodes: [{ role: { value: "RootWebArea" } }]
+    });
+    const page = createPage(
+      context,
+      "https://www.linkedin.com/feed/update/urn:li:activity:123"
+    );
+
+    let thrownError: unknown;
+    try {
+      await executeConfirmActionWithArtifacts({
+        runtime,
+        context,
+        page,
+        actionId: "act-1",
+        actionType: "feed.like_post",
+        profileName: "default",
+        targetUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123",
+        errorDetails: {
+          post_url: "https://www.linkedin.com/feed/update/urn:li:activity:123"
+        },
+        mapError: (error) =>
+          asLinkedInAssistantError(error, "UNKNOWN", "Like action failed."),
+        execute: async () => {
+          throw new LinkedInAssistantError("UNKNOWN", "boom", {
+            selector_key: "reaction_button"
+          });
+        }
+      });
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toBeInstanceOf(LinkedInAssistantError);
+    const assistantError = thrownError as LinkedInAssistantError;
+    const artifactPaths = assistantError.details.artifact_paths as string[];
+
+    expect(assistantError.details.artifacts).toEqual(artifactPaths);
+    expect(assistantError.details.action_id).toBe("act-1");
+    expect(assistantError.details.post_url).toBe(
+      "https://www.linkedin.com/feed/update/urn:li:activity:123"
+    );
+    expect(artifactPaths).toHaveLength(4);
+    expect(artifactPaths).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("screenshot-confirm-error-feed-like-post"),
+        expect.stringContaining("dom-confirm-error-feed-like-post"),
+        expect.stringContaining("accessibility-confirm-error-feed-like-post"),
+        expect.stringContaining("trace-confirm-feed-like-post")
+      ])
+    );
+
+    for (const artifactPath of artifactPaths) {
+      expect(statSync(runtime.artifacts.resolve(artifactPath)).size).toBeGreaterThan(0);
+    }
+
+    const tracePath = artifactPaths.find((artifactPath) =>
+      artifactPath.includes("trace-confirm-feed-like-post")
+    );
+    expect(tracePath).toBeDefined();
+
+    const absoluteTracePath = runtime.artifacts.resolve(tracePath!);
+    expect(statSync(absoluteTracePath).size).toBeLessThanOrEqual(600);
+    const traceEntries = Object.keys(unzipSync(readFileSync(absoluteTracePath)));
+    expect(traceEntries).toContain("trace.trace");
+    expect(traceEntries).toContain("trace.network");
+    expect(traceEntries).not.toContain("resources/large-resource.txt");
+
+    expect(runtime.logger.log).toHaveBeenCalledWith(
+      "info",
+      "confirm.trace.pruned",
+      expect.objectContaining({
+        action_id: "act-1",
+        action_type: "feed.like_post",
+        max_bytes: 600
+      })
+    );
+  });
+
+  it("can persist a trace on successful confirm actions", async () => {
+    const runtime = createTestRuntime(2_048);
+    const context = createContext(createTraceArchive(), {
+      nodes: [{ role: { value: "RootWebArea" } }]
+    });
+    const page = createPage(
+      context,
+      "https://www.linkedin.com/messaging/thread/123/"
+    );
+
+    const result = await executeConfirmActionWithArtifacts({
+      runtime,
+      context,
+      page,
+      actionId: "act-2",
+      actionType: "send_message",
+      profileName: "default",
+      targetUrl: "https://www.linkedin.com/messaging/thread/123/",
+      persistTraceOnSuccess: true,
+      mapError: (error) => asLinkedInAssistantError(error, "UNKNOWN", "Send failed."),
+      execute: async () => ({
+        ok: true,
+        result: {
+          sent: true
+        },
+        artifacts: []
+      })
+    });
+
+    expect(result.artifacts).toHaveLength(1);
+    expect(result.artifacts[0]).toContain("trace-confirm-send-message");
+    expect(statSync(runtime.artifacts.resolve(result.artifacts[0])).size).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -15,6 +15,28 @@ export interface ConfigPaths {
   dbPath: string;
 }
 
+export const DEFAULT_CONFIRM_TRACE_MAX_BYTES = 25 * 1024 * 1024;
+
+export interface ConfirmFailureArtifactConfig {
+  traceMaxBytes: number;
+}
+
+function parsePositiveInteger(
+  value: string | undefined,
+  fallback: number
+): number {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
 export function resolveConfigPaths(baseDir?: string): ConfigPaths {
   const resolvedBaseDir =
     baseDir ??
@@ -33,4 +55,13 @@ export function ensureConfigPaths(paths: ConfigPaths): void {
   mkdirSync(paths.baseDir, { recursive: true });
   mkdirSync(paths.artifactsDir, { recursive: true });
   mkdirSync(paths.profilesDir, { recursive: true });
+}
+
+export function resolveConfirmFailureArtifactConfig(): ConfirmFailureArtifactConfig {
+  return {
+    traceMaxBytes: parsePositiveInteger(
+      process.env.LINKEDIN_ASSISTANT_CONFIRM_TRACE_MAX_BYTES,
+      DEFAULT_CONFIRM_TRACE_MAX_BYTES
+    )
+  };
 }

--- a/packages/core/src/confirmArtifacts.ts
+++ b/packages/core/src/confirmArtifacts.ts
@@ -1,0 +1,541 @@
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { unzipSync, zipSync } from "fflate";
+import type { BrowserContext, Page } from "playwright-core";
+import type { ArtifactHelpers } from "./artifacts.js";
+import type { ConfirmFailureArtifactConfig } from "./config.js";
+import { LinkedInAssistantError } from "./errors.js";
+import type { JsonEventLogger } from "./logging.js";
+import type { ActionExecutorResult } from "./twoPhaseCommit.js";
+
+interface TraceArchiveResizeResult {
+  originalBytes: number;
+  finalBytes: number;
+  trimmedToLimit: boolean;
+  pruned: boolean;
+  keptEntries: string[];
+  droppedEntries: string[];
+}
+
+export interface ConfirmFailureArtifactRuntime {
+  artifacts: ArtifactHelpers;
+  logger: Pick<JsonEventLogger, "log">;
+  confirmFailureArtifacts: ConfirmFailureArtifactConfig;
+}
+
+export interface ExecuteConfirmActionWithArtifactsInput<
+  TRuntime extends ConfirmFailureArtifactRuntime
+> {
+  runtime: TRuntime;
+  context: BrowserContext;
+  page: Page;
+  actionId: string;
+  actionType: string;
+  profileName: string;
+  targetUrl?: string | undefined;
+  persistTraceOnSuccess?: boolean;
+  metadata?: Record<string, unknown> | undefined;
+  errorDetails?: Record<string, unknown> | undefined;
+  mapError: (error: unknown) => LinkedInAssistantError;
+  execute: () => Promise<ActionExecutorResult>;
+}
+
+function slugifyActionType(actionType: string): string {
+  return actionType
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "action";
+}
+
+function getArtifactPathsFromUnknown(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function getArtifactPathsFromError(error: unknown): string[] {
+  if (!(error instanceof LinkedInAssistantError)) {
+    return [];
+  }
+
+  return [
+    ...getArtifactPathsFromUnknown(error.details.artifact_paths),
+    ...getArtifactPathsFromUnknown(error.details.artifacts)
+  ];
+}
+
+function dedupeArtifactPaths(paths: string[]): string[] {
+  return [...new Set(paths.filter((path) => path.length > 0))];
+}
+
+function attachArtifactPaths(
+  error: LinkedInAssistantError,
+  artifactPaths: string[],
+  extraDetails: Record<string, unknown>
+): LinkedInAssistantError {
+  const mergedArtifactPaths = dedupeArtifactPaths([
+    ...getArtifactPathsFromError(error),
+    ...artifactPaths
+  ]);
+
+  for (const [key, value] of Object.entries(extraDetails)) {
+    if (value === undefined || key in error.details) {
+      continue;
+    }
+    error.details[key] = value;
+  }
+
+  error.details.artifact_paths = mergedArtifactPaths;
+  error.details.artifacts = mergedArtifactPaths;
+
+  return error;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+function getPageUrl(page: Page): string {
+  try {
+    return page.url();
+  } catch {
+    return "";
+  }
+}
+
+async function captureAccessibilitySnapshot(page: Page): Promise<unknown> {
+  const cdpSession = await page.context().newCDPSession(page);
+  try {
+    return await cdpSession.send("Accessibility.getFullAXTree");
+  } finally {
+    await cdpSession.detach().catch(() => undefined);
+  }
+}
+
+function buildArtifactPath(
+  prefix: string,
+  actionType: string,
+  extension: string,
+  timestampMs: number
+): string {
+  return `${prefix}-${slugifyActionType(actionType)}-${timestampMs}.${extension}`;
+}
+
+function filterTraceEntries(
+  entries: Record<string, Uint8Array>,
+  predicate: (entryName: string) => boolean
+): Record<string, Uint8Array> {
+  return Object.fromEntries(
+    Object.entries(entries).filter(([entryName]) => predicate(entryName))
+  );
+}
+
+function resizeTraceArchive(
+  absoluteTracePath: string,
+  maxBytes: number
+): TraceArchiveResizeResult {
+  const originalBytes = statSync(absoluteTracePath).size;
+  if (originalBytes <= maxBytes) {
+    return {
+      originalBytes,
+      finalBytes: originalBytes,
+      trimmedToLimit: true,
+      pruned: false,
+      keptEntries: [],
+      droppedEntries: []
+    };
+  }
+
+  try {
+    const archive = unzipSync(readFileSync(absoluteTracePath));
+    const entryNames = Object.keys(archive);
+    const strategies = [
+      (entryName: string) =>
+        !entryName.startsWith("resources/") &&
+        !entryName.startsWith("src@") &&
+        !entryName.startsWith("sources/"),
+      (entryName: string) =>
+        !entryName.includes("/") || /\.(trace|network|stacks|json)$/i.test(entryName),
+      (entryName: string) => /\.(trace|network|stacks)$/i.test(entryName),
+      (entryName: string) => /\.(trace|network)$/i.test(entryName),
+      (entryName: string) => /\.trace$/i.test(entryName)
+    ] as const;
+
+    let smallestArchive: {
+      bytes: Uint8Array;
+      keptEntries: string[];
+    } | null = null;
+
+    for (const strategy of strategies) {
+      const reducedEntries = filterTraceEntries(archive, strategy);
+      const keptEntries = Object.keys(reducedEntries);
+      if (keptEntries.length === 0) {
+        continue;
+      }
+
+      const reducedArchive = zipSync(reducedEntries, { level: 9 });
+      if (smallestArchive === null || reducedArchive.length < smallestArchive.bytes.length) {
+        smallestArchive = {
+          bytes: reducedArchive,
+          keptEntries
+        };
+      }
+
+      if (reducedArchive.length <= maxBytes) {
+        writeFileSync(absoluteTracePath, Buffer.from(reducedArchive));
+        return {
+          originalBytes,
+          finalBytes: reducedArchive.length,
+          trimmedToLimit: true,
+          pruned: true,
+          keptEntries,
+          droppedEntries: entryNames.filter((entryName) => !keptEntries.includes(entryName))
+        };
+      }
+    }
+
+    if (smallestArchive !== null && smallestArchive.bytes.length < originalBytes) {
+      writeFileSync(absoluteTracePath, Buffer.from(smallestArchive.bytes));
+      return {
+        originalBytes,
+        finalBytes: smallestArchive.bytes.length,
+        trimmedToLimit: smallestArchive.bytes.length <= maxBytes,
+        pruned: true,
+        keptEntries: smallestArchive.keptEntries,
+        droppedEntries: entryNames.filter(
+          (entryName) => !smallestArchive.keptEntries.includes(entryName)
+        )
+      };
+    }
+  } catch {
+    // Fall back to the original trace archive when pruning fails.
+  }
+
+  return {
+    originalBytes,
+    finalBytes: originalBytes,
+    trimmedToLimit: false,
+    pruned: false,
+    keptEntries: [],
+    droppedEntries: []
+  };
+}
+
+async function captureScreenshotArtifact(
+  runtime: ConfirmFailureArtifactRuntime,
+  page: Page,
+  relativePath: string,
+  metadata: Record<string, unknown>
+): Promise<string> {
+  const absolutePath = runtime.artifacts.resolve(relativePath);
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
+  await page.screenshot({ path: absolutePath, fullPage: true });
+  runtime.artifacts.registerArtifact(relativePath, "image/png", metadata);
+  return relativePath;
+}
+
+async function captureFailureArtifacts(
+  input: {
+    runtime: ConfirmFailureArtifactRuntime;
+    page: Page;
+    actionId: string;
+    actionType: string;
+    profileName: string;
+    targetUrl?: string | undefined;
+    metadata?: Record<string, unknown> | undefined;
+    timestampMs: number;
+  }
+): Promise<string[]> {
+  const currentUrl = getPageUrl(input.page);
+  const artifactDetails = {
+    action: input.actionType,
+    action_id: input.actionId,
+    action_type: input.actionType,
+    profile_name: input.profileName,
+    target_url: input.targetUrl,
+    current_url: currentUrl,
+    capture_stage: "confirm_failure",
+    ...input.metadata
+  };
+  const artifactPaths: string[] = [];
+  const attempts = [
+    {
+      artifactPath: buildArtifactPath(
+        "linkedin/screenshot-confirm-error",
+        input.actionType,
+        "png",
+        input.timestampMs
+      ),
+      capture: async () => {
+        await captureScreenshotArtifact(
+          input.runtime,
+          input.page,
+          buildArtifactPath(
+            "linkedin/screenshot-confirm-error",
+            input.actionType,
+            "png",
+            input.timestampMs
+          ),
+          {
+            ...artifactDetails,
+            artifact_role: "failure_screenshot"
+          }
+        );
+      }
+    },
+    {
+      artifactPath: buildArtifactPath(
+        "linkedin/dom-confirm-error",
+        input.actionType,
+        "html",
+        input.timestampMs
+      ),
+      capture: async () => {
+        input.runtime.artifacts.writeText(
+          buildArtifactPath(
+            "linkedin/dom-confirm-error",
+            input.actionType,
+            "html",
+            input.timestampMs
+          ),
+          await input.page.content(),
+          "text/html",
+          {
+            ...artifactDetails,
+            artifact_role: "failure_dom"
+          }
+        );
+      }
+    },
+    {
+      artifactPath: buildArtifactPath(
+        "linkedin/accessibility-confirm-error",
+        input.actionType,
+        "json",
+        input.timestampMs
+      ),
+      capture: async () => {
+        input.runtime.artifacts.writeJson(
+          buildArtifactPath(
+            "linkedin/accessibility-confirm-error",
+            input.actionType,
+            "json",
+            input.timestampMs
+          ),
+          await captureAccessibilitySnapshot(input.page),
+          {
+            ...artifactDetails,
+            artifact_role: "failure_accessibility"
+          }
+        );
+      }
+    }
+  ] as const;
+
+  for (const attempt of attempts) {
+    try {
+      await attempt.capture();
+      artifactPaths.push(attempt.artifactPath);
+    } catch (error) {
+      input.runtime.logger.log("warn", "confirm.failure_artifact.capture_failed", {
+        action_id: input.actionId,
+        action_type: input.actionType,
+        artifact_path: attempt.artifactPath,
+        message: getErrorMessage(error)
+      });
+    }
+  }
+
+  return artifactPaths;
+}
+
+async function stopTracingWithPersistence(
+  input: {
+    runtime: ConfirmFailureArtifactRuntime;
+    context: BrowserContext;
+    actionId: string;
+    actionType: string;
+    profileName: string;
+    targetUrl?: string | undefined;
+    metadata?: Record<string, unknown> | undefined;
+    timestampMs: number;
+  }
+): Promise<string[]> {
+  const tracePath = buildArtifactPath(
+    "linkedin/trace-confirm",
+    input.actionType,
+    "zip",
+    input.timestampMs
+  );
+  const absoluteTracePath = input.runtime.artifacts.resolve(tracePath);
+  mkdirSync(path.dirname(absoluteTracePath), { recursive: true });
+
+  try {
+    await input.context.tracing.stop({ path: absoluteTracePath });
+  } catch (error) {
+    input.runtime.logger.log("warn", "confirm.trace.stop_failed", {
+      action_id: input.actionId,
+      action_type: input.actionType,
+      message: getErrorMessage(error)
+    });
+    return [];
+  }
+
+  const traceResize = resizeTraceArchive(
+    absoluteTracePath,
+    input.runtime.confirmFailureArtifacts.traceMaxBytes
+  );
+
+  if (traceResize.pruned) {
+    input.runtime.logger.log("info", "confirm.trace.pruned", {
+      action_id: input.actionId,
+      action_type: input.actionType,
+      original_bytes: traceResize.originalBytes,
+      final_bytes: traceResize.finalBytes,
+      max_bytes: input.runtime.confirmFailureArtifacts.traceMaxBytes,
+      trimmed_to_limit: traceResize.trimmedToLimit
+    });
+  }
+
+  if (!traceResize.trimmedToLimit) {
+    input.runtime.logger.log("warn", "confirm.trace.limit_exceeded", {
+      action_id: input.actionId,
+      action_type: input.actionType,
+      original_bytes: traceResize.originalBytes,
+      final_bytes: traceResize.finalBytes,
+      max_bytes: input.runtime.confirmFailureArtifacts.traceMaxBytes
+    });
+  }
+
+  input.runtime.artifacts.registerArtifact(tracePath, "application/zip", {
+    action: input.actionType,
+    action_id: input.actionId,
+    action_type: input.actionType,
+    profile_name: input.profileName,
+    target_url: input.targetUrl,
+    capture_stage: "confirm_trace",
+    trace_max_bytes: input.runtime.confirmFailureArtifacts.traceMaxBytes,
+    trace_original_bytes: traceResize.originalBytes,
+    trace_final_bytes: traceResize.finalBytes,
+    trace_pruned: traceResize.pruned,
+    trace_trimmed_to_limit: traceResize.trimmedToLimit,
+    trace_kept_entries: traceResize.keptEntries,
+    trace_dropped_entries: traceResize.droppedEntries,
+    ...input.metadata
+  });
+
+  return [tracePath];
+}
+
+export async function executeConfirmActionWithArtifacts<
+  TRuntime extends ConfirmFailureArtifactRuntime
+>(
+  input: ExecuteConfirmActionWithArtifactsInput<TRuntime>
+): Promise<ActionExecutorResult> {
+  const timestampMs = Date.now();
+  let tracingStarted = false;
+
+  try {
+    await input.context.tracing.start({
+      screenshots: false,
+      snapshots: false,
+      sources: false
+    });
+    tracingStarted = true;
+  } catch (error) {
+    input.runtime.logger.log("warn", "confirm.trace.start_failed", {
+      action_id: input.actionId,
+      action_type: input.actionType,
+      message: getErrorMessage(error)
+    });
+  }
+
+  try {
+    const result = await input.execute();
+    const artifactPaths = [...result.artifacts];
+
+    if (tracingStarted) {
+      if (input.persistTraceOnSuccess) {
+        artifactPaths.push(
+          ...(
+            await stopTracingWithPersistence({
+              runtime: input.runtime,
+              context: input.context,
+              actionId: input.actionId,
+              actionType: input.actionType,
+              profileName: input.profileName,
+              targetUrl: input.targetUrl,
+              metadata: input.metadata,
+              timestampMs
+            })
+          )
+        );
+      } else {
+        try {
+          await input.context.tracing.stop();
+        } catch (error) {
+          input.runtime.logger.log("warn", "confirm.trace.stop_failed", {
+            action_id: input.actionId,
+            action_type: input.actionType,
+            message: getErrorMessage(error)
+          });
+        }
+      }
+    }
+
+    return {
+      ...result,
+      artifacts: dedupeArtifactPaths(artifactPaths)
+    };
+  } catch (error) {
+    const capturedArtifacts = await captureFailureArtifacts({
+      runtime: input.runtime,
+      page: input.page,
+      actionId: input.actionId,
+      actionType: input.actionType,
+      profileName: input.profileName,
+      targetUrl: input.targetUrl,
+      metadata: input.metadata,
+      timestampMs
+    });
+
+    const traceArtifacts = tracingStarted
+      ? await stopTracingWithPersistence({
+          runtime: input.runtime,
+          context: input.context,
+          actionId: input.actionId,
+          actionType: input.actionType,
+          profileName: input.profileName,
+          targetUrl: input.targetUrl,
+          metadata: input.metadata,
+          timestampMs
+        })
+      : [];
+
+    const assistantError = attachArtifactPaths(
+      input.mapError(error),
+      dedupeArtifactPaths([
+        ...getArtifactPathsFromError(error),
+        ...capturedArtifacts,
+        ...traceArtifacts
+      ]),
+      {
+        action_id: input.actionId,
+        action_type: input.actionType,
+        profile_name: input.profileName,
+        target_url: input.targetUrl,
+        current_url: getPageUrl(input.page),
+        ...input.errorDetails
+      }
+    );
+
+    throw assistantError;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export * from "./auth/rateLimitState.js";
 export * from "./auth/session.js";
 export * from "./connectionPool.js";
 export * from "./config.js";
+export * from "./confirmArtifacts.js";
 export * from "./db/database.js";
 export * from "./errors.js";
 export * from "./healthCheck.js";

--- a/packages/core/src/linkedinConnections.ts
+++ b/packages/core/src/linkedinConnections.ts
@@ -1,5 +1,7 @@
 import { type BrowserContext, type Locator, type Page } from "playwright-core";
 import type { LinkedInAuthService } from "./auth/session.js";
+import { executeConfirmActionWithArtifacts } from "./confirmArtifacts.js";
+import type { ConfirmFailureArtifactConfig } from "./config.js";
 import { LinkedInAssistantError, asLinkedInAssistantError } from "./errors.js";
 import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
@@ -66,6 +68,7 @@ export interface LinkedInConnectionsExecutorRuntime {
   profileManager: ProfileManager;
   logger: JsonEventLogger;
   artifacts: ArtifactHelpers;
+  confirmFailureArtifacts: ConfirmFailureArtifactConfig;
 }
 
 /**
@@ -329,6 +332,7 @@ async function scrapePendingInvitations(
 
 async function executeSendInvitation(
   runtime: LinkedInConnectionsExecutorRuntime,
+  actionId: string,
   target: Record<string, unknown>,
   payload: Record<string, unknown>
 ): Promise<{ result: Record<string, unknown>; artifacts: string[] }> {
@@ -345,6 +349,31 @@ async function executeSendInvitation(
     },
     async (context) => {
       const page = await getOrCreatePage(context);
+      return executeConfirmActionWithArtifacts({
+        runtime,
+        context,
+        page,
+        actionId,
+        actionType: SEND_INVITATION_ACTION_TYPE,
+        profileName,
+        targetUrl: profileUrl,
+        metadata: {
+          target_profile: targetProfile,
+          profile_url: profileUrl,
+          note_included: note.length > 0
+        },
+        errorDetails: {
+          target_profile: targetProfile,
+          profile_url: profileUrl,
+          note_included: note.length > 0
+        },
+        mapError: (error) =>
+          asLinkedInAssistantError(
+            error,
+            "UNKNOWN",
+            "Failed to execute LinkedIn send_invitation action."
+          ),
+        execute: async () => {
       await page.goto(profileUrl, { waitUntil: "domcontentloaded" });
       await waitForNetworkIdleBestEffort(page);
 
@@ -615,6 +644,7 @@ async function executeSendInvitation(
       }
 
       return {
+        ok: true,
         result: {
           status: "invitation_sent",
           target_profile: targetProfile,
@@ -625,12 +655,15 @@ async function executeSendInvitation(
         },
         artifacts: []
       };
+        }
+      });
     }
   );
 }
 
 async function executeAcceptInvitation(
   runtime: LinkedInConnectionsExecutorRuntime,
+  actionId: string,
   target: Record<string, unknown>
 ): Promise<{ result: Record<string, unknown>; artifacts: string[] }> {
   const targetProfile = String(target.target_profile ?? "");
@@ -644,6 +677,27 @@ async function executeAcceptInvitation(
     },
     async (context) => {
       const page = await getOrCreatePage(context);
+      return executeConfirmActionWithArtifacts({
+        runtime,
+        context,
+        page,
+        actionId,
+        actionType: ACCEPT_INVITATION_ACTION_TYPE,
+        profileName,
+        targetUrl: INVITATIONS_RECEIVED_URL,
+        metadata: {
+          target_profile: targetProfile
+        },
+        errorDetails: {
+          target_profile: targetProfile
+        },
+        mapError: (error) =>
+          asLinkedInAssistantError(
+            error,
+            "UNKNOWN",
+            "Failed to execute LinkedIn accept_invitation action."
+          ),
+        execute: async () => {
       await page.goto(INVITATIONS_RECEIVED_URL, { waitUntil: "domcontentloaded" });
       await waitForNetworkIdleBestEffort(page);
 
@@ -664,18 +718,22 @@ async function executeAcceptInvitation(
       }
 
       return {
+        ok: true,
         result: {
           status: "invitation_accepted",
           target_profile: targetProfile
         },
         artifacts: []
       };
+        }
+      });
     }
   );
 }
 
 async function executeWithdrawInvitation(
   runtime: LinkedInConnectionsExecutorRuntime,
+  actionId: string,
   target: Record<string, unknown>
 ): Promise<{ result: Record<string, unknown>; artifacts: string[] }> {
   const targetProfile = String(target.target_profile ?? "");
@@ -689,6 +747,27 @@ async function executeWithdrawInvitation(
     },
     async (context) => {
       const page = await getOrCreatePage(context);
+      return executeConfirmActionWithArtifacts({
+        runtime,
+        context,
+        page,
+        actionId,
+        actionType: WITHDRAW_INVITATION_ACTION_TYPE,
+        profileName,
+        targetUrl: INVITATIONS_SENT_URL,
+        metadata: {
+          target_profile: targetProfile
+        },
+        errorDetails: {
+          target_profile: targetProfile
+        },
+        mapError: (error) =>
+          asLinkedInAssistantError(
+            error,
+            "UNKNOWN",
+            "Failed to execute LinkedIn withdraw_invitation action."
+          ),
+        execute: async () => {
       await page.goto(INVITATIONS_SENT_URL, { waitUntil: "domcontentloaded" });
       await waitForNetworkIdleBestEffort(page);
 
@@ -716,12 +795,15 @@ async function executeWithdrawInvitation(
       }
 
       return {
+        ok: true,
         result: {
           status: "invitation_withdrawn",
           target_profile: targetProfile
         },
         artifacts: []
       };
+        }
+      });
     }
   );
 }
@@ -744,6 +826,7 @@ export class SendInvitationActionExecutor
   ): Promise<ActionExecutorResult> {
     const { result, artifacts } = await executeSendInvitation(
       input.runtime,
+      input.action.id,
       input.action.target,
       input.action.payload
     );
@@ -759,6 +842,7 @@ export class AcceptInvitationActionExecutor
   ): Promise<ActionExecutorResult> {
     const { result, artifacts } = await executeAcceptInvitation(
       input.runtime,
+      input.action.id,
       input.action.target
     );
     return { ok: true, result, artifacts };
@@ -773,6 +857,7 @@ export class WithdrawInvitationActionExecutor
   ): Promise<ActionExecutorResult> {
     const { result, artifacts } = await executeWithdrawInvitation(
       input.runtime,
+      input.action.id,
       input.action.target
     );
     return { ok: true, result, artifacts };

--- a/packages/core/src/linkedinFeed.ts
+++ b/packages/core/src/linkedinFeed.ts
@@ -1,6 +1,10 @@
+import { mkdirSync } from "node:fs";
+import path from "node:path";
 import { type BrowserContext, type Locator, type Page } from "playwright-core";
 import type { ArtifactHelpers } from "./artifacts.js";
 import type { LinkedInAuthService } from "./auth/session.js";
+import { executeConfirmActionWithArtifacts } from "./confirmArtifacts.js";
+import type { ConfirmFailureArtifactConfig } from "./config.js";
 import { LinkedInAssistantError, asLinkedInAssistantError } from "./errors.js";
 import type { JsonEventLogger } from "./logging.js";
 import type { ProfileManager } from "./profileManager.js";
@@ -56,6 +60,7 @@ export interface LinkedInFeedExecutorRuntime {
   logger: JsonEventLogger;
   rateLimiter: RateLimiter;
   artifacts: ArtifactHelpers;
+  confirmFailureArtifacts: ConfirmFailureArtifactConfig;
 }
 
 export interface LinkedInFeedRuntime extends LinkedInFeedExecutorRuntime {
@@ -402,6 +407,7 @@ async function captureScreenshotArtifact(
   metadata: Record<string, unknown> = {}
 ): Promise<string> {
   const absolutePath = runtime.artifacts.resolve(relativePath);
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
   await page.screenshot({ path: absolutePath, fullPage: true });
   runtime.artifacts.registerArtifact(relativePath, "image/png", metadata);
   return relativePath;
@@ -1064,7 +1070,29 @@ export class LikePostActionExecutor
       async (context) => {
         const page = await getOrCreatePage(context);
 
-        try {
+        return executeConfirmActionWithArtifacts({
+          runtime,
+          context,
+          page,
+          actionId: action.id,
+          actionType: LIKE_POST_ACTION_TYPE,
+          profileName,
+          targetUrl: postUrl,
+          metadata: {
+            post_url: postUrl,
+            requested_reaction: reaction
+          },
+          errorDetails: {
+            post_url: postUrl,
+            requested_reaction: reaction
+          },
+          mapError: (error) =>
+            asLinkedInAssistantError(
+              error,
+              "UNKNOWN",
+              "Failed to execute LinkedIn like_post action."
+            ),
+          execute: async () => {
           const rateLimitState = runtime.rateLimiter.consume(
             LIKE_RATE_LIMIT_CONFIG
           );
@@ -1199,6 +1227,7 @@ export class LikePostActionExecutor
           const screenshotPath = `linkedin/screenshot-feed-like-${Date.now()}.png`;
           await captureScreenshotArtifact(runtime, page, screenshotPath, {
             action: LIKE_POST_ACTION_TYPE,
+            action_id: action.id,
             profile_name: profileName,
             post_url: postUrl,
             reaction,
@@ -1220,13 +1249,8 @@ export class LikePostActionExecutor
             },
             artifacts: [screenshotPath]
           };
-        } catch (error) {
-          throw asLinkedInAssistantError(
-            error,
-            "UNKNOWN",
-            "Failed to execute LinkedIn like_post action."
-          );
-        }
+          }
+        });
       }
     );
   }
@@ -1263,7 +1287,29 @@ export class CommentOnPostActionExecutor
       async (context) => {
         const page = await getOrCreatePage(context);
 
-        try {
+        return executeConfirmActionWithArtifacts({
+          runtime,
+          context,
+          page,
+          actionId: action.id,
+          actionType: COMMENT_ON_POST_ACTION_TYPE,
+          profileName,
+          targetUrl: postUrl,
+          metadata: {
+            post_url: postUrl,
+            comment_text: text
+          },
+          errorDetails: {
+            post_url: postUrl,
+            comment_text: text
+          },
+          mapError: (error) =>
+            asLinkedInAssistantError(
+              error,
+              "UNKNOWN",
+              "Failed to execute LinkedIn comment_on_post action."
+            ),
+          execute: async () => {
           const rateLimitState = runtime.rateLimiter.consume(
             COMMENT_RATE_LIMIT_CONFIG
           );
@@ -1469,6 +1515,7 @@ export class CommentOnPostActionExecutor
           const screenshotPath = `linkedin/screenshot-feed-comment-${Date.now()}.png`;
           await captureScreenshotArtifact(runtime, page, screenshotPath, {
             action: COMMENT_ON_POST_ACTION_TYPE,
+            action_id: action.id,
             profile_name: profileName,
             post_url: postUrl,
             selector_key: submitButton.key,
@@ -1485,13 +1532,8 @@ export class CommentOnPostActionExecutor
             },
             artifacts: [screenshotPath]
           };
-        } catch (error) {
-          throw asLinkedInAssistantError(
-            error,
-            "UNKNOWN",
-            "Failed to execute LinkedIn comment_on_post action."
-          );
-        }
+          }
+        });
       }
     );
   }

--- a/packages/core/src/linkedinInbox.ts
+++ b/packages/core/src/linkedinInbox.ts
@@ -1,3 +1,5 @@
+import { mkdirSync } from "node:fs";
+import path from "node:path";
 import {
   errors as playwrightErrors,
   type BrowserContext,
@@ -7,6 +9,8 @@ import {
 } from "playwright-core";
 import type { ArtifactHelpers } from "./artifacts.js";
 import type { LinkedInAuthService } from "./auth/session.js";
+import { executeConfirmActionWithArtifacts } from "./confirmArtifacts.js";
+import type { ConfirmFailureArtifactConfig } from "./config.js";
 import {
   LinkedInAssistantError,
   asLinkedInAssistantError
@@ -126,6 +130,7 @@ export interface LinkedInMessagingRuntime {
   cdpUrl?: string | undefined;
   profileManager: ProfileManager;
   artifacts: ArtifactHelpers;
+  confirmFailureArtifacts: ConfirmFailureArtifactConfig;
   rateLimiter: RateLimiter;
   logger: JsonEventLogger;
 }
@@ -1033,6 +1038,7 @@ async function captureScreenshotArtifact(
   metadata: Record<string, unknown> = {}
 ): Promise<string> {
   const absolutePath = runtime.artifacts.resolve(relativePath);
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
   await page.screenshot({ path: absolutePath, fullPage: true });
   runtime.artifacts.registerArtifact(relativePath, "image/png", metadata);
   return relativePath;
@@ -1320,8 +1326,6 @@ class SendMessageActionExecutor
       "target"
     );
     const text = getRequiredStringField(action.payload, "text", action.id, "payload");
-    const tracePath = `linkedin/trace-confirm-${Date.now()}.zip`;
-    const artifactPaths: string[] = [tracePath];
 
     await runtime.auth.ensureAuthenticated({
       profileName,
@@ -1336,15 +1340,30 @@ class SendMessageActionExecutor
       },
       async (context) => {
         const page = await getOrCreatePage(context);
-        let tracingStarted = false;
-
-        try {
-          await context.tracing.start({
-            screenshots: true,
-            snapshots: true,
-            sources: true
-          });
-          tracingStarted = true;
+        return executeConfirmActionWithArtifacts({
+          runtime,
+          context,
+          page,
+          actionId: action.id,
+          actionType: SEND_MESSAGE_ACTION_TYPE,
+          profileName,
+          targetUrl: threadUrl,
+          persistTraceOnSuccess: true,
+          metadata: {
+            thread_url: threadUrl,
+            selector_context: SEND_MESSAGE_ACTION_TYPE
+          },
+          errorDetails: {
+            selector_context: SEND_MESSAGE_ACTION_TYPE,
+            thread_url: threadUrl
+          },
+          mapError: (error) =>
+            toAutomationError(error, "Failed to execute LinkedIn send_message action.", {
+              selector_context: SEND_MESSAGE_ACTION_TYPE,
+              thread_url: threadUrl
+            }),
+          execute: async () => {
+            const artifactPaths: string[] = [];
 
           const detail = await extractThreadDetailWithNetwork(page, threadUrl, 20);
           validateThreadTarget(action, detail, page.url());
@@ -1438,6 +1457,7 @@ class SendMessageActionExecutor
           const postSendScreenshot = `linkedin/screenshot-confirm-${Date.now()}.png`;
           await captureScreenshotArtifact(runtime, page, postSendScreenshot, {
             action: SEND_MESSAGE_ACTION_TYPE,
+            action_id: action.id,
             profile_name: profileName,
             thread_url: threadUrl
           });
@@ -1450,46 +1470,8 @@ class SendMessageActionExecutor
             },
             artifacts: artifactPaths
           };
-        } catch (error) {
-          const failureScreenshot = `linkedin/screenshot-confirm-error-${Date.now()}.png`;
-          try {
-            await captureScreenshotArtifact(runtime, page, failureScreenshot, {
-              action: `${SEND_MESSAGE_ACTION_TYPE}_error`,
-              profile_name: profileName,
-              thread_url: threadUrl
-            });
-            artifactPaths.push(failureScreenshot);
-          } catch {
-            // Best-effort error screenshot.
           }
-
-          throw toAutomationError(
-            error,
-            "Failed to execute LinkedIn send_message action.",
-            {
-              action_id: action.id,
-              current_url: page.url(),
-              selector_context: SEND_MESSAGE_ACTION_TYPE,
-              artifact_paths: artifactPaths
-            }
-          );
-        } finally {
-          if (tracingStarted) {
-            try {
-              const absoluteTracePath = runtime.artifacts.resolve(tracePath);
-              await context.tracing.stop({ path: absoluteTracePath });
-              runtime.artifacts.registerArtifact(tracePath, "application/zip", {
-                action: SEND_MESSAGE_ACTION_TYPE,
-                profile_name: profileName
-              });
-            } catch (error) {
-              runtime.logger.log("warn", "linkedin.send_message.trace.stop_failed", {
-                action_id: action.id,
-                message: error instanceof Error ? error.message : String(error)
-              });
-            }
-          }
-        }
+        });
       }
     );
   }

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1,5 +1,11 @@
 import { ArtifactHelpers } from "./artifacts.js";
-import { ensureConfigPaths, resolveConfigPaths, type ConfigPaths } from "./config.js";
+import {
+  ensureConfigPaths,
+  resolveConfigPaths,
+  resolveConfirmFailureArtifactConfig,
+  type ConfigPaths,
+  type ConfirmFailureArtifactConfig
+} from "./config.js";
 import { AssistantDatabase } from "./db/database.js";
 import { LinkedInAuthService } from "./auth/session.js";
 import {
@@ -57,6 +63,7 @@ export interface CoreRuntime {
   paths: ConfigPaths;
   runId: string;
   cdpUrl?: string | undefined;
+  confirmFailureArtifacts: ConfirmFailureArtifactConfig;
   db: AssistantDatabase;
   logger: JsonEventLogger;
   artifacts: ArtifactHelpers;
@@ -86,6 +93,7 @@ export function createCoreRuntime(
   const runId = options.runId ?? createRunId();
   const logger = new JsonEventLogger(paths, runId, db);
   const artifacts = new ArtifactHelpers(paths, runId, db);
+  const confirmFailureArtifacts = resolveConfirmFailureArtifactConfig();
   const profileManager = new ProfileManager(paths);
   let runtime: CoreRuntime;
 
@@ -114,6 +122,7 @@ export function createCoreRuntime(
     paths,
     runId,
     cdpUrl: options.cdpUrl,
+    confirmFailureArtifacts,
     db,
     logger,
     artifacts,


### PR DESCRIPTION
## Summary\n- add shared confirm-action failure capture for screenshot, DOM, accessibility, and Playwright trace artifacts\n- apply the shared capture flow to inbox, feed, and connections confirms, and surface artifact paths in structured errors\n- cap persisted confirm traces with a configurable byte limit and cover the behavior with focused unit tests\n\n## Testing\n- npm run typecheck\n- npm run lint\n- npm test\n- npm run build\n\nCloses #6