### PR TITLE
test: harden selector audit coverage for #20

### DIFF
--- a/packages/core/src/__tests__/selectorAudit.test.ts
+++ b/packages/core/src/__tests__/selectorAudit.test.ts
@@ -1,165 +1,52 @@
-import { mkdtemp, rm, stat, writeFile } from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import type { BrowserContext, Locator, Page } from "playwright-core";
-import { ArtifactHelpers } from "../artifacts.js";
-import { ensureConfigPaths, resolveConfigPaths } from "../config.js";
+import { stat } from "node:fs/promises";
+import { errors as playwrightErrors } from "playwright-core";
+import { afterEach, describe, expect, it } from "vitest";
 import {
-  LinkedInSelectorAuditService,
-  type SelectorAuditPageDefinition
+  LINKEDIN_SELECTOR_AUDIT_PAGES,
+  LINKEDIN_SELECTOR_AUDIT_STRATEGIES,
+  createLinkedInSelectorAuditRegistry
 } from "../selectorAudit.js";
-
-class MockLocatorImpl {
-  constructor(
-    private readonly selector: string,
-    private readonly visibleSelectors: ReadonlySet<string>
-  ) {}
-
-  first(): Locator {
-    return this as unknown as Locator;
-  }
-
-  async waitFor(): Promise<void> {
-    if (!this.visibleSelectors.has(this.selector)) {
-      throw new Error(`Selector not visible: ${this.selector}`);
-    }
-  }
-}
-
-function createMockPage(options: {
-  initialUrl?: string;
-  visibleSelectors: string[];
-  gotoError?: Error;
-}): Page {
-  let currentUrl = options.initialUrl ?? "https://example.test/";
-  const visibleSelectors = new Set(options.visibleSelectors);
-
-  return {
-    goto: vi.fn(async (url: string) => {
-      if (options.gotoError) {
-        throw options.gotoError;
-      }
-
-      currentUrl = url;
-      return null;
-    }),
-    waitForLoadState: vi.fn(async () => {}),
-    url: vi.fn(() => currentUrl),
-    locator: vi.fn((selector: string) => {
-      return new MockLocatorImpl(selector, visibleSelectors) as unknown as Locator;
-    }),
-    content: vi.fn(async () => "<html><body>selector audit</body></html>"),
-    screenshot: vi.fn(async ({ path: screenshotPath }: { path?: string }) => {
-      if (typeof screenshotPath === "string") {
-        await writeFile(screenshotPath, "png");
-      }
-    }),
-    accessibility: {
-      snapshot: vi.fn(async () => ({ role: "WebArea", name: "selector audit" }))
-    }
-  } as unknown as Page;
-}
-
-function createMockContext(page: Page): BrowserContext {
-  return {
-    pages: vi.fn(() => [page]),
-    newPage: vi.fn(async () => page)
-  } as unknown as BrowserContext;
-}
-
-function createRegistry(): SelectorAuditPageDefinition[] {
-  return [
-    {
-      page: "feed",
-      url: "https://example.test/feed",
-      selectors: [
-        {
-          key: "selector_group",
-          description: "Selector group",
-          candidates: [
-            {
-              strategy: "primary",
-              key: "primary-key",
-              selectorHint: "primary",
-              locatorFactory: (page) => page.locator("primary")
-            },
-            {
-              strategy: "secondary",
-              key: "secondary-key",
-              selectorHint: "secondary",
-              locatorFactory: (page) => page.locator("secondary")
-            },
-            {
-              strategy: "tertiary",
-              key: "tertiary-key",
-              selectorHint: "tertiary",
-              locatorFactory: (page) => page.locator("tertiary")
-            }
-          ]
-        }
-      ]
-    }
-  ];
-}
-
-const tempDirs: string[] = [];
+import {
+  cleanupSelectorAuditTestHarnesses,
+  createSelectorAuditCandidate,
+  createSelectorAuditPageDefinition,
+  createSelectorAuditSelectorDefinition,
+  createSelectorAuditTestHarness
+} from "./selectorAuditTestUtils.js";
 
 afterEach(async () => {
-  await Promise.all(
-    tempDirs.splice(0).map(async (dir) => {
-      await rm(dir, { recursive: true, force: true });
-    })
-  );
+  await cleanupSelectorAuditTestHarnesses();
 });
 
