### PR TITLE
docs: plan issue #9 data deletion command

### DIFF
--- a/docs/.plan-issue-9.md
+++ b/docs/.plan-issue-9.md
@@ -1,0 +1,297 @@
+# Execution plan — issue #9 data deletion command
+
+## Intent
+
+Implement issue #9 as a **filesystem-first CLI workflow** that inventories and removes tool-owned local state **without** booting the normal runtime.
+The parent issue names the command as:
+
+- `linkedin data delete [--include-profile]`
+
+Based on `docs/.research-brief-issue-9.md`, the cleanest first implementation is a **global local-state wipe** with an **optional browser-profile wipe**, not a per-profile cleanup command.
+Most stored state today is shared across profiles, so the command should act on owned storage roots rather than try to surgically partition shared state.
+
+This plan assumes the command deletes **runtime state, logs, artifacts, keepalive files, and rate-limit state**, while **preserving `config.json` by default**.
+That keeps the feature aligned with privacy cleanup without turning it into a full factory reset unless product direction changes later.
+
+## Recommended approach
+
+### 1) Treat deletion as a standalone local-state workflow
+
+The most important implementation choice is to **avoid `createCoreRuntime()` entirely**.
+The current runtime boot path creates directories, opens `state.sqlite`, applies migrations, starts run logging, and logs again on shutdown.
+That behavior is a poor fit for a command whose whole purpose is to remove those paths.
+
+The deletion command should instead:
+
+- resolve the owned filesystem paths up front
+- build an inventory of what exists
+- print that inventory in dry-run mode
+- delete those paths with `node:fs/promises` helpers during the destructive phase
+
+This is the right place for a small, standalone core helper module.
+It should depend on path resolution and filesystem operations only, not on the runtime graph, DB construction, or feature services.
+
+### 2) Make the scope explicit: shared state first, profiles only by opt-in
+
+The research brief shows that the tool stores data in more places than the parent issue summary alone suggests.
+A good first-pass scope is:
+
+#### Always delete
+
+- `<baseDir>/state.sqlite`
+- SQLite sidecars when present:
+  - `<baseDir>/state.sqlite-journal`
+  - `<baseDir>/state.sqlite-wal`
+  - `<baseDir>/state.sqlite-shm`
+- `<baseDir>/artifacts/`
+- `<baseDir>/keepalive/`
+- `~/.linkedin-assistant/rate-limit-state.json`
+
+#### Delete only with `--include-profile`
+
+- `<baseDir>/profiles/`
+
+#### Preserve by default
+
+- `<baseDir>/config.json`
+
+That means `--include-profile` should likely mean **all tool-owned Playwright profiles**, not a single named profile.
+Trying to make this command profile-scoped would immediately run into shared DB, artifact, keepalive, and rate-limit state.
+If the product later wants selective profile cleanup, that can be a follow-up issue with a narrower scope.
+
+### 3) Make dry-run unavoidable in practice
+
+Issue #45 calls out dry-run as mandatory before destructive work.
+The exact flag surface can stay flexible, but the operator should **always see the deletion inventory before removal begins**.
+
+One reasonable first implementation is:
+
+- default to a dry-run report when the operator runs `linkedin data delete`
+- allow `linkedin data delete --include-profile` to still be a dry-run preview, just with a wider scope
+- require an explicit destructive mode for the second invocation
+- keep the dry-run and delete output shapes closely aligned so the preview matches the real action
+
+The key invariant matters more than the exact flag spelling:
+
+- the command must have a non-destructive preview mode
+- the preview must cover every owned state location
+- the destructive phase should not proceed until the operator has seen what will be removed
+
+### 4) Keep confirmation interactive only, with no bypass flag
+
+The command should follow the repo’s current confirmation style for TTY gating, but **not** its `--yes` bypass.
+The existing `promptYesNo()` and `stdin.isTTY` / `stdout.isTTY` checks are good precedents.
+
+A solid first-pass UX would be:
+
+- refuse to run destructively in non-interactive mode
+- print a clear inventory summary immediately before deletion
+- prompt the operator explicitly before any files are removed
+- make the prompt stronger when `--include-profile` is present because browser sessions and cookies will be lost
+
+Reusing `Type "yes" to confirm` is acceptable.
+If the builder prefers a stronger prompt for profile deletion, that is fine as long as it stays additive and does not introduce a bypass path.
+
+### 5) Reject external-browser mode explicitly
+
+`--cdp-url` is appropriate for normal browser automation, but it is the wrong abstraction for local-state deletion.
+The tool can only delete **tool-owned filesystem state**.
+It cannot promise deletion of cookies or storage inside an arbitrary externally managed Chrome session.
+
+The plan should therefore assume:
+
+- `linkedin data delete` rejects `--cdp-url`
+- the error message explains that attached browser data is outside tool ownership
+
+### 6) Centralize owned-path discovery before writing deletion logic
+
+The most valuable reusable code here is not the delete loop itself; it is the **owned-path inventory**.
+That inventory should know how to resolve:
+
+- `baseDir`, `artifactsDir`, `profilesDir`, and `dbPath`
+- SQLite sidecar files
+- the keepalive directory and/or per-profile keepalive files
+- the operator-authored `config.json`
+- the off-path rate-limit cooldown file
+
+This can live either in a new helper module or in a small extension around `config.ts`.
+The important thing is to avoid burying deletion ownership rules inside `packages/cli/src/bin/linkedin.ts` string concatenation.
+
+### 7) Treat keepalive daemons as a precondition, not an afterthought
+
+Deletion can race with live keepalive daemons or active profile locks.
+The safest first implementation is probably:
+
+- recover stale keepalive PID files automatically
+- detect any live keepalive daemons before deleting keepalive/profile state
+- refuse deletion while a live daemon is still running
+- tell the operator which `linkedin keepalive stop --profile ...` command to run first
+
+Auto-stopping daemons could be a later enhancement, but shipping deletion without a live-process guard would make partial cleanup and confusing failures more likely.
+
+### 8) Keep deletion logging explicit about durability
+
+Issue #9 says the command should log the deletion action itself before wiping.
+This is real, but it should not push the implementation back toward the normal runtime logger.
+
+The clean interpretation for the first implementation is:
+
+- use structured stdout / JSON output for the dry-run report and final result
+- optionally emit a one-shot pre-delete log line to the console
+- do **not** rely on `run_log` or `events.jsonl` as the durable audit record, because those are part of what is being deleted
+
+If the product later wants durable deletion receipts, that should be an explicit follow-up with a documented retention/privacy tradeoff.
+
+## Suggested files to touch, in order
+
+1. `packages/core/src/dataDeletion.ts`
+   - Add the standalone path inventory types, dry-run report types, best-effort size calculation, and deletion executor.
+   - Keep this module filesystem-first and runtime-free.
+
+2. `packages/core/src/auth/rateLimitState.ts`
+   - Export the default rate-limit state path or a tiny public resolver so deletion code can discover the off-path file without copying private path logic.
+
+3. `packages/core/src/config.ts`
+   - Optionally add small path helpers if that keeps ownership rules centralized.
+   - Keep this light; the goal is path discovery, not a new configuration layer.
+
+4. `packages/core/src/index.ts`
+   - Re-export the deletion helper and its report types for CLI use.
+   - No runtime wiring should be required.
+
+5. `packages/cli/src/bin/linkedin.ts`
+   - Add a `data` command group and a `delete` subcommand.
+   - Keep the CLI thin: parse flags, reject `--cdp-url`, call the core helper, print dry-run/delete output, and prompt interactively.
+
+6. `packages/core/src/__tests__/dataDeletion.test.ts`
+   - Add focused tests for path inventory, sidecar discovery, config preservation, profile opt-in, dry-run reporting, and idempotent deletion.
+
+7. `packages/cli/test/linkedinDataDelete.test.ts`
+   - Add CLI-focused tests if the command grows enough branching to justify them.
+   - If bin-level testing is awkward, extract the smallest reasonable helper(s) and test those instead.
+
+8. `README.md` or command docs only if the repo’s CLI documentation is being kept current elsewhere
+   - This should stay secondary to the implementation and tests.
+
+## Existing utilities and patterns to reuse
+
+### Reuse directly
+
+- `packages/core/src/config.ts`
+  - reuse `resolveConfigPaths()` for the base, artifacts, profiles, and DB roots
+- `packages/core/src/auth/rateLimitState.ts`
+  - reuse the existing file-clearing behavior and expose path resolution rather than duplicating it
+- `packages/core/src/errors.ts`
+  - use `LinkedInAssistantError` for non-interactive refusal, unsupported `--cdp-url`, and active-keepalive preconditions
+- `packages/cli/src/bin/linkedin.ts`
+  - reuse `printJson()` for structured output
+  - reuse the thin `run*()` helper style for command implementation
+  - reuse `promptYesNo()` and the current TTY checks as the confirmation precedent
+
+### Reuse conceptually, but not literally
+
+- Commander organization: parse in CLI, implement in small helpers
+- structured operator-facing output, but not the runtime-backed `JsonEventLogger`
+- additive re-exports via `packages/core/src/index.ts`
+
+### Avoid reusing for this command
+
+- `packages/core/src/runtime.ts`
+- `packages/core/src/db/database.ts`
+- `packages/core/src/twoPhaseCommit.ts`
+- feature modules such as inbox/feed/connections/posts
+- MCP wiring in `packages/mcp/`
+
+This feature is local housekeeping, not a normal LinkedIn runtime action.
+
+## Test strategy
+
+The first implementation should stay in unit and CLI-focused tests.
+No real LinkedIn E2E coverage is needed for the deletion feature itself.
+
+Recommended coverage:
+
+- inventory includes all expected owned paths
+- inventory omits `profiles/` unless `--include-profile` is enabled
+- inventory preserves `config.json` by default
+- dry-run reports missing paths cleanly instead of failing
+- delete execution is idempotent when some targets are already gone
+- SQLite sidecars are removed with the main DB file
+- stale keepalive PID files do not block deletion
+- live keepalive detection blocks deletion with a helpful error
+- non-interactive destructive execution is refused
+- `--cdp-url` is refused for this command
+
+One extra testing guardrail is worth planning up front: keep the filesystem helper injectable enough that tests do **not** touch the operator’s real home directory.
+That is especially important for the off-path rate-limit file.
+
+## Main risks to watch
+
+### 1) Recreating state during deletion
+
+Any code path that boots the normal runtime can recreate the very directories and DB file the command is trying to remove.
+That is the main architectural trap.
+
+### 2) Partial deletion
+
+Deleting only `state.sqlite` and `artifacts/` would leave behind browser profiles, keepalive files, the rate-limit cooldown file, or SQLite sidecars.
+The operator-facing promise is broader than that.
+
+### 3) Live-process conflicts
+
+Keepalive daemons or active profile locks can make deletion flaky or partial if they are not detected first.
+
+### 4) Scope confusion
+
+The command name can sound profile-scoped, but the storage model is mostly global.
+The UX and help text should make that clear.
+
+### 5) Overpromising “secure deletion”
+
+The implementation can remove application-managed files from the filesystem view.
+It should not imply guaranteed forensic erasure on SSDs or all filesystems unless the product chooses a stronger platform-specific strategy.
+
+### 6) Accidental config loss
+
+`config.json` is operator-authored state, not just runtime residue.
+Deleting it by default would change the feature from “privacy cleanup” to “factory reset.”
+
+### 7) Tests touching real state
+
+Because one owned file lives outside `LINKEDIN_ASSISTANT_HOME`, the first implementation should keep path resolution overridable enough for safe tests.
+
+## Guardrails
+
+### Do touch
+
+- a new standalone core deletion helper
+- minimal path-resolution helpers
+- CLI wiring for `data delete`
+- focused tests around dry-run, deletion, and refusal behavior
+
+### Do not touch unless the implementation proves it is necessary
+
+- `packages/core/src/runtime.ts`
+- `packages/core/src/profileManager.ts`
+- `packages/core/src/db/database.ts`
+- `packages/core/src/twoPhaseCommit.ts`
+- `packages/mcp/src/bin/linkedin-mcp.ts`
+- feature modules under `packages/core/src/linkedin*.ts`
+
+### Leave room for the builder
+
+The plan should stay opinionated about invariants, not about every flag spelling.
+There is room to choose the exact dry-run/apply flag surface and whether keepalive handling begins as “refuse only” or grows into a stop-first flow later.
+The important part is to keep the first implementation:
+
+- filesystem-first
+- global in scope for shared state
+- explicit about profile deletion
+- interactive for destructive work
+- well covered by focused tests
+
+## Implementation compass
+
+If the builder ends up with a small path-inventory layer, one standalone core deletion helper, thin CLI wiring, and targeted tests, the work is probably on the right track.
+
+If the builder starts routing deletion through `createCoreRuntime()`, using the shared DB as a deletion control plane, adding two-phase commit, or trying to make the first version profile-scoped inside shared tables, the work has probably drifted out of scope.


### PR DESCRIPTION
## Summary
- add `docs/.plan-issue-9.md` with a filesystem-first execution plan for issue #9
- recommend global shared-state deletion with optional profile deletion and dry-run-first UX
- call out files to touch, patterns to reuse, and the runtime boot constraint to avoid eager DB recreation

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

Closes #45