### PR TITLE
docs: document selector audit workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### Added
+
+- Selector audit documentation covering CLI usage, sample output, core API
+  configuration, README discoverability, CLI `--help` references, and MCP
+  tool-description breadcrumbs.

--- a/README.md
+++ b/README.md
@@ -92,18 +92,75 @@ npm exec -w @linkedin-assistant/cli -- linkedin keepalive stop --profile default
 
 - Keepalive state/log files are stored under `~/.linkedin-assistant/linkedin-owa-agentools/keepalive/`.
 
-Selector audit (read-only, CI-friendly):
+### Selector audit
+
+Selector audit is a read-only diagnostic that checks the built-in selector
+registry across the LinkedIn feed, inbox, profile, connections, and
+notifications pages. It is designed for CI and maintenance work: it captures
+failure artifacts, reports fallback-only matches before they become hard
+failures, and exits non-zero only when a selector group fails across every
+strategy.
+
+See `docs/selector-audit.md` for the full guide.
 
 ```bash
+# Interactive summary with per-page progress
 npm exec -w @linkedin-assistant/cli -- linkedin audit selectors --profile default
+
+# Machine-readable report for CI or scripts
 npm exec -w @linkedin-assistant/cli -- linkedin audit selectors --profile default --json
+
+# Expand the human summary with selector-by-selector detail
+npm exec -w @linkedin-assistant/cli -- linkedin audit selectors --profile default --verbose
+
+# Audit an attached logged-in browser instead of the tool-owned profile
+npm exec -w @linkedin-assistant/cli -- linkedin audit selectors --profile default --cdp-url http://127.0.0.1:18800
+
+# Show command help and doc reference
+npm exec -w @linkedin-assistant/cli -- linkedin audit selectors --help
 ```
 
-- Interactive terminals show per-page progress plus a human-readable summary with clear failures, fallbacks, warnings, and next steps.
+Representative human-readable output:
+
+```text
+Starting selector audit for profile default (2 pages).
+Checking page 1/2: feed (2 selector groups)...
+Finished page 1/2: feed — 1 passed, 1 failed, 1 fallback.
+Checking page 2/2: inbox (1 selector group)...
+Finished page 2/2: inbox — 1 passed, 0 failed, 0 fallback.
+Selector audit finished. Report: /tmp/run_test/selector-audit/report.json
+
+Selector Audit: FAIL
+Profile: default
+Checked At: 2026-03-08T12:00:00.000Z
+Summary: Checked 3 selector groups across 2 pages. 2 passed. 1 failed. 1 used fallback selectors.
+Report JSON: /tmp/run_test/selector-audit/report.json
+Artifacts: /tmp/run_test/selector-audit
+
+Pages
+- FAIL feed: 1 passed, 1 failed, 1 fallback-only
+- PASS inbox: 1 passed, 0 failed, 0 fallback-only
+
+Failures
+- feed/post_composer_trigger — Feed post composer trigger
+  Error: No selector strategy matched for post_composer_trigger on feed. Review the failure artifacts, update the selector registry if LinkedIn's UI changed, and rerun the selector audit.
+  Artifacts: screenshot=/tmp/run_test/selector-audit/feed/post_composer_trigger.png | dom=/tmp/run_test/selector-audit/feed/post_composer_trigger.html | a11y=/tmp/run_test/selector-audit/feed/post_composer_trigger.a11y.json
+  Next: Open the captured failure artifacts for post_composer_trigger on feed, update that selector group in the registry, and rerun the selector audit.
+```
+
+- Interactive terminals show per-page progress plus a human-readable summary
+  with failures, fallbacks, warnings, and next steps.
 - Use `--json` for machine-readable output in CI, scripts, or agent workflows.
