### PR TITLE
docs: research selector locale support for issue #8

### DIFF
--- a/docs/.research-brief-issue-33.md
+++ b/docs/.research-brief-issue-33.md
@@ -1,0 +1,352 @@
+# Research brief — issue #33 i18n / locale support for selectors
+
+Reviewed on: 2026-03-08  
+Related issues: #33, #8, #4
+
+## Executive summary
+
+The repo does **not** currently have a locale-aware selector layer.
+Support for non-English LinkedIn UIs is mainly blocked by English text embedded directly inside:
+
+- `getByRole(..., { name: /.../i })`
+- `aria-label` contains selectors
+- `:has-text(...)` / `hasText` checks
+- `page.evaluate()` heuristics that look for English section headings or English state words
+
+The safest implementation path for issue #8 is **additive**, not architectural:
+
+- keep selectors close to the feature modules that already use them
+- add one small shared locale dictionary + selector-builder layer for text-bearing selectors
+- keep non-language selectors (URLs, structural CSS, `data-*`, stable classes, scoped containers) as the preferred stable path
+- thread an explicit selector locale through config/runtime/CLI/MCP
+- use selector audit as the read-only validation surface for locale coverage and fallback behavior
+
+The highest-risk modules are:
+
+- `packages/core/src/selectorAudit.ts`
+- `packages/core/src/linkedinConnections.ts`
+- `packages/core/src/linkedinFeed.ts`
+- `packages/core/src/linkedinInbox.ts`
+- `packages/core/src/auth/sessionInspection.ts`
+- `packages/core/src/linkedinProfile.ts`
+- `packages/core/src/linkedinNotifications.ts`
+
+## What issue #8 requires
+
+Issue #8 asks for:
+
+- per-locale text dictionaries for text-based selectors
+- preference for aria labels and stable attributes over text matching
+- a configurable locale setting
+- graceful fallback across locale-specific text and English
+
+There is one important ambiguity to resolve before implementation:
+
+- the project spec says selector resilience should be `role -> attribute -> text`
+- issue #8 says to prefer aria labels and stable attributes over text matching
+- issue #8 also says fallback should try locale-specific text, then English, then attribute-based
+
+Those instructions are not fully aligned.
+The cleanest interpretation is:
+
+- treat **non-language attributes** as the most stable fallback (`href`, `data-*`, structural classes, scoped containers)
+- treat **`aria-label` as locale-sensitive text**, not as a universally stable attribute
+- keep broad free-text matching as the loosest fallback
+
+That gives a practical order of preference:
+
+1. scoped role-based locators
+2. scoped non-language attributes / structural selectors
+3. locale-specific accessible-name / `aria-label` / text matches
+4. English accessible-name / `aria-label` / text matches
+5. last-resort broad CSS fallbacks
+
+## Current selector architecture
+
+The codebase currently uses three selector styles.
+
+| Pattern | Main files | Current shape | Locale impact |
+| --- | --- | --- | --- |
+| Central selector audit registry | `packages/core/src/selectorAudit.ts` | `SelectorAuditPageDefinition` with `primary` / `secondary` / `tertiary` candidate factories | High |
+| Feature-local mutation selectors | `packages/core/src/linkedinInbox.ts`, `packages/core/src/linkedinConnections.ts`, `packages/core/src/linkedinFeed.ts`, `packages/core/src/linkedinPosts.ts`, `packages/core/src/linkedinFollowups.ts` | local `{ key, selectorHint, locatorFactory }` or `VisibleLocatorCandidate[]` arrays plus ordered probing helpers | High |
+| Read-only scraping heuristics | `packages/core/src/linkedinProfile.ts`, `packages/core/src/linkedinNotifications.ts`, `packages/core/src/linkedinSearch.ts`, `packages/core/src/linkedinJobs.ts` | ordered CSS arrays and `pickText` / `pickHref` helpers inside `page.evaluate()` | Medium |
+
+### 1) The selector audit registry is centralized, but only for audit
+
+`packages/core/src/selectorAudit.ts` is the only true registry-like selector surface in the repo.
+It currently hard-codes English expectations for all five built-in pages:
+
+- feed
+- inbox
+- profile
+- connections
+- notifications
+
+Examples of English-only audit probes today include:
+
+- `start a post`
+- `write a message`
+- `connections`
+- `notifications`
+- `about`, `experience`, `education`, `resources`, `open to`
+- `ago`
+
+This means the selector audit will report failures or fallback usage on non-English LinkedIn sessions even when the underlying UI is healthy.
+
+### 2) Mutation flows use local candidate arrays and ordered probing
+
+The strongest selector pattern in the repo is already close to what issue #8 needs:
+
+- candidate arrays with `key`, `selectorHint`, and `locatorFactory`
+- ordered fallback probing
+- narrow scoping to a top card, post root, dialog, or composer root
+- `UI_CHANGED_SELECTOR_FAILED` errors with `selector_key` and `attempted_selectors`
+
+This is good news.
+Locale support does **not** require rewriting the automation model.
+It mainly requires changing how text-bearing candidates are produced.
+
+### 3) Read-only scrapers mix structural selectors with English text heuristics
+
+The read-only services are less likely to click the wrong thing, but they can silently degrade data quality.
+Their risks are different:
+
+- `linkedinProfile.ts` looks for English section headings like `about`, `experience`, and `education`
+- `linkedinNotifications.ts` infers type and read state from English words like `message`, `comment`, `reaction`, `follow`, `unread`, and `read`
+- `linkedinSearch.ts` and `linkedinJobs.ts` are mostly structural and URL-based, so they are lower risk
+
+## Locale-sensitive hotspots by module
+
+| File | English assumptions today | Why it matters |
+| --- | --- | --- |
+| `packages/core/src/selectorAudit.ts` | `start a post`, `messaging`, `write a message`, `connections`, `notifications`, `about`, `experience`, `education`, `ago` | The built-in audit becomes noisy or misleading on non-English sessions |
+| `packages/core/src/linkedinConnections.ts` | `Connect`, `More`, `Add a note`, `Send`, `Send without a note`, `Pending`, `Withdraw`, `invitation sent`, plus invitation card filters like `/withdraw|sent/` and `/accept|ignore|decline|respond/` | Highest mutation risk; can fail to find controls or fail to verify invitation state |
+| `packages/core/src/linkedinFeed.ts` | reaction labels (`Like`, `Celebrate`, `Support`, `Love`, `Insightful`, `Funny`), `Comment`, `Add a comment`, `Post` | Affects both selector matching and canonical reaction-to-UI mapping |
+| `packages/core/src/linkedinInbox.ts` | `Write a message`, `message`, `Send` | Directly affects reply confirmation flow |
+| `packages/core/src/auth/sessionInspection.ts` | `button[aria-label*='Me']` | Can falsely report a healthy non-English session as unauthenticated |
+| `packages/core/src/linkedinProfile.ts` | `about`, `experience`, `education`, plus `1st|2nd|3rd` degree parsing | Read-only profile extraction can silently return partial data |
+| `packages/core/src/linkedinNotifications.ts` | `message`, `job`, `comment`, `reaction`, `like`, `mention`, `connection`, `invite`, `follow`, `unread`, `new`, `read` | Notification typing and unread detection are language-sensitive today |
+| `packages/core/src/linkedinPosts.ts` | visibility labels like `Public`, `Anyone`, `Connections`, `Connections only` | Locale support for post creation will need the same dictionary approach |
+| `packages/core/src/linkedinFollowups.ts` | inbox-like message composer and send-button selectors | Likely benefits automatically once shared messaging selector helpers exist |
+
+## What is already relatively locale-safe
+
+Some existing selector shapes should be preserved because they are mostly language-independent:
+
+- `a[href*='/messaging/thread/']`
+- `a[href*='/in/']`
+- `button.msg-form__send-button`
+- `.msg-form__contenteditable[contenteditable='true']`
+- `div[data-urn]`
+- `.nt-card`, `.notification-card`
+- structural containers such as profile headers, feed posts, and search result cards
+
+These are the selectors that should remain the preferred fallback path wherever LinkedIn keeps them stable.
+
+## Recommended design for issue #8
+
+### 1) Add one small shared locale layer in core
+
+Do **not** centralize every selector in the repo.
+Instead, add a focused helper module in `packages/core/src/` that provides:
+
+- a supported selector-locale type
+- semantic phrase keys
+- per-locale phrase dictionaries
+- builder helpers for `getByRole`, `aria-label`, and text selectors
+
+Suggested shape:
+
+```ts
+export type LinkedInSelectorLocale = "en" | "<second-locale>";
+
+export type LinkedInSelectorTextKey =
+  | "send"
+  | "write_message"
+  | "connect"
+  | "more"
+  | "add_note"
+  | "pending"
+  | "withdraw"
+  | "comment"
+  | "add_comment"
+  | "post"
+  | "start_post"
+  | "notifications"
+  | "connections"
+  | "about"
+  | "experience"
+  | "education"
+  | "unread"
+  | "read";
+```
+
+Then expose small helpers such as:
+
+- `getSelectorPhrases(key, locale)`
+- `buildLocalizedNameRegex(key, locale)`
+- `buildLocalizedAriaContainsSelector(key, locale)`
+- `buildLocaleFallbackRegex(key, locale, { includeEnglish: true })`
+
+### 2) Keep English API values canonical
+
+Public inputs should remain stable and English-like even when UI labels vary.
+For example:
+
+- feed reaction inputs should still normalize to canonical values like `like`, `support`, `funny`
+- post visibility should still normalize to canonical values like `public` and `connections`
+
+Only the selector-facing UI phrases should change by locale.
+
+### 3) Prefer explicit configuration over implicit detection
+
+Issue #8 requires a configurable locale setting.
+That should be the source of truth.
+
+Recommended approach:
+
+- add selector locale resolution in `packages/core/src/config.ts`
+- thread it into `CreateCoreRuntimeOptions` and `CoreRuntime`
+- expose it through the CLI and MCP surfaces
+
+Optional detection such as `document.documentElement.lang` or browser language can still be logged for diagnostics, but it should not replace explicit config in the first pass.
+
+### 4) Build locale-aware selector audit first
+
+The audit path is the safest first implementation target because it is read-only and already centralized.
+
+Recommended approach:
+
+- generate a locale-aware selector audit registry from one dictionary source
+- keep the page IDs and selector keys stable
+- keep `primary` / `secondary` / `tertiary` semantics stable unless a migration is absolutely necessary
+
+One implementation constraint matters here:
+
+- the audit validator rejects duplicate strategies inside a selector group
+
+That means locale support should be implemented by either:
+
+- building a per-locale registry, or
+- making one candidate factory handle multiple localized phrases inside the same strategy
+
+Avoid naively cloning `primary` or `secondary` entries once per locale phrase.
+
+### 5) Retrofit mutation flows incrementally
+
+Recommended order after audit:
+
+1. `packages/core/src/auth/sessionInspection.ts`
+2. `packages/core/src/linkedinInbox.ts`
+3. `packages/core/src/linkedinConnections.ts`
+4. `packages/core/src/linkedinFeed.ts`
+5. `packages/core/src/linkedinPosts.ts`
+6. `packages/core/src/linkedinFollowups.ts`
+7. `packages/core/src/linkedinProfile.ts`
+8. `packages/core/src/linkedinNotifications.ts`
+
+This order reduces risk by fixing session detection first, then the highest-value mutation paths, and finally the read-only extraction heuristics.
+
+## Main regression risks
+
+### 1) Candidate ordering drift
+
+The repo already treats candidate order as meaningful.
+Changing order can change:
+
+- which selector actually wins
+- which selector key gets recorded in success/failure payloads
+- whether selector audit reports a fallback or a primary match
+
+Mitigation:
+
+- keep existing selector keys wherever possible
+- make locale support generate the same logical candidate groups, not brand-new ones
+
+### 2) Over-broad localized text matches
+
+Adding more phrases increases false-positive risk, especially for common words like:
+
+- `Send`
+- `More`
+- `Comment`
+- `Post`
+- `Connect`
+
+Mitigation:
+
+- preserve scoping to `topCardRoot`, `composerRoot`, `postRoot`, and dialog roots
+- prefer exact or anchored matches when the control text is short
+
+### 3) Auth false negatives
+
+The current session inspection code depends on English `Me`.
+If that is not fixed early, non-English users may fail before any selector fallback logic runs.
+
+Mitigation:
+
+- remove or localize the `Me` dependency as part of the first implementation slice
+
+### 4) Silent read-only extraction regressions
+
+Mutation flows usually throw when selectors fail.
+Read-only scrapers often do not.
+They may simply return emptier or lower-quality data.
+
+Mitigation:
+
+- add targeted tests for profile section extraction and notification classification
+- prefer structural selectors over text heuristics where possible
+
+### 5) Audit output churn
+
+Selector audit reports are operator-facing.
+If selector keys, strategy names, or failure messages change too much, maintenance workflows get noisier.
+
+Mitigation:
+
+- keep report schema stable
+- preserve selector keys even if the phrase builder changes internally
+
+### 6) Canonical UI labels vs canonical API values
+
+Reaction names and visibility names are currently doing double duty as both user inputs and UI labels.
+Locale support will break that assumption if it is not split cleanly.
+
+Mitigation:
+
+- keep public enums canonical
+- store UI phrases in locale dictionaries only
+
+### 7) English-locked tests
+
+Most current selector-oriented tests and selector-audit fixtures assume English labels and English selector hints.
+
+Mitigation:
+
+- add dictionary-level tests
+- add locale-aware selector-audit tests
+- update service tests to assert fallback behavior rather than specific English strings when appropriate
+
+## Suggested phase-1 acceptance plan
+
+To satisfy issue #8 without over-scoping:
+
+1. add explicit selector locale config with default `en`
+2. support English plus one additional locale that the team can validate in a real LinkedIn session
+3. make selector audit locale-aware and keep its JSON schema stable
+4. update the session-inspection, inbox, connections, and feed flows to use shared phrase builders
+5. cover dictionary resolution, fallback order, and audit registry generation in unit tests
+6. run selector audit against both locales before shipping
+
+## Bottom line
+
+Issue #8 is very feasible in this codebase, but only if it stays **narrow and additive**.
+The repo already has strong selector fallback conventions and good failure reporting.
+The missing piece is not a wholesale selector rewrite; it is a shared way to express **locale-specific UI phrases** without losing the current scoping, fallback ordering, and error telemetry.
+
+That makes the recommended next step clear:
+
+- implement one small selector-locale helper layer in core
+- wire it into selector audit first
+- then retrofit the highest-risk mutation flows with minimal churn


### PR DESCRIPTION
## Summary\n- add a research brief for issue #33 covering the current selector architecture\n- document the main locale-sensitive selector hotspots across audit, auth, inbox, connections, feed, profile, notifications, and posts\n- outline the recommended additive implementation path and the main regression risks for issue #8\n\n## Validation\n- npm run typecheck\n- npm run lint\n- npm test\n- npm run build\n\nCloses #33