### PR TITLE
docs: plan selector audit command implementation

### DIFF
--- a/docs/.plan-issue-4.md
+++ b/docs/.plan-issue-4.md
@@ -1,0 +1,289 @@
+# Execution plan — issue #4 selector audit command
+
+## Intent
+
+Implement issue #4 as a **read-only CLI workflow** that checks key selector groups on live LinkedIn pages and reports what still works.
+The target command from the parent issue is:
+
+- `linkedin audit selectors [--profile default]`
+
+The implementation should **surface and normalize selector groups that already exist** instead of introducing a brand-new selector system.
+This is the main takeaway from `docs/.research-brief-issue-4.md`.
+
+## Recommended approach
+
+### 1) Keep the CLI thin and put the logic in core
+
+The CLI should mostly parse input, call a core service, and render the report.
+The audit behavior itself belongs in a new core module so the logic stays testable and can later be reused by maintenance tooling.
+
+Suggested shape:
+
+- add a new core module for selector auditing, likely `packages/core/src/linkedinSelectorAudit.ts`
+- define audit input/output types there
+- define a normalized audit result shape there
+- let that module orchestrate authentication, page loading, selector checks, and failure artifact capture
+
+### 2) Reuse existing selector groups where they already live
+
+Do **not** start by building a repo-wide selector registry.
+The current codebase stores selectors close to the features that use them, and the safest first pass is to expose **narrow audit-friendly exports** from those feature modules.
+
+That means the builder should prefer:
+
+- small exported audit descriptor/factory functions from existing feature files
+- additive exports of existing selector groups or selector-group builders
+- a normalization layer in the audit module that can consume mixed selector shapes
+
+instead of:
+
+- moving all selectors into one central file
+- rewriting current feature flows to share a new abstraction before the audit command exists
+
+### 3) Normalize mixed selector styles at the audit boundary
+
+The research brief shows four different selector styles already in use:
+
+- ordered string selector arrays
+- `SelectorCandidate[]`
+- `VisibleLocatorCandidate[]`
+- `page.evaluate()` selector arrays with local `pickText()` / `pickHref()` helpers
+
+The audit module should treat those as different **sources** of selector groups but convert them into one common report model.
+That is the right place to define concepts like:
+
+- page
+- selector key
+- selector strategy / candidate order
+- pass / fail
+- fallback used
+- locale context
+- failure screenshot path
+
+### 4) Start with the MVP audit pages only
+
+Keep the first implementation aligned to issue #4:
+
+- feed
+- inbox
+- profile
+- connections
+- notifications
+
+Other selector-heavy modules are useful references, but they should stay out of the first implementation unless a shared helper is clearly reusable without widening scope.
+
+### 5) Treat “fallback used” as ordered-candidate reporting, not as a new policy engine
+
+The parent issue wants the report to show whether a fallback was used.
+The implementation should likely derive that from the existing candidate order:
+
+- first working candidate = pass without fallback
+- later working candidate = pass with fallback
+- no working candidate = fail
+
+This should stay simple. Do not introduce a new selector policy system unless the implementation proves it is necessary.
+
+## Suggested files to touch, in order
+
+This order is meant to reduce churn and keep the implementation incremental.
+
+1. `packages/core/src/linkedinSelectorAudit.ts`
+   - Add the audit service, normalized result types, and page orchestration.
+   - Make this the place where mixed selector definitions become one report shape.
+
+2. `packages/core/src/linkedinFeed.ts`
+   - Expose audit-friendly selector groups for feed surface and the highest-value post interaction groups.
+   - This is a strong first target because it already has explicit candidate lists and selector failure metadata.
+
+3. `packages/core/src/linkedinInbox.ts`
+   - Expose audit-friendly groups for thread surface, composer detection, and send-button detection.
+   - Prefer reusing existing candidate lists over inventing new ones.
+
+4. `packages/core/src/linkedinConnections.ts`
+   - Expose audit-friendly groups for connect / more / add-note / note-field / send / pending-state selectors.
+   - This is the highest-risk text-heavy module, so it is worth addressing early.
+
+5. `packages/core/src/linkedinProfile.ts`
+   - Expose only the high-signal profile selectors needed for the audit MVP.
+   - Do not try to turn every `page.evaluate()` extraction selector into a public registry in the first pass.
+
+6. `packages/core/src/linkedinNotifications.ts`
+   - Expose page-surface and unread-status related selector groups that matter for breakage detection.
+
+7. `packages/core/src/runtime.ts`
+   - Wire the new audit service into the runtime.
+   - Keep the service read-only and independent from two-phase commit.
+
+8. `packages/core/src/index.ts`
+   - Re-export the new audit service and types.
+
+9. `packages/cli/src/bin/linkedin.ts`
+   - Add the `audit selectors` command and report rendering.
+   - Keep formatting operator-friendly and machine-readable enough for maintenance workflows.
+
+10. `packages/core/src/__tests__/linkedinSelectorAudit.test.ts`
+   - Add focused tests for normalization and reporting behavior.
+   - Add adjacent module test updates only where selector export surfaces need coverage.
+
+11. `packages/core/src/__tests__/e2e/`
+   - Only add or adjust real-session coverage if there is a small, high-value smoke path.
+   - Broader hardening belongs to issue #20.
+
+## Existing utilities and patterns to reuse
+
+### Reuse directly
+
+- `packages/core/src/auth/session.ts`
+  - use `ensureAuthenticated()` before auditing live pages
+- `packages/core/src/profileManager.ts`
+  - reuse the existing persistent profile / page lifecycle
+- `packages/core/src/pageLoad.ts`
+  - reuse `waitForNetworkIdleBestEffort()` before probing selector groups
+- `packages/core/src/errors.ts`
+  - keep selector breakage under `UI_CHANGED_SELECTOR_FAILED`
+- `packages/core/src/logging.ts`
+  - keep audit logging structured via `runtime.logger.log(...)`
+- `packages/core/src/artifacts.ts`
+  - use the existing artifact path conventions for failure screenshots
+- `packages/core/src/confirmArtifacts.ts`
+  - reuse the reporting style and artifact discipline, even if the helper itself is not used as-is
+- `packages/core/src/linkedinPosts.ts`
+  - use it as the best current example of clean in-file selector candidate factories
+
+### Reuse conceptually, but avoid centralizing yet
+
+- `SelectorCandidate` / `VisibleLocatorCandidate` shapes
+- local visible-locator probe helpers
+- `pickText()` / `pickHref()` patterns inside `page.evaluate()`
+- local text-normalization helpers
+
+These are obvious simplification candidates for issue #19, but issue #4 does not need a big extraction pass to ship value.
+
+## New code that is justified
+
+The builder will likely need some net-new code in the first implementation:
+
+- one new core audit module
+- small exported audit descriptor/factory functions from the five in-scope feature modules
+- one CLI command surface
+- one normalized report/result type family
+- one read-only screenshot capture path for audit failures if the existing confirm helper is too mutation-specific
+
+That is enough for the MVP.
+Anything beyond that should clear a high scope bar.
+
+## Main risks to watch
+
+### 1) Issue #8 overlap: locale-sensitive selectors
+
+This is the most important architectural risk.
+Current selector chains often rely on English button text or aria labels such as:
+
+- Message
+- Connect
+- More
+- Add a note
+- Send
+- Comment
+- Unread
+- About / Experience / Education
+
+Planning response:
+
+- make locale/session language part of the audit result context from day one
+- keep selector execution order separate from any future locale dictionary work
+- avoid hard-coding a public assumption that “primary / secondary / tertiary” permanently maps to role > attribute > English text
+
+### 2) Scope creep from registry extraction
+
+The fastest way to get stuck is to stop and redesign the selector architecture for the whole repo.
+The research brief is clear: selectors are fragmented, but they are already good enough to audit if surfaced carefully.
+
+Planning response:
+
+- expose thin audit surfaces from existing modules
+- defer broad deduplication and shared selector types to issue #19
+
+### 3) Read-only guarantee
+
+Some selectors are only exercised today inside mutating flows.
+The audit command must stay read-only.
+
+Planning response:
+
+- prefer visibility / presence / readiness checks over click-driven verification
+- do not route the audit through prepare/confirm executors
+- do not click controls that can send, post, comment, invite, accept, or withdraw
+
+### 4) Artifact volume and noise
+
+Screenshots on every failed selector are useful, but they can also create noisy runs.
+
+Planning response:
+
+- capture artifacts only for failures or clearly degraded selector groups
+- keep artifact naming/reporting consistent with current run directories
+
+### 5) CI and maintenance workflow expectations
+
+Issue #4 wants a command that can be used in CI or maintenance workflows, but the project still depends on an authenticated LinkedIn session.
+
+Planning response:
+
+- fail clearly when authentication is missing
+- keep the report structured enough that automation can inspect it later
+- avoid baking local-only assumptions into the output format
+
+### 6) Privacy and logging
+
+Audit output should remain compatible with the current privacy/redaction model.
+
+Planning response:
+
+- report selector metadata and artifact paths, not unnecessary page content
+- stay consistent with the existing structured logging and redaction behavior
+
+## Guardrails
+
+### Do touch
+
+- core runtime wiring
+- CLI command wiring
+- additive audit exports in the five in-scope feature modules
+- focused tests that support the new audit surface
+
+### Do not touch unless the implementation proves it is necessary
+
+- `packages/mcp/src/bin/linkedin-mcp.ts`
+- `packages/mcp/src/index.ts`
+- `packages/core/src/twoPhaseCommit.ts`
+- `packages/core/src/rateLimiter.ts`
+- `packages/core/src/db/database.ts`
+- `packages/core/src/linkedinPosts.ts` beyond using it as a reference
+- `packages/core/src/linkedinFollowups.ts`
+- `packages/core/src/linkedinJobs.ts`
+- `packages/core/src/linkedinSearch.ts`
+
+### Avoid these traps
+
+- do not rewrite all selector code into one registry before the command works
+- do not mix audit-specific report shaping into unrelated feature behavior
+- do not introduce a new persistence layer for audit runs unless a clear requirement appears
+- do not solve issue #8 in full inside issue #4; leave room for locale dictionaries later
+- do not weaken the current `UI_CHANGED_SELECTOR_FAILED`, `selector_key`, and `attempted_selectors` conventions
+
+## Conventions to follow
+
+- keep TypeScript strict and additive
+- use ESM imports with `.js` extensions
+- use `node:` imports for built-ins
+- use type-only imports where appropriate
+- keep runtime logging structured
+- prefer small exported helpers over moving large private functions around
+- preserve existing module ownership of selector knowledge wherever practical
+
+## Implementation compass
+
+If the builder stays within one new core audit module, five additive feature-module touchpoints, runtime wiring, and one CLI command, the work is probably on the right track.
+
+If the builder starts redesigning selector storage for the entire repo, touching MCP parity, or rewriting mutation flows, the work has probably drifted out of scope.


### PR DESCRIPTION
## Summary
- add `docs/.plan-issue-4.md` as the execution plan for issue #4
- outline the recommended module boundaries, file touch order, reusable patterns, and scope guardrails
- call out the main architectural risk around locale-sensitive selectors from issue #8

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

## Links
- Refs #4
- Closes #18