-- Use `--verbose` to expand the human-readable summary with selector-by-selector details.
-- Use `--no-progress` to suppress live progress updates when you only want the final summary.
-- Exits non-zero only when a selector group fully fails across all fallback strategies.
+- Use `--verbose` to expand the human-readable summary with selector-by-selector
+  details.
+- Use `--no-progress` to suppress live progress updates when you only want the
+  final summary.
+- Reports are written under the run artifact directory as
+  `selector-audit/report.json`; screenshots, DOM snapshots, and accessibility
+  snapshots are captured only for failures.
+- The CLI has no selector-audit-specific env vars today; configuration is via
+  `--profile`, optional `--cdp-url`, and the programmatic core service options
+  documented in `docs/selector-audit.md`.
 
 Inbox MVP commands:
 
@@ -141,11 +198,31 @@ Exposed tools:
 
 - `linkedin.session.status`
 - `linkedin.session.open_login`
+- `linkedin.profile.view`
+- `linkedin.search`
 - `linkedin.inbox.list_threads`
 - `linkedin.inbox.get_thread`
 - `linkedin.inbox.prepare_reply`
+- `linkedin.connections.list`
+- `linkedin.connections.pending`
+- `linkedin.connections.invite`
+- `linkedin.connections.accept`
+- `linkedin.connections.withdraw`
+- `linkedin.feed.list`
+- `linkedin.feed.view_post`
+- `linkedin.feed.like`
+- `linkedin.feed.comment`
+- `linkedin.post.prepare_create`
+- `linkedin.notifications.list`
+- `linkedin.jobs.search`
+- `linkedin.jobs.view`
 - `linkedin.network.prepare_followup_after_accept`
 - `linkedin.actions.confirm`
+
+Selector audit is currently a CLI-only diagnostic. When an MCP read-only tool
+starts failing because LinkedIn's UI changed, run
+`linkedin audit selectors --profile <profile>` and follow `docs/selector-audit.md`.
+The read-only MCP tool descriptions reference this diagnostic path.
 
 ## MVP Flow
 

