### PR TITLE
feat: improve selector audit UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,13 @@ Selector audit (read-only, CI-friendly):
 
 ```bash
 npm exec -w @linkedin-assistant/cli -- linkedin audit selectors --profile default
+npm exec -w @linkedin-assistant/cli -- linkedin audit selectors --profile default --json
 ```
 
-- Produces structured JSON with selector status, fallback usage, and failure artifact paths.
+- Interactive terminals show per-page progress plus a human-readable summary with clear failures, fallbacks, warnings, and next steps.
+- Use `--json` for machine-readable output in CI, scripts, or agent workflows.
+- Use `--verbose` to expand the human-readable summary with selector-by-selector details.
+- Use `--no-progress` to suppress live progress updates when you only want the final summary.
 - Exits non-zero only when a selector group fully fails across all fallback strategies.
 
 Inbox MVP commands:

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -20,8 +20,15 @@ import {
   resolveConfigPaths,
   resolvePrivacyConfig,
   toLinkedInAssistantErrorPayload,
-  type SearchCategory
+  type SearchCategory,
+  type SelectorAuditReport
 } from "@linkedin-assistant/core";
+import {
+  formatSelectorAuditError,
+  formatSelectorAuditReport,
+  resolveSelectorAuditOutputMode,
+  SelectorAuditProgressReporter
+} from "../selectorAuditOutput.js";
 
 const cliPrivacyConfig = resolvePrivacyConfig();
 
