### PR TITLE
docs: add draft-quality evaluation research brief

### DIFF
--- a/docs/.research-brief-issue-10.md
+++ b/docs/.research-brief-issue-10.md
@@ -1,0 +1,510 @@
+# Research brief — Issue #10 draft quality evaluation harness
+
+Related issues: #35 (research), #10 (implementation)
+
+Date: 2026-03-08
+
+## Goal
+
+Issue #10 asks for an evaluation harness that can measure the quality of AI-generated draft replies against expected attributes instead of exact reference text.
+
+Required outcome from the issue:
+
+- dataset format with thread context and expected attributes
+- evaluation script that compares generated drafts to those attributes
+- metrics for relevance, tone match, and length compliance
+- support for both automated and manual evaluation
+- output report with pass/fail per attribute
+
+## Current repo fit
+
+This repository already has the right foundations for a first-pass evaluation harness, but it does **not** yet have a dedicated draft-generation module.
+
+Relevant findings from the current codebase:
+
+- the monorepo is split into `packages/core`, `packages/cli`, and `packages/mcp`
+- the root scripts already define the expected project quality gates: `npm run typecheck`, `npm run lint`, `npm test`, and `npm run build`
+- `packages/core` is the right place for reusable scoring logic because both CLI and MCP already depend on it
+- `scripts/integration-test.ts` shows an existing pattern for repository-level TypeScript utilities that run outside the main runtime graph
+- current tests are Vitest-based and mostly unit/integration oriented
+- there is no existing LLM client, prompt pipeline, or draft reply generator in the repo today
+
+### Implication
+
+The harness for issue #10 should start as an **offline, repo-native evaluation layer** that accepts candidate drafts as input rather than coupling the first version to any specific model provider.
+
+That keeps the work aligned with the current architecture:
+
+- no LinkedIn session required
+- no browser automation required
+- no vendor lock-in
+- easy CI execution
+- reusable by future CLI, MCP, or local agent workflows
+
+## Evaluation patterns worth adopting
+
+The best fit for this project is a layered evaluation approach.
+
+### 1. Deterministic assertions for hard constraints
+
+Use deterministic checks for requirements that should behave like normal tests:
+
+- minimum and maximum word count
+- required points that must appear in the draft
+- forbidden phrases or claims
+- required CTA or reply shape when the case demands it
+- presence or absence of personalization markers
+
+This should be the base layer because it is reproducible, debuggable, cheap, and safe to run in CI.
+
+### 2. Attribute scoring for nuanced quality
+
+Tone and relevance are often too subjective for exact-match metrics. Instead of comparing to a single “golden” reply, score the draft against a rubric:
+
+- does it address the latest inbound message?
+- does it cover the required key points?
+- does it sound warm, professional, concise, or curious when requested?
+- does it avoid unwanted tones like pushy, robotic, or overly casual?
+
+This is the correct evaluation shape for issue #10 because the issue is attribute-based, not reference-text-based.
+
+### 3. Human calibration set
+
+Automated evaluation should be calibrated against a small human-reviewed set.
+
+Recommendation:
+
+- maintain a small benchmark set of 20–30 representative thread cases
+- have a human reviewer mark pass/fail and add notes
+- compare automated scoring with human judgments before tightening CI thresholds
+
+This reduces the risk of building a brittle scoring function that looks precise but tracks human quality poorly.
+
+### 4. Keep exact-match metrics secondary
+
+BLEU-, ROUGE-, or edit-distance-style metrics are not a good primary measure for this issue.
+
+They can be useful as secondary diagnostics when reference drafts exist, but they should not define pass/fail because high-quality replies can vary substantially while still matching the desired tone, relevance, and length.
+
+## Recommended metric model
+
+Issue #10 explicitly calls out three metrics. The harness should treat them differently depending on whether they are hard or soft constraints.
+
+### Relevance
+
+**What it means here**
+
+The draft addresses the active thread, responds to the latest inbound message, and covers the expected key points.
+
+**How to score it programmatically**
+
+Start with deterministic point coverage:
+
+- each expected point gets an `id`
+- each point can define one or more acceptable aliases or phrase patterns
+- the evaluator reports which points were covered and which were missed
+
+Recommended scoring:
+
+- `score = coveredRequiredPoints / totalRequiredPoints`
+- pass only if all blocking points are covered
+- optionally allow non-blocking “nice to have” points later
+
+Recommended report details:
+
+- `covered_point_ids`
+- `missing_point_ids`
+- `off_topic_signals`
+
+### Tone match
+
+**What it means here**
+
+The draft matches the requested interpersonal style without drifting into an unwanted tone.
+
+**How to score it programmatically**
+
+Start with a small closed vocabulary of tone labels, for example:
+
+- `professional`
+- `warm`
+- `friendly`
+- `concise`
+- `curious`
+- `appreciative`
+- `direct`
+
+Each dataset case should define:
+
+- required tone labels
+- optional tone labels
+- forbidden tone labels
+
+For the first implementation, tone can be scored with rule-based heuristics plus reviewer override. If the project later adds judge-based scoring, the same dataset can power that without redesign.
+
+Recommended first-pass behavior:
+
+- pass when all required tone labels are matched
+- fail when any forbidden tone label is triggered
+- include rationale strings in the report instead of a raw score only
+
+### Length compliance
+
+**What it means here**
+
+The draft stays within the expected size envelope for the scenario.
+
+**How to score it programmatically**
+
+Use deterministic bounds:
+
+- `minWords`
+
+- `maxWords`
+
+- optional `maxSentences`
+
+- optional `targetWords` for reporting distance from ideal length
+
+Recommended first-pass behavior:
+
+- pass when the draft is inside the bounds
+- otherwise fail with exact observed values
+
+Recommended report details:
+
+- `word_count`
+- `sentence_count`
+- `min_words`
+- `max_words`
+
+### Recommended extra metrics for later phases
+
+Not required for issue #10, but worth reserving in the schema:
+
+- `safety` — avoids hallucinated facts, overclaiming, or risky promises
+- `actionability` — contains a clear next step when the case expects one
+- `personalization` — reflects thread-specific details rather than generic filler
+- `naturalness` — sounds like a human reply rather than a templated response
+
+## Dataset design recommendation
+
+Use JSON files first. They fit the repo’s TypeScript tooling, are easy to validate, and can be checked into git without extra parsers.
+
+### Why JSON over YAML or CSV
+
+- JSON is already natural for TypeScript and strict typing
+- nested thread/message structure is awkward in CSV
+- YAML is readable but adds parser complexity and linting decisions the repo does not currently need
+
+### Proposed case shape
+
+```json
+{
+  "id": "followup_meeting_request_001",
+  "channel": "linkedin_inbox",
+  "thread": {
+    "participants": [
+      { "role": "operator", "displayName": "You" },
+      { "role": "contact", "displayName": "Prospect" }
+    ],
+    "messages": [
+      {
+        "authorRole": "contact",
+        "text": "Thanks for reaching out. I am interested, but this week is packed.",
+        "timestamp": "2026-03-05T10:00:00.000Z"
+      }
+    ]
+  },
+  "expectations": {
+    "tone": {
+      "required": ["warm", "professional", "concise"],
+      "forbidden": ["pushy", "robotic"]
+    },
+    "length": {
+      "minWords": 20,
+      "maxWords": 50,
+      "targetWords": 35
+    },
+    "requiredPoints": [
+      {
+        "id": "acknowledge_busyness",
+        "aliases": ["busy", "packed", "totally understand", "no worries"]
+      },
+      {
+        "id": "propose_next_week",
+        "aliases": ["next week", "another time", "when your schedule opens up"]
+      }
+    ],
+    "forbiddenPhrases": [
+      "just circling back",
+      "as an AI"
+    ]
+  },
+  "candidateDrafts": [
+    {
+      "id": "baseline_manual",
+      "source": "manual",
+      "text": "Thanks for the reply — totally understand that this week is packed. Happy to reconnect next week if that is easier for you."
+    }
+  ],
+  "metadata": {
+    "difficulty": "normal",
+    "source": "synthetic"
+  }
+}
+```
+
+### Dataset principles
+
+- keep repo fixtures synthetic or strongly redacted
+- do not commit live LinkedIn conversations to git
+- represent realistic thread structure, not single-message prompts only
+- include happy-path, ambiguous, and adversarial cases
+- include cases where the correct reply is intentionally short
+- include cases where the correct outcome is “decline politely” or “ask a clarifying question”
+
+## Input modes the harness should support
+
+To satisfy “manual and automated evaluation,” the evaluator should support two distinct modes.
+
+### Mode A — evaluate provided candidate drafts
+
+Use this for:
+
+- manually written drafts
+- drafts exported from another system
+- side-by-side model experiments
+
+Input:
+
+- dataset file with embedded `candidateDrafts`, or
+- separate candidates file keyed by `caseId`
+
+### Mode B — generate drafts through an adapter
+
+Use this for:
+
+- future LLM integration
+- benchmark runs across prompt or model variants
+
+Input:
+
+- dataset file
+- generator adapter function or command
+
+Recommendation for issue #10 MVP:
+
+- build Mode A first
+- make the runner’s internal API generator-friendly so Mode B can be added without changing dataset or report schemas
+
+## Report design recommendation
+
+The output should be both machine-readable and easy to inspect locally.
+
+### Machine-readable JSON report
+
+```json
+{
+  "runId": "dq_20260308_120000",
+  "datasetPath": "packages/core/test/fixtures/draft-quality/smoke.json",
+  "summary": {
+    "totalCases": 10,
+    "totalDrafts": 12,
+    "passRate": 0.75,
+    "metricAverages": {
+      "relevance": 0.9,
+      "tone": 0.7,
+      "length": 1.0
+    }
+  },
+  "cases": [
+    {
+      "caseId": "followup_meeting_request_001",
+      "draftId": "baseline_manual",
+      "overall": {
+        "passed": true,
+        "score": 0.87
+      },
+      "metrics": {
+        "relevance": {
+          "passed": true,
+          "score": 1,
+          "details": {
+            "coveredPointIds": ["acknowledge_busyness", "propose_next_week"],
+            "missingPointIds": []
+          }
+        },
+        "tone": {
+          "passed": true,
+          "score": 0.67,
+          "details": {
+            "matched": ["warm", "professional"],
+            "missing": ["concise"],
+            "forbiddenTriggered": []
+          }
+        },
+        "length": {
+          "passed": true,
+          "score": 1,
+          "details": {
+            "wordCount": 24,
+            "minWords": 20,
+            "maxWords": 50
+          }
+        }
+      },
+      "notes": []
+    }
+  ]
+}
+```
+
+### Human-readable summary
+
+Also emit a concise terminal summary:
+
+- overall pass rate
+- per-metric averages
+- failing cases with explicit reasons
+- missing key points and tone mismatches
+
+This mirrors the repo’s existing pattern of human + JSON output seen in the selector audit work.
+
+## Recommended implementation shape for issue #10
+
+The simplest implementation that fits the current repo is:
+
+### Code layout
+
+- `packages/core/src/draftQualityEval.ts` — pure evaluation logic
+- `packages/core/src/draftQualityTypes.ts` — dataset/report types
+- `packages/core/src/__tests__/draftQualityEval.test.ts` — deterministic unit tests
+- `packages/core/test/fixtures/draft-quality/` — synthetic evaluation fixtures
+- `scripts/evaluate-draft-quality.ts` — repo-level runner for local usage and CI
+
+### Why this shape fits
+
+- pure functions stay reusable from CLI and MCP later
+- fixtures live near tests
+- the script follows the repo’s existing `scripts/` pattern
+- no browser state or LinkedIn session is required
+- issue #10 can be completed without introducing a model SDK prematurely
+
+## Testing strategy recommendation
+
+### Unit tests
+
+Add Vitest coverage for:
+
+- word counting and bounds checking
+- required point detection
+- forbidden phrase detection
+- tone label matching heuristics
+- report aggregation
+
+### Smoke dataset
+
+Keep a very small synthetic dataset in-repo for CI:
+
+- 5–10 cases
+- stable expected outcomes
+- no real LinkedIn content
+
+### Calibration set
+
+Keep a separate, larger local-only dataset for experimentation if needed. That dataset should not be committed if it contains sensitive or real-world text.
+
+## What to avoid
+
+- do not make exact-text similarity the primary gate
+- do not require browser automation for evaluation runs
+- do not tie the first version to a single model provider
+- do not use real inbox data in committed fixtures
+- do not let one opaque overall score hide per-attribute failures
+
+## Tooling options considered
+
+### Option 1 — repo-native TypeScript harness
+
+**Recommendation: adopt for issue #10**
+
+Pros:
+
+- best fit for current repo stack
+- easy CI integration
+- deterministic checks are straightforward
+- no external service dependency
+- minimal conceptual overhead for contributors
+
+Cons:
+
+- less advanced experiment tracking
+- judge-based scoring would need extra work later
+
+### Option 2 — Promptfoo
+
+Promptfoo is a strong option if the project later wants matrix-style prompt/model comparisons with configurable assertions and model-graded checks.
+
+Pros:
+
+- built for eval datasets and assertion-based testing
+- good at comparing outputs across prompts/models
+- can complement repo-local datasets later
+
+Cons for this repo right now:
+
+- adds a second evaluation configuration system
+- shifts logic away from the repo’s existing TypeScript domain model
+- more valuable after a draft generator actually exists
+
+### Option 3 — Braintrust / DeepEval / hosted eval tooling
+
+These tools become attractive when the project needs experiment dashboards, judge models, annotation workflows, and larger-scale prompt iteration.
+
+Pros:
+
+- richer experiment management
+- better for long-term model iteration workflows
+- support nuanced scoring strategies
+
+Cons for this repo right now:
+
+- introduces external service coupling or new workflow complexity
+- exceeds the scope of a phase-0 harness
+- premature before there is a stable draft-generation path in the repo
+
+## Recommended decision
+
+For issue #10, build a **small, deterministic, repo-native harness first**.
+
+That MVP should:
+
+1. load synthetic thread cases from JSON
+2. evaluate provided candidate drafts against attribute-based expectations
+3. produce JSON plus readable terminal output
+4. expose pass/fail per attribute
+5. run in CI with no browser, no LinkedIn session, and no model dependency
+
+Then, in a later phase, add:
+
+- generator adapters for automated draft creation
+- judge-based scoring for tone/relevance nuance
+- optional external eval tooling if experimentation volume justifies it
+
+## Suggested acceptance criteria for implementation issue #10
+
+The issue is likely done when the repo can:
+
+- run a script against a small dataset of synthetic thread cases
+- evaluate one or more candidate drafts per case
+- emit pass/fail for relevance, tone, and length per draft
+- output a JSON report suitable for CI artifacts
+- keep unit tests around the scoring logic
+
+## References
+
+- OpenAI, “Evaluation best practices”: https://platform.openai.com/docs/guides/evaluation-best-practices
+- Promptfoo, “Assertions and Metrics”: https://www.promptfoo.dev/docs/configuration/expected-outputs/
+- Braintrust, “Evaluation quickstart”: https://www.braintrust.dev/docs/quickstart-sdk
+- DeepEval overview: https://deepeval.com/


### PR DESCRIPTION
## Summary
- add a phase-0 research brief for issue #10 at `docs/.research-brief-issue-10.md`
- map the current repo architecture to a repo-native evaluation harness design
- recommend dataset, metrics, reporting, testing, and phased implementation details

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #35