### PR TITLE
docs: add scheduler research brief for #32

### DIFF
--- a/docs/.research-brief-issue-5.md
+++ b/docs/.research-brief-issue-5.md
@@ -1,0 +1,424 @@
+# Research brief — issue #5 scheduled follow-ups (local scheduler)
+
+Reviewed on: 2026-03-08  
+Related issues: #1, #5, #7, #11, #32
+
+## Executive summary
+
+The codebase already has the hardest part of the follow-up workflow in place:
+
+- sent invitation state is persisted in SQLite
+- accepted invitations can be detected from that state plus a live profile probe
+- follow-up messages already use the existing prepare → confirm safety model
+- follow-up state already records whether a follow-up was prepared or confirmed
+
+That means issue #5 does **not** need a brand-new outbound action system.
+The safest implementation path is to add a **local scheduler/job layer on top of the existing follow-up prepare flow**.
+
+The main architectural gaps today are:
+
+- no scheduler config surface in `packages/core/src/config.ts`
+- no scheduler job table or worker state in SQLite
+- no reusable business-hours / due-time helpers
+- no public single-target follow-up prepare API
+- no existing daemon/worker dedicated to job execution
+
+The biggest regression risk is that prepared actions currently expire after **30 minutes**.
+A scheduler that prepares follow-ups too early will generate expired confirm tokens before the operator can review them.
+
+## What exists today
+
+### 1) The accepted-invitation follow-up flow is already end-to-end
+
+`packages/core/src/linkedinFollowups.ts` already provides a full prepare-only flow for accepted connections:
+
+- `listAcceptedConnections()` refreshes acceptance state and returns follow-up status metadata
+- `prepareFollowupsAfterAccept()` prepares follow-ups only for accepted connections that still need one
+- `createFollowupActionExecutors()` registers the confirm-time executor for `network.followup_after_accept`
+
+The current status model is already useful for scheduler idempotency:
+
+- `not_prepared`
+- `prepared`
+- `executed`
+- `failed`
+- `expired`
+
+This means a scheduler can build on top of existing state instead of inventing a second source of truth for whether a follow-up was already prepared.
+
+### 2) SQLite already stores the state a scheduler will depend on
+
+`packages/core/src/db/migrations.ts` and `packages/core/src/db/database.ts` already define `sent_invitation_state` with:
+
+- invite discovery timestamps (`first_seen_sent_at`, `last_seen_sent_at`)
+- acceptance detection (`accepted_at`, `accepted_detection`)
+- follow-up lifecycle (`followup_prepared_at`, `followup_prepared_action_id`, `followup_confirmed_at`)
+
+That table is enough to know:
+
+- which sent invites are still pending
+- which ones became accepted
+- whether a follow-up has already been prepared or confirmed
+
+What is missing is a separate scheduler-oriented table for:
+
+- due times
+- retry/backoff state
+- per-job status and attempts
+- lane ordering / leasing
+
+### 3) The project already has a local daemon control pattern
+
+`packages/cli/src/bin/linkedin.ts` already implements a detached local daemon flow for keepalive:
+
+- `linkedin keepalive start`
+- `linkedin keepalive status`
+- `linkedin keepalive stop`
+- internal `keepalive __run`
+
+That existing pattern already handles:
+
+- detached process startup via `spawn(..., { detached: true })`
+- PID and state files under the tool home directory
+- stale PID cleanup
+- looped execution with jitter and graceful stop handling
+
+This is the strongest existing pattern for a local scheduler operator surface.
+
+### 4) Browser/profile contention is already a known concern
+
+`packages/core/src/profileManager.ts` enforces a per-profile lock for persistent contexts.
+That means concurrent CLI/MCP/scheduler work on the same profile will conflict unless the scheduler treats lock contention as a soft retry condition.
+
+This matters because:
+
+- the keepalive daemon already exists
+- CLI commands can run at any time
+- MCP tools share the same profile/runtime behavior
+
+Any scheduler worker must assume that “profile busy” is normal and should usually reschedule rather than fail the job permanently.
+
+### 5) Issue #5’s spec references are stale
+
+Issue #5 references `PROJECT.md` sections `10.3` and `19.3 item 3`, but the current `PROJECT.md` is only 89 lines and has no scheduler section.
+For implementation planning, the issue body itself should be treated as the source of truth.
+
+## Lane readiness by existing service
+
+| Lane from issue #5 | Existing service support | Readiness | Notes |
+| --- | --- | --- | --- |
+| Follow-up preparation | `packages/core/src/linkedinFollowups.ts` | High | Already prepares accepted-connection follow-ups with two-phase commit and state tracking |
+| Pending invite checks | `packages/core/src/linkedinConnections.ts` | High | `listPendingInvitations({ filter: "sent" })` already syncs `sent_invitation_state` |
+| Inbox triage | `packages/core/src/linkedinInbox.ts` | Low | Read-only listing/detail APIs exist, but there is no persisted triage queue or selection policy |
+| Feed engagement | `packages/core/src/linkedinFeed.ts` | Low | Prepare APIs exist, but they require an explicit post URL and, for comments, explicit text |
+
+### Follow-up preparation is the only lane that is scheduler-ready today
+
+The current follow-up flow already satisfies the key safety requirement from issue #5:
+
+- preparation can be automated
+- confirmation remains manual
+
+That makes it a strong phase-1 scheduler target.
+
+### Pending invite checks are already embedded in the follow-up refresh path
+
+`LinkedInFollowupsService.refreshAcceptanceState()` already calls `connections.listPendingInvitations({ filter: "sent" })` before probing accepted candidates.
+
+That means a separate “pending invite checks” lane is optional for the first iteration.
+It only becomes necessary if the scheduler wants to:
+
+- refresh invitation state on a different cadence from follow-up preparation
+- surface pending-invite scans as their own operator-visible jobs
+
+### Inbox triage and feed engagement are not ready for unattended scheduling
+
+These lanes are the main scope-creep risk.
+
+Current blockers:
+
+- inbox triage has no queue model, no triage state table, and no decision policy for what counts as “triaged”
+- feed engagement has no selection/ranking model for choosing a post
+- feed comment preparation requires comment text, but the codebase has no scheduler-safe comment drafting policy
+
+Recommendation: define lane enums now if desired, but only implement the `followup_preparation` lane in the first scheduler milestone.
+
+## Important implementation constraints
+
+### 1) Prepared actions expire after 30 minutes
+
+`packages/core/src/twoPhaseCommit.ts` uses `DEFAULT_CONFIRM_TOKEN_TTL_MS = 30 * 60 * 1000`.
+
+This is the most important functional constraint for issue #5.
+
+Implications:
+
+- the scheduler should prepare actions close to the expected review window
+- preparing a large queue at 09:00 can easily produce expired tokens by 09:45
+- “business hours” should not be interpreted as “prepare everything at the start of the window”
+
+The implementation should either:
+
+- schedule preparation close to the due time, or
+- explicitly add a scheduler-specific prepare TTL override
+
+Without one of those, the feature will technically work but create poor operator UX.
+
+### 2) The current follow-up API is batch-oriented, not job-oriented
+
+`prepareFollowupsAfterAccept()` works by scanning all accepted connections inside a lookback window and preparing any that still need a follow-up.
+
+That is good for manual CLI use, but it is awkward for a scheduler job table because one job should ideally map to one target.
+
+The scheduler will likely need a new public helper in `packages/core/src/linkedinFollowups.ts`, such as:
+
+- “prepare follow-up for one accepted connection by `profile_url_key`”
+- or an extracted internal helper that both batch prepare and scheduler jobs can reuse
+
+Without that extraction, a scheduler job would either:
+
+- call the batch method and prepare more than one follow-up at once, or
+- duplicate private logic from `prepareAcceptedConnections()`
+
+### 3) Long-lived runtime instances would mix unrelated runs and artifacts
+
+`createCoreRuntime()` creates a single `runId`, logger, artifact directory, and DB handle.
+
+That is fine for short CLI commands, but a long-running scheduler daemon would accumulate:
+
+- one very large artifact/log run directory
+- mixed job logs from unrelated ticks
+- harder-to-debug artifact trails
+
+Recommendation: keep the daemon loop thin and create a **fresh runtime per tick or per job batch**.
+
+### 4) Business hours require new configuration semantics
+
+`packages/core/src/config.ts` currently exposes:
+
+- home/artifacts/profiles/db paths
+- confirm-failure trace size
+
+There is no existing config surface for:
+
+- business-hour start/end
+- timezone
+- poll interval
+- lane ordering or enablement
+- retry/backoff policy
+
+That config needs to be added deliberately instead of scattered across CLI flags.
+
+### 5) The repo has no scheduler/date library today
+
+There is no cron parser or timezone helper dependency in `package.json`.
+
+That means the implementation will need to choose between:
+
+- a minimal in-house “poll + business window” model using built-in date/time APIs, or
+- a new dependency for richer schedule/timezone handling
+
+For issue #5 as written, the built-in polling model is likely enough and has the lowest regression risk.
+
+## Recommended approach
+
+### 1) Keep the scheduler separate from keepalive
+
+The scheduler should reuse the **CLI daemon control pattern** from keepalive, but it should **not** be folded into `packages/core/src/keepAlive.ts`.
+
+Reasons:
+
+- keepalive is health-focused, not job-focused
+- scheduler needs DB job selection, backoff, and lane dispatch
+- scheduler will produce prepared actions and artifacts, which keepalive does not manage
+
+Recommended shape:
+
+- add a new core module, likely `packages/core/src/scheduler.ts`
+- add a dedicated CLI surface such as `linkedin scheduler start|status|stop|run-once`
+- store scheduler PID/state JSON separately from keepalive state files
+
+### 2) Add a real scheduler job table in SQLite
+
+Issue #5 explicitly asks for a job table.
+The table should be generic enough for future lanes, but the first worker can still execute only follow-up jobs.
+
+Minimum useful fields:
+
+- `id`
+- `profile_name`
+- `lane`
+- `action_type`
+- `target_json`
+- `payload_json`
+- `status`
+- `scheduled_for_at`
+- `available_at`
+- `attempt_count`
+- `last_error_code`
+- `last_error_message`
+- `prepared_action_id`
+- `created_at`
+- `updated_at`
+
+Strongly recommended additional fields:
+
+- `dedupe_key` for idempotent enqueue
+- `started_at` / `finished_at`
+- `lease_owner` / `lease_expires_at` for crash-safe recovery
+
+### 3) Make job payloads minimal and derive outbound text at execution time
+
+The current privacy model already redacts/seals prepared action payloads.
+The scheduler should avoid duplicating that complexity unless it truly needs to.
+
+For follow-up jobs, the safest approach is:
+
+- store target identity and schedule metadata in the job row
+- derive the follow-up text at prepare time using the existing follow-up logic
+
+That avoids storing unnecessary message text twice.
+
+### 4) Split follow-up scheduling into detection, enqueue, and prepare
+
+The cleanest job flow is:
+
+1. refresh sent invitation state
+2. detect newly accepted invitations
+3. enqueue one job per accepted connection with a due time
+4. when a job becomes due inside business hours, prepare the follow-up for that target
+
+This is safer than repeatedly calling the batch prepare method on a sliding lookback window because it gives the scheduler:
+
+- one job per target
+- clean retry/backoff semantics
+- explicit due times
+- clearer operator/debug visibility
+
+### 5) Start with strict lane ordering, not a complex priority engine
+
+Issue #5 mentions priority lanes, but the codebase has no general task orchestrator today.
+
+The safest first pass is a simple ordered loop such as:
+
+1. inbox triage
+2. pending invite checks
+3. follow-up preparation
+4. feed engagement
+
+In practice, only `follow-up preparation` should execute mutating prepare flows in phase 1.
+The other lanes can remain disabled or read-only until they have clear outputs and tests.
+
+### 6) Use per-job backoff tied to existing error taxonomy
+
+The repo already normalizes errors into codes like:
+
+- `AUTH_REQUIRED`
+- `CAPTCHA_OR_CHALLENGE`
+- `RATE_LIMITED`
+- `UI_CHANGED_SELECTOR_FAILED`
+- `NETWORK_ERROR`
+- `TIMEOUT`
+- `ACTION_PRECONDITION_FAILED`
+
+That existing taxonomy is exactly what a scheduler should store on failed jobs.
+
+Suggested backoff policy:
+
+- `NETWORK_ERROR` / `TIMEOUT`: short exponential backoff
+- `RATE_LIMITED`: longer backoff and skip other browser-heavy jobs for the profile
+- `AUTH_REQUIRED` / `CAPTCHA_OR_CHALLENGE`: pause the lane until the operator restores the session
+- `UI_CHANGED_SELECTOR_FAILED`: stop retrying quickly and surface operator action
+- `ACTION_PRECONDITION_FAILED`: mark terminal unless the message explains a transient condition
+
+## Suggested files to touch, in order
+
+1. `packages/core/src/db/migrations.ts`
+   - add the scheduler job table and indexes
+
+2. `packages/core/src/db/database.ts`
+   - add CRUD/lease/backoff helpers for scheduler jobs
+
+3. `packages/core/src/config.ts`
+   - add scheduler config resolution for business hours, polling, and lane enablement
+
+4. `packages/core/src/linkedinFollowups.ts`
+   - extract a public single-target prepare path and keep batch prepare on top of it
+
+5. `packages/core/src/scheduler.ts`
+   - add the scheduler service, lane dispatch, business-window checks, and job retry handling
+
+6. `packages/core/src/runtime.ts`
+   - wire the scheduler service into the runtime if the chosen architecture needs runtime-level access
+
+7. `packages/core/src/index.ts`
+   - re-export scheduler types/service
+
+8. `packages/cli/src/bin/linkedin.ts`
+   - add `scheduler start|status|stop|run-once` or equivalent commands
+
+9. `packages/core/src/__tests__/`
+   - add focused scheduler job selection/backoff/business-hours tests
+
+10. `README.md`
+    - document the operator workflow only after the feature exists
+
+## Main risks to watch
+
+### 1) Expired confirm tokens
+
+This is the top product risk.
+If scheduled preparation runs too early, the operator receives prepared actions that are already expired.
+
+### 2) Duplicate follow-up jobs or duplicate prepared actions
+
+Acceptance detection is currently batch-oriented.
+Without a dedupe key or explicit job linkage, repeated scans could enqueue or prepare the same follow-up more than once.
+
+### 3) Profile lock contention with normal operator work
+
+The scheduler will compete with:
+
+- manual CLI commands
+- MCP tool calls
+- keepalive
+
+The worker must treat profile-busy conditions as routine and retry later.
+
+### 4) Business-hours and DST edge cases
+
+If business hours are defined without a clear timezone policy, the worker will behave unexpectedly during DST changes or when the host timezone changes.
+
+### 5) Scope creep from non-follow-up lanes
+
+Inbox triage and feed engagement are not close to scheduler-ready yet.
+Trying to implement them in the same milestone would likely force new queueing, ranking, and content-generation policy work.
+
+### 6) Privacy duplication in scheduler storage
+
+If the job table stores full outbound text or rich previews, the implementation will have to duplicate privacy/sealing behavior that already exists in two-phase commit.
+
+### 7) Long-lived daemon observability noise
+
+If the scheduler reuses one long-lived runtime, logs and artifacts will become harder to inspect than the current one-command-per-run model.
+
+## Guardrails
+
+### Do touch
+
+- additive DB migrations and DB helpers
+- a new scheduler core module
+- follow-up service refactors that expose a single-target prepare path
+- CLI daemon commands modeled after keepalive
+- focused unit tests for scheduling logic
+
+### Do not touch unless the implementation proves it is necessary
+
+- `packages/core/src/twoPhaseCommit.ts`
+- `packages/core/src/linkedinInbox.ts`
+- `packages/core/src/linkedinFeed.ts`
+- `packages/mcp/src/bin/linkedin-mcp.ts`
+- `packages/mcp/src/index.ts`
+
+The parent issue is about a **local scheduler for follow-ups**.
+It does not require broad MCP changes or a generalized autonomous action engine in the first pass.


### PR DESCRIPTION
## Summary\n- add a phase-0 research brief for issue #5's local scheduler\n- document the follow-up, SQLite, daemon, and locking patterns the implementation should reuse\n- call out the main regression risks, especially confirm-token expiry, batch-vs-job API mismatch, and profile contention\n\n## Testing\n- npm run typecheck\n- npm run lint\n- npm test\n- npm run build\n\nCloses #32