### PR TITLE
feat: add privacy redaction for logs and storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ Default tool-owned state home (profiles, DB, artifacts):
 - Override with `LINKEDIN_ASSISTANT_HOME=/custom/path`
 - Confirm-failure trace size cap: `LINKEDIN_ASSISTANT_CONFIRM_TRACE_MAX_BYTES` (defaults to `26214400`)
 
+Privacy / redaction controls:
+
+- `LINKEDIN_ASSISTANT_REDACTION_MODE=off|partial|full`
+- `LINKEDIN_ASSISTANT_STORAGE_MODE=full|excerpt`
+- `LINKEDIN_ASSISTANT_MESSAGE_EXCERPT_LENGTH=80`
+- `LINKEDIN_ASSISTANT_REDACTION_HASH_SALT=your-local-salt`
+
+`partial` hashes names and stores/logs only short message excerpts. `full` replaces sensitive message bodies with fully redacted markers.
+
 ## CLI Usage
 
 Run commands via workspace binaries:
@@ -108,7 +117,7 @@ Exposed tools:
 1. Prepare send:
    - `linkedin inbox prepare-reply ...`
    - captures pre-send screenshot artifact
-   - stores prepared action with preview JSON + payload/preview hashes
+   - stores redacted preview JSON plus hashes; sensitive target/payload fields are sealed for confirm-time restore when needed
    - returns `preparedActionId` and `confirmToken`
 2. Confirm send:
    - `linkedin actions confirm --token ct_...`
@@ -121,6 +130,7 @@ Exposed tools:
 
 - Two-phase commit stores:
   - `target_json`, `payload_json`, `preview_json`
+  - optional sealed target/payload blobs when storage redaction is enabled
   - `payload_hash` and `preview_hash` (`sha256` base64url)
   - confirmation and execution metadata (`confirmed_at`, `executed_at`, result/error fields)
 - Errors use structured taxonomy:

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -16,10 +16,14 @@ import {
   normalizeLinkedInFeedReaction,
   normalizeLinkedInPostVisibility,
   resolveFollowupSinceWindow,
+  redactStructuredValue,
   resolveConfigPaths,
+  resolvePrivacyConfig,
   toLinkedInAssistantErrorPayload,
   type SearchCategory
 } from "@linkedin-assistant/core";