--- a/docs/selector-audit.md
+++ b/docs/selector-audit.md
@@ -1,0 +1,170 @@
+# Selector audit
+
+`linkedin audit selectors` is a read-only diagnostic for the built-in LinkedIn
+selector registry. It navigates across key pages, checks each selector group in
+primary-to-tertiary order, captures artifacts for failures, and writes a
+structured JSON report for humans and automation.
+
+The selector audit feature is also exported from `@linkedin-assistant/core` via
+`packages/core/src/index.ts`.
+
+## What it checks
+
+- Pages: `feed`, `inbox`, `profile`, `connections`, `notifications`
+- Strategies per selector group: `primary`, `secondary`, `tertiary`
+- Page readiness before selector checks, but as a warning instead of a hard stop
+- Failure artifacts: screenshot, DOM snapshot, accessibility snapshot
+
+## Quick start
+
+```bash
+# Human-readable summary with progress
+npm exec -w @linkedin-assistant/cli -- linkedin audit selectors --profile default
+
+# Verbose human-readable summary
+npm exec -w @linkedin-assistant/cli -- linkedin audit selectors --profile default --verbose
+
+# JSON for CI, scripts, or agent workflows
+npm exec -w @linkedin-assistant/cli -- linkedin audit selectors --profile default --json
+
+# Attach to an existing authenticated browser session
+npm exec -w @linkedin-assistant/cli -- linkedin audit selectors --profile default --cdp-url http://127.0.0.1:18800
+
+# Show built-in help and doc pointer
+npm exec -w @linkedin-assistant/cli -- linkedin audit selectors --help
+```
+
+## Reading the result
+
+- `PASS`: every selector group matched a primary selector
+- `PASS WITH FALLBACKS`: at least one selector group matched only a secondary or
+  tertiary selector
+- `FAIL`: at least one selector group failed across every strategy
+- Exit code `0`: no hard failures
+- Exit code `1`: at least one hard failure or command/runtime failure
+
+Representative output:
+
+```text
+Starting selector audit for profile default (2 pages).
+Checking page 1/2: feed (2 selector groups)...
+Finished page 1/2: feed — 1 passed, 1 failed, 1 fallback.
+Checking page 2/2: inbox (1 selector group)...
+Finished page 2/2: inbox — 1 passed, 0 failed, 0 fallback.
+Selector audit finished. Report: /tmp/run_test/selector-audit/report.json
+
+Selector Audit: FAIL
+Profile: default
+Checked At: 2026-03-08T12:00:00.000Z
+Summary: Checked 3 selector groups across 2 pages. 2 passed. 1 failed. 1 used fallback selectors.
+Report JSON: /tmp/run_test/selector-audit/report.json
+Artifacts: /tmp/run_test/selector-audit
+
+Pages
+- FAIL feed: 1 passed, 1 failed, 1 fallback-only
+- PASS inbox: 1 passed, 0 failed, 0 fallback-only
+
+Failures
+- feed/post_composer_trigger — Feed post composer trigger
+  Error: No selector strategy matched for post_composer_trigger on feed. Review the failure artifacts, update the selector registry if LinkedIn's UI changed, and rerun the selector audit.
+  Artifacts: screenshot=/tmp/run_test/selector-audit/feed/post_composer_trigger.png | dom=/tmp/run_test/selector-audit/feed/post_composer_trigger.html | a11y=/tmp/run_test/selector-audit/feed/post_composer_trigger.a11y.json
+  Next: Open the captured failure artifacts for post_composer_trigger on feed, update that selector group in the registry, and rerun the selector audit.
+```
+
+Typical JSON fields:
+
+```json
+{
+  "outcome": "pass_with_fallbacks",
+  "summary": "Checked 14 selector groups across 5 pages. 14 passed. 0 failed. 2 used fallback selectors.",
+  "artifact_dir": "/path/to/run/selector-audit",
+  "report_path": "/path/to/run/selector-audit/report.json",
+  "page_summaries": [
+    {
+      "page": "feed",
+      "total_count": 4,
+      "pass_count": 4,
+      "fail_count": 0,
+      "fallback_count": 1
+    }
+  ],
+  "failed_selectors": [],
+  "fallback_selectors": [
+    {
+      "page": "feed",
+      "selector_key": "feed_sort_menu",
+      "fallback_strategy": "secondary",
+      "fallback_used": "css-feed-sort-menu"
+    }
+  ]
+}
+```
+
+## Artifacts and report files
+
+- The JSON report is written to `selector-audit/report.json` under the current
+  run artifact directory.
+- Failure artifact paths are absolute paths in the returned report so they are
+  easy to open from CI logs or agent output.
+- Screenshots, DOM snapshots, and accessibility snapshots are captured only for
+  failures to keep successful runs lightweight.
+
+## Configuration
+
+### CLI
+
+Available switches:
+
+- `--profile <profile>`: choose the persistent Playwright profile
+- `--json`: emit the full structured report
+- `--verbose`: add selector-by-selector detail to human output
+- `--no-progress`: suppress live progress lines in human output
+- `--cdp-url <url>`: attach to an existing authenticated browser session
+
+There are no selector-audit-specific environment variables today. General tool
+state and artifacts still follow `LINKEDIN_ASSISTANT_HOME`.
+
+### Core API
+
+The core service supports registry and timeout overrides:
+
+```ts
+import {
+  LinkedInSelectorAuditService,
+  createCoreRuntime,
+  createLinkedInSelectorAuditRegistry
+} from "@linkedin-assistant/core";
+
+const runtime = createCoreRuntime();
+const registry = createLinkedInSelectorAuditRegistry();
+
+const selectorAudit = new LinkedInSelectorAuditService(runtime, {
+  registry,
+  candidateTimeoutMs: 2500,
+  pageReadyTimeoutMs: 10000,
+  pageNavigationTimeoutMs: 20000
+});
+
+const report = await selectorAudit.auditSelectors({
+  profileName: "default"
+});
+
+console.log(report.outcome, report.report_path);
+runtime.close();
+```
+
+Public selector-audit exports include:
+
+- `LinkedInSelectorAuditService`
+- `createLinkedInSelectorAuditRegistry`
+- `LINKEDIN_SELECTOR_AUDIT_PAGES`
+- `LINKEDIN_SELECTOR_AUDIT_STRATEGIES`
+- `SelectorAuditReport` and related result types
+
+## Where to find it
+
+- README quick start: `README.md`
+- CLI help: `linkedin audit selectors --help`
+- MCP discoverability: read-only tool descriptions point operators back to the
+  CLI selector audit when investigating UI drift
+- Core exports: `packages/core/src/index.ts`

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -31,6 +31,9 @@ import {
 } from "../selectorAuditOutput.js";
 
 const cliPrivacyConfig = resolvePrivacyConfig();
