### PR TITLE
docs: add data deletion research brief for #34

### DIFF
--- a/docs/.research-brief-issue-9.md
+++ b/docs/.research-brief-issue-9.md
@@ -1,0 +1,427 @@
+# Research brief — issue #9 data deletion command
+
+Reviewed on: 2026-03-08  
+Related issues: #9, #34, #5, #7, #10, #11
+
+## Executive summary
+
+The codebase already has a clear **tool-owned local state footprint**, but it is split across two places:
+
+- the main runtime home under `LINKEDIN_ASSISTANT_HOME` / `~/.linkedin-assistant/linkedin-owa-agentools`
+- a separate auth cooldown file at `~/.linkedin-assistant/rate-limit-state.json`
+
+The main deletion target is therefore broader than the current issue text implies. Today the tool persists:
+
+- a shared SQLite database with prepared actions, run logs, artifact indexes, rate-limit counters, and follow-up state
+- per-run artifact directories with JSON logs, DOM snapshots, accessibility snapshots, screenshots, selector-audit reports, and trace archives
+- Playwright persistent browser profiles containing cookies, local storage, and other browser session material
+- keepalive daemon PID / state / event-log files
+- an optional operator-authored `config.json`
+- a separate rate-limit cooldown JSON file outside the main tool home
+
+The biggest implementation constraint is that the **normal runtime boot path is a poor fit for deletion**:
+
+- `createCoreRuntime()` eagerly creates directories, opens the database, and writes startup logs
+- `runtime.close()` writes a shutdown log on teardown
+- `AssistantDatabase` creates the database directory and applies migrations on construction
+
+That means a future `linkedin data delete` command should probably **avoid creating the normal runtime at all** and instead use filesystem-first helpers.
+
+The biggest privacy takeaway is that issue #7’s redaction work helps, but it does **not** eliminate the need for deletion:
+
+- redaction defaults are still permissive (`redactionMode: off`, `storageMode: full`)
+- binary artifacts such as screenshots and Playwright traces are stored raw
+- persistent Playwright profiles hold the most sensitive material of all: authenticated browser state
+
+The biggest product ambiguity is **scope**. Current CLI flows are mostly per-profile, but most stored state is shared across profiles. Because `state.sqlite`, `artifacts/`, `keepalive/`, and the rate-limit file are global, issue #9 is much more naturally a **global local-state wipe** than a profile-scoped cleanup.
+
+## What exists today
+
+### 1) Main tool-owned storage root
+
+`packages/core/src/config.ts` defines the default state home and the core runtime paths:
+
+- base dir: `~/.linkedin-assistant/linkedin-owa-agentools`
+- artifacts dir: `<baseDir>/artifacts`
+- profiles dir: `<baseDir>/profiles`
+- database path: `<baseDir>/state.sqlite`
+
+`createCoreRuntime()` calls `ensureConfigPaths()` immediately, so normal runtime creation always materializes the state root, artifacts directory, and profiles directory even before any LinkedIn action runs.
+
+### 2) Current on-disk inventory
+
+| Location | Owner today | Contents | Sensitivity | Notes for issue #9 |
+| --- | --- | --- | --- | --- |
+| `<baseDir>/state.sqlite` | `AssistantDatabase` | shared SQLite database | High | Required delete target |
+| `<baseDir>/artifacts/<runId>/events.jsonl` | `JsonEventLogger` | structured per-run JSON logs | Medium to high | Required delete target |
+| `<baseDir>/artifacts/<runId>/...` | `ArtifactHelpers`, confirm artifacts, selector audit | screenshots, DOM, accessibility, report JSON, trace zips | High | Required delete target |
+| `<baseDir>/profiles/<profile>/` | `ProfileManager` / Playwright | cookies, local storage, browser cache, session state, `.profile.lock` | Very high | Optional delete target per issue text |
+| `<baseDir>/keepalive/*.pid` | CLI keepalive commands | daemon PID files | Low | Should be deleted |
+| `<baseDir>/keepalive/*.state.json` | CLI keepalive commands | daemon health / last URL / error state | Medium | Should be deleted |
+| `<baseDir>/keepalive/*.events.jsonl` | CLI keepalive commands | daemon event logs | Medium | Should be deleted |
+| `<baseDir>/config.json` | `linkedinPosts.ts` config loader | operator-authored post safety config | Low to medium | Requirement is ambiguous; likely preserve by default |
+| `~/.linkedin-assistant/rate-limit-state.json` | `auth/rateLimitState.ts` | login cooldown state | Low to medium | Should be deleted even though it lives outside `baseDir` |
+
+### 3) SQLite schema and data classes
+
+The SQLite database is shared across the whole tool, not partitioned per profile at the file level.
+The current schema in `packages/core/src/db/migrations.ts` includes:
+
+| Table | Stored data | Sensitivity | Research notes |
+| --- | --- | --- | --- |
+| `prepared_action` | action type, redacted target/payload/preview JSON, token hash, operator note, execution result, errors, optional sealed raw target/payload | High | Most sensitive structured state in the DB |
+| `run_log` | structured event payload JSON per run | Medium to high | Duplicates some data also written to `events.jsonl` |
+| `artifact_index` | artifact paths and metadata | Medium | Index only; actual artifacts live on disk |
+| `rate_limit_counter` | action counters and windows | Low | Local behavior state |
+| `sent_invitation_state` | profile URLs, names, headlines, acceptance/follow-up timestamps | High | Persistent contact graph / outreach history |
+| `account` | profile name, email, display name, status | High if used | Exists in schema, appears unused today |
+| `schema_migrations` | migration bookkeeping | Low | Internal only |
+
+Important deletion implications:
+
+- deleting `state.sqlite` is simpler and safer than table-by-table cleanup
+- future features can add new tables without requiring the deletion command to know each one
+- SQLite sidecar files should be considered too if present:
+  - `state.sqlite-journal`
+  - `state.sqlite-wal`
+  - `state.sqlite-shm`
+
+### 4) Artifact behavior and privacy exposure
+
+The project writes both redacted text/json artifacts and raw binary artifacts.
+
+#### Text / JSON artifacts
+
+`ArtifactHelpers.writeText()` and `ArtifactHelpers.writeJson()` pass data through the privacy redaction layer before writing. This helps for:
+
+- JSON reports
+- DOM dumps stored as text
+- accessibility snapshots stored as JSON
+
+#### Binary artifacts
+
+Binary artifacts are not redacted before persistence.
+Examples in `packages/core/src/confirmArtifacts.ts` and `packages/core/src/selectorAudit.ts` register raw files after Playwright writes them:
+
+- full-page screenshots (`image/png`)
+- Playwright trace archives (`application/zip`)
+
+These files can contain:
+
+- LinkedIn message content
+- profile names and headlines
+- notifications and feed content
+- authenticated URLs and page state
+
+This means artifact deletion is not just hygiene — it is one of the highest-value privacy controls in the repo.
+
+### 5) Browser profile storage is the highest-risk data
+
+`ProfileManager` launches Playwright persistent contexts under `<baseDir>/profiles/<profile>`.
+Those directories can contain:
+
+- session cookies
+- local storage / IndexedDB
+- browser cache
+- remembered MFA / login state
+- Playwright / Chromium lock files such as `.profile.lock`
+
+Issue #9 already calls out `--include-profile`, and that is correct: this is the most sensitive local state. It is also the one area where deletion is most likely to invalidate an operator’s future login state.
+
+### 6) One important off-path file exists today
+
+The auth cooldown helper in `packages/core/src/auth/rateLimitState.ts` stores rate-limit state outside the main tool home:
+
+- `~/.linkedin-assistant/rate-limit-state.json`
+
+This matters because a command that only wipes `LINKEDIN_ASSISTANT_HOME` will leave behind local behavioral state that still changes later CLI behavior.
+A “delete all local data” command should explicitly remove this file too.
+
+## Privacy model implications
+
+### 1) Redaction reduces exposure, but does not remove the need for deletion
+
+Issue #7 added privacy redaction for logs and stored output, but the current defaults still favor retention:
+
+- `LINKEDIN_ASSISTANT_REDACTION_MODE` defaults to `off`
+- `LINKEDIN_ASSISTANT_STORAGE_MODE` defaults to `full`
+
+So out of the box, the tool still stores rich local state unless the operator opts into stronger redaction.
+
+### 2) Prepared actions can still retain recoverable raw payloads
+
+`TwoPhaseCommitService.prepare()` stores redacted JSON in `target_json` / `payload_json`, but when redaction changes the value it also stores sealed originals in:
+
+- `sealed_target_json`
+- `sealed_payload_json`
+
+Those sealed fields are encrypted with a key derived from the confirm token and privacy salt. That is a meaningful improvement over storing plaintext, but it is still persisted local data and should be deleted with the rest of the database.
+
+### 3) Binary artifacts bypass redaction entirely
+
+This is the largest privacy blind spot in the current storage model.
+A screenshot or trace can contain more sensitive page content than the database or JSON logs, even when redaction is enabled.
+
+### 4) “Secure deletion” is a product term that needs care
+
+Issue #9 says “securely delete all local data,” but the current stack is standard filesystem deletion.
+On modern filesystems and SSDs, overwriting files from Node.js does **not** guarantee forensic erasure.
+
+Research takeaway:
+
+- the implementation can reliably remove tool-owned files from the live filesystem view
+- it should avoid overpromising cryptographic or forensic secure erase semantics unless the project defines a stricter threat model
+
+A better interpretation of the current requirement is likely:
+
+- remove all tool-owned local state that the application knows how to manage
+- avoid leaving easy-to-discover residual files behind
+
+## CLI command patterns relevant to `linkedin data delete`
+
+### 1) Commander structure stays thin
+
+The CLI entry point in `packages/cli/src/bin/linkedin.ts` follows a consistent pattern:
+
+- Commander parses input at the CLI layer
+- small `run*()` helpers do the command work
+- structured output is printed via `printJson()`
+- user-facing validation errors use `LinkedInAssistantError`
+
+A future deletion command fits that style well.
+
+### 2) Interactive confirmation precedent already exists
+
+`runConfirmAction()` already implements the repo’s confirmation convention:
+
+- if `--yes` is absent, require `stdin.isTTY` and `stdout.isTTY`
+- otherwise throw `ACTION_PRECONDITION_FAILED`
+- prompt the operator with `Type "yes" to confirm`
+
+Issue #9 explicitly says **no `--yes` bypass**. The existing pattern is still useful, but only the TTY gate + prompt should be reused. The bypass flag should not be added.
+
+### 3) Global `--cdp-url` is a bad fit for deletion
+
+The CLI defines `--cdp-url` as a global option. For most commands this means “attach to an existing browser session instead of using a tool-owned Playwright profile.”
+
+For `data delete`, that is actively misleading:
+
+- attached browser state is outside tool ownership
+- the command cannot safely delete cookies or profile data from an arbitrary external Chrome session
+- accepting `--cdp-url` would imply a capability the tool does not have
+
+Research recommendation:
+
+- explicitly reject `--cdp-url` for `linkedin data delete`
+
+### 4) The normal runtime should probably not be used
+
+This is the most important implementation seam discovered in research.
+
+`createCoreRuntime()` currently:
+
+- resolves config paths
+- creates directories
+- opens `state.sqlite`
+- creates a run-specific artifact directory
+- logs `runtime.started`
+
+`runtime.close()` then logs `runtime.closed`.
+
+That is awkward for a deletion command because it can:
+
+- recreate directories that were just deleted
+- reopen or recreate `state.sqlite`
+- emit logs into paths that are about to be removed
+- fail during teardown if the command deletes its own active log directory first
+
+Research recommendation:
+
+- implement deletion with standalone path + filesystem helpers rather than the full runtime graph
+- only reuse low-level helpers that do **not** create state as a side effect
+
+### 5) Keepalive adds live-process coordination needs
+
+The keepalive daemon stores:
+
+- PID files
+- JSON state files
+- JSONL event logs
+
+It can also keep a profile actively in use.
+That means a deletion command should not assume the filesystem is idle.
+
+At minimum it should:
+
+- detect and stop active keepalive daemons before deleting keepalive/profile state
+- or refuse deletion while a daemon is active and tell the operator how to stop it first
+
+Because keepalive state is under the main tool home, not handling it explicitly risks partial cleanup and confusing stale state.
+
+## Scope and semantics questions raised by the current codebase
+
+### 1) The command is more naturally global than per-profile
+
+Current feature commands are usually profile-scoped, but the stored data is not.
+
+Global/shared state today includes:
+
+- `state.sqlite`
+- `artifacts/`
+- `keepalive/`
+- `~/.linkedin-assistant/rate-limit-state.json`
+
+Only `profiles/<profile>/` is clearly profile-specific.
+
+This makes the issue text `linkedin data delete [--include-profile]` read more naturally as:
+
+- delete all shared tool state
+- optionally also delete all tool-owned Playwright profiles
+
+That is much cleaner than trying to thread a `--profile` flag through a shared database and shared artifacts tree.
+
+### 2) `--include-profile` likely means “all tool-owned profiles”
+
+The singular flag name is slightly ambiguous because the repo supports multiple named profiles.
+Given the rest of the storage model, the least surprising interpretation is:
+
+- without `--include-profile`: keep everything under `<baseDir>/profiles/`
+- with `--include-profile`: remove the whole `<baseDir>/profiles/` tree
+
+### 3) `config.json` is the one obvious policy decision
+
+`linkedinPosts.ts` supports an optional operator-authored config file at:
+
+- `<baseDir>/config.json`
+
+This file is not generated runtime history. It is a user-supplied preference file.
+The issue text does not say whether configuration should be deleted.
+
+Research recommendation:
+
+- preserve `config.json` by default
+- describe the command as deleting runtime state, logs, artifacts, and optional browser profiles
+- only expand to config deletion if the product explicitly wants a “factory reset” behavior
+
+### 4) The deletion log requirement is real but not durable by default
+
+Issue #9 says the command should “log the deletion action itself before wiping.”
+There is a tension here:
+
+- if the command logs into `run_log` or `events.jsonl` and then deletes them, the record is gone
+- if it writes a durable tombstone outside the deletion set, the tool has technically re-created local state immediately after deletion
+
+Research recommendation:
+
+- clarify whether “log before wiping” means transient operational logging or durable audit logging
+- if the intent is only operational traceability, stdout/stderr plus pre-delete JSONL logging is enough
+- if durable audit logging is required, the product needs an explicitly out-of-scope receipt location and a documented privacy tradeoff
+
+## Open issue overlap review
+
+All currently open product issues were reviewed for storage / deletion overlap.
+
+| Issue | Title | Overlap | Notes |
+| --- | --- | --- | --- |
+| #5 | Scheduled follow-ups (local scheduler) | Medium / future | Likely to add more local scheduling state; deleting whole DB + runtime-owned dirs is future-proof |
+| #8 | Internationalization/locale support for selectors | None | No meaningful deletion overlap |
+| #9 | Data deletion command | Direct | Parent feature |
+| #10 | Evaluation harness for draft quality | Medium / future | Likely to add local outputs or artifacts; deletion strategy should prefer deleting owned roots, not table-by-table special cases |
+| #11 | E2E test coverage hardening | Medium | Good future home for destructive command tests and non-interactive refusal coverage |
+| #34 | [Research] Issue #9: Data deletion command | Direct | Current task |
+
+Closed but highly relevant issue:
+
+| Issue | Title | Why it matters |
+| --- | --- | --- |
+| #7 | Privacy/redaction mode for logs and storage | Defines current redaction model, sealed prepared-action fields, and the privacy expectations deletion must complement |
+
+## Recent commits / PRs that matter
+
+As of 2026-03-08 there are no open PRs. The most relevant recent merged changes are:
+
+| Date | Ref | What changed | Why it matters for issue #9 |
+| --- | --- | --- | --- |
+| 2026-02-23 | `44d8f4b` | hardened auth isolation and added keepalive daemon | Introduced keepalive state files and active-process coordination needs |
+| 2026-03-08 | PR #15 / `338eb4d` | added privacy redaction for logs and stored output | Clarifies what is redacted, what is sealed, and what still needs deletion |
+| 2026-03-08 | PR #13 / `740280c` | added confirm-failure artifact capture | Increased the volume and sensitivity of raw artifacts stored on disk |
+| 2026-03-08 | PR #16 / `f0c0ff5` | added post safety lint config via `config.json` and env overrides | Introduced an operator-authored config file inside the tool home |
+| 2026-03-08 | PR #26 / `d6aa8c2` | added selector audit command | Added another path that writes reports and failure artifacts under the shared artifacts tree |
+| 2026-02-24 | `6dc8a92` | hardened auth, feed reactions, connections, jobs, notifications, profile, and search flows | Reinforces that artifacts/logs can now span many feature areas, not just messaging |
+
+## Dependency graph for a future deletion command
+
+### Low-level modules that matter most
+
+| Module | Why it matters |
+| --- | --- |
+| `packages/core/src/config.ts` | source of truth for base, artifacts, profiles, and SQLite paths |
+| `packages/core/src/auth/rateLimitState.ts` | source of truth for the off-path cooldown file |
+| `packages/cli/src/bin/linkedin.ts` | current home of keepalive path helpers and interactive prompt helpers |
+| `packages/core/src/profileManager.ts` | defines profile directory layout and lock file behavior |
+| `packages/core/src/db/database.ts` | proves DB creation is eager and file-level deletion is safer than row-level cleanup |
+| `packages/core/src/logging.ts` | explains why the standard runtime logging lifecycle conflicts with self-deletion |
+| `packages/core/src/artifacts.ts` | defines run-directory artifact layout |
+| `packages/core/src/confirmArtifacts.ts` | demonstrates that screenshots and traces are raw, high-sensitivity delete targets |
+| `packages/core/src/selectorAudit.ts` | adds more report and failure-artifact files under the shared artifacts tree |
+
+### Modules that are less useful to reuse directly
+
+| Module | Why it is a weak fit |
+| --- | --- |
+| `packages/core/src/runtime.ts` | creates state eagerly and logs on close |
+| `packages/core/src/twoPhaseCommit.ts` | relevant for understanding stored data, but not for implementing deletion behavior |
+| feature modules such as inbox/feed/connections/posts | important because they create data, not because they should drive deletion |
+
+## Main risks and takeaways
+
+### 1) Avoid partial deletion
+
+A command that removes only `state.sqlite` and `artifacts/` would still leave behind:
+
+- persistent browser profiles
+- keepalive files
+- rate-limit cooldown state
+- possibly SQLite sidecars
+
+That would not match the user-facing promise of deleting local data.
+
+### 2) Avoid using the standard runtime graph
+
+The repo’s normal runtime lifecycle is optimized for feature execution, not self-cleanup.
+Deletion should be a special-case filesystem workflow.
+
+### 3) Treat external browser sessions as out of scope
+
+`--cdp-url` is for attaching to an existing browser, not for owning its data.
+A delete command should reject that mode explicitly.
+
+### 4) Be precise about what “secure” means
+
+The feature can remove application-managed state reliably.
+It should not imply guaranteed forensic wipe semantics on all filesystems unless the product adopts a stronger, platform-specific strategy.
+
+### 5) Expect destructive-command testing to be special
+
+This command will need targeted test strategy later because it is:
+
+- destructive
+- interactive-only
+- process-sensitive when keepalive is running
+- path-sensitive because one file lives outside `LINKEDIN_ASSISTANT_HOME`
+
+## Research conclusion
+
+Issue #9 is feasible with the current codebase, but the implementation should be framed as a **filesystem-level local-state wipe**, not as just another runtime-backed command.
+
+The most important conclusions from this research are:
+
+- deletion scope is broader than the issue summary alone suggests
+- the command should likely be global, not profile-scoped
+- `--cdp-url` should be rejected
+- `config.json` needs an explicit product decision
+- the standard runtime boot/close path should probably be avoided
+- binary artifacts and browser profiles are the strongest privacy drivers for the feature
+- “logs the deletion action itself” needs a clarified durability expectation
+
+That should give the planning / implementation phases a clean starting point without rediscovering the storage map or the privacy tradeoffs.


### PR DESCRIPTION
## Summary
- add `docs/.research-brief-issue-9.md` for the phase-0 research task behind issue #9
- map the current storage footprint across SQLite, artifacts, keepalive state, Playwright profiles, config, and the off-path auth cooldown file
- document the CLI conventions and privacy constraints that shape a future `linkedin data delete` implementation

## Why
The delete command needs to account for shared-vs-profile scope, runtime side effects, raw binary artifacts, and the off-path rate-limit state file. Capturing those constraints now keeps the later planning and build phases focused.

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

Closes #34