+
+const cliPrivacyConfig = resolvePrivacyConfig();
 
 function coercePositiveInt(value: string, label: string): number {
   const parsed = Number.parseInt(value, 10);
@@ -44,7 +48,9 @@ function coerceSearchCategory(value: string): SearchCategory {
 }
 
 function printJson(value: unknown): void {
-  console.log(JSON.stringify(value, null, 2));
+  console.log(
+    JSON.stringify(redactStructuredValue(value, cliPrivacyConfig, "cli"), null, 2)
+  );
 }
 
 function createRuntime(cdpUrl?: string) {
@@ -58,7 +64,11 @@ function createRuntime(cdpUrl?: string) {
     );
     process.stderr.write("\n");
   }
-  return createCoreRuntime(cdpUrl ? { cdpUrl } : {});
+  return createCoreRuntime(
+    cdpUrl
+      ? { cdpUrl, privacy: cliPrivacyConfig }
+      : { privacy: cliPrivacyConfig }
+  );
 }
 
 interface KeepAliveState {
@@ -1432,8 +1442,13 @@ async function runConfirmAction(input: {
       typeof preview.preview.summary === "string"
         ? preview.preview.summary
         : `Action ${preview.actionType}`;
+    const summaryPayload = redactStructuredValue(
+      { summary },
+      cliPrivacyConfig,
+      "cli"
+    );
 
-    console.log(`Preview summary: ${summary}`);
+    console.log(`Preview summary: ${summaryPayload.summary}`);
     printJson({
       prepared_action_id: preview.preparedActionId,
       action_type: preview.actionType,
@@ -2141,7 +2156,7 @@ async function main(): Promise<void> {
 }
 
 main().catch((error: unknown) => {
-  const payload = toLinkedInAssistantErrorPayload(error);
+  const payload = toLinkedInAssistantErrorPayload(error, cliPrivacyConfig);
   console.error(JSON.stringify(payload, null, 2));
   process.exit(1);
 });

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -2,6 +2,11 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import type { ConfigPaths } from "./config.js";
 import type { AssistantDatabase } from "./db/database.js";
+import {
+  redactStructuredValue,
+  resolvePrivacyConfig,
+  type PrivacyConfig
+} from "./privacy.js";
 
 function assertWithinRunDir(runDir: string, targetPath: string): void {
   if (targetPath === runDir) {
@@ -19,7 +24,8 @@ export class ArtifactHelpers {
   constructor(
     private readonly paths: ConfigPaths,
     private readonly runId: string,
-    private readonly db?: AssistantDatabase
+    private readonly db?: AssistantDatabase,
+    private readonly privacy: PrivacyConfig = resolvePrivacyConfig()
   ) {
     this.runDir = path.join(this.paths.artifactsDir, this.runId);
     mkdirSync(this.runDir, { recursive: true });
@@ -43,7 +49,14 @@ export class ArtifactHelpers {
   ): string {
     const artifactPath = this.resolve(relativePath);
     mkdirSync(path.dirname(artifactPath), { recursive: true });
-    writeFileSync(artifactPath, contents, "utf8");
+    const redacted = redactStructuredValue(
+      { body: contents },
+      this.privacy,
+      "artifact"
+    );
+    const sanitizedContents =
+      typeof redacted.body === "string" ? redacted.body : contents;
+    writeFileSync(artifactPath, sanitizedContents, "utf8");
     this.indexArtifact(relativePath, artifactType, metadata);
     return artifactPath;
   }
@@ -53,12 +66,12 @@ export class ArtifactHelpers {
     value: unknown,
     metadata: Record<string, unknown> = {}
   ): string {
-    return this.writeText(
-      relativePath,
-      `${JSON.stringify(value, null, 2)}\n`,
-      "application/json",
-      metadata
-    );
+    const artifactPath = this.resolve(relativePath);
+    mkdirSync(path.dirname(artifactPath), { recursive: true });
+    const sanitizedValue = redactStructuredValue(value, this.privacy, "artifact");
+    writeFileSync(artifactPath, `${JSON.stringify(sanitizedValue, null, 2)}\n`, "utf8");
+    this.indexArtifact(relativePath, "application/json", metadata);
+    return artifactPath;
   }
 
   registerArtifact(
@@ -80,11 +93,17 @@ export class ArtifactHelpers {
       return;
     }
 
+    const sanitizedMetadata = redactStructuredValue(
+      metadata,
+      this.privacy,
+      "artifact"
+    );
+
     this.db.insertArtifactIndex({
       runId: this.runId,
       artifactPath: relativePath,
       artifactType,
-      metadataJson: JSON.stringify(metadata),
+      metadataJson: JSON.stringify(sanitizedMetadata),
       createdAtMs: Date.now()
     });
   }

--- a/packages/core/src/db/database.ts
+++ b/packages/core/src/db/database.ts
@@ -15,6 +15,15 @@ export interface RunLogInsert {
   createdAtMs: number;
 }
 
+export interface RunLogRow {
+  id: number;
+  run_id: string;
+  level: string;
+  event_name: string;
+  payload_json: string;
+  created_at: number;
+}
+
 export interface ArtifactIndexInsert {
   runId: string;
   artifactPath: string;
@@ -23,11 +32,22 @@ export interface ArtifactIndexInsert {
   createdAtMs: number;
 }
 
+export interface ArtifactIndexRow {
+  id: number;
+  run_id: string;
+  artifact_path: string;
+  artifact_type: string;
+  metadata_json: string;
+  created_at: number;
+}
+
 export interface PreparedActionInsert {
   id: string;
   actionType: string;
   targetJson: string;
+  sealedTargetJson: string | null;
   payloadJson: string;
+  sealedPayloadJson: string | null;
   previewJson: string;
   payloadHash: string;
   previewHash: string;
@@ -42,7 +62,9 @@ export interface PreparedActionRow {
   id: string;
   action_type: string;
   target_json: string;
+  sealed_target_json: string | null;
   payload_json: string;
+  sealed_payload_json: string | null;
   preview_json: string;
   payload_hash: string;
   preview_hash: string;
@@ -201,7 +223,9 @@ INSERT INTO prepared_action (
   id,
   action_type,
   target_json,
+  sealed_target_json,
   payload_json,
+  sealed_payload_json,
   preview_json,
   payload_hash,
   preview_hash,
@@ -215,7 +239,9 @@ VALUES (
   @id,
   @actionType,
   @targetJson,
+  @sealedTargetJson,
   @payloadJson,
+  @sealedPayloadJson,
   @previewJson,
   @payloadHash,
   @previewHash,
@@ -238,7 +264,9 @@ SELECT
   id,
   action_type,
   target_json,
+  sealed_target_json,
   payload_json,
+  sealed_payload_json,
   preview_json,
   payload_hash,
   preview_hash,
@@ -269,7 +297,9 @@ SELECT
   id,
   action_type,
   target_json,
+  sealed_target_json,
   payload_json,
+  sealed_payload_json,
   preview_json,
   payload_hash,
   preview_hash,
@@ -290,6 +320,32 @@ LIMIT 1
 `
       )
       .get(confirmTokenHash);
+  }
+
+  listRunLogs(runId: string): RunLogRow[] {
+    return this.db
+      .prepare<unknown[], RunLogRow>(
+        `
+SELECT id, run_id, level, event_name, payload_json, created_at
+FROM run_log
+WHERE run_id = ?
+ORDER BY created_at ASC, id ASC
+`
+      )
+      .all(runId);
+  }
+
+  listArtifactIndex(runId: string): ArtifactIndexRow[] {
+    return this.db
+      .prepare<unknown[], ArtifactIndexRow>(
+        `
+SELECT id, run_id, artifact_path, artifact_type, metadata_json, created_at
+FROM artifact_index
+WHERE run_id = ?
+ORDER BY created_at ASC, id ASC
+`
+      )
+      .all(runId);
   }
 
   markPreparedActionExecuted(input: PreparedActionExecutedUpdate): boolean {

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -170,5 +170,12 @@ CREATE INDEX IF NOT EXISTS sent_invitation_state_profile_accepted_idx
 CREATE INDEX IF NOT EXISTS sent_invitation_state_followup_action_idx
   ON sent_invitation_state(followup_prepared_action_id);
 `
+  },
+  {
+    id: "004_prepared_action_sealed_fields",
+    sql: `
+ALTER TABLE prepared_action ADD COLUMN sealed_target_json TEXT;
+ALTER TABLE prepared_action ADD COLUMN sealed_payload_json TEXT;
+`
   }
 ];

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,3 +1,10 @@
+import {
+  redactFreeformText,
+  redactStructuredValue,
+  resolvePrivacyConfig,
+  type PrivacyConfig
+} from "./privacy.js";
+
 export const LINKEDIN_ASSISTANT_ERROR_CODES = [
   "AUTH_REQUIRED",
   "CAPTCHA_OR_CHALLENGE",
@@ -53,28 +60,48 @@ function summarizeUnknownError(error: unknown): Record<string, unknown> {
 }
 
 export function toLinkedInAssistantErrorPayload(
-  error: unknown
+  error: unknown,
+  privacy?: Partial<PrivacyConfig>
 ): LinkedInAssistantErrorPayload {
+  const privacyConfig = resolvePrivacyConfig(privacy);
+
   if (error instanceof LinkedInAssistantError) {
     return {
       code: error.code,
-      message: error.message,
-      details: error.details
+      message:
+        privacyConfig.redactionMode === "off"
+          ? error.message
+          : redactFreeformText(error.message, privacyConfig),
+      details: redactStructuredValue(error.details, privacyConfig, "error")
     };
   }
 
   if (error instanceof Error) {
     return {
       code: "UNKNOWN",
-      message: error.message,
-      details: summarizeUnknownError(error)
+      message:
+        privacyConfig.redactionMode === "off"
+          ? error.message
+          : redactFreeformText(error.message, privacyConfig),
+      details: redactStructuredValue(
+        summarizeUnknownError(error),
+        privacyConfig,
+        "error"
+      )
     };
   }
 
   return {
     code: "UNKNOWN",
-    message: String(error),
-    details: summarizeUnknownError(error)
+    message:
+      privacyConfig.redactionMode === "off"
+        ? String(error)
+        : redactFreeformText(String(error), privacyConfig),
+    details: redactStructuredValue(
+      summarizeUnknownError(error),
+      privacyConfig,
+      "error"
+    )
   };
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,7 @@ export * from "./linkedinNotifications.js";
 export * from "./linkedinPosts.js";
 export * from "./linkedinSearch.js";
 export * from "./logging.js";
+export * from "./privacy.js";
 export * from "./profileManager.js";
 export * from "./rateLimiter.js";
 export * from "./run.js";

--- a/packages/core/src/logging.ts
+++ b/packages/core/src/logging.ts
@@ -2,6 +2,11 @@ import { appendFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import type { ConfigPaths } from "./config.js";
 import type { AssistantDatabase } from "./db/database.js";
+import {
+  redactStructuredValue,
+  resolvePrivacyConfig,
+  type PrivacyConfig
+} from "./privacy.js";
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
 
@@ -19,7 +24,8 @@ export class JsonEventLogger {
   constructor(
     private readonly paths: ConfigPaths,
     private readonly runId: string,
-    private readonly db?: AssistantDatabase
+    private readonly db?: AssistantDatabase,
+    private readonly privacy: PrivacyConfig = resolvePrivacyConfig()
   ) {
     const runDir = path.join(this.paths.artifactsDir, this.runId);
     mkdirSync(runDir, { recursive: true });
@@ -35,12 +41,13 @@ export class JsonEventLogger {
     event: string,
     payload: Record<string, unknown> = {}
   ): JsonLogEntry {
+    const sanitizedPayload = redactStructuredValue(payload, this.privacy, "log");
     const entry: JsonLogEntry = {
       ts: new Date().toISOString(),
       run_id: this.runId,
       level,
       event,
-      payload
+      payload: sanitizedPayload
     };
 
     appendFileSync(this.eventsPath, `${JSON.stringify(entry)}\n`, "utf8");
@@ -50,7 +57,7 @@ export class JsonEventLogger {
         runId: this.runId,
         level,
         eventName: event,
-        payloadJson: JSON.stringify(payload),
+        payloadJson: JSON.stringify(sanitizedPayload),
         createdAtMs: Date.now()
       });
     }

--- a/packages/core/src/privacy.ts
+++ b/packages/core/src/privacy.ts
@@ -1,0 +1,468 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  randomBytes
+} from "node:crypto";
+
+export const PRIVACY_REDACTION_MODES = ["off", "partial", "full"] as const;
+export type PrivacyRedactionMode = (typeof PRIVACY_REDACTION_MODES)[number];
+
+export const PRIVACY_STORAGE_MODES = ["full", "excerpt"] as const;
+export type PrivacyStorageMode = (typeof PRIVACY_STORAGE_MODES)[number];
+
+export type PrivacySurface = "log" | "cli" | "error" | "storage" | "artifact";
+
+export interface PrivacyConfig {
+  redactionMode: PrivacyRedactionMode;
+  storageMode: PrivacyStorageMode;
+  hashSalt: string;
+  messageExcerptLength: number;
+}
+
+type EnvironmentMap = Record<string, string | undefined>;
+
+interface RedactionContext {
+  config: PrivacyConfig;
+  surface: PrivacySurface;
+  path: string[];
+  key?: string;
+  parent?: Record<string, unknown>;
+}
+
+const DEFAULT_HASH_NAMESPACE = "linkedin-assistant-privacy-v1";
+const DEFAULT_MESSAGE_EXCERPT_LENGTH = 80;
+const EMAIL_PATTERN = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi;
+const LIKELY_FULL_NAME_PATTERN = /\b[A-Z][A-Za-z'’-]+ [A-Z][A-Za-z'’-]+\b/g;
+const LINKEDIN_PROFILE_URL_PATTERN =
+  /((?:https?:\/\/)?(?:www\.)?linkedin\.com\/in\/|\/in\/)([^/?#\s]+)/gi;
+
+const EXPLICIT_NAME_KEYS = new Set([
+  "author",
+  "author_name",
+  "display_name",
+  "expected_participant_name",
+  "full_name",
+  "participant_name",
+  "provided_profile_name",
+  "target_profile",
+  "vanity_name"
+]);
+
+const MESSAGE_KEYS = new Set(["body", "note", "snippet", "text"]);
+
+function isPrivacyRedactionMode(value: string): value is PrivacyRedactionMode {
+  return (PRIVACY_REDACTION_MODES as readonly string[]).includes(value);
+}
+
+function isPrivacyStorageMode(value: string): value is PrivacyStorageMode {
+  return (PRIVACY_STORAGE_MODES as readonly string[]).includes(value);
+}
+
+function normalizeKey(key: string | undefined): string {
+  return (key ?? "")
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/-/g, "_")
+    .toLowerCase();
+}
+
+function clampExcerptLength(value: number): number {
+  if (!Number.isFinite(value)) {
+    return DEFAULT_MESSAGE_EXCERPT_LENGTH;
+  }
+
+  return Math.max(8, Math.min(512, Math.floor(value)));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function objectLooksLikePerson(parent: Record<string, unknown> | undefined): boolean {
+  if (!parent) {
+    return false;
+  }
+
+  return (
+    "profile_url" in parent ||
+    "vanity_name" in parent ||
+    "connection_degree" in parent ||
+    "mutual_connections" in parent ||
+    "author_profile_url" in parent
+  );
+}
+
+function objectLooksLikeInboxThread(parent: Record<string, unknown> | undefined): boolean {
+  if (!parent) {
+    return false;
+  }
+
+  return (
+    "thread_id" in parent ||
+    "thread_url" in parent ||
+    "unread_count" in parent ||
+    "messages" in parent
+  );
+}
+
+function objectLooksLikeNotification(
+  parent: Record<string, unknown> | undefined
+): boolean {
+  if (!parent) {
+    return false;
+  }
+
+  return "timestamp" in parent && "is_read" in parent && "link" in parent;
+}
+
+function shouldHashNames(config: PrivacyConfig, surface: PrivacySurface): boolean {
+  if (surface === "storage" || surface === "artifact") {
+    return config.redactionMode !== "off";
+  }
+
+  return config.redactionMode !== "off";
+}
+
+function shouldHashNameValue(context: RedactionContext): boolean {
+  if (!shouldHashNames(context.config, context.surface)) {
+    return false;
+  }
+
+  const key = normalizeKey(context.key);
+
+  if (EXPLICIT_NAME_KEYS.has(key)) {
+    return true;
+  }
+
+  if (key === "name") {
+    return objectLooksLikePerson(context.parent);
+  }
+
+  if (key === "title" || key === "actual_title") {
+    return objectLooksLikeInboxThread(context.parent);
+  }
+
+  return false;
+}
+
+function shouldRedactMessageValue(context: RedactionContext): boolean {
+  const key = normalizeKey(context.key);
+
+  if (MESSAGE_KEYS.has(key)) {
+    return true;
+  }
+
+  if (key !== "message") {
+    return false;
+  }
+
+  return (
+    objectLooksLikeNotification(context.parent) ||
+    context.path.includes("messages") ||
+    context.path.includes("notifications") ||
+    context.path.includes("outbound")
+  );
+}
+
+function shouldUseFullMessageRedaction(
+  config: PrivacyConfig,
+  surface: PrivacySurface
+): boolean {
+  if (surface === "storage" || surface === "artifact") {
+    return config.redactionMode === "full";
+  }
+
+  return config.redactionMode === "full";
+}
+
+function shouldUseExcerptMessageRedaction(
+  config: PrivacyConfig,
+  surface: PrivacySurface
+): boolean {
+  if (surface === "storage" || surface === "artifact") {
+    return config.redactionMode === "partial" || config.storageMode === "excerpt";
+  }
+
+  return config.redactionMode === "partial";
+}
+
+function shortHash(kind: string, value: string, config: PrivacyConfig): string {
+  return createHash("sha256")
+    .update(DEFAULT_HASH_NAMESPACE)
+    .update("\0")
+    .update(kind)
+    .update("\0")
+    .update(config.hashSalt)
+    .update("\0")
+    .update(value)
+    .digest("base64url")
+    .slice(0, 12);
+}
+
+function redactName(value: string, config: PrivacyConfig): string {
+  return `person#${shortHash("person", value, config)}`;
+}
+
+function redactEmail(value: string, config: PrivacyConfig): string {
+  return `email#${shortHash("email", value, config)}`;
+}
+
+function redactProfileSlug(value: string, config: PrivacyConfig): string {
+  return `profile#${shortHash("profile", value, config)}`;
+}
+
+function redactProfileUrls(value: string, config: PrivacyConfig): string {
+  return value.replace(LINKEDIN_PROFILE_URL_PATTERN, (_, prefix: string, slug: string) => {
+    return `${prefix}${redactProfileSlug(slug, config)}`;
+  });
+}
+
+function redactEmails(value: string, config: PrivacyConfig): string {
+  return value.replace(EMAIL_PATTERN, (email) => redactEmail(email, config));
+}
+
+function redactLikelyFullNames(value: string, config: PrivacyConfig): string {
+  return value.replace(LIKELY_FULL_NAME_PATTERN, (match) => redactName(match, config));
+}
+
+function redactActionSummary(value: string, config: PrivacyConfig): string {
+  const replacements = [
+    {
+      regex: /(Send message to )"([^"]+)"/,
+      replacer: (prefix: string, subject: string) => `${prefix}"${redactName(subject, config)}"`
+    },
+    {
+      regex: /(Send connection invitation to )(.+)$/,
+      replacer: (prefix: string, subject: string) => `${prefix}${redactName(subject, config)}`
+    },
+    {
+      regex: /(Accept connection invitation from )(.+)$/,
+      replacer: (prefix: string, subject: string) => `${prefix}${redactName(subject, config)}`
+    },
+    {
+      regex: /(Withdraw sent invitation to )(.+)$/,
+      replacer: (prefix: string, subject: string) => `${prefix}${redactName(subject, config)}`
+    }
+  ] as const;
+
+  let sanitized = value;
+
+  for (const replacement of replacements) {
+    sanitized = sanitized.replace(replacement.regex, (_, prefix: string, subject: string) => {
+      return replacement.replacer(prefix, subject.trim());
+    });
+  }
+
+  return sanitized;
+}
+
+export function redactFreeformText(value: string, config: PrivacyConfig): string {
+  let sanitized = redactEmails(value, config);
+  sanitized = redactProfileUrls(sanitized, config);
+  sanitized = redactActionSummary(sanitized, config);
+  sanitized = sanitized.replace(/(profile )"([^"]+)"/gi, (_, prefix: string, subject: string) => {
+    return `${prefix}"${redactName(subject, config)}"`;
+  });
+  return sanitized;
+}
+
+function redactMessageText(
+  value: string,
+  config: PrivacyConfig,
+  surface: PrivacySurface
+): string {
+  const sanitized = redactLikelyFullNames(redactFreeformText(value, config), config);
+  const hash = shortHash("text", value, config);
+  const originalLength = value.length;
+
+  if (shouldUseFullMessageRedaction(config, surface)) {
+    return `[redacted len=${originalLength} hash=${hash}]`;
+  }
+
+  if (!shouldUseExcerptMessageRedaction(config, surface)) {
+    return sanitized;
+  }
+
+  if (originalLength <= 1) {
+    return `[excerpt len=${originalLength} hash=${hash}]`;
+  }
+
+  const revealLength = Math.min(config.messageExcerptLength, originalLength - 1);
+  const excerpt = sanitized.slice(0, revealLength);
+  return `${excerpt}… [len=${originalLength} hash=${hash}]`;
+}
+
+function redactStringValue(value: string, context: RedactionContext): string {
+  const key = normalizeKey(context.key);
+
+  if (key === "summary" && shouldHashNames(context.config, context.surface)) {
+    return redactActionSummary(redactFreeformText(value, context.config), context.config);
+  }
+
+  if (key === "email") {
+    return redactEmail(value, context.config);
+  }
+
+  if (shouldHashNameValue(context)) {
+    return redactName(value, context.config);
+  }
+
+  if (shouldRedactMessageValue(context)) {
+    return redactMessageText(value, context.config, context.surface);
+  }
+
+  if (shouldHashNames(context.config, context.surface)) {
+    return redactFreeformText(value, context.config);
+  }
+
+  return value;
+}
+
+function redactUnknownValue(value: unknown, context: RedactionContext): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item, index) =>
+      redactUnknownValue(item, {
+        ...context,
+        key: String(index),
+        path: [...context.path, String(index)]
+      })
+    );
+  }
+
+  if (isRecord(value)) {
+    const output: Record<string, unknown> = {};
+    for (const [entryKey, entryValue] of Object.entries(value)) {
+      output[entryKey] = redactUnknownValue(entryValue, {
+        ...context,
+        key: entryKey,
+        path: [...context.path, entryKey],
+        parent: value
+      });
+    }
+    return output;
+  }
+
+  if (typeof value === "string") {
+    return redactStringValue(value, context);
+  }
+
+  return value;
+}
+
+function deriveCipherKey(confirmToken: string, config: PrivacyConfig): Buffer {
+  return createHash("sha256")
+    .update(DEFAULT_HASH_NAMESPACE)
+    .update("\0")
+    .update("cipher")
+    .update("\0")
+    .update(config.hashSalt)
+    .update("\0")
+    .update(confirmToken)
+    .digest();
+}
+
+export function sealJsonRecord(
+  value: Record<string, unknown>,
+  confirmToken: string,
+  config: PrivacyConfig
+): string {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", deriveCipherKey(confirmToken, config), iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(value), "utf8"),
+    cipher.final()
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  return [
+    "v1",
+    iv.toString("base64url"),
+    authTag.toString("base64url"),
+    ciphertext.toString("base64url")
+  ].join(".");
+}
+
+export function unsealJsonRecord(
+  sealedValue: string,
+  confirmToken: string,
+  config: PrivacyConfig
+): Record<string, unknown> {
+  const [version, ivEncoded, authTagEncoded, ciphertextEncoded] = sealedValue.split(".");
+  if (
+    version !== "v1" ||
+    !ivEncoded ||
+    !authTagEncoded ||
+    !ciphertextEncoded
+  ) {
+    throw new Error("Invalid sealed JSON record format.");
+  }
+
+  const decipher = createDecipheriv(
+    "aes-256-gcm",
+    deriveCipherKey(confirmToken, config),
+    Buffer.from(ivEncoded, "base64url")
+  );
+  decipher.setAuthTag(Buffer.from(authTagEncoded, "base64url"));
+
+  const decrypted = Buffer.concat([
+    decipher.update(Buffer.from(ciphertextEncoded, "base64url")),
+    decipher.final()
+  ]).toString("utf8");
+
+  const parsed = JSON.parse(decrypted) as unknown;
+  if (!isRecord(parsed)) {
+    throw new Error("Decrypted JSON record must be an object.");
+  }
+
+  return parsed;
+}
+
+export function createDefaultPrivacyConfig(
+  env: EnvironmentMap = process.env
+): PrivacyConfig {
+  const redactionModeRaw = env.LINKEDIN_ASSISTANT_REDACTION_MODE?.trim().toLowerCase();
+  const storageModeRaw = env.LINKEDIN_ASSISTANT_STORAGE_MODE?.trim().toLowerCase();
+  const messageExcerptLengthRaw = Number.parseInt(
+    env.LINKEDIN_ASSISTANT_MESSAGE_EXCERPT_LENGTH ?? "",
+    10
+  );
+
+  return {
+    redactionMode: redactionModeRaw && isPrivacyRedactionMode(redactionModeRaw)
+      ? redactionModeRaw
+      : "off",
+    storageMode: storageModeRaw && isPrivacyStorageMode(storageModeRaw)
+      ? storageModeRaw
+      : "full",
+    hashSalt: env.LINKEDIN_ASSISTANT_REDACTION_HASH_SALT ?? "",
+    messageExcerptLength: clampExcerptLength(messageExcerptLengthRaw)
+  };
+}
+
+export function resolvePrivacyConfig(
+  overrides: Partial<PrivacyConfig> = {},
+  env: EnvironmentMap = process.env
+): PrivacyConfig {
+  const defaults = createDefaultPrivacyConfig(env);
+
+  return {
+    redactionMode: overrides.redactionMode ?? defaults.redactionMode,
+    storageMode: overrides.storageMode ?? defaults.storageMode,
+    hashSalt: overrides.hashSalt ?? defaults.hashSalt,
+    messageExcerptLength: clampExcerptLength(
+      overrides.messageExcerptLength ?? defaults.messageExcerptLength
+    )
+  };
+}
+
+export function redactStructuredValue<T>(
+  value: T,
+  config: PrivacyConfig,
+  surface: PrivacySurface
+): T {
+  return redactUnknownValue(value, {
+    config,
+    surface,
+    path: []
+  }) as T;
+}

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -61,12 +61,14 @@ import {
   createDefaultTestAutoConfirmConfig,
   type TestAutoConfirmConfig
 } from "./twoPhaseCommit.js";
+import { resolvePrivacyConfig, type PrivacyConfig } from "./privacy.js";
 
 export interface CreateCoreRuntimeOptions {
   baseDir?: string;
   dbPath?: string;
   runId?: string;
   cdpUrl?: string | undefined;
+  privacy?: Partial<PrivacyConfig>;
 }
 
 export interface CoreRuntime {
@@ -74,6 +76,7 @@ export interface CoreRuntime {
   runId: string;
   cdpUrl?: string | undefined;
   confirmFailureArtifacts: ConfirmFailureArtifactConfig;
+  privacy: PrivacyConfig;
   db: AssistantDatabase;
   logger: JsonEventLogger;
   artifacts: ArtifactHelpers;
@@ -100,11 +103,12 @@ export function createCoreRuntime(
 ): CoreRuntime {
   const paths = resolveConfigPaths(options.baseDir);
   ensureConfigPaths(paths);
+  const privacy = resolvePrivacyConfig(options.privacy);
 
   const db = new AssistantDatabase(options.dbPath ?? paths.dbPath);
   const runId = options.runId ?? createRunId();
-  const logger = new JsonEventLogger(paths, runId, db);
-  const artifacts = new ArtifactHelpers(paths, runId, db);
+  const logger = new JsonEventLogger(paths, runId, db, privacy);
+  const artifacts = new ArtifactHelpers(paths, runId, db, privacy);
   const confirmFailureArtifacts = resolveConfirmFailureArtifactConfig();
   const profileManager = new ProfileManager(paths);
   let runtime: CoreRuntime;
@@ -129,6 +133,7 @@ export function createCoreRuntime(
   >;
   const testEchoExecutor = new TestEchoActionExecutor<LinkedInMessagingRuntime>();
   const twoPhaseCommit = new TwoPhaseCommitService<LinkedInMessagingRuntime>(db, {
+    privacy,
     executors: {
       ...linkedInExecutors,
       ...connectionExecutors,
@@ -145,6 +150,7 @@ export function createCoreRuntime(
     runId,
     cdpUrl: options.cdpUrl,
     confirmFailureArtifacts,
+    privacy,
     db,
     logger,
     artifacts,

--- a/packages/core/src/twoPhaseCommit.ts
+++ b/packages/core/src/twoPhaseCommit.ts
@@ -2,8 +2,16 @@ import { createHash, randomBytes, randomUUID } from "node:crypto";
 import type { AssistantDatabase, PreparedActionRow } from "./db/database.js";
 import {
   LinkedInAssistantError,
-  asLinkedInAssistantError
+  asLinkedInAssistantError,
+  toLinkedInAssistantErrorPayload
 } from "./errors.js";
+import {
+  redactStructuredValue,
+  resolvePrivacyConfig,
+  sealJsonRecord,
+  unsealJsonRecord,
+  type PrivacyConfig
+} from "./privacy.js";
 
 export const DEFAULT_CONFIRM_TOKEN_TTL_MS = 30 * 60 * 1000;
 
@@ -20,10 +28,8 @@ export function createDefaultTestAutoConfirmConfig(): TestAutoConfirmConfig {
   const enabled =
     process.env.LINKEDIN_TEST_AUTO_CONFIRM_ENABLED === "true" ||
     process.env.LINKEDIN_TEST_AUTO_CONFIRM_ENABLED === "1";
-  const ttlMs = Number.parseInt(
-    process.env.LINKEDIN_TEST_AUTO_CONFIRM_TTL_MS ?? "0",
-    10
-  ) || 0;
+  const ttlMs =
+    Number.parseInt(process.env.LINKEDIN_TEST_AUTO_CONFIRM_TTL_MS ?? "0", 10) || 0;
   const allowedTargetsRaw = process.env.LINKEDIN_TEST_AUTO_CONFIRM_TARGETS ?? "";
   const allowedTargets = allowedTargetsRaw
     .split(",")
@@ -51,9 +57,7 @@ export function isTestAutoConfirmAllowedTarget(
   if (config.allowedTargets.length === 0) {
     return true;
   }
-  return config.allowedTargets.some(
-    (allowed) => targetUrl.includes(allowed)
-  );
+  return config.allowedTargets.some((allowed) => targetUrl.includes(allowed));
 }
 
 export interface PrepareActionInput {
@@ -140,6 +144,7 @@ export interface PreparedActionPreview {
 export interface TwoPhaseCommitServiceOptions<TRuntime> {
   executors?: ActionExecutorRegistry<TRuntime>;
   getRuntime?: () => TRuntime;
+  privacy?: Partial<PrivacyConfig>;
 }
 
 export function generateConfirmToken(entropyBytes: number = 24): string {
@@ -182,6 +187,28 @@ function parseJsonObject(
   }
 }
 
+function unsealPreparedJsonObject(
+  label: string,
+  value: string,
+  actionId: string,
+  confirmToken: string,
+  privacy: PrivacyConfig
+): Record<string, unknown> {
+  try {
+    return unsealJsonRecord(value, confirmToken, privacy);
+  } catch (error) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `Prepared action ${actionId} has invalid ${label}.`,
+      {
+        action_id: actionId,
+        label
+      },
+      { cause: error instanceof Error ? error : undefined }
+    );
+  }
+}
+
 function parseExecutionResult(
   executionResultJson: string | null,
   actionId: string
@@ -193,12 +220,19 @@ function parseExecutionResult(
   return parseJsonObject("execution_result_json", executionResultJson, actionId);
 }
 
-function mapPreparedActionRow(row: PreparedActionRow): PreparedAction {
+function mapPreparedActionRow(
+  row: PreparedActionRow,
+  overrides: {
+    target?: Record<string, unknown>;
+    payload?: Record<string, unknown>;
+  } = {}
+): PreparedAction {
   return {
     id: row.id,
     actionType: row.action_type,
-    target: parseJsonObject("target_json", row.target_json, row.id),
-    payload: parseJsonObject("payload_json", row.payload_json, row.id),
+    target: overrides.target ?? parseJsonObject("target_json", row.target_json, row.id),
+    payload:
+      overrides.payload ?? parseJsonObject("payload_json", row.payload_json, row.id),
     preview: parseJsonObject("preview_json", row.preview_json, row.id),
     payloadHash: row.payload_hash,
     previewHash: row.preview_hash,
@@ -212,6 +246,36 @@ function mapPreparedActionRow(row: PreparedActionRow): PreparedAction {
     errorCode: row.error_code,
     errorMessage: row.error_message
   };
+}
+
+function hydratePreparedActionForConfirmation(
+  row: PreparedActionRow,
+  confirmToken: string,
+  privacy: PrivacyConfig
+): PreparedAction {
+  const target = row.sealed_target_json
+    ? unsealPreparedJsonObject(
+        "sealed_target_json",
+        row.sealed_target_json,
+        row.id,
+        confirmToken,
+        privacy
+      )
+    : parseJsonObject("target_json", row.target_json, row.id);
+  const payload = row.sealed_payload_json
+    ? unsealPreparedJsonObject(
+        "sealed_payload_json",
+        row.sealed_payload_json,
+        row.id,
+        confirmToken,
+        privacy
+      )
+    : parseJsonObject("payload_json", row.payload_json, row.id);
+
+  return mapPreparedActionRow(row, {
+    target,
+    payload
+  });
 }
 
 function assertPreparedActionByToken(
@@ -231,10 +295,7 @@ function assertPreparedActionByToken(
   return row;
 }
 
-function assertPreparedActionIsReady(
-  action: PreparedAction,
-  nowMs: number
-): void {
+function assertPreparedActionIsReady(action: PreparedAction, nowMs: number): void {
   if (action.status !== "prepared") {
     throw new LinkedInAssistantError(
       "ACTION_PRECONDITION_FAILED",
@@ -262,6 +323,7 @@ function assertPreparedActionIsReady(
 export class TwoPhaseCommitService<TRuntime = unknown> {
   private readonly executors: ActionExecutorRegistry<TRuntime>;
   private readonly getRuntime: (() => TRuntime) | undefined;
+  private readonly privacy: PrivacyConfig;
 
   constructor(
     private readonly db: AssistantDatabase,
@@ -269,6 +331,7 @@ export class TwoPhaseCommitService<TRuntime = unknown> {
   ) {
     this.executors = options.executors ?? {};
     this.getRuntime = options.getRuntime;
+    this.privacy = resolvePrivacyConfig(options.privacy);
   }
 
   prepare(input: PrepareActionInput): PreparedActionResult {
@@ -282,22 +345,49 @@ export class TwoPhaseCommitService<TRuntime = unknown> {
     const targetJson = JSON.stringify(input.target);
     const payloadJson = JSON.stringify(input.payload);
     const previewJson = JSON.stringify(input.preview);
+    const storedTarget = redactStructuredValue(input.target, this.privacy, "storage");
+    const storedPayload = redactStructuredValue(input.payload, this.privacy, "storage");
+    const storedPreview = redactStructuredValue(input.preview, this.privacy, "storage");
+    const storedTargetJson = JSON.stringify(storedTarget);
+    const storedPayloadJson = JSON.stringify(storedPayload);
+    const storedPreviewJson = JSON.stringify(storedPreview);
+    const storedOperatorNote =
+      typeof input.operatorNote === "string"
+        ? (() => {
+            const sanitized = redactStructuredValue(
+              { note: input.operatorNote },
+              this.privacy,
+              "storage"
+            );
+            return typeof sanitized.note === "string"
+              ? sanitized.note
+              : input.operatorNote;
+          })()
+        : null;
     const payloadHash = hashJsonPayload(payloadJson);
     const previewHash = hashJsonPayload(previewJson);
 
     this.db.insertPreparedAction({
       id: preparedActionId,
       actionType: input.actionType,
-      targetJson,
-      payloadJson,
-      previewJson,
+      targetJson: storedTargetJson,
+      sealedTargetJson:
+        storedTargetJson === targetJson
+          ? null
+          : sealJsonRecord(input.target, confirmToken, this.privacy),
+      payloadJson: storedPayloadJson,
+      sealedPayloadJson:
+        storedPayloadJson === payloadJson
+          ? null
+          : sealJsonRecord(input.payload, confirmToken, this.privacy),
+      previewJson: storedPreviewJson,
       payloadHash,
       previewHash,
       status: "prepared",
       confirmTokenHash,
       expiresAtMs,
       createdAtMs: nowMs,
-      operatorNote: input.operatorNote ?? null
+      operatorNote: storedOperatorNote
     });
 
     return {
@@ -337,7 +427,11 @@ export class TwoPhaseCommitService<TRuntime = unknown> {
       this.db.getPreparedActionByConfirmTokenHash(confirmTokenHash),
       confirmTokenHash
     );
-    const action = mapPreparedActionRow(row);
+    const action = hydratePreparedActionForConfirmation(
+      row,
+      input.confirmToken,
+      this.privacy
+    );
     const nowMs = input.nowMs ?? Date.now();
 
     assertPreparedActionIsReady(action, nowMs);
@@ -373,12 +467,13 @@ export class TwoPhaseCommitService<TRuntime = unknown> {
       });
     } catch (error) {
       const assistantError = asLinkedInAssistantError(error);
+      const errorPayload = toLinkedInAssistantErrorPayload(assistantError, this.privacy);
       const updated = this.db.markPreparedActionFailed({
         id: action.id,
         confirmedAtMs: nowMs,
         executedAtMs: nowMs,
         errorCode: assistantError.code,
-        errorMessage: assistantError.message
+        errorMessage: errorPayload.message
       });
 
       if (!updated) {
@@ -394,14 +489,19 @@ export class TwoPhaseCommitService<TRuntime = unknown> {
       throw assistantError;
     }
 
+    const storedExecutionResult = redactStructuredValue(
+      {
+        result: executionResult.result,
+        artifacts: executionResult.artifacts
+      },
+      this.privacy,
+      "storage"
+    );
     const updated = this.db.markPreparedActionExecuted({
       id: action.id,
       confirmedAtMs: nowMs,
       executedAtMs: nowMs,
-      executionResultJson: JSON.stringify({
-        result: executionResult.result,
-        artifacts: executionResult.artifacts
-      })
+      executionResultJson: JSON.stringify(storedExecutionResult)
     });
 
     if (!updated) {

--- a/packages/core/test/privacy.test.ts
+++ b/packages/core/test/privacy.test.ts
@@ -1,0 +1,253 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ArtifactHelpers,
+  AssistantDatabase,
+  JsonEventLogger,
+  LinkedInAssistantError,
+  TwoPhaseCommitService,
+  ensureConfigPaths,
+  redactStructuredValue,
+  resolveConfigPaths,
+  toLinkedInAssistantErrorPayload,
+  type PrivacyConfig
+} from "../src/index.js";
+
+const privacyConfig: PrivacyConfig = {
+  redactionMode: "partial",
+  storageMode: "excerpt",
+  hashSalt: "test-salt",
+  messageExcerptLength: 12
+};
+
+const privateBody =
+  "Hello Simon Miller, this is a private message body that should never be stored verbatim.";
+
+const createdTempDirs: string[] = [];
+
+function createTempBaseDir(): string {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "linkedin-privacy-"));
+  createdTempDirs.push(tempDir);
+  return tempDir;
+}
+
+afterEach(() => {
+  for (const tempDir of createdTempDirs.splice(0)) {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe("privacy redaction", () => {
+  it("redacts structured values for user-facing output", () => {
+    const output = redactStructuredValue(
+      {
+        full_name: "Simon Miller",
+        email: "simon@example.com",
+        profile_url: "https://www.linkedin.com/in/simon-miller/",
+        summary: 'Send message to "Simon Miller"',
+        threads: [
+          {
+            thread_id: "thread-1",
+            thread_url: "https://www.linkedin.com/messaging/thread/thread-1/",
+            title: "Simon Miller",
+            snippet: privateBody,
+            messages: [
+              {
+                author: "Simon Miller",
+                text: privateBody
+              }
+            ]
+          }
+        ],
+        notification: {
+          message: privateBody,
+          timestamp: "now",
+          link: "https://www.linkedin.com/notifications/1/",
+          is_read: false
+        }
+      },
+      privacyConfig,
+      "cli"
+    );
+
+    const serialized = JSON.stringify(output);
+
+    expect(serialized).not.toContain("Simon Miller");
+    expect(serialized).not.toContain("simon@example.com");
+    expect(serialized).not.toContain(privateBody);
+    expect(serialized).toContain("person#");
+    expect(serialized).toContain("profile#");
+    expect(serialized).toContain("[len=");
+  });
+
+  it("redacts logs and stored artifact metadata", () => {
+    const baseDir = createTempBaseDir();
+    const paths = resolveConfigPaths(baseDir);
+    ensureConfigPaths(paths);
+
+    const db = new AssistantDatabase(paths.dbPath);
+
+    try {
+      const logger = new JsonEventLogger(paths, "run_privacy", db, privacyConfig);
+      logger.log("info", "privacy.test", {
+        full_name: "Simon Miller",
+        email: "simon@example.com",
+        messages: [
+          {
+            author: "Simon Miller",
+            text: privateBody
+          }
+        ]
+      });
+
+      const eventsPath = path.join(paths.artifactsDir, "run_privacy", "events.jsonl");
+      const events = readFileSync(eventsPath, "utf8");
+      expect(events).not.toContain("Simon Miller");
+      expect(events).not.toContain("simon@example.com");
+      expect(events).not.toContain(privateBody);
+
+      const logs = db.listRunLogs("run_privacy");
+      expect(logs).toHaveLength(1);
+      expect(logs[0]?.payload_json).not.toContain("Simon Miller");
+      expect(logs[0]?.payload_json).not.toContain(privateBody);
+
+      const artifacts = new ArtifactHelpers(paths, "run_privacy", db, privacyConfig);
+      artifacts.writeJson(
+        "privacy/thread.json",
+        {
+          full_name: "Simon Miller",
+          messages: [{ text: privateBody }]
+        },
+        {
+          participant_name: "Simon Miller"
+        }
+      );
+
+      const artifactJson = readFileSync(
+        path.join(paths.artifactsDir, "run_privacy", "privacy", "thread.json"),
+        "utf8"
+      );
+      expect(artifactJson).not.toContain("Simon Miller");
+      expect(artifactJson).not.toContain(privateBody);
+
+      const artifactIndex = db.listArtifactIndex("run_privacy");
+      expect(artifactIndex).toHaveLength(1);
+      expect(artifactIndex[0]?.metadata_json).not.toContain("Simon Miller");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("stores redacted prepared actions but restores sealed payloads for execution", async () => {
+    const db = new AssistantDatabase(":memory:");
+
+    try {
+      const service = new TwoPhaseCommitService(db, {
+        privacy: privacyConfig,
+        getRuntime: () => ({ label: "runtime" }),
+        executors: {
+          send_message: {
+            execute: ({ action }) => {
+              expect(action.target.participant_name).toBe("Simon Miller");
+              expect(action.payload.text).toBe(privateBody);
+              return {
+                ok: true,
+                result: {
+                  full_name: String(action.target.participant_name ?? ""),
+                  text: String(action.payload.text ?? "")
+                },
+                artifacts: []
+              };
+            }
+          }
+        }
+      });
+
+      const target = {
+        profile_name: "default",
+        thread_id: "thread-1",
+        thread_url: "https://www.linkedin.com/messaging/thread/thread-1/",
+        title: "Simon Miller",
+        participant_name: "Simon Miller"
+      };
+      const preview = {
+        summary: 'Send message to "Simon Miller"',
+        target,
+        outbound: {
+          text: privateBody
+        }
+      };
+      const operatorNote =
+        "Reply to Simon Miller with a private follow-up that should also be redacted.";
+
+      const prepared = service.prepare({
+        actionType: "send_message",
+        target,
+        payload: { text: privateBody },
+        preview,
+        operatorNote,
+        nowMs: 1_700_000_000_000
+      });
+
+      const row = db.getPreparedActionById(prepared.preparedActionId);
+      expect(row).toBeDefined();
+      expect(row?.target_json).not.toContain("Simon Miller");
+      expect(row?.preview_json).not.toContain("Simon Miller");
+      expect(row?.payload_json).not.toContain(privateBody);
+      expect(row?.operator_note).not.toContain("Simon Miller");
+      expect(row?.sealed_target_json).toBeTruthy();
+      expect(row?.sealed_payload_json).toBeTruthy();
+
+      const storedPreview = service.getPreparedActionPreviewByToken({
+        confirmToken: prepared.confirmToken
+      });
+      const storedPreviewJson = JSON.stringify(storedPreview);
+      expect(storedPreviewJson).not.toContain("Simon Miller");
+      expect(storedPreviewJson).not.toContain(privateBody);
+
+      const confirmed = await service.confirmByToken({
+        confirmToken: prepared.confirmToken,
+        nowMs: 1_700_000_000_100
+      });
+      expect(confirmed.result).toEqual({
+        full_name: "Simon Miller",
+        text: privateBody
+      });
+
+      const executedRow = db.getPreparedActionById(prepared.preparedActionId);
+      expect(executedRow?.execution_result_json).toBeDefined();
+      expect(executedRow?.execution_result_json).not.toContain("Simon Miller");
+      expect(executedRow?.execution_result_json).not.toContain(privateBody);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("redacts structured error payloads", () => {
+    const error = new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      'Prepared action belongs to profile "Simon Miller", but "default" was requested.',
+      {
+        expected_participant_name: "Simon Miller",
+        notification: {
+          message: privateBody,
+          timestamp: "now",
+          link: "https://www.linkedin.com/notifications/1/",
+          is_read: false
+        },
+        email: "simon@example.com"
+      }
+    );
+
+    const payload = toLinkedInAssistantErrorPayload(error, privacyConfig);
+    const serialized = JSON.stringify(payload);
+
+    expect(serialized).not.toContain("Simon Miller");
+    expect(serialized).not.toContain("simon@example.com");
+    expect(serialized).not.toContain(privateBody);
+    expect(serialized).toContain("person#");
+    expect(serialized).toContain("email#");
+  });
+});

--- a/packages/mcp/src/bin/linkedin-mcp.ts
+++ b/packages/mcp/src/bin/linkedin-mcp.ts
@@ -8,6 +8,8 @@ import {
   normalizeLinkedInFeedReaction,
   normalizeLinkedInPostVisibility,
   resolveFollowupSinceWindow,
+  redactStructuredValue,
+  resolvePrivacyConfig,
   toLinkedInAssistantErrorPayload,
   type SearchCategory
 } from "@linkedin-assistant/core";
@@ -45,6 +47,8 @@ import {
 
 type ToolArgs = Record<string, unknown>;
 type ToolResult = { content: Array<{ type: "text"; text: string }> };
+
+const mcpPrivacyConfig = resolvePrivacyConfig();
 
 function readString(args: ToolArgs, key: string, fallback: string): string {
   const value = args[key];
@@ -115,7 +119,11 @@ function toToolResult(payload: unknown): ToolResult {
     content: [
       {
         type: "text",
-        text: JSON.stringify(payload, null, 2)
+        text: JSON.stringify(
+          redactStructuredValue(payload, mcpPrivacyConfig, "cli"),
+          null,
+          2
+        )
       }
     ]
   };
@@ -130,7 +138,11 @@ function toErrorResult(error: unknown): {
     content: [
       {
         type: "text",
-        text: JSON.stringify(toLinkedInAssistantErrorPayload(error), null, 2)
+        text: JSON.stringify(
+          toLinkedInAssistantErrorPayload(error, mcpPrivacyConfig),
+          null,
+          2
+        )
       }
     ]
   };
@@ -161,7 +173,11 @@ function withCdpSchemaProperties(
 
 function createRuntime(args: ToolArgs) {
   const cdpUrl = readString(args, "cdpUrl", "");
-  return createCoreRuntime(cdpUrl ? { cdpUrl } : {});
+  return createCoreRuntime(
+    cdpUrl
+      ? { cdpUrl, privacy: mcpPrivacyConfig }
+      : { privacy: mcpPrivacyConfig }
+  );
 }
 
 async function handleSessionStatus(args: ToolArgs): Promise<ToolResult> {
@@ -1602,6 +1618,8 @@ async function main(): Promise<void> {
 }
 
 main().catch((error: unknown) => {
-  console.error(JSON.stringify(toLinkedInAssistantErrorPayload(error), null, 2));
+  console.error(
+    JSON.stringify(toLinkedInAssistantErrorPayload(error, mcpPrivacyConfig), null, 2)
+  );
   process.exit(1);
 });


### PR DESCRIPTION
## Summary\n- add a shared privacy/redaction layer with configurable log/output redaction and storage excerpt handling\n- redact CLI/MCP output, structured errors, log payloads, artifact metadata, and stored prepared-action previews\n- seal sensitive prepared-action target/payload fields so confirmations can still execute with full data\n- add focused privacy tests and document the new environment variables\n\n## Testing\n- npm run typecheck\n- npm run lint\n- npm test\n- npm run build\n\nCloses #7