### PR TITLE
docs: add issue #5 local scheduler execution plan

### DIFF
--- a/docs/.plan-issue-5.md
+++ b/docs/.plan-issue-5.md
@@ -1,0 +1,389 @@
+# Execution plan — issue #5 scheduled follow-ups (local scheduler)
+
+## Intent
+
+Implement issue #5 as a **local, operator-visible scheduler** that notices accepted invitations, queues follow-up preparation work, and prepares those follow-ups near the review window while keeping **manual confirm** in place.
+
+The implementation should **extend the current accepted-connection follow-up flow** instead of inventing a second outbound action system. The existing prepare → confirm safety model, `sent_invitation_state`, and follow-up status metadata are already the hard part.
+
+Phase-1 scope should stay deliberately narrow:
+
+- the scheduler is local-only
+- follow-up preparation is the only mutating lane
+- confirmation remains manual
+- pending-invite refresh can remain an internal precursor instead of a separate product surface
+- inbox/feed lanes can stay disabled or placeholder-only until they have a real queueing policy
+
+Treat `docs/.research-brief-issue-5.md` and the issue body as the source of truth. The `PROJECT.md` references in the parent issue are stale.
+
+## Recommended approach
+
+### 1) Add a scheduler layer, not a new action engine
+
+The scheduler should sit **above** `LinkedInFollowupsService` and `TwoPhaseCommitService`.
+Its job is orchestration:
+
+- decide when work is due
+- lease and dispatch jobs safely
+- respect business hours
+- reschedule on transient failures
+- keep operator-visible state
+
+It should not:
+
+- send messages directly
+- bypass prepared actions
+- invent a second notion of follow-up completion
+
+A good first shape is a new core module such as `packages/core/src/scheduler.ts` plus a thin CLI daemon surface.
+
+### 2) Model the work as detection → enqueue → prepare
+
+The scheduler should avoid repeatedly calling the current batch prepare flow on a sliding window and hoping idempotency is enough.
+
+A cleaner phase-1 flow is:
+
+1. refresh sent invitation state
+2. detect newly accepted invitations
+3. enqueue or upsert one scheduler job per accepted connection
+4. when the job becomes due inside business hours, prepare that single follow-up
+5. record the prepared action id on both the job row and `sent_invitation_state`
+
+This keeps the responsibilities clear:
+
+- `sent_invitation_state` remains the source of truth for invitation/follow-up lifecycle
+- the scheduler job table becomes the operational queue for timing, retries, and leasing
+
+### 3) Extract a single-target follow-up prepare path
+
+The current `prepareFollowupsAfterAccept()` API is batch-oriented, which is right for manual CLI use but awkward for a job queue.
+
+The implementation should likely expose one reusable path that can prepare a follow-up for a single accepted connection by stable identity, such as `profile_url_key`, while keeping the current batch API as a thin wrapper over that lower-level helper.
+
+That gives the scheduler:
+
+- one job mapped to one target
+- clean retry semantics
+- simpler dedupe rules
+- less risk of preparing extra follow-ups during one job run
+
+### 4) Keep the scheduler separate from keepalive
+
+The keepalive daemon is the best existing operator-control pattern, but its responsibility is health, not job orchestration.
+
+Reuse the keepalive shape:
+
+- detached CLI process
+- pid/state/event files under the tool home directory
+- start/status/stop commands
+- jittered polling loop
+- graceful shutdown
+
+But keep the implementation separate so the scheduler can own:
+
+- DB-backed job selection
+- due-time evaluation
+- backoff
+- lane ordering
+- preparation results
+- scheduler-specific observability
+
+### 5) Use additive config with an explicit timezone policy
+
+Issue #5 needs config that the repo does not currently have.
+Add it intentionally in `packages/core/src/config.ts` instead of scattering scheduler flags or magic constants across the CLI.
+
+The first version likely needs:
+
+- enable/disable switch
+- poll interval
+- business-hours start and end
+- timezone
+- lane enablement or a single active-lane list
+- retry/backoff defaults
+
+Prefer a simple window-based model over cron-like complexity unless the implementation proves otherwise. Built-in date/time APIs are probably enough for the first pass.
+
+### 6) Keep runtime instances short-lived
+
+A long-lived scheduler daemon should not hold one giant runtime forever.
+`createCoreRuntime()` creates a single `runId`, artifact directory, logger, and DB handle that fit short CLI commands much better than an always-on loop.
+
+Prefer:
+
+- a thin daemon loop
+- a fresh runtime per tick or per claimed job batch
+
+This keeps artifacts and logs understandable and avoids one noisy perpetual run directory.
+
+### 7) Start with one real lane, not a generalized orchestration framework
+
+It is fine to define lane enums or status names that leave room for future scheduler lanes.
+It is not necessary to implement real inbox triage or feed engagement yet.
+
+Phase 1 should only execute the lane that is already scheduler-ready:
+
+- `followup_preparation`
+
+If the builder wants lane ordering from day one, keep it simple and static.
+Do not block the feature on a priority engine.
+
+## Suggested implementation slices
+
+### Slice 1: Storage and state
+
+Add the scheduler job table, indexes, and database helpers first.
+This is the backbone for due times, retries, dedupe, and crash recovery.
+
+### Slice 2: Follow-up extraction
+
+Expose a single-target follow-up preparation path so scheduler jobs can call stable, testable business logic without duplicating internals.
+
+### Slice 3: Scheduler core
+
+Add a core scheduler service that can:
+
+- enqueue follow-up jobs from accepted connections
+- select due jobs
+- lease them
+- run one tick or one dispatch cycle
+- reschedule or finish jobs based on structured outcomes
+
+### Slice 4: CLI daemon surface
+
+Add local operator commands for running the scheduler once or as a daemon.
+Keep CLI glue thin and keep control/state files separate from keepalive.
+
+### Slice 5: Hardening
+
+Add focused tests for business windows, due-job selection, dedupe, backoff, and profile-lock/auth edge cases. Document the operator workflow after the feature exists.
+
+## Suggested files to touch, in order
+
+This order is meant to keep the work incremental and reduce churn.
+
+1. `packages/core/src/db/migrations.ts`
+   - add an additive scheduler job table and indexes
+   - keep the schema generic enough for future lanes without solving future lanes now
+
+2. `packages/core/src/db/database.ts`
+   - add scheduler job CRUD, upsert, lease, reschedule, and completion helpers
+   - keep these helpers strongly typed and close to the SQL
+
+3. `packages/core/src/config.ts`
+   - add scheduler config resolution for polling, business hours, timezone, and lane enablement
+   - keep defaults centralized here
+
+4. `packages/core/src/linkedinFollowups.ts`
+   - extract a reusable single-target prepare path
+   - keep `prepareFollowupsAfterAccept()` as the batch/operator surface built on that path
+
+5. `packages/core/src/scheduler.ts`
+   - add the scheduler service, tick orchestration, business-window checks, and job dispatch
+   - keep the scheduler focused on local follow-up preparation in phase 1
+
+6. `packages/core/src/runtime.ts`
+   - wire the scheduler service or its dependencies into the runtime only as far as it helps avoid duplication
+   - do not turn runtime itself into the daemon loop
+
+7. `packages/core/src/index.ts`
+   - re-export scheduler types and service
+
+8. `packages/cli/src/bin/linkedin.ts`
+   - add `scheduler start`, `scheduler status`, `scheduler stop`, and `scheduler run-once` or equivalent
+   - reuse the current daemon-control idioms from keepalive
+
+9. `packages/core/src/__tests__/`
+   - add focused scheduler tests for queue selection, backoff, business hours, and single-target follow-up preparation
+   - adjust follow-up tests only where the extracted single-target API needs coverage
+
+10. `README.md`
+    - document the operator workflow once the implementation exists
+    - do not let docs drive premature design complexity
+
+## Existing utilities and patterns to reuse
+
+### Reuse directly
+
+- `packages/core/src/linkedinFollowups.ts`
+  - `refreshAcceptanceState()` already syncs pending sent invites and probes accepted ones
+  - the follow-up status model already exposes `not_prepared`, `prepared`, `executed`, `failed`, and `expired`
+  - `buildDefaultFollowupText()` already provides the current default outbound text
+
+- `packages/core/src/linkedinConnections.ts`
+  - `listPendingInvitations({ filter: "sent" })` is already the canonical refresh path for sent-invite state
+
+- `packages/core/src/db/database.ts`
+  - `sent_invitation_state` already tracks acceptance and follow-up lifecycle
+  - prepared-action lookup is already available for interpreting current follow-up status
+
+- `packages/core/src/twoPhaseCommit.ts`
+  - keep the current prepare → confirm safety model intact
+  - reuse prepared actions rather than creating scheduler-specific outbound execution
+
+- `packages/core/src/profileManager.ts`
+  - keep using the existing profile lock and browser lifecycle
+  - treat lock contention as a transient scheduler condition, not a permanent failure
+
+- `packages/core/src/errors.ts`
+  - store and branch on the existing structured error codes for retry/backoff decisions
+
+- `packages/core/src/logging.ts`
+  - keep scheduler logging structured and compatible with current run logs
+
+- `packages/core/src/artifacts.ts`
+  - reuse artifact paths and registration for any scheduler-created screenshots or traces
+
+- `packages/cli/src/bin/linkedin.ts`
+  - reuse the keepalive daemon’s pid/state/log file pattern and detached startup flow
+
+### Reuse conceptually, but keep the extraction small
+
+- lookback-window parsing patterns in `packages/core/src/linkedinFollowups.ts`
+- additive migration style in `packages/core/src/db/migrations.ts`
+- thin CLI → core service handoff used throughout the repo
+- focused Vitest unit tests that isolate pure orchestration logic from live browser behavior
+
+## New code that is justified
+
+The first implementation will likely need some net-new code, and that is appropriate here:
+
+- one new scheduler core module
+- one scheduler job table plus typed DB helpers
+- one small scheduler config surface
+- one reusable business-hours / due-time helper layer
+- one extracted single-target follow-up preparation path
+- one local CLI daemon surface
+- focused unit tests for the scheduler logic
+
+That is enough for issue #5’s first milestone.
+Anything larger should clear a high scope bar.
+
+## Main risks to watch
+
+### 1) Expired confirm tokens
+
+This is the biggest product risk.
+Prepared actions currently have a short confirm lifetime, and the follow-up flow uses a 30-minute default window today. Preparing everything at the start of the business window will create poor operator UX.
+
+Planning response:
+
+- schedule work near due time, not just near business-window start
+- keep due-time and preparation-time logic explicit
+- prefer near-due scheduling before adding any scheduler-specific TTL customization
+
+### 2) Duplicate jobs or duplicate prepared actions
+
+Acceptance detection is still batch-driven today.
+Without a stable dedupe story, repeated scans can enqueue the same target more than once or prepare twice.
+
+Planning response:
+
+- add a dedupe key or equivalent unique identity for scheduler jobs
+- link jobs to `profile_name`, lane, and target identity
+- keep `sent_invitation_state` and `prepared_action_id` in the loop when deciding if work is still needed
+
+### 3) Profile lock contention with normal operator work
+
+The scheduler will compete with manual CLI work, MCP use, and keepalive on the same profile.
+
+Planning response:
+
+- treat profile-busy conditions as normal transient failures
+- reschedule instead of permanently failing
+- keep one job small and retry-friendly
+
+### 4) Auth, rate limit, and challenge handling
+
+The scheduler will eventually run into expired sessions, rate limits, or LinkedIn challenges.
+
+Planning response:
+
+- use the existing error taxonomy for backoff and pause behavior
+- retry short-lived network/timeouts
+- pause or surface operator action quickly for auth/challenge conditions
+- keep the first version conservative rather than aggressive
+
+### 5) Business-hours and DST edge cases
+
+A scheduler without a clear timezone policy will behave unpredictably across daylight saving changes or host timezone drift.
+
+Planning response:
+
+- require an explicit timezone setting or a clearly documented fallback
+- keep the first model simple and test the window logic directly
+
+### 6) Privacy duplication
+
+If the scheduler stores full outbound text or rich previews in its own table, it will duplicate privacy and sealing concerns that already exist elsewhere.
+
+Planning response:
+
+- keep scheduler jobs minimal
+- derive follow-up text at prepare time using existing logic
+- let prepared actions remain the place where outbound payloads are stored and sealed
+
+### 7) Long-lived observability noise
+
+A daemon that reuses one runtime forever will produce noisy logs and hard-to-trace artifacts.
+
+Planning response:
+
+- keep the loop thin
+- prefer fresh runtimes for work execution
+- keep daemon state files human-readable and per-profile
+
+### 8) Scope creep from future lanes
+
+Inbox triage and feed engagement are attractive on paper but not operationally ready in this codebase.
+
+Planning response:
+
+- design the job table to tolerate future lanes
+- keep actual phase-1 execution limited to follow-up preparation
+
+## Guardrails
+
+### Do touch
+
+- additive DB migrations and typed DB helpers
+- one new scheduler core module
+- follow-up service refactors that expose a reusable single-target prepare path
+- config additions for scheduler behavior
+- CLI daemon wiring modeled after keepalive
+- focused unit tests for scheduler logic
+
+### Do not touch unless the implementation proves it is necessary
+
+- `packages/core/src/twoPhaseCommit.ts`
+- `packages/core/src/linkedinInbox.ts`
+- `packages/core/src/linkedinFeed.ts`
+- `packages/mcp/src/bin/linkedin-mcp.ts`
+- `packages/mcp/src/index.ts`
+- large dependency additions for cron or timezone handling
+
+### Avoid these traps
+
+- do not prepare a large batch of follow-ups at the top of the day
+- do not make scheduler jobs call the current batch prepare API as their steady-state path
+- do not store full outbound message text twice
+- do not treat profile-lock errors as terminal failures
+- do not create one always-on runtime with one endless artifact trail
+- do not widen the milestone into a generalized autonomous action engine
+
+## Conventions to follow
+
+- keep TypeScript strict and additive
+- use ESM imports with `.js` extensions
+- use `node:` imports for built-ins
+- use type-only imports where appropriate
+- keep runtime logging structured
+- keep the CLI thin; put scheduler behavior in core
+- keep confirmation manual and explicit
+- prefer minimal, well-tested helpers over a large scheduling framework
+
+## Implementation compass
+
+If the builder stays within additive DB work, a small scheduler core, a single-target follow-up extraction, runtime/CLI wiring, and focused tests, the implementation is probably on track.
+
+If the builder starts redesigning the whole outbound action system, adding MCP parity, building real inbox/feed lane policy, or introducing heavy scheduling dependencies before the simple model works, the work has probably drifted out of scope.


### PR DESCRIPTION
## Summary
- add `docs/.plan-issue-5.md` for issue #5 scheduled follow-ups
- outline the recommended approach, likely files to touch, reusable patterns, and justified new code
- capture the main risks, guardrails, and scope boundaries for the builder

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #40