-async function createService(
-  options: {
-    visibleSelectors?: string[];
-    registry?: SelectorAuditPageDefinition[];
-    gotoError?: Error;
-  } = {}
-) {
-  const baseDir = await mkdtemp(path.join(os.tmpdir(), "selector-audit-test-"));
-  tempDirs.push(baseDir);
+describe("createLinkedInSelectorAuditRegistry", () => {
+  it("covers the audit-scope pages with normalized strategies", () => {
+    const registry = createLinkedInSelectorAuditRegistry();
 
-  const paths = resolveConfigPaths(baseDir);
-  ensureConfigPaths(paths);
+    expect(registry.map((pageDefinition) => pageDefinition.page)).toEqual([
+      ...LINKEDIN_SELECTOR_AUDIT_PAGES
+    ]);
 
-  const artifacts = new ArtifactHelpers(paths, "run_test");
-  const page = createMockPage({
-    visibleSelectors: options.visibleSelectors ?? [],
-    gotoError: options.gotoError
+    for (const pageDefinition of registry) {
+      expect(pageDefinition.selectors.length).toBeGreaterThan(0);
+
+      for (const selectorDefinition of pageDefinition.selectors) {
+        expect(selectorDefinition.description.length).toBeGreaterThan(0);
+        expect(selectorDefinition.candidates.map((candidate) => candidate.strategy)).toEqual([
+          ...LINKEDIN_SELECTOR_AUDIT_STRATEGIES
+        ]);
+
+        for (const candidate of selectorDefinition.candidates) {
+          expect(candidate.key.length).toBeGreaterThan(0);
+          expect(candidate.selectorHint.length).toBeGreaterThan(0);
+        }
+      }
+    }
   });
-  const context = createMockContext(page);
-
-  const runtime = {
-    runId: "run_test",
-    auth: {
-      ensureAuthenticated: vi.fn(async () => ({ authenticated: true }))
-    },
-    cdpUrl: undefined,
-    profileManager: {
-      runWithContext: vi.fn(async (_options, callback) => callback(context))
-    },
-    logger: {
-      log: vi.fn()
-    },
-    artifacts
-  };
-
-  const service = new LinkedInSelectorAuditService(runtime as never, {
-    registry: options.registry ?? createRegistry(),
-    candidateTimeoutMs: 10,
-    pageReadyTimeoutMs: 10
-  });
-
-  return { service, page, baseDir };
-}
+});
 
 describe("LinkedInSelectorAuditService", () => {
   it("marks fallback usage when secondary selector is the first passing strategy", async () => {
-    const { service } = await createService({
+    const { service } = await createSelectorAuditTestHarness({
       visibleSelectors: ["secondary", "tertiary"]
     });
 
@@ -193,7 +80,7 @@ describe("LinkedInSelectorAuditService", () => {
   });
 
   it("captures failure artifacts when no selector strategy matches", async () => {
-    const { service } = await createService();
+    const { service } = await createSelectorAuditTestHarness();
 
     const report = await service.auditSelectors({ profileName: "default" });
     const [result] = report.results;
@@ -222,8 +109,184 @@ describe("LinkedInSelectorAuditService", () => {
     await expect(stat(report.report_path)).resolves.toBeTruthy();
   });
 
+  it("aggregates page summaries across passes, failures, and fallback usage", async () => {
+    const registry = [
+      createSelectorAuditPageDefinition({
+        page: "feed",
+        selectors: [
+          createSelectorAuditSelectorDefinition({
+            key: "feed_primary",
+            description: "Feed primary selector",
+            candidates: [
+              createSelectorAuditCandidate({
+                strategy: "primary",
+                key: "feed-primary-key",
+                selectorHint: "feed-primary",
+                selector: "feed-primary"
+              }),
+              createSelectorAuditCandidate({
+                strategy: "secondary",
+                key: "feed-primary-secondary",
+                selectorHint: "feed-primary-secondary",
+                selector: "feed-primary-secondary"
+              }),
+              createSelectorAuditCandidate({
+                strategy: "tertiary",
+                key: "feed-primary-tertiary",
+                selectorHint: "feed-primary-tertiary",
+                selector: "feed-primary-tertiary"
+              })
+            ]
+          }),
+          createSelectorAuditSelectorDefinition({
+            key: "feed_missing",
+            description: "Feed missing selector",
+            candidates: [
+              createSelectorAuditCandidate({
+                strategy: "primary",
+                key: "feed-missing-primary",
+                selectorHint: "feed-missing-primary",
+                selector: "feed-missing-primary"
+              }),
+              createSelectorAuditCandidate({
+                strategy: "secondary",
+                key: "feed-missing-secondary",
+                selectorHint: "feed-missing-secondary",
+                selector: "feed-missing-secondary"
+              }),
+              createSelectorAuditCandidate({
+                strategy: "tertiary",
+                key: "feed-missing-tertiary",
+                selectorHint: "feed-missing-tertiary",
+                selector: "feed-missing-tertiary"
+              })
+            ]
+          })
+        ]
+      }),
+      createSelectorAuditPageDefinition({
+        page: "inbox",
+        selectors: [
+          createSelectorAuditSelectorDefinition({
+            key: "inbox_fallback",
+            description: "Inbox fallback selector",
+            candidates: [
+              createSelectorAuditCandidate({
+                strategy: "primary",
+                key: "inbox-primary-key",
+                selectorHint: "inbox-primary",
+                selector: "inbox-primary"
+              }),
+              createSelectorAuditCandidate({
+                strategy: "secondary",
+                key: "inbox-secondary-key",
+                selectorHint: "inbox-secondary",
+                selector: "inbox-secondary"
+              }),
+              createSelectorAuditCandidate({
+                strategy: "tertiary",
+                key: "inbox-tertiary-key",
+                selectorHint: "inbox-tertiary",
+                selector: "inbox-tertiary"
+              })
+            ]
+          })
+        ]
+      })
+    ];
+
+    const { runtime, service } = await createSelectorAuditTestHarness({
+      cdpUrl: "http://127.0.0.1:18800",
+      registry,
+      visibleSelectors: ["feed-primary", "inbox-secondary"]
+    });
+
+    const report = await service.auditSelectors({ profileName: "work" });
+
+    expect(report.total_count).toBe(3);
+    expect(report.pass_count).toBe(2);
+    expect(report.fail_count).toBe(1);
+    expect(report.fallback_count).toBe(1);
+    expect(report.page_summaries).toEqual([
+      {
+        page: "feed",
+        total_count: 2,
+        pass_count: 1,
+        fail_count: 1,
+        fallback_count: 0
+      },
+      {
+        page: "inbox",
+        total_count: 1,
+        pass_count: 1,
+        fail_count: 0,
+        fallback_count: 1
+      }
+    ]);
+    expect(runtime.auth.ensureAuthenticated).toHaveBeenCalledWith({
+      profileName: "work"
+    });
+    expect(runtime.profileManager.runWithContext).toHaveBeenCalledWith(
+      {
+        cdpUrl: "http://127.0.0.1:18800",
+        profileName: "work",
+        headless: true
+      },
+      expect.any(Function)
+    );
+  });
+
+  it("defaults to the default profile and opens a page when the context is empty", async () => {
+    const { context, runtime, service } = await createSelectorAuditTestHarness({
+      existingPages: [],
+      visibleSelectors: ["primary"]
+    });
+
+    const report = await service.auditSelectors();
+
+    expect(report.profile_name).toBe("default");
+    expect(runtime.auth.ensureAuthenticated).toHaveBeenCalledWith({
+      profileName: "default"
+    });
+    expect(context.pages).toHaveBeenCalledTimes(1);
+    expect(context.newPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues auditing when network idle times out", async () => {
+    const { page, service } = await createSelectorAuditTestHarness({
+      visibleSelectors: ["primary"],
+      waitForLoadStateError: new playwrightErrors.TimeoutError(
+        "Timed out waiting for network idle"
+      )
+    });
+
+    const report = await service.auditSelectors({ profileName: "default" });
+
+    expect(report.pass_count).toBe(1);
+    expect(page.waitForLoadState).toHaveBeenCalledWith("networkidle", {
+      timeout: 5_000
+    });
+  });
+
+  it("marks selector groups failed when page stabilization throws", async () => {
+    const { service } = await createSelectorAuditTestHarness({
+      waitForLoadStateError: new Error("Renderer crashed")
+    });
+
+    const report = await service.auditSelectors({ profileName: "default" });
+
+    expect(report.pass_count).toBe(0);
+    expect(report.fail_count).toBe(1);
+    expect(report.results[0]).toMatchObject({
+      page: "feed",
+      selector_key: "selector_group",
+      status: "fail",
+      error: "Renderer crashed"
+    });
+  });
+
   it("marks selector groups failed when navigation fails", async () => {
-    const { service } = await createService({
+    const { service } = await createSelectorAuditTestHarness({
       gotoError: new Error("Navigation failed")
     });
 
@@ -240,36 +303,239 @@ describe("LinkedInSelectorAuditService", () => {
     expect(report.results[0]?.strategies.primary.error).toBe("Navigation failed");
   });
 
+  it("fills in missing strategy slots for partial selector definitions", async () => {
+    const registry = [
+      createSelectorAuditPageDefinition({
+        page: "feed",
+        selectors: [
+          createSelectorAuditSelectorDefinition({
+            key: "selector_group",
+            description: "Selector group",
+            candidates: [
+              createSelectorAuditCandidate({
+                strategy: "secondary",
+                key: "secondary-key",
+                selectorHint: "secondary",
+                selector: "secondary"
+              })
+            ]
+          })
+        ]
+      })
+    ];
+
+    const { service } = await createSelectorAuditTestHarness({
+      registry,
+      visibleSelectors: ["secondary"]
+    });
+
+    const report = await service.auditSelectors({ profileName: "default" });
+    const [result] = report.results;
+
+    expect(result).toMatchObject({
+      status: "pass",
+      matched_strategy: "secondary",
+      matched_selector_key: "secondary-key",
+      fallback_used: "secondary-key",
+      fallback_strategy: "secondary"
+    });
+    expect(result?.strategies.primary).toMatchObject({
+      status: "fail",
+      selector_key: "missing-primary",
+      error: "Primary selector missing from registry."
+    });
+    expect(result?.strategies.secondary).toMatchObject({
+      status: "pass",
+      selector_key: "secondary-key"
+    });
+    expect(result?.strategies.tertiary).toMatchObject({
+      status: "fail",
+      selector_key: "missing-tertiary",
+      error: "Tertiary selector missing from registry."
+    });
+  });
+
+  it("propagates authentication failures before opening a browser context", async () => {
+    const authError = new Error("LinkedIn session expired");
+    const { runtime, service } = await createSelectorAuditTestHarness({
+      authError,
+      visibleSelectors: ["primary"]
+    });
+
+    await expect(
+      service.auditSelectors({ profileName: "default" })
+    ).rejects.toThrow("LinkedIn session expired");
+
+    expect(runtime.profileManager.runWithContext).not.toHaveBeenCalled();
+  });
+
+  it("keeps failure reporting intact when artifact capture steps fail", async () => {
+    const { service } = await createSelectorAuditTestHarness({
+      accessibilitySnapshotError: new Error("Accessibility tree unavailable"),
+      contentError: new Error("DOM snapshot unavailable"),
+      screenshotError: new Error("Screenshot unavailable")
+    });
+
+    const report = await service.auditSelectors({ profileName: "default" });
+
+    expect(report.fail_count).toBe(1);
+    expect(report.results[0]?.failure_artifacts).toEqual({});
+    await expect(stat(report.report_path)).resolves.toBeTruthy();
+  });
+
   it("rejects duplicate strategies in injected selector registries", async () => {
     await expect(
-      createService({
+      createSelectorAuditTestHarness({
         registry: [
-          {
+          createSelectorAuditPageDefinition({
             page: "feed",
-            url: "https://example.test/feed",
             selectors: [
-              {
+              createSelectorAuditSelectorDefinition({
                 key: "selector_group",
                 description: "Selector group",
                 candidates: [
-                  {
+                  createSelectorAuditCandidate({
                     strategy: "primary",
                     key: "primary-one",
                     selectorHint: "primary-one",
-                    locatorFactory: (page) => page.locator("primary-one")
-                  },
-                  {
+                    selector: "primary-one"
+                  }),
+                  createSelectorAuditCandidate({
                     strategy: "primary",
                     key: "primary-two",
                     selectorHint: "primary-two",
-                    locatorFactory: (page) => page.locator("primary-two")
-                  }
+                    selector: "primary-two"
+                  })
                 ]
-              }
+              })
             ]
-          }
+          })
         ]
       })
     ).rejects.toThrow("Duplicate selector audit strategy primary on feed:selector_group.");
+  });
+
+  it.each([
+    {
+      name: "duplicate page definitions",
+      message: "Duplicate selector audit page definition: feed",
+      registry: [
+        createSelectorAuditPageDefinition({
+          page: "feed",
+          selectors: [
+            createSelectorAuditSelectorDefinition({
+              key: "selector_group",
+              candidates: [
+                createSelectorAuditCandidate({
+                  strategy: "primary",
+                  selector: "primary"
+                })
+              ]
+            })
+          ]
+        }),
+        createSelectorAuditPageDefinition({
+          page: "feed",
+          selectors: [
+            createSelectorAuditSelectorDefinition({
+              key: "selector_group_two",
+              candidates: [
+                createSelectorAuditCandidate({
+                  strategy: "primary",
+                  selector: "primary-two"
+                })
+              ]
+            })
+          ]
+        })
+      ]
+    },
+    {
+      name: "duplicate selector keys",
+      message: "Duplicate selector audit key selector_group on feed.",
+      registry: [
+        createSelectorAuditPageDefinition({
+          page: "feed",
+          selectors: [
+            createSelectorAuditSelectorDefinition({
+              key: "selector_group",
+              candidates: [
+                createSelectorAuditCandidate({
+                  strategy: "primary",
+                  selector: "primary"
+                })
+              ]
+            }),
+            createSelectorAuditSelectorDefinition({
+              key: "selector_group",
+              candidates: [
+                createSelectorAuditCandidate({
+                  strategy: "secondary",
+                  selector: "secondary"
+                })
+              ]
+            })
+          ]
+        })
+      ]
+    },
+    {
+      name: "duplicate candidate keys",
+      message:
+        "Duplicate selector audit candidate key duplicate on feed:selector_group.",
+      registry: [
+        createSelectorAuditPageDefinition({
+          page: "feed",
+          selectors: [
+            createSelectorAuditSelectorDefinition({
+              key: "selector_group",
+              candidates: [
+                createSelectorAuditCandidate({
+                  strategy: "primary",
+                  key: "duplicate",
+                  selector: "primary"
+                }),
+                createSelectorAuditCandidate({
+                  strategy: "secondary",
+                  key: "duplicate",
+                  selector: "secondary"
+                })
+              ]
+            })
+          ]
+        })
+      ]
+    },
+    {
+      name: "pages without selectors",
+      message: "Selector audit page feed has no selectors.",
+      registry: [
+        createSelectorAuditPageDefinition({
+          page: "feed",
+          selectors: []
+        })
+      ]
+    },
+    {
+      name: "selector groups without candidates",
+      message: "Selector audit key selector_group on feed has no candidates.",
+      registry: [
+        createSelectorAuditPageDefinition({
+          page: "feed",
+          selectors: [
+            createSelectorAuditSelectorDefinition({
+              key: "selector_group",
+              candidates: []
+            })
+          ]
+        })
+      ]
+    }
+  ])("rejects malformed registry input: $name", async ({ message, registry }) => {
+    await expect(
+      createSelectorAuditTestHarness({
+        registry
+      })
+    ).rejects.toThrow(message);
   });
 });

--- a/packages/core/src/__tests__/selectorAuditTestUtils.ts
+++ b/packages/core/src/__tests__/selectorAuditTestUtils.ts
@@ -1,0 +1,318 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { BrowserContext, Locator, Page } from "playwright-core";
+import { vi } from "vitest";
+import { ArtifactHelpers } from "../artifacts.js";
+import { ensureConfigPaths, resolveConfigPaths } from "../config.js";
+import {
+  LinkedInSelectorAuditService,
+  type LinkedInSelectorAuditPage,
+  type LinkedInSelectorAuditRuntime,
+  type LinkedInSelectorAuditStrategy,
+  type SelectorAuditCandidate,
+  type SelectorAuditPageDefinition,
+  type SelectorAuditSelectorDefinition
+} from "../selectorAudit.js";
+
+const tempDirs: string[] = [];
+
+export interface MockSelectorAuditPageOptions {
+  initialUrl?: string;
+  visibleSelectors?: string[];
+  gotoError?: unknown;
+  waitForLoadStateError?: unknown;
+  locatorErrors?: Record<string, unknown>;
+  contentError?: unknown;
+  screenshotError?: unknown;
+  accessibilitySnapshotError?: unknown;
+  accessibilitySnapshotValue?: unknown;
+  includeAccessibility?: boolean;
+  contentHtml?: string;
+}
+
+export interface SelectorAuditTestHarnessOptions extends MockSelectorAuditPageOptions {
+  registry?: SelectorAuditPageDefinition[];
+  authError?: unknown;
+  cdpUrl?: string;
+  existingPages?: Page[];
+  newPageError?: unknown;
+}
+
+interface MockPageAccessibility {
+  snapshot: ReturnType<typeof vi.fn>;
+}
+
+export interface SelectorAuditTestRuntime {
+  runId: string;
+  auth: {
+    ensureAuthenticated: ReturnType<typeof vi.fn>;
+  };
+  cdpUrl?: string;
+  profileManager: {
+    runWithContext: ReturnType<typeof vi.fn>;
+  };
+  logger: {
+    log: ReturnType<typeof vi.fn>;
+  };
+  artifacts: ArtifactHelpers;
+}
+
+export interface SelectorAuditTestHarness {
+  service: LinkedInSelectorAuditService;
+  runtime: SelectorAuditTestRuntime;
+  context: BrowserContext;
+  page: Page;
+  baseDir: string;
+}
+
+class MockLocatorImpl {
+  constructor(
+    private readonly selector: string,
+    private readonly visibleSelectors: ReadonlySet<string>,
+    private readonly locatorErrors: ReadonlyMap<string, unknown>
+  ) {}
+
+  first(): Locator {
+    return this as unknown as Locator;
+  }
+
+  async waitFor(): Promise<void> {
+    const locatorError = this.locatorErrors.get(this.selector);
+    if (locatorError !== undefined) {
+      throw locatorError;
+    }
+
+    if (!this.visibleSelectors.has(this.selector)) {
+      throw new Error(`Selector not visible: ${this.selector}`);
+    }
+  }
+}
+
+function sanitizeKey(value: string): string {
+  return value.replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-+|-+$/g, "").toLowerCase();
+}
+
+export function createSelectorAuditCandidate(options: {
+  strategy: LinkedInSelectorAuditStrategy;
+  selector: string;
+  key?: string;
+  selectorHint?: string;
+}): SelectorAuditCandidate {
+  return {
+    strategy: options.strategy,
+    key: options.key ?? `${options.strategy}-${sanitizeKey(options.selector)}`,
+    selectorHint: options.selectorHint ?? options.selector,
+    locatorFactory: (page) => page.locator(options.selector)
+  };
+}
+
+export function createSelectorAuditSelectorDefinition(options: {
+  key: string;
+  description?: string;
+  candidates: SelectorAuditCandidate[];
+}): SelectorAuditSelectorDefinition {
+  return {
+    key: options.key,
+    description: options.description ?? options.key,
+    candidates: options.candidates
+  };
+}
+
+export function createSelectorAuditPageDefinition(options: {
+  page: LinkedInSelectorAuditPage;
+  url?: string;
+  selectors: SelectorAuditSelectorDefinition[];
+  readyCandidates?: SelectorAuditCandidate[];
+}): SelectorAuditPageDefinition {
+  return {
+    page: options.page,
+    url: options.url ?? `https://example.test/${options.page}`,
+    selectors: options.selectors,
+    readyCandidates: options.readyCandidates
+  };
+}
+
+export function createSelectorAuditTestRegistry(): SelectorAuditPageDefinition[] {
+  return [
+    createSelectorAuditPageDefinition({
+      page: "feed",
+      selectors: [
+        createSelectorAuditSelectorDefinition({
+          key: "selector_group",
+          description: "Selector group",
+          candidates: [
+            createSelectorAuditCandidate({
+              strategy: "primary",
+              key: "primary-key",
+              selectorHint: "primary",
+              selector: "primary"
+            }),
+            createSelectorAuditCandidate({
+              strategy: "secondary",
+              key: "secondary-key",
+              selectorHint: "secondary",
+              selector: "secondary"
+            }),
+            createSelectorAuditCandidate({
+              strategy: "tertiary",
+              key: "tertiary-key",
+              selectorHint: "tertiary",
+              selector: "tertiary"
+            })
+          ]
+        })
+      ]
+    })
+  ];
+}
+
+export function createMockSelectorAuditPage(
+  options: MockSelectorAuditPageOptions = {}
+): Page {
+  let currentUrl = options.initialUrl ?? "https://example.test/";
+  const visibleSelectors = new Set(options.visibleSelectors ?? []);
+  const locatorErrors = new Map(Object.entries(options.locatorErrors ?? {}));
+
+  const page: Partial<Page> & { accessibility?: MockPageAccessibility } = {
+    goto: vi.fn(async (url: string, gotoOptions?: { waitUntil?: string }) => {
+      void gotoOptions;
+
+      if (options.gotoError !== undefined) {
+        throw options.gotoError;
+      }
+
+      currentUrl = url;
+      return null;
+    }),
+    waitForLoadState: vi.fn(async (state?: string, loadOptions?: { timeout?: number }) => {
+      void state;
+      void loadOptions;
+
+      if (options.waitForLoadStateError !== undefined) {
+        throw options.waitForLoadStateError;
+      }
+    }),
+    url: vi.fn(() => currentUrl),
+    locator: vi.fn((selector: string) => {
+      return new MockLocatorImpl(selector, visibleSelectors, locatorErrors) as unknown as Locator;
+    }),
+    content: vi.fn(async () => {
+      if (options.contentError !== undefined) {
+        throw options.contentError;
+      }
+
+      return options.contentHtml ?? "<html><body>selector audit</body></html>";
+    }),
+    screenshot: vi.fn(async (screenshotOptions?: { path?: string; fullPage?: boolean }) => {
+      if (options.screenshotError !== undefined) {
+        throw options.screenshotError;
+      }
+
+      if (typeof screenshotOptions?.path === "string") {
+        await writeFile(screenshotOptions.path, "png");
+      }
+    })
+  };
+
+  if (options.includeAccessibility !== false) {
+    page.accessibility = {
+      snapshot: vi.fn(async () => {
+        if (options.accessibilitySnapshotError !== undefined) {
+          throw options.accessibilitySnapshotError;
+        }
+
+        return options.accessibilitySnapshotValue ?? {
+          role: "WebArea",
+          name: "selector audit"
+        };
+      })
+    };
+  }
+
+  return page as Page;
+}
+
+export function createMockSelectorAuditContext(
+  page: Page,
+  options: {
+    existingPages?: Page[];
+    newPageError?: unknown;
+  } = {}
+): BrowserContext {
+  return {
+    pages: vi.fn(() => options.existingPages ?? [page]),
+    newPage: vi.fn(async () => {
+      if (options.newPageError !== undefined) {
+        throw options.newPageError;
+      }
+
+      return page;
+    })
+  } as unknown as BrowserContext;
+}
+
+export async function createSelectorAuditTestHarness(
+  options: SelectorAuditTestHarnessOptions = {}
+): Promise<SelectorAuditTestHarness> {
+  const baseDir = await mkdtemp(path.join(os.tmpdir(), "selector-audit-test-"));
+  tempDirs.push(baseDir);
+
+  const paths = resolveConfigPaths(baseDir);
+  ensureConfigPaths(paths);
+
+  const artifacts = new ArtifactHelpers(paths, "run_test");
+  const page = createMockSelectorAuditPage(options);
+  const context = createMockSelectorAuditContext(page, {
+    existingPages: options.existingPages,
+    newPageError: options.newPageError
+  });
+
+  const runtime: SelectorAuditTestRuntime = {
+    runId: "run_test",
+    auth: {
+      ensureAuthenticated: vi.fn(async () => {
+        if (options.authError !== undefined) {
+          throw options.authError;
+        }
+
+        return { authenticated: true };
+      })
+    },
+    cdpUrl: options.cdpUrl,
+    profileManager: {
+      runWithContext: vi.fn(async (_runtimeOptions: unknown, callback: (context: BrowserContext) => Promise<unknown>) => {
+        return callback(context);
+      })
+    },
+    logger: {
+      log: vi.fn()
+    },
+    artifacts
+  };
+
+  const service = new LinkedInSelectorAuditService(
+    runtime as unknown as LinkedInSelectorAuditRuntime,
+    {
+    registry: options.registry ?? createSelectorAuditTestRegistry(),
+    candidateTimeoutMs: 10,
+    pageReadyTimeoutMs: 10
+    }
+  );
+
+  return {
+    service,
+    runtime,
+    context,
+    page,
+    baseDir
+  };
+}
+
+export async function cleanupSelectorAuditTestHarnesses(): Promise<void> {
+  await Promise.all(
+    tempDirs.splice(0).map(async (dir) => {
+      await rm(dir, { recursive: true, force: true });
+    })
+  );
+}


### PR DESCRIPTION
## Summary\n- add a reusable selector audit test harness for mocked pages, browser contexts, and registries\n- expand selector audit coverage across multi-page aggregation, auth failures, network-idle stabilization, partial registries, and malformed registry input\n- lock in the default audit registry scope and normalized fallback strategies for the five audited LinkedIn surfaces\n\n## Validation\n- npm run typecheck\n- npm run lint\n- npm test\n- npm run build\n\nCloses #20