+const SELECTOR_AUDIT_DOC_PATH = "docs/selector-audit.md";
+const SELECTOR_AUDIT_DOC_REFERENCE =
+  `See ${SELECTOR_AUDIT_DOC_PATH} for sample output, configuration, and troubleshooting.`;
 
 function coercePositiveInt(value: string, label: string): number {
   const parsed = Number.parseInt(value, 10);
@@ -1454,6 +1457,8 @@ async function runSelectorAudit(input: {
     const selectorAuditRuntime = runtime;
 
     const originalLog = selectorAuditRuntime.logger.log.bind(selectorAuditRuntime.logger);
+    // Mirror stable selector-audit lifecycle logs into the optional progress
+    // reporter without changing the core service API surface.
     selectorAuditRuntime.logger.log = ((level, event, payload = {}) => {
       const entry = originalLog(level, event, payload);
       progressReporter.handleLog(entry);
@@ -1622,6 +1627,15 @@ async function main(): Promise<void> {
     .option(
       "--cdp-url <url>",
       "Connect to existing browser via CDP endpoint (e.g., http://127.0.0.1:18800)"
+    )
+    .addHelpText(
+      "after",
+      [
+        "",
+        "Diagnostics:",
+        "  linkedin audit selectors --help",
+        `  ${SELECTOR_AUDIT_DOC_REFERENCE}`
+      ].join("\n")
     );
 
   const readCdpUrl = (): string | undefined => {
@@ -2253,7 +2267,8 @@ async function main(): Promise<void> {
       [
         "",
         "Interactive terminals default to a human-readable summary with per-page progress.",
-        "Use --json for automation, piping, or other agent workflows."
+        "Use --json for automation, piping, or other agent workflows.",
+        SELECTOR_AUDIT_DOC_REFERENCE
       ].join("\n")
     )
     .action(async (options: {

--- a/packages/cli/src/selectorAuditOutput.ts
+++ b/packages/cli/src/selectorAuditOutput.ts
@@ -9,12 +9,21 @@ import type {
   SelectorAuditResult
 } from "@linkedin-assistant/core";
 
+/**
+ * Output formats supported by the selector audit CLI.
+ */
 export type SelectorAuditOutputMode = "human" | "json";
 
+/**
+ * Optional display flags for the human-readable report formatter.
+ */
 export interface FormatSelectorAuditReportOptions {
   verbose?: boolean;
 }
 
+/**
+ * Configuration for {@link SelectorAuditProgressReporter}.
+ */
 export interface SelectorAuditProgressReporterOptions {
   enabled?: boolean;
   writeLine?: (line: string) => void;
@@ -194,12 +203,18 @@ function readNumber(payload: Record<string, unknown>, key: string): number | nul
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
+/**
+ * Selects JSON or human-readable output for the selector audit command.
+ */
 export function resolveSelectorAuditOutputMode(options: {
   json: boolean;
 }, isInteractiveOutput: boolean): SelectorAuditOutputMode {
   return options.json || !isInteractiveOutput ? "json" : "human";
 }
 
+/**
+ * Formats a structured selector audit report for terminal output.
+ */
 export function formatSelectorAuditReport(
   report: SelectorAuditReport,
   options: FormatSelectorAuditReportOptions = {}
@@ -247,6 +262,9 @@ export function formatSelectorAuditReport(
   return lines.join("\n");
 }
 
+/**
+ * Formats a structured selector audit failure into a concise terminal message.
+ */
 export function formatSelectorAuditError(
   payload: LinkedInAssistantErrorPayload
 ): string {
@@ -263,6 +281,12 @@ export function formatSelectorAuditError(
   return lines.join("\n");
 }
 
+/**
+ * Consumes selector-audit log events and emits lightweight progress lines.
+ *
+ * This keeps the CLI progress view aligned with the core service lifecycle
+ * without introducing a second progress callback API.
+ */
 export class SelectorAuditProgressReporter {
   private readonly enabled: boolean;
   private readonly writeLine: (line: string) => void;
@@ -280,6 +304,8 @@ export class SelectorAuditProgressReporter {
       return;
     }
 
+    // Only a small, stable subset of audit lifecycle events is surfaced so the
+    // progress UI stays predictable even if lower-level log events evolve.
     if (entry.event === "selector.audit.start") {
       this.totalPages = readNumber(entry.payload, "pageCount");
       const profileName = readString(entry.payload, "profileName");

--- a/packages/core/src/selectorAudit.ts
+++ b/packages/core/src/selectorAudit.ts
@@ -13,6 +13,9 @@ import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
 
+/**
+ * Canonical LinkedIn page identifiers covered by the built-in selector audit.
+ */
 export const LINKEDIN_SELECTOR_AUDIT_PAGES = [
   "feed",
   "inbox",
@@ -21,18 +24,34 @@ export const LINKEDIN_SELECTOR_AUDIT_PAGES = [
   "notifications"
 ] as const;
 
+/**
+ * One supported page identifier in the selector audit registry.
+ */
 export type LinkedInSelectorAuditPage =
   (typeof LINKEDIN_SELECTOR_AUDIT_PAGES)[number];
 
+/**
+ * Ordered selector fallback tiers checked for every selector group.
+ *
+ * `primary` is the preferred stable selector. `secondary` and `tertiary` are
+ * tolerated fallbacks that keep the audit actionable while still surfacing UI
+ * drift in the final report.
+ */
 export const LINKEDIN_SELECTOR_AUDIT_STRATEGIES = [
   "primary",
   "secondary",
   "tertiary"
 ] as const;
 
+/**
+ * One selector fallback tier supported by the audit.
+ */
 export type LinkedInSelectorAuditStrategy =
   (typeof LINKEDIN_SELECTOR_AUDIT_STRATEGIES)[number];
 
+/**
+ * One concrete Playwright locator candidate inside a selector group.
+ */
 export interface SelectorAuditCandidate {
   strategy: LinkedInSelectorAuditStrategy;
   key: string;
@@ -40,12 +59,18 @@ export interface SelectorAuditCandidate {
   locatorFactory: (page: Page) => Locator;
 }
 
+/**
+ * A logical selector group that should resolve on a page.
+ */
 export interface SelectorAuditSelectorDefinition {
   key: string;
   description: string;
   candidates: SelectorAuditCandidate[];
 }
 
+/**
+ * Selector audit definition for one LinkedIn page.
+ */
 export interface SelectorAuditPageDefinition {
   page: LinkedInSelectorAuditPage;
   url: string;
@@ -53,10 +78,16 @@ export interface SelectorAuditPageDefinition {
   readyCandidates?: SelectorAuditCandidate[];
 }
 
+/**
+ * Input accepted by {@link LinkedInSelectorAuditService.auditSelectors}.
+ */
 export interface SelectorAuditInput {
   profileName?: string;
 }
 
+/**
+ * Per-candidate outcome captured for reporting and troubleshooting.
+ */
 export interface SelectorAuditStrategyResult {
   strategy: LinkedInSelectorAuditStrategy;
   status: "pass" | "fail";
@@ -65,6 +96,9 @@ export interface SelectorAuditStrategyResult {
   error?: string;
 }
 
+/**
+ * Failure artifact paths captured when a selector group cannot be matched.
+ */
 export interface SelectorAuditFailureArtifacts {
   screenshot_path?: string;
   dom_snapshot_path?: string;
@@ -72,6 +106,9 @@ export interface SelectorAuditFailureArtifacts {
   capture_warnings?: string[];
 }
 
+/**
+ * Full audit outcome for one selector group on one page.
+ */
 export interface SelectorAuditResult {
   page: LinkedInSelectorAuditPage;
   page_url: string;
@@ -88,6 +125,9 @@ export interface SelectorAuditResult {
   error?: string;
 }
 
+/**
+ * Per-page aggregate counts included in the top-level report.
+ */
 export interface SelectorAuditPageSummary {
   page: LinkedInSelectorAuditPage;
   total_count: number;
@@ -96,13 +136,22 @@ export interface SelectorAuditPageSummary {
   fallback_count: number;
 }
 
+/**
+ * Top-level outcome for a selector audit run.
+ */
 export type SelectorAuditOutcome = "pass" | "pass_with_fallbacks" | "fail";
 
+/**
+ * Page-level warnings that applied to every selector evaluated on that page.
+ */
 export interface SelectorAuditPageWarningSummary {
   page: LinkedInSelectorAuditPage;
   warnings: string[];
 }
 
+/**
+ * Failure summary promoted to the top-level report for quick triage.
+ */
 export interface SelectorAuditFailureSummary {
   page: LinkedInSelectorAuditPage;
   page_url: string;
@@ -114,6 +163,10 @@ export interface SelectorAuditFailureSummary {
   recommended_action: string;
 }
 
+/**
+ * Fallback summary promoted to the top-level report when only non-primary
+ * selectors matched.
+ */
 export interface SelectorAuditFallbackSummary {
   page: LinkedInSelectorAuditPage;
   page_url: string;
@@ -125,6 +178,9 @@ export interface SelectorAuditFallbackSummary {
   recommended_action: string;
 }
 
+/**
+ * Structured result returned by the selector audit CLI and core API.
+ */
 export interface SelectorAuditReport {
   run_id: string;
   profile_name: string;
@@ -145,6 +201,12 @@ export interface SelectorAuditReport {
   results: SelectorAuditResult[];
 }
 
+/**
+ * Runtime dependencies required by {@link LinkedInSelectorAuditService}.
+ *
+ * This shape is exported so tests and alternate runtimes can provide a narrow
+ * selector-audit-compatible runtime without constructing the full app graph.
+ */
 export interface LinkedInSelectorAuditRuntime {
   runId: string;
   auth: LinkedInAuthService;
@@ -154,6 +216,9 @@ export interface LinkedInSelectorAuditRuntime {
   artifacts: ArtifactHelpers;
 }
 
+/**
+ * Optional overrides for the selector audit registry and timeouts.
+ */
 export interface LinkedInSelectorAuditServiceOptions {
   registry?: SelectorAuditPageDefinition[];
   candidateTimeoutMs?: number;
@@ -1006,6 +1071,10 @@ function createArtifactCaptureWarning(
   return `Could not capture the ${artifactKind} for ${selectorDefinition.key} on ${pageDefinition.page}: ${getErrorMessage(error)}.`;
 }
 
+/**
+ * Audits selector groups across core LinkedIn pages and emits a structured
+ * report with pass/fail/fallback summaries plus failure artifacts.
+ */
 export class LinkedInSelectorAuditService {
   private readonly registry: SelectorAuditPageDefinition[];
   private readonly candidateTimeoutMs: number;
@@ -1036,6 +1105,14 @@ export class LinkedInSelectorAuditService {
     );
   }
 
+  /**
+   * Runs the selector audit for one authenticated profile.
+   *
+   * The audit is read-only: it navigates across the configured pages, checks
+   * each selector group in primary-to-tertiary order, captures artifacts only
+   * for failures, writes a JSON report into the run artifact directory, and
+   * returns the same report to the caller.
+   */
   async auditSelectors(input: SelectorAuditInput = {}): Promise<SelectorAuditReport> {
     const normalizedInput = validateSelectorAuditInput(input);
     const profileName = validateProfileName(normalizedInput.profileName);
@@ -1181,6 +1258,8 @@ export class LinkedInSelectorAuditService {
 
       const pageReadyFailures = await this.waitForPageReady(page, pageDefinition);
       if (pageReadyFailures !== null) {
+        // Page-readiness is advisory instead of fatal so the audit can still
+        // collect selector drift evidence from the current DOM state.
         const warning = createPageReadinessWarning(
           pageDefinition,
           this.pageReadyTimeoutMs,
@@ -1299,6 +1378,8 @@ export class LinkedInSelectorAuditService {
 
     const matchedResult = strategyResults.find((result) => result.status === "pass") ?? null;
     const failureArtifacts =
+      // Failure artifacts are intentionally captured only when every candidate
+      // misses so successful audits stay lightweight and focused.
       matchedResult === null
         ? await this.captureFailureArtifacts(page, pageDefinition, selectorDefinition)
         : {};
@@ -1414,6 +1495,8 @@ export class LinkedInSelectorAuditService {
     pageDefinition: SelectorAuditPageDefinition,
     selectorDefinition: SelectorAuditSelectorDefinition
   ): Promise<SelectorAuditFailureArtifacts> {
+    // Timestamped file names avoid collisions when the same selector key fails
+    // multiple times during one run or across quick successive reruns.
     const prefix = path.join(
       SELECTOR_AUDIT_ARTIFACT_DIR,
       sanitizePathSegment(pageDefinition.page),
@@ -1531,6 +1614,12 @@ export class LinkedInSelectorAuditService {
   }
 }
 
+/**
+ * Returns a fresh copy of the built-in selector audit registry.
+ *
+ * Callers can inspect or clone this registry before passing a customized copy
+ * to {@link LinkedInSelectorAuditServiceOptions.registry}.
+ */
 export function createLinkedInSelectorAuditRegistry(): SelectorAuditPageDefinition[] {
   return createDefaultSelectorAuditRegistry();
 }

--- a/packages/mcp/src/bin/linkedin-mcp.ts
+++ b/packages/mcp/src/bin/linkedin-mcp.ts
@@ -49,6 +49,13 @@ type ToolArgs = Record<string, unknown>;
 type ToolResult = { content: Array<{ type: "text"; text: string }> };
 
 const mcpPrivacyConfig = resolvePrivacyConfig();
+const SELECTOR_AUDIT_DOC_PATH = "docs/selector-audit.md";
+const SELECTOR_AUDIT_MCP_HINT =
+  `For broader UI-drift diagnostics, run the CLI selector audit ("linkedin audit selectors") and see ${SELECTOR_AUDIT_DOC_PATH}.`;
+
+function withSelectorAuditHint(description: string): string {
+  return `${description} ${SELECTOR_AUDIT_MCP_HINT}`;
+}
 
 function readString(args: ToolArgs, key: string, fallback: string): string {
   const value = args[key];
@@ -1020,7 +1027,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: LINKEDIN_INBOX_LIST_THREADS_TOOL,
-        description: "List LinkedIn inbox threads for a profile.",
+        description: withSelectorAuditHint(
+          "List LinkedIn inbox threads for a profile."
+        ),
         inputSchema: {
           type: "object",
           additionalProperties: false,
@@ -1042,7 +1051,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: LINKEDIN_INBOX_GET_THREAD_TOOL,
-        description: "Get one LinkedIn thread with recent messages.",
+        description: withSelectorAuditHint(
+          "Get one LinkedIn thread with recent messages."
+        ),
         inputSchema: {
           type: "object",
           additionalProperties: false,
@@ -1093,7 +1104,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: LINKEDIN_PROFILE_VIEW_TOOL,
         description:
-          "View a LinkedIn profile. Returns structured profile data including name, headline, location, about, experience, and education.",
+          withSelectorAuditHint(
+            "View a LinkedIn profile. Returns structured profile data including name, headline, location, about, experience, and education."
+          ),
         inputSchema: {
           type: "object",
           additionalProperties: false,
@@ -1112,7 +1125,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: LINKEDIN_SEARCH_TOOL,
-        description: "Search LinkedIn for people, companies, or jobs.",
+        description: withSelectorAuditHint(
+          "Search LinkedIn for people, companies, or jobs."
+        ),
         inputSchema: {
           type: "object",
           additionalProperties: false,
@@ -1142,7 +1157,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: LINKEDIN_CONNECTIONS_LIST_TOOL,
         description:
-          "List your LinkedIn connections. Returns connection names, headlines, profile URLs, and when connected.",
+          withSelectorAuditHint(
+            "List your LinkedIn connections. Returns connection names, headlines, profile URLs, and when connected."
+          ),
         inputSchema: {
           type: "object",
           additionalProperties: false,
@@ -1162,7 +1179,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: LINKEDIN_CONNECTIONS_PENDING_TOOL,
         description:
-          "List pending LinkedIn connection invitations (sent, received, or both).",
+          withSelectorAuditHint(
+            "List pending LinkedIn connection invitations (sent, received, or both)."
+          ),
         inputSchema: {
           type: "object",
           additionalProperties: false,
@@ -1291,7 +1310,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: LINKEDIN_FEED_LIST_TOOL,
         description:
-          "List posts from your LinkedIn feed with author, text, and engagement counts.",
+          withSelectorAuditHint(
+            "List posts from your LinkedIn feed with author, text, and engagement counts."
+          ),
         inputSchema: {
           type: "object",
           additionalProperties: false,
@@ -1310,7 +1331,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: LINKEDIN_FEED_VIEW_POST_TOOL,
-        description: "View one LinkedIn feed post by URL, URN, or activity id.",
+        description: withSelectorAuditHint(
+          "View one LinkedIn feed post by URL, URN, or activity id."
+        ),
         inputSchema: {
           type: "object",
           additionalProperties: false,
@@ -1420,7 +1443,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: LINKEDIN_NOTIFICATIONS_LIST_TOOL,
         description:
-          "List your LinkedIn notifications. Returns notification type, message, timestamp, link, and read/unread status.",
+          withSelectorAuditHint(
+            "List your LinkedIn notifications. Returns notification type, message, timestamp, link, and read/unread status."
+          ),
         inputSchema: {
           type: "object",
           additionalProperties: false,
@@ -1440,7 +1465,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: LINKEDIN_JOBS_SEARCH_TOOL,
         description:
-          "Search for LinkedIn job postings by keyword and optional location.",
+          withSelectorAuditHint(
+            "Search for LinkedIn job postings by keyword and optional location."
+          ),
         inputSchema: {
           type: "object",
           additionalProperties: false,
@@ -1469,7 +1496,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: LINKEDIN_JOBS_VIEW_TOOL,
         description:
-          "View details of a specific LinkedIn job posting by job ID.",
+          withSelectorAuditHint(
+            "View details of a specific LinkedIn job posting by job ID."
+          ),
         inputSchema: {
           type: "object",
           additionalProperties: false,


### PR DESCRIPTION
## Summary
- add TSDoc and inline docs for the selector audit core and CLI surfaces
- add README quick start plus a dedicated selector audit guide with sample output and configuration details
- improve discoverability from CLI help, MCP tool descriptions, and a changelog entry

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #23