### PR TITLE
docs: add selector audit research brief

### DIFF
--- a/docs/.research-brief-issue-4.md
+++ b/docs/.research-brief-issue-4.md
@@ -1,0 +1,383 @@
+# Research brief — issue #4 selector audit command
+
+Reviewed on: 2026-03-08  
+Related issues: #4, #8, #11, #17-#23
+
+## Executive summary
+
+The codebase does **not** currently have a central selector registry or selector-specific config surface.
+Selectors are embedded inside feature modules as ordered fallback lists, local candidate factories, and inline `page.evaluate()` DOM queries.
+
+That means issue #4 is partly aligned with the current implementation style, but not with the project spec wording around a reusable “selector registry”. The closest existing pattern is:
+
+- ordered selector candidates in feature modules
+- failures reported as `UI_CHANGED_SELECTOR_FAILED`
+- structured metadata such as `selector_key` and `attempted_selectors`
+- confirm-time artifact capture for mutating flows
+
+The biggest design constraint for a future audit command is that **selector groups are mostly private and inconsistently shaped**:
+
+- some modules use named Playwright locator candidates
+- some use raw string selector arrays
+- some use `page.evaluate()` with local `pickText` / `pickHref` helpers
+- fallback order exists, but “primary / secondary / tertiary” is not normalized across modules
+
+## What exists today
+
+### 1) Selector “infrastructure” is local, not centralized
+
+There is no shared selector registry in:
+
+- `packages/core/src/runtime.ts`
+- `packages/core/src/config.ts`
+- `packages/cli/src/bin/linkedin.ts`
+- `packages/mcp/src/bin/linkedin-mcp.ts`
+
+`packages/core/src/config.ts` currently exposes config for:
+
+- home / artifacts / profiles / SQLite paths
+- confirm-failure trace capture limits
+
+It does **not** expose:
+
+- selector registry paths
+- selector audit configuration
+- locale / language configuration
+- selector fallback policy configuration
+
+### 2) The strongest selector patterns already in use
+
+The project spec in `PROJECT.md` says selectors should be:
+
+- primary: role-based
+- secondary: attribute-based
+- tertiary: text-based
+
+That pattern broadly exists in the codebase, but only as a convention.
+
+Common traits across selector-heavy modules:
+
+- ordered fallback lists
+- `key` + `selectorHint` metadata per candidate
+- scoped locators rooted to a dialog, card, or top-card region before probing children
+- failure payloads with `selector_key`, `attempted_selectors`, and current URL
+- local helper functions such as `findVisibleLocatorOrThrow`, `findVisibleLocator`, `pickText`, and `pickHref`
+
+### 3) Failure handling conventions already exist
+
+Selector failures already map cleanly onto the existing error taxonomy:
+
+- `packages/core/src/errors.ts` defines `UI_CHANGED_SELECTOR_FAILED`
+- selector-heavy modules throw that error with structured details
+- mutating confirm flows can attach screenshots / DOM / accessibility / trace artifacts via `packages/core/src/confirmArtifacts.ts`
+
+This is important because issue #4 requires actionable output and failure screenshots. The conventions already exist; the missing piece is a unified selector inventory.
+
+## Selector inventory by module
+
+## Audit-scope modules for issue #4
+
+| Module | Pages / flows | How selectors are organized today | Notes |
+| --- | --- | --- | --- |
+| `packages/core/src/linkedinFeed.ts` | feed list, single post, like, comment | surface-level string arrays plus local `SelectorCandidate[]` groups | Best existing audit target for feed page + nested action selectors |
+| `packages/core/src/linkedinInbox.ts` | inbox list, thread view, reply composer, send | string/locator arrays plus local `SelectorCandidate[]` groups | Already reports `thread_surface` and other selector groups |
+| `packages/core/src/linkedinConnections.ts` | connections pages, invite / note / send / pending states | local `VisibleLocatorCandidate[]` groups | Strongly selector-driven; heavy use of English text / aria labels |
+| `packages/core/src/linkedinProfile.ts` | profile view | mostly `page.evaluate()` helpers with CSS arrays; only a light outer `h1` wait | No named registry-like groups today |
+| `packages/core/src/linkedinNotifications.ts` | notifications list | simple surface selector array + `page.evaluate()` scraping | Good fit for read-only audit of page-surface selectors |
+
+## Adjacent selector-heavy modules outside issue #4’s MVP page list
+
+| Module | Why it matters |
+| --- | --- |
+| `packages/core/src/linkedinPosts.ts` | Most structured local selector DSL in the repo; likely best template if a registry is later extracted |
+| `packages/core/src/linkedinFollowups.ts` | Reuses the same profile-top-card and message-composer patterns as connections + inbox |
+| `packages/core/src/linkedinJobs.ts` | Uses the same page-surface string-array approach as notifications |
+| `packages/core/src/linkedinSearch.ts` | Read-only scraping with repeated `pickText` / `pickHref` patterns |
+
+## Current selector organization details
+
+### `linkedinFeed.ts`
+
+Patterns already present:
+
+- `waitForFeedSurface()` uses ordered string selectors for the feed shell
+- `waitForPostSurface()` uses ordered string selectors for single-post pages
+- local `SelectorCandidate` lists handle target post resolution, reaction buttons, comment triggers, comment input, and submit buttons
+- failures include `selector_key`, `attempted_selectors`, and current URL
+
+Why it matters for issue #4:
+
+- feed is explicitly in audit scope
+- feed already has multiple fallback chains that could be reported as “fallback used”
+- however, those chains are local private functions, not exported selector definitions
+
+### `linkedinInbox.ts`
+
+Patterns already present:
+
+- `waitForThreadSurface()` exposes an explicit `thread_surface` group
+- inbox list and thread detail scraping use DOM selectors inside `page.evaluate()`
+- reply confirm flow uses ordered candidate lists for composer and send button
+
+Why it matters for issue #4:
+
+- inbox is explicitly in audit scope
+- this module has both page-surface selectors and mutation selectors
+- the audit command can easily cover read-only page selectors, but composer/send coverage would require either reusing private helpers or extracting them
+
+### `linkedinConnections.ts`
+
+Patterns already present:
+
+- `VisibleLocatorCandidate` groups for connect button, “More” menu, add-note button, note field, send button, and pending state checks
+- selectors mix role, text, aria-label, and bare CSS fallbacks
+- result logging includes which selector keys won
+
+Why it matters for issue #4:
+
+- connections is explicitly in audit scope
+- it is one of the most brittle areas because it depends heavily on English UI text like “Connect”, “More”, “Add a note”, and “Send”
+- it already resembles the kind of selector-group inventory issue #4 wants, but only inside one file
+
+### `linkedinProfile.ts`
+
+Patterns already present:
+
+- only a minimal outer wait: `h1`
+- most extraction happens inside `page.evaluate()` using CSS arrays and section-heading text matching
+- section discovery relies partly on label text such as “About”, “Experience”, and “Education”
+
+Why it matters for issue #4:
+
+- profile is explicitly in audit scope
+- there is no named selector-group abstraction here today
+- locale support (#8) will affect this module because section heading matching is language-sensitive
+
+### `linkedinNotifications.ts`
+
+Patterns already present:
+
+- simple page-surface selector array for shell detection
+- read-only extraction via `page.evaluate()` with `pickText` / `pickHref`
+- unread detection also inspects `aria-label` values containing “Unread”
+
+Why it matters for issue #4:
+
+- notifications is explicitly in audit scope
+- it is a good candidate for an early read-only audit pass
+- it also has locale sensitivity via unread-label heuristics
+
+## Open issue overlap review
+
+All currently open issues were reviewed.
+
+| Issue | Title | Overlap | Notes |
+| --- | --- | --- | --- |
+| #4 | Selector audit command | Direct | Parent feature. The brief maps the implementation starting point and current gaps. |
+| #5 | Scheduled follow-ups (local scheduler) | Low / adjacent | Not in the audit MVP page list, but depends on selector-heavy follow-up, inbox, and connection flows. |
+| #8 | Internationalization/locale support for selectors | Critical | Strongest overlap. Many current selector chains assume English button text and aria-labels. Audit output should be locale-aware from day one. |
+| #9 | Data deletion command | None | No selector overlap beyond shared runtime wiring. |
+| #10 | Evaluation harness for draft quality | None | Draft-evaluation work does not touch selectors. |
+| #11 | E2E test coverage hardening | Medium | Audit command should likely share real-session test patterns and UI-change regression coverage. |
+| #17 | [Research] Issue #4: Selector audit command | Direct | Current task. |
+| #18 | [Plan] Issue #4: Selector audit command | Direct dependency | Consumes this research brief. |
+| #19 | [Simplify] Issue #4: Selector audit command | Direct dependency | Most likely place to extract shared selector utilities after initial implementation. |
+| #20 | [Test] Issue #4: Selector audit command | Direct dependency | Should turn the risks below into regression coverage. |
+| #21 | [Harden] Issue #4: Selector audit command | Direct dependency | Will need to align with existing selector-failure and artifact-capture behavior. |
+| #22 | [UX] Issue #4: Selector audit command | Direct dependency | Report format and operator-facing error output depend on current selector metadata shape. |
+| #23 | [Docs] Issue #4: Selector audit command | Direct dependency | Final docs should explain what is being audited and what “fallback used” means. |
+
+### Specific note on #8 (i18n selectors)
+
+Issue #8 is the most important overlap because current mutation flows frequently rely on English-only labels such as:
+
+- “Message”
+- “Connect”
+- “More”
+- “Add a note”
+- “Send”
+- “Comment”
+- “Start a post”
+- “Anyone” / “Connections only” / “Done” / “Post”
+
+Implication for issue #4:
+
+- an audit report that only says pass/fail per selector chain will be incomplete if it does not record locale context
+- “primary / secondary / tertiary” should not be assumed to mean role > aria > English text forever
+- future extraction work should keep locale dictionaries separate from selector execution order
+
+## Recent commits / PRs that matter
+
+As of 2026-03-08 there are **no open PRs**. The most relevant recent merged PRs and commits are:
+
+| Date | Ref | What changed | Why it matters for issue #4 |
+| --- | --- | --- | --- |
+| 2026-02-24 | `6dc8a92` | hardened auth, feed reactions, and connection flows; touched feed, inbox, connections, jobs, notifications, profile, search; added `pageLoad.ts` | This is the main “selector resilience” baseline already in `main` |
+| 2026-03-08 | PR #13 / `740280c` | added shared confirm-failure artifact capture and applied it to inbox / feed / connections | Audit command can reuse the artifact/reporting conventions rather than inventing new failure plumbing |
+| 2026-03-08 | PR #12 / `ccdd5e6` | added `linkedinPosts.ts` with the most structured local selector candidate factories in the repo | Best current template for future registry extraction, even though posts are outside issue #4’s MVP pages |
+| 2026-03-08 | PR #14 / `ef8882a` | added `linkedinFollowups.ts` and more selector-heavy top-card / messaging flows | Confirms selector abstractions are being copied file-to-file rather than centralized |
+| 2026-03-08 | PR #15 / `338eb4d` | added privacy redaction for logs and stored output | Audit output will need to remain compatible with the current logging / redaction model |
+| 2026-03-08 | PR #16 / `f0c0ff5` | expanded `linkedinPosts.ts` with post safety lint | Not selector-first, but it increases the complexity of the one module that currently looks most “registry ready” |
+
+## Dependency graph for affected areas
+
+## Top-level wiring
+
+`packages/core/src/runtime.ts` is the root integration point.
+It constructs and exposes:
+
+- `profile`
+- `search`
+- `jobs`
+- `notifications`
+- `connections`
+- `followups`
+- `feed`
+- `posts`
+- `inbox`
+
+and registers action executors for mutating flows.
+
+## Shared dependencies used by selector-heavy modules
+
+| Shared module | Used for |
+| --- | --- |
+| `packages/core/src/auth/session.ts` | ensure authenticated LinkedIn session before page access |
+| `packages/core/src/profileManager.ts` | create / reuse Playwright persistent contexts |
+| `packages/core/src/pageLoad.ts` | best-effort network idle waiting after navigation |
+| `packages/core/src/errors.ts` | structured `UI_CHANGED_SELECTOR_FAILED` and related errors |
+| `packages/core/src/logging.ts` | structured event logging |
+
+## Extra dependencies used by mutating selector flows
+
+| Shared module | Used by |
+| --- | --- |
+| `packages/core/src/twoPhaseCommit.ts` | inbox, feed, connections, followups, posts |
+| `packages/core/src/rateLimiter.ts` | inbox, feed, followups, posts |
+| `packages/core/src/artifacts.ts` | inbox, feed, connections, followups, posts |
+| `packages/core/src/confirmArtifacts.ts` | inbox, feed, connections confirms |
+| `packages/core/src/config.ts` | confirm-failure artifact settings; not selector config |
+| `packages/core/src/db/database.ts` | inbox, connections, followups |
+
+## Cross-module coupling to note
+
+- `packages/core/src/linkedinConnections.ts` imports profile URL normalization helpers from `packages/core/src/linkedinProfile.ts`
+- `packages/core/src/linkedinFollowups.ts` imports `SEND_MESSAGE_RATE_LIMIT_CONFIG` from `packages/core/src/linkedinInbox.ts`
+- `packages/core/src/linkedinFollowups.ts` also imports profile URL normalization from `packages/core/src/linkedinProfile.ts`
+- `packages/cli/src/bin/linkedin.ts` and `packages/mcp/src/bin/linkedin-mcp.ts` call runtime service methods directly; there is no intermediate selector abstraction layer
+
+## Downstream consumers at regression risk
+
+| Area | Risk | Why |
+| --- | --- | --- |
+| Feed view / like / comment | High | Several nested selector chains, visible fallback order, and existing artifact capture already depend on selector metadata shape |
+| Inbox list / thread / send | High | Combines page-surface detection, evaluate-based scraping, composer detection, and 2PC confirm flow |
+| Connections list / invite / accept / withdraw | High | One of the heaviest English-text / aria-label consumers in the repo |
+| Profile view | Medium-High | Read-only, but extraction relies on DOM structure and section-heading text |
+| Notifications list | Medium | Read-only and simpler, but still sensitive to DOM + unread aria-label wording |
+| Followups | Medium-High | Outside issue #4’s MVP, but depends on the same profile-top-card and message-composer patterns |
+| Posts composer | Medium-High | Outside issue #4’s MVP, but contains the most structured selector grouping to learn from |
+| Search / Jobs | Medium | Mostly read-only scraping; less interactive, but still sensitive to DOM drift |
+
+## Test and script coverage snapshot
+
+### Existing E2E coverage
+
+The audit-scope areas already have real-session E2E coverage in:
+
+- `packages/core/src/__tests__/e2e/feed.e2e.test.ts`
+- `packages/core/src/__tests__/e2e/feed-write.e2e.test.ts`
+- `packages/core/src/__tests__/e2e/inbox.e2e.test.ts`
+- `packages/core/src/__tests__/e2e/inbox-write.e2e.test.ts`
+- `packages/core/src/__tests__/e2e/connections.e2e.test.ts`
+- `packages/core/src/__tests__/e2e/profile.e2e.test.ts`
+- `packages/core/src/__tests__/e2e/notifications.e2e.test.ts`
+
+Adjacent selector-heavy areas also have E2E coverage in:
+
+- `packages/core/src/__tests__/e2e/post-write.e2e.test.ts`
+- `packages/core/src/__tests__/e2e/jobs.e2e.test.ts`
+- `packages/core/src/__tests__/e2e/search.e2e.test.ts`
+
+### Unit coverage reality
+
+Unit coverage is much thinner for selector resolution itself. The most relevant selector-adjacent tests today are:
+
+- `packages/core/src/__tests__/confirmArtifacts.test.ts` for selector metadata and failure artifacts
+- `packages/core/src/__tests__/linkedinFollowups.test.ts` for accepted-connection detection metadata
+- `packages/core/src/__tests__/sessionAuth.test.ts` and `packages/core/src/__tests__/healthCheck.test.ts` for mocked visibility / authentication probes
+
+This means issue #20 ([Test]) will likely need to add selector-resolution-focused tests rather than relying only on today’s E2E coverage.
+
+### Existing manual smoke script
+
+`scripts/integration-test.ts` is also relevant research context:
+
+- it already treats LinkedIn as a moving target
+- it explicitly notes that LinkedIn has moved toward obfuscated CSS modules
+- it prefers semantic / ARIA-oriented detection for feed smoke checks
+
+That script is not a selector registry, but it confirms the same resilience strategy described in `PROJECT.md`.
+
+## Existing patterns, utilities, and conventions
+
+### Shared conventions worth preserving
+
+- **Ordered fallback lists** are the de facto registry format today.
+- **`key` + `selectorHint` metadata** is already used for debugging and should remain the unit of reporting.
+- **Scoped locators first, child selectors second** is the most reliable pattern in mutating flows.
+- **`UI_CHANGED_SELECTOR_FAILED`** is the existing failure contract and should remain the audit command’s error family.
+- **`waitForNetworkIdleBestEffort()`** is the standard navigation stabilizer before extraction or interaction.
+- **Structured artifacts** already exist for confirm-time failures and should influence audit failure reporting.
+
+### Repeated local utilities that are obvious extraction candidates later
+
+These are duplicated across modules today:
+
+- `SelectorCandidate` / `VisibleLocatorCandidate`-style types
+- visible-locator probe helpers
+- `pickText()` / `pickHref()` helpers inside `page.evaluate()`
+- `normalizeText()` helpers
+
+This duplication is useful research context for #19 ([Simplify]) but should not be changed in the research phase.
+
+## Key gaps between issue #4 and the current codebase
+
+1. **No central selector registry exists yet.**  
+   Issue #4 references selector groups and a registry-like audit model, but the implementation today is file-local.
+
+2. **Selector groups are not consistently exportable.**  
+   Most candidate arrays are private helpers inside service files.
+
+3. **Fallback level semantics are implicit, not standardized.**  
+   The code has ordered fallbacks, but it does not consistently label them as primary / secondary / tertiary.
+
+4. **Read-only modules and mutating modules use different selector representations.**  
+   Audit logic will need to handle both Playwright locator candidates and in-page DOM selector arrays.
+
+5. **Locale is not part of selector state today.**  
+   This is the main overlap with #8 and the main architectural risk if issue #4 is implemented in an English-only way.
+
+6. **Artifacts exist for confirm failures, not generic read-only audits.**  
+   Issue #4 can reuse the patterns, but not the implementation as-is for every page.
+
+## Research conclusions
+
+The codebase already contains enough selector metadata and fallback behavior to support a useful selector audit command, but the selector inventory is fragmented across feature modules.
+
+The safest mental model for issue #4 is:
+
+- **not** “add a brand-new selector system”
+- **instead** “surface and normalize the selector groups that already exist”
+
+The most important architectural consideration is issue #8:
+
+- if selector groups are extracted for auditing, the extraction format should leave room for locale-specific text dictionaries and locale-aware reporting
+- otherwise the audit command risks hard-coding today’s English assumptions into a new public surface
+
+The best local examples to study when implementation begins are:
+
+- `packages/core/src/linkedinFeed.ts` for page-surface + nested action selectors
+- `packages/core/src/linkedinInbox.ts` for page-surface + composer/send selector groups
+- `packages/core/src/linkedinConnections.ts` for interactive dialog/button fallback chains
+- `packages/core/src/linkedinPosts.ts` for the cleanest in-file selector candidate factory pattern


### PR DESCRIPTION
## Summary
- add `docs/.research-brief-issue-4.md` for issue #4 phase-0 research
- map the current selector infrastructure, dependency graph, shared patterns, and regression risks
- review open-issue overlap and recent selector-related PR/commit history

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

## Notes
- research only; no implementation code added
- focuses on issue #4 while closing the phase-0 research task

Closes #17