@@ -1423,18 +1430,49 @@ async function runJobsView(input: {
 
 async function runSelectorAudit(input: {
   profileName: string;
+  json: boolean;
+  progress: boolean;
+  verbose: boolean;
 }, cdpUrl?: string): Promise<void> {
-  const profileName = coerceProfileName(input.profileName);
-  const runtime = createRuntime(cdpUrl);
+  const outputMode = resolveSelectorAuditOutputMode(
+    { json: input.json },
+    Boolean(stdout.isTTY)
+  );
+  const progressReporter = new SelectorAuditProgressReporter({
+    enabled:
+      outputMode === "human" &&
+      input.progress &&
+      Boolean(process.stderr.isTTY)
+  });
+  let profileName = input.profileName;
+  let runtime: ReturnType<typeof createRuntime> | undefined;
+  let restoreLogger = () => {};
 
   try {
-    runtime.logger.log("info", "cli.audit.selectors.start", {
-      profileName
+    profileName = coerceProfileName(input.profileName);
+    runtime = createRuntime(cdpUrl);
+    const selectorAuditRuntime = runtime;
+
+    const originalLog = selectorAuditRuntime.logger.log.bind(selectorAuditRuntime.logger);
+    selectorAuditRuntime.logger.log = ((level, event, payload = {}) => {
+      const entry = originalLog(level, event, payload);
+      progressReporter.handleLog(entry);
+      return entry;
+    }) as typeof selectorAuditRuntime.logger.log;
+    restoreLogger = () => {
+      selectorAuditRuntime.logger.log = originalLog;
+    };
+
+    selectorAuditRuntime.logger.log("info", "cli.audit.selectors.start", {
+      profileName,
+      outputMode,
+      verbose: input.verbose,
+      progress: outputMode === "human" && input.progress
     });
 
-    const report = await runtime.selectorAudit.auditSelectors({ profileName });
+    const report = await selectorAuditRuntime.selectorAudit.auditSelectors({ profileName });
 
-    runtime.logger.log("info", "cli.audit.selectors.done", {
+    selectorAuditRuntime.logger.log("info", "cli.audit.selectors.done", {
       profileName,
       totalCount: report.total_count,
       passCount: report.pass_count,
@@ -1443,19 +1481,42 @@ async function runSelectorAudit(input: {
       reportPath: report.report_path
     });
 
-    printJson(report);
+    if (outputMode === "json") {
+      printJson(report);
+    } else {
+      const redactedReport = redactStructuredValue(
+        report,
+        cliPrivacyConfig,
+        "cli"
+      ) as SelectorAuditReport;
+
+      console.log(
+        formatSelectorAuditReport(redactedReport, {
+          verbose: input.verbose
+        })
+      );
+    }
 
     if (report.fail_count > 0) {
       process.exitCode = 1;
     }
   } catch (error) {
-    runtime.logger.log("error", "cli.audit.selectors.failed", {
+    const errorPayload = toLinkedInAssistantErrorPayload(error, cliPrivacyConfig);
+
+    runtime?.logger.log("error", "cli.audit.selectors.failed", {
       profileName,
-      error: toLinkedInAssistantErrorPayload(error, cliPrivacyConfig)
+      error: errorPayload
     });
-    throw error;
+
+    if (outputMode === "json") {
+      throw error;
+    }
+
+    process.stderr.write(`${formatSelectorAuditError(errorPayload)}\n`);
+    process.exitCode = 1;
   } finally {
-    runtime.close();
+    restoreLogger();
+    runtime?.close();
   }
 }
 
@@ -2174,15 +2235,38 @@ async function main(): Promise<void> {
 
   const auditCommand = program
     .command("audit")
-    .description("Run read-only LinkedIn audits");
+    .description("Run read-only LinkedIn audits and diagnostics");
 
   auditCommand
     .command("selectors")
-    .description("Audit selector fallbacks across LinkedIn pages")
+    .description("Audit selector groups across key LinkedIn pages and capture failure artifacts")
     .option("-p, --profile <profile>", "Profile name", "default")
-    .action(async (options: { profile: string }) => {
+    .option("--json", "Print the full JSON report (recommended for automation)", false)
+    .option(
+      "--verbose",
+      "Show selector-by-selector details in human-readable output",
+      false
+    )
+    .option("--no-progress", "Hide per-page progress updates in human-readable output")
+    .addHelpText(
+      "after",
+      [
+        "",
+        "Interactive terminals default to a human-readable summary with per-page progress.",
+        "Use --json for automation, piping, or other agent workflows."
+      ].join("\n")
+    )
+    .action(async (options: {
+      profile: string;
+      json: boolean;
+      progress: boolean;
+      verbose: boolean;
+    }) => {
       await runSelectorAudit({
-        profileName: options.profile
+        profileName: options.profile,
+        json: options.json,
+        progress: options.progress,
+        verbose: options.verbose
       }, readCdpUrl());
     });
 

--- a/packages/cli/src/selectorAuditOutput.ts
+++ b/packages/cli/src/selectorAuditOutput.ts
@@ -1,0 +1,337 @@
+import type {
+  JsonLogEntry,
+  LinkedInAssistantErrorPayload,
+  SelectorAuditFailureSummary,
+  SelectorAuditFallbackSummary,
+  SelectorAuditPageSummary,
+  SelectorAuditPageWarningSummary,
+  SelectorAuditReport,
+  SelectorAuditResult
+} from "@linkedin-assistant/core";
+
+export type SelectorAuditOutputMode = "human" | "json";
+
+export interface FormatSelectorAuditReportOptions {
+  verbose?: boolean;
+}
+
+export interface SelectorAuditProgressReporterOptions {
+  enabled?: boolean;
+  writeLine?: (line: string) => void;
+}
+
+function formatCountLabel(
+  count: number,
+  singular: string,
+  plural: string = `${singular}s`
+): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function formatOutcome(report: SelectorAuditReport): string {
+  if (report.outcome === "fail") {
+    return "FAIL";
+  }
+
+  if (report.outcome === "pass_with_fallbacks") {
+    return "PASS WITH FALLBACKS";
+  }
+
+  return "PASS";
+}
+
+function formatPageStatus(summary: SelectorAuditPageSummary): string {
+  if (summary.fail_count > 0) {
+    return "FAIL";
+  }
+
+  if (summary.fallback_count > 0) {
+    return "WARN";
+  }
+
+  return "PASS";
+}
+
+function formatSelectorStatus(result: SelectorAuditResult): string {
+  if (result.status === "fail") {
+    return "FAIL";
+  }
+
+  if (result.fallback_strategy !== null) {
+    return "WARN";
+  }
+
+  return "PASS";
+}
+
+function truncateForDisplay(value: string, maxLength: number = 180): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
+}
+
+function formatValueForDisplay(value: unknown): string {
+  if (typeof value === "string") {
+    return truncateForDisplay(value);
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  if (value === null || value === undefined) {
+    return String(value);
+  }
+
+  return truncateForDisplay(JSON.stringify(value));
+}
+
+function formatFailureArtifacts(
+  failure: SelectorAuditFailureSummary
+): string[] {
+  const artifactEntries: string[] = [];
+
+  if (failure.failure_artifacts.screenshot_path) {
+    artifactEntries.push(`screenshot=${failure.failure_artifacts.screenshot_path}`);
+  }
+
+  if (failure.failure_artifacts.dom_snapshot_path) {
+    artifactEntries.push(`dom=${failure.failure_artifacts.dom_snapshot_path}`);
+  }
+
+  if (failure.failure_artifacts.accessibility_snapshot_path) {
+    artifactEntries.push(`a11y=${failure.failure_artifacts.accessibility_snapshot_path}`);
+  }
+
+  return artifactEntries;
+}
+
+function formatFailureBlock(failure: SelectorAuditFailureSummary): string[] {
+  const artifactEntries = formatFailureArtifacts(failure);
+
+  return [
+    `- ${failure.page}/${failure.selector_key} — ${failure.description}`,
+    `  Error: ${failure.error}`,
+    ...(failure.warnings ?? []).map((warning) => `  Warning: ${warning}`),
+    ...(artifactEntries.length > 0 ? [`  Artifacts: ${artifactEntries.join(" | ")}`] : []),
+    ...((failure.failure_artifacts.capture_warnings ?? []).map(
+      (warning) => `  Artifact warning: ${warning}`
+    )),
+    `  Next: ${failure.recommended_action}`
+  ];
+}
+
+function formatFallbackBlock(fallback: SelectorAuditFallbackSummary): string[] {
+  return [
+    `- ${fallback.page}/${fallback.selector_key} — ${fallback.description}`,
+    `  Matched via ${fallback.fallback_strategy}: ${fallback.fallback_used}`,
+    ...(fallback.warnings ?? []).map((warning) => `  Warning: ${warning}`),
+    `  Next: ${fallback.recommended_action}`
+  ];
+}
+
+function formatPageWarningBlock(pageWarning: SelectorAuditPageWarningSummary): string[] {
+  return [
+    `- ${pageWarning.page}`,
+    ...pageWarning.warnings.map((warning) => `  Warning: ${warning}`)
+  ];
+}
+
+function formatResultStrategySummary(result: SelectorAuditResult): string {
+  return Object.values(result.strategies)
+    .map((strategyResult) => {
+      const status = strategyResult.status.toUpperCase();
+      return `${strategyResult.strategy}=${status}`;
+    })
+    .join(", ");
+}
+
+function formatResultSummary(result: SelectorAuditResult): string {
+  if (result.status === "fail") {
+    return result.error ?? "Selector group failed.";
+  }
+
+  if (result.fallback_strategy !== null && result.fallback_used !== null) {
+    return `Matched via ${result.fallback_strategy}: ${result.fallback_used}`;
+  }
+
+  return `Matched primary selector: ${result.matched_selector_key ?? "unknown"}`;
+}
+
+function formatVerboseResultBlock(result: SelectorAuditResult): string[] {
+  return [
+    `- ${formatSelectorStatus(result)} ${result.page}/${result.selector_key} — ${result.description}`,
+    `  Result: ${formatResultSummary(result)}`,
+    `  Strategies: ${formatResultStrategySummary(result)}`,
+    ...(result.warnings ?? []).map((warning) => `  Warning: ${warning}`),
+    ...(result.status === "fail" && result.error ? [`  Error: ${result.error}`] : [])
+  ];
+}
+
+function appendSection(lines: string[], title: string, entries: string[]): void {
+  if (entries.length === 0) {
+    return;
+  }
+
+  lines.push("");
+  lines.push(title);
+  lines.push(...entries);
+}
+
+function formatPageSummary(summary: SelectorAuditPageSummary): string {
+  return `- ${formatPageStatus(summary)} ${summary.page}: ${summary.pass_count} passed, ${summary.fail_count} failed, ${summary.fallback_count} fallback-only`;
+}
+
+function formatProgressPageIndex(index: number, totalPages: number | null): string {
+  return totalPages === null ? `page ${index}` : `page ${index}/${totalPages}`;
+}
+
+function readString(payload: Record<string, unknown>, key: string): string | null {
+  const value = payload[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function readNumber(payload: Record<string, unknown>, key: string): number | null {
+  const value = payload[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export function resolveSelectorAuditOutputMode(options: {
+  json: boolean;
+}, isInteractiveOutput: boolean): SelectorAuditOutputMode {
+  return options.json || !isInteractiveOutput ? "json" : "human";
+}
+
+export function formatSelectorAuditReport(
+  report: SelectorAuditReport,
+  options: FormatSelectorAuditReportOptions = {}
+): string {
+  const lines = [
+    `Selector Audit: ${formatOutcome(report)}`,
+    `Profile: ${report.profile_name}`,
+    `Checked At: ${report.checked_at}`,
+    `Summary: ${report.summary}`,
+    `Report JSON: ${report.report_path}`,
+    `Artifacts: ${report.artifact_dir}`
+  ];
+
+  appendSection(lines, "Pages", report.page_summaries.map(formatPageSummary));
+  appendSection(
+    lines,
+    "Failures",
+    report.failed_selectors.flatMap((failure) => formatFailureBlock(failure))
+  );
+  appendSection(
+    lines,
+    "Fallbacks",
+    report.fallback_selectors.flatMap((fallback) => formatFallbackBlock(fallback))
+  );
+  appendSection(
+    lines,
+    "Warnings",
+    report.page_warnings.flatMap((pageWarning) => formatPageWarningBlock(pageWarning))
+  );
+
+  if (options.verbose) {
+    appendSection(
+      lines,
+      "Selector Details",
+      report.results.flatMap((result) => formatVerboseResultBlock(result))
+    );
+  }
+
+  appendSection(
+    lines,
+    "Next Steps",
+    report.recommended_actions.map((action) => `- ${action}`)
+  );
+
+  return lines.join("\n");
+}
+
+export function formatSelectorAuditError(
+  payload: LinkedInAssistantErrorPayload
+): string {
+  const lines = [`Selector audit failed [${payload.code}]`, payload.message];
+  const detailEntries = Object.entries(payload.details);
+
+  if (detailEntries.length > 0) {
+    lines.push(
+      `Details: ${detailEntries.map(([key, value]) => `${key}=${formatValueForDisplay(value)}`).join(", ")}`
+    );
+  }
+
+  lines.push("Tip: rerun with --json if you need the structured error payload.");
+  return lines.join("\n");
+}
+
+export class SelectorAuditProgressReporter {
+  private readonly enabled: boolean;
+  private readonly writeLine: (line: string) => void;
+  private totalPages: number | null = null;
+  private nextPageIndex = 1;
+  private readonly pageIndexes = new Map<string, number>();
+
+  constructor(options: SelectorAuditProgressReporterOptions = {}) {
+    this.enabled = options.enabled ?? true;
+    this.writeLine = options.writeLine ?? ((line: string) => process.stderr.write(`${line}\n`));
+  }
+
+  handleLog(entry: JsonLogEntry): void {
+    if (!this.enabled) {
+      return;
+    }
+
+    if (entry.event === "selector.audit.start") {
+      this.totalPages = readNumber(entry.payload, "pageCount");
+      const profileName = readString(entry.payload, "profileName");
+      const pageCountSuffix =
+        this.totalPages === null ? "" : ` (${formatCountLabel(this.totalPages, "page")})`;
+      this.writeLine(
+        `Starting selector audit${profileName ? ` for profile ${profileName}` : ""}${pageCountSuffix}.`
+      );
+      return;
+    }
+
+    if (entry.event === "selector.audit.page.start") {
+      const page = readString(entry.payload, "page") ?? "unknown";
+      const selectorCount = readNumber(entry.payload, "selectorCount");
+      const pageIndex = this.getPageIndex(page);
+      const selectorSuffix =
+        selectorCount === null ? "" : ` (${formatCountLabel(selectorCount, "selector group")})`;
+      this.writeLine(
+        `Checking ${formatProgressPageIndex(pageIndex, this.totalPages)}: ${page}${selectorSuffix}...`
+      );
+      return;
+    }
+
+    if (entry.event === "selector.audit.page.done") {
+      const page = readString(entry.payload, "page") ?? "unknown";
+      const pageIndex = this.getPageIndex(page);
+      const passCount = readNumber(entry.payload, "passCount") ?? 0;
+      const failCount = readNumber(entry.payload, "failCount") ?? 0;
+      const fallbackCount = readNumber(entry.payload, "fallbackCount") ?? 0;
+      this.writeLine(
+        `Finished ${formatProgressPageIndex(pageIndex, this.totalPages)}: ${page} — ${passCount} passed, ${failCount} failed, ${fallbackCount} fallback.`
+      );
+      return;
+    }
+
+    if (entry.event === "selector.audit.done") {
+      const reportPath = readString(entry.payload, "reportPath");
+      this.writeLine(
+        `Selector audit finished${reportPath ? `. Report: ${reportPath}` : "."}`
+      );
+    }
+  }
+
+  private getPageIndex(page: string): number {
+    const existing = this.pageIndexes.get(page);
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const pageIndex = this.nextPageIndex;
+    this.pageIndexes.set(page, pageIndex);
+    this.nextPageIndex += 1;
+    return pageIndex;
+  }
+}

--- a/packages/cli/test/selectorAuditOutput.test.ts
+++ b/packages/cli/test/selectorAuditOutput.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, it } from "vitest";
+import type {
+  JsonLogEntry,
+  LinkedInAssistantErrorPayload,
+  SelectorAuditReport
+} from "@linkedin-assistant/core";
+import {
+  formatSelectorAuditError,
+  formatSelectorAuditReport,
+  resolveSelectorAuditOutputMode,
+  SelectorAuditProgressReporter
+} from "../src/selectorAuditOutput.js";
+
+function createLogEntry(entry: {
+  event: string;
+  payload: Record<string, unknown>;
+}): JsonLogEntry {
+  return {
+    ts: "2026-03-08T12:00:00.000Z",
+    run_id: "run_test",
+    level: "info",
+    event: entry.event,
+    payload: entry.payload
+  };
+}
+
+function createSelectorAuditReportFixture(): SelectorAuditReport {
+  return {
+    run_id: "run_test",
+    profile_name: "default",
+    checked_at: "2026-03-08T12:00:00.000Z",
+    outcome: "fail",
+    summary:
+      "Checked 3 selector groups across 2 pages. 2 passed. 1 failed. 1 used fallback selectors.",
+    total_count: 3,
+    pass_count: 2,
+    fail_count: 1,
+    fallback_count: 1,
+    artifact_dir: "/tmp/run_test/selector-audit",
+    report_path: "/tmp/run_test/selector-audit/report.json",
+    page_summaries: [
+      {
+        page: "feed",
+        total_count: 2,
+        pass_count: 1,
+        fail_count: 1,
+        fallback_count: 1
+      },
+      {
+        page: "inbox",
+        total_count: 1,
+        pass_count: 1,
+        fail_count: 0,
+        fallback_count: 0
+      }
+    ],
+    page_warnings: [
+      {
+        page: "feed",
+        warnings: [
+          "The feed page did not reach network idle within 5000ms. Selector checks continued with the current DOM state."
+        ]
+      }
+    ],
+    failed_selectors: [
+      {
+        page: "feed",
+        page_url: "https://www.linkedin.com/feed/",
+        selector_key: "post_composer_trigger",
+        description: "Feed post composer trigger",
+        error:
+          "No selector strategy matched for post_composer_trigger on feed. Review the failure artifacts, update the selector registry if LinkedIn's UI changed, and rerun the selector audit.",
+        warnings: [
+          "The feed page did not reach network idle within 5000ms. Selector checks continued with the current DOM state."
+        ],
+        failure_artifacts: {
+          screenshot_path: "/tmp/run_test/selector-audit/feed/post_composer_trigger.png",
+          dom_snapshot_path: "/tmp/run_test/selector-audit/feed/post_composer_trigger.html",
+          accessibility_snapshot_path:
+            "/tmp/run_test/selector-audit/feed/post_composer_trigger.a11y.json",
+          capture_warnings: [
+            "Could not capture the DOM snapshot for post_composer_trigger on feed: Snapshot unavailable."
+          ]
+        },
+        recommended_action:
+          "Open the captured failure artifacts for post_composer_trigger on feed, update that selector group in the registry, and rerun the selector audit."
+      }
+    ],
+    fallback_selectors: [
+      {
+        page: "feed",
+        page_url: "https://www.linkedin.com/feed/",
+        selector_key: "feed_sort_menu",
+        description: "Feed sort menu",
+        fallback_strategy: "secondary",
+        fallback_used: "css-feed-sort-menu",
+        recommended_action:
+          "Primary selectors did not match for feed_sort_menu on feed. Review the primary selector and keep css-feed-sort-menu (secondary) only if it reflects the stable LinkedIn UI."
+      }
+    ],
+    recommended_actions: [
+      "Open /tmp/run_test/selector-audit/report.json and the captured artifacts for failed selector groups before changing the registry.",
+      "Update the selector registry entries for the failed selector groups, then rerun linkedin audit selectors --profile default.",
+      "Review selector groups that only matched via fallback and refresh their primary selectors before they fail completely.",
+      "Some pages were not fully stable during the audit. Refresh the LinkedIn session or attached browser and rerun before treating warnings as definitive UI drift."
+    ],
+    results: [
+      {
+        page: "feed",
+        page_url: "https://www.linkedin.com/feed/",
+        selector_key: "post_composer_trigger",
+        description: "Feed post composer trigger",
+        status: "fail",
+        matched_strategy: null,
+        matched_selector_key: null,
+        fallback_used: null,
+        fallback_strategy: null,
+        strategies: {
+          primary: {
+            strategy: "primary",
+            status: "fail",
+            selector_key: "role-button-start-post",
+            selector_hint: "getByRole(button, /start a post/i)",
+            error: "Selector not visible"
+          },
+          secondary: {
+            strategy: "secondary",
+            status: "fail",
+            selector_key: "css-start-post",
+            selector_hint: ".share-box-feed-entry__trigger",
+            error: "Selector not visible"
+          },
+          tertiary: {
+            strategy: "tertiary",
+            status: "fail",
+            selector_key: "text-start-post",
+            selector_hint: "text=Start a post",
+            error: "Selector not visible"
+          }
+        },
+        failure_artifacts: {
+          screenshot_path: "/tmp/run_test/selector-audit/feed/post_composer_trigger.png",
+          dom_snapshot_path: "/tmp/run_test/selector-audit/feed/post_composer_trigger.html",
+          accessibility_snapshot_path:
+            "/tmp/run_test/selector-audit/feed/post_composer_trigger.a11y.json",
+          capture_warnings: [
+            "Could not capture the DOM snapshot for post_composer_trigger on feed: Snapshot unavailable."
+          ]
+        },
+        warnings: [
+          "The feed page did not reach network idle within 5000ms. Selector checks continued with the current DOM state."
+        ],
+        error:
+          "No selector strategy matched for post_composer_trigger on feed. Review the failure artifacts, update the selector registry if LinkedIn's UI changed, and rerun the selector audit."
+      },
+      {
+        page: "feed",
+        page_url: "https://www.linkedin.com/feed/",
+        selector_key: "feed_sort_menu",
+        description: "Feed sort menu",
+        status: "pass",
+        matched_strategy: "secondary",
+        matched_selector_key: "css-feed-sort-menu",
+        fallback_used: "css-feed-sort-menu",
+        fallback_strategy: "secondary",
+        strategies: {
+          primary: {
+            strategy: "primary",
+            status: "fail",
+            selector_key: "role-feed-sort-menu",
+            selector_hint: "getByRole(button, /sort/i)",
+            error: "Selector not visible"
+          },
+          secondary: {
+            strategy: "secondary",
+            status: "pass",
+            selector_key: "css-feed-sort-menu",
+            selector_hint: ".feed-sort-menu"
+          },
+          tertiary: {
+            strategy: "tertiary",
+            status: "fail",
+            selector_key: "text-feed-sort-menu",
+            selector_hint: "text=Sort",
+            error: "Selector not visible"
+          }
+        },
+        failure_artifacts: {}
+      },
+      {
+        page: "inbox",
+        page_url: "https://www.linkedin.com/messaging/",
+        selector_key: "thread_list",
+        description: "Inbox thread list",
+        status: "pass",
+        matched_strategy: "primary",
+        matched_selector_key: "role-thread-list",
+        fallback_used: null,
+        fallback_strategy: null,
+        strategies: {
+          primary: {
+            strategy: "primary",
+            status: "pass",
+            selector_key: "role-thread-list",
+            selector_hint: "getByRole(list, /conversation/i)"
+          },
+          secondary: {
+            strategy: "secondary",
+            status: "fail",
+            selector_key: "css-thread-list",
+            selector_hint: ".msg-conversations-container__conversations-list",
+            error: "Selector not visible"
+          },
+          tertiary: {
+            strategy: "tertiary",
+            status: "fail",
+            selector_key: "text-thread-list",
+            selector_hint: "text=Conversations",
+            error: "Selector not visible"
+          }
+        },
+        failure_artifacts: {}
+      }
+    ]
+  };
+}
+
+describe("selector audit output helpers", () => {
+  it("defaults to human output in interactive terminals unless JSON is forced", () => {
+    expect(resolveSelectorAuditOutputMode({ json: false }, true)).toBe("human");
+    expect(resolveSelectorAuditOutputMode({ json: false }, false)).toBe("json");
+    expect(resolveSelectorAuditOutputMode({ json: true }, true)).toBe("json");
+  });
+
+  it("renders a scannable human-readable report", () => {
+    const output = formatSelectorAuditReport(createSelectorAuditReportFixture());
+
+    expect(output).toContain("Selector Audit: FAIL");
+    expect(output).toContain(
+      "Summary: Checked 3 selector groups across 2 pages. 2 passed. 1 failed. 1 used fallback selectors."
+    );
+    expect(output).toContain("Pages");
+    expect(output).toContain("Failures");
+    expect(output).toContain("Fallbacks");
+    expect(output).toContain("Warnings");
+    expect(output).toContain("Next Steps");
+    expect(output).toContain("Artifacts: /tmp/run_test/selector-audit");
+    expect(output).toContain("screenshot=/tmp/run_test/selector-audit/feed/post_composer_trigger.png");
+  });
+
+  it("adds selector-by-selector detail in verbose mode", () => {
+    const output = formatSelectorAuditReport(createSelectorAuditReportFixture(), {
+      verbose: true
+    });
+
+    expect(output).toContain("Selector Details");
+    expect(output).toContain("FAIL feed/post_composer_trigger — Feed post composer trigger");
+    expect(output).toContain("Strategies: primary=FAIL, secondary=FAIL, tertiary=FAIL");
+    expect(output).toContain("WARN feed/feed_sort_menu — Feed sort menu");
+    expect(output).toContain("Matched via secondary: css-feed-sort-menu");
+  });
+
+  it("formats friendly human-facing errors", () => {
+    const payload: LinkedInAssistantErrorPayload = {
+      code: "NETWORK_ERROR",
+      message: "Could not load the feed page because the browser or network connection failed.",
+      details: {
+        page: "feed",
+        page_url: "https://www.linkedin.com/feed/"
+      }
+    };
+
+    const output = formatSelectorAuditError(payload);
+
+    expect(output).toContain("Selector audit failed [NETWORK_ERROR]");
+    expect(output).toContain("page=feed");
+    expect(output).toContain("Tip: rerun with --json");
+  });
+
+  it("emits clear per-page progress lines", () => {
+    const lines: string[] = [];
+    const reporter = new SelectorAuditProgressReporter({
+      writeLine: (line) => {
+        lines.push(line);
+      }
+    });
+
+    reporter.handleLog(
+      createLogEntry({
+        event: "selector.audit.start",
+        payload: {
+          profileName: "default",
+          pageCount: 2
+        }
+      })
+    );
+    reporter.handleLog(
+      createLogEntry({
+        event: "selector.audit.page.start",
+        payload: {
+          page: "feed",
+          selectorCount: 2
+        }
+      })
+    );
+    reporter.handleLog(
+      createLogEntry({
+        event: "selector.audit.page.done",
+        payload: {
+          page: "feed",
+          passCount: 1,
+          failCount: 1,
+          fallbackCount: 1
+        }
+      })
+    );
+    reporter.handleLog(
+      createLogEntry({
+        event: "selector.audit.done",
+        payload: {
+          reportPath: "/tmp/run_test/selector-audit/report.json"
+        }
+      })
+    );
+
+    expect(lines).toEqual([
+      "Starting selector audit for profile default (2 pages).",
+      "Checking page 1/2: feed (2 selector groups)...",
+      "Finished page 1/2: feed — 1 passed, 1 failed, 1 fallback.",
+      "Selector audit finished. Report: /tmp/run_test/selector-audit/report.json"
+    ]);
+  });
+});

--- a/packages/core/src/__tests__/selectorAudit.test.ts
+++ b/packages/core/src/__tests__/selectorAudit.test.ts
@@ -59,6 +59,10 @@ describe("LinkedInSelectorAuditService", () => {
     expect(report.pass_count).toBe(1);
     expect(report.fail_count).toBe(0);
     expect(report.fallback_count).toBe(1);
+    expect(report.outcome).toBe("pass_with_fallbacks");
+    expect(report.summary).toBe(
+      "Checked 1 selector group across 1 page. 1 passed. 0 failed. 1 used fallback selectors."
+    );
     expect(report.page_summaries).toEqual([
       {
         page: "feed",
@@ -79,6 +83,23 @@ describe("LinkedInSelectorAuditService", () => {
     });
     expect(report.results[0]?.strategies.primary.status).toBe("fail");
     expect(report.results[0]?.strategies.secondary.status).toBe("pass");
+    expect(report.failed_selectors).toEqual([]);
+    expect(report.page_warnings).toEqual([]);
+    expect(report.fallback_selectors).toMatchObject([
+      {
+        page: "feed",
+        selector_key: "selector_group",
+        description: "Selector group",
+        fallback_strategy: "secondary",
+        fallback_used: "secondary-key"
+      }
+    ]);
+    expect(report.fallback_selectors[0]?.recommended_action).toContain(
+      "Primary selectors did not match"
+    );
+    expect(report.recommended_actions).toEqual([
+      "Review selector groups that only matched via fallback and refresh their primary selectors before they fail completely."
+    ]);
     await expect(stat(report.report_path)).resolves.toBeTruthy();
   });
 
@@ -92,6 +113,7 @@ describe("LinkedInSelectorAuditService", () => {
     expect(report.pass_count).toBe(0);
     expect(report.fail_count).toBe(1);
     expect(report.fallback_count).toBe(0);
+    expect(report.outcome).toBe("fail");
     expect(result).toMatchObject({
       page: "feed",
       selector_key: "selector_group",
@@ -109,6 +131,38 @@ describe("LinkedInSelectorAuditService", () => {
     await expect(
       stat(result!.failure_artifacts.accessibility_snapshot_path!)
     ).resolves.toBeTruthy();
+    expect(report.page_warnings).toEqual([
+      {
+        page: "feed",
+        warnings: [
+          "Could not confirm that the feed page was ready within 10ms. Last check: Selector check failed for primary selector primary-key (primary): Selector not visible: primary. Verify the page is fully loaded, or update the selector registry before rerunning the selector audit.. Selector checks continued with the current DOM state; if failures persist, reload the page or update the ready selectors and rerun the selector audit."
+        ]
+      }
+    ]);
+    expect(report.fallback_selectors).toEqual([]);
+    expect(report.failed_selectors).toMatchObject([
+      {
+        page: "feed",
+        selector_key: "selector_group",
+        description: "Selector group",
+        error:
+          "No selector strategy matched for selector_group on feed. Review the failure artifacts, update the selector registry if LinkedIn's UI changed, and rerun the selector audit.",
+        failure_artifacts: {
+          screenshot_path: result?.failure_artifacts.screenshot_path,
+          dom_snapshot_path: result?.failure_artifacts.dom_snapshot_path,
+          accessibility_snapshot_path: result?.failure_artifacts.accessibility_snapshot_path
+        }
+      }
+    ]);
+    expect(report.failed_selectors[0]?.recommended_action).toContain(
+      "update that selector group in the registry"
+    );
+    expect(report.recommended_actions).toContain(
+      `Open ${report.report_path} and the captured artifacts for failed selector groups before changing the registry.`
+    );
+    expect(report.recommended_actions).toContain(
+      "Some pages were not fully stable during the audit. Refresh the LinkedIn session or attached browser and rerun before treating warnings as definitive UI drift."
+    );
     await expect(stat(report.report_path)).resolves.toBeTruthy();
   });
 
@@ -272,6 +326,17 @@ describe("LinkedInSelectorAuditService", () => {
     expect(report.results[0]?.warnings).toEqual([
       "The feed page did not reach network idle within 5000ms. Selector checks continued with the current DOM state."
     ]);
+    expect(report.page_warnings).toEqual([
+      {
+        page: "feed",
+        warnings: [
+          "The feed page did not reach network idle within 5000ms. Selector checks continued with the current DOM state."
+        ]
+      }
+    ]);
+    expect(report.recommended_actions).toContain(
+      "Some pages were not fully stable during the audit. Refresh the LinkedIn session or attached browser and rerun before treating warnings as definitive UI drift."
+    );
   });
 
   it("marks selector groups failed when page stabilization throws", async () => {

--- a/packages/core/src/selectorAudit.ts
+++ b/packages/core/src/selectorAudit.ts
@@ -96,10 +96,41 @@ export interface SelectorAuditPageSummary {
   fallback_count: number;
 }
 
+export type SelectorAuditOutcome = "pass" | "pass_with_fallbacks" | "fail";
+
+export interface SelectorAuditPageWarningSummary {
+  page: LinkedInSelectorAuditPage;
+  warnings: string[];
+}
+
+export interface SelectorAuditFailureSummary {
+  page: LinkedInSelectorAuditPage;
+  page_url: string;
+  selector_key: string;
+  description: string;
+  error: string;
+  warnings?: string[];
+  failure_artifacts: SelectorAuditFailureArtifacts;
+  recommended_action: string;
+}
+
+export interface SelectorAuditFallbackSummary {
+  page: LinkedInSelectorAuditPage;
+  page_url: string;
+  selector_key: string;
+  description: string;
+  fallback_strategy: Exclude<LinkedInSelectorAuditStrategy, "primary">;
+  fallback_used: string;
+  warnings?: string[];
+  recommended_action: string;
+}
+
 export interface SelectorAuditReport {
   run_id: string;
   profile_name: string;
   checked_at: string;
+  outcome: SelectorAuditOutcome;
+  summary: string;
   total_count: number;
   pass_count: number;
   fail_count: number;
@@ -107,6 +138,10 @@ export interface SelectorAuditReport {
   artifact_dir: string;
   report_path: string;
   page_summaries: SelectorAuditPageSummary[];
+  page_warnings: SelectorAuditPageWarningSummary[];
+  failed_selectors: SelectorAuditFailureSummary[];
+  fallback_selectors: SelectorAuditFallbackSummary[];
+  recommended_actions: string[];
   results: SelectorAuditResult[];
 }
 
@@ -520,6 +555,178 @@ function countSelectorAuditResults(
   );
 }
 
+function formatCountLabel(
+  count: number,
+  singular: string,
+  plural: string = `${singular}s`
+): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function createSelectorAuditOutcome(
+  counts: SelectorAuditSummaryCounts
+): SelectorAuditOutcome {
+  if (counts.failCount > 0) {
+    return "fail";
+  }
+
+  if (counts.fallbackCount > 0) {
+    return "pass_with_fallbacks";
+  }
+
+  return "pass";
+}
+
+function createSelectorAuditSummary(
+  counts: SelectorAuditSummaryCounts,
+  pageCount: number
+): string {
+  return [
+    `Checked ${formatCountLabel(counts.totalCount, "selector group")} across ${formatCountLabel(pageCount, "page")}.`,
+    `${counts.passCount} passed.`,
+    `${counts.failCount} failed.`,
+    `${counts.fallbackCount} used fallback selectors.`
+  ].join(" ");
+}
+
+function createFailureRecommendedAction(result: SelectorAuditResult): string {
+  return `Open the captured failure artifacts for ${result.selector_key} on ${result.page}, update that selector group in the registry, and rerun the selector audit.`;
+}
+
+function createFallbackRecommendedAction(result: SelectorAuditResult): string {
+  return `Primary selectors did not match for ${result.selector_key} on ${result.page}. Review the primary selector and keep ${result.fallback_used} (${result.fallback_strategy}) only if it reflects the stable LinkedIn UI.`;
+}
+
+function buildPageWarningSummaries(
+  pageOrder: readonly LinkedInSelectorAuditPage[],
+  results: SelectorAuditResult[]
+): SelectorAuditPageWarningSummary[] {
+  const warningsByPage = new Map<LinkedInSelectorAuditPage, string[]>();
+
+  for (const result of results) {
+    if (!result.warnings || result.warnings.length === 0) {
+      continue;
+    }
+
+    const warnings = warningsByPage.get(result.page) ?? [];
+    for (const warning of result.warnings) {
+      if (!warnings.includes(warning)) {
+        warnings.push(warning);
+      }
+    }
+    warningsByPage.set(result.page, warnings);
+  }
+
+  return pageOrder.flatMap((page) => {
+    const warnings = warningsByPage.get(page);
+    return warnings && warnings.length > 0 ? [{ page, warnings }] : [];
+  });
+}
+
+function buildFailureSummaries(
+  results: SelectorAuditResult[]
+): SelectorAuditFailureSummary[] {
+  return results.flatMap((result) => {
+    if (result.status !== "fail") {
+      return [];
+    }
+
+    return [
+      {
+        page: result.page,
+        page_url: result.page_url,
+        selector_key: result.selector_key,
+        description: result.description,
+        error:
+          result.error ??
+          createSelectorDefinitionFailureMessage(
+            {
+              page: result.page,
+              url: result.page_url,
+              selectors: [],
+              ...(result.warnings ? { readyCandidates: [] } : {})
+            },
+            {
+              key: result.selector_key,
+              description: result.description,
+              candidates: []
+            }
+          ),
+        ...(result.warnings ? { warnings: [...result.warnings] } : {}),
+        failure_artifacts: result.failure_artifacts,
+        recommended_action: createFailureRecommendedAction(result)
+      }
+    ];
+  });
+}
+
+function buildFallbackSummaries(
+  results: SelectorAuditResult[]
+): SelectorAuditFallbackSummary[] {
+  return results.flatMap((result) => {
+    if (
+      result.status !== "pass" ||
+      result.fallback_strategy === null ||
+      result.fallback_strategy === "primary" ||
+      result.fallback_used === null
+    ) {
+      return [];
+    }
+
+    return [
+      {
+        page: result.page,
+        page_url: result.page_url,
+        selector_key: result.selector_key,
+        description: result.description,
+        fallback_strategy: result.fallback_strategy,
+        fallback_used: result.fallback_used,
+        ...(result.warnings ? { warnings: [...result.warnings] } : {}),
+        recommended_action: createFallbackRecommendedAction(result)
+      }
+    ];
+  });
+}
+
+function buildRecommendedActions(options: {
+  profileName: string;
+  reportPath: string;
+  failedSelectors: SelectorAuditFailureSummary[];
+  fallbackSelectors: SelectorAuditFallbackSummary[];
+  pageWarnings: SelectorAuditPageWarningSummary[];
+}): string[] {
+  const actions: string[] = [];
+
+  if (options.failedSelectors.length > 0) {
+    actions.push(
+      `Open ${options.reportPath} and the captured artifacts for failed selector groups before changing the registry.`
+    );
+    actions.push(
+      `Update the selector registry entries for the failed selector groups, then rerun linkedin audit selectors --profile ${options.profileName}.`
+    );
+  }
+
+  if (options.fallbackSelectors.length > 0) {
+    actions.push(
+      "Review selector groups that only matched via fallback and refresh their primary selectors before they fail completely."
+    );
+  }
+
+  if (options.pageWarnings.length > 0) {
+    actions.push(
+      "Some pages were not fully stable during the audit. Refresh the LinkedIn session or attached browser and rerun before treating warnings as definitive UI drift."
+    );
+  }
+
+  if (actions.length === 0) {
+    actions.push(
+      "No follow-up is required right now. Keep the selector audit in regular maintenance or CI to catch future UI drift."
+    );
+  }
+
+  return actions;
+}
+
 function validateSelectorAuditRegistry(
   registry: SelectorAuditPageDefinition[]
 ): SelectorAuditPageDefinition[] {
@@ -888,10 +1095,25 @@ export class LinkedInSelectorAuditService {
     const checkedAt = new Date().toISOString();
     const pageSummaries = this.buildPageSummaries(results);
     const counts = countSelectorAuditResults(results);
+    const pageWarnings = buildPageWarningSummaries(
+      this.registry.map((pageDefinition) => pageDefinition.page),
+      results
+    );
+    const failedSelectors = buildFailureSummaries(results);
+    const fallbackSelectors = buildFallbackSummaries(results);
+    const recommendedActions = buildRecommendedActions({
+      profileName,
+      reportPath,
+      failedSelectors,
+      fallbackSelectors,
+      pageWarnings
+    });
     const report: SelectorAuditReport = {
       run_id: this.runtime.runId,
       profile_name: profileName,
       checked_at: checkedAt,
+      outcome: createSelectorAuditOutcome(counts),
+      summary: createSelectorAuditSummary(counts, this.registry.length),
       total_count: counts.totalCount,
       pass_count: counts.passCount,
       fail_count: counts.failCount,
@@ -899,6 +1121,10 @@ export class LinkedInSelectorAuditService {
       artifact_dir: artifactDir,
       report_path: reportPath,
       page_summaries: pageSummaries,
+      page_warnings: pageWarnings,
+      failed_selectors: failedSelectors,
+      fallback_selectors: fallbackSelectors,
+      recommended_actions: recommendedActions,
       results
     };
 


### PR DESCRIPTION
## Summary
- add human-readable selector audit output with per-page progress plus `--json`, `--verbose`, and `--no-progress` options
- enrich selector audit reports with outcome, warnings, actionable failure and fallback summaries, and next steps
- add focused CLI/core tests and update the README for the new workflow

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #22