### PR TITLE
docs: plan locale-aware selector work for issue #8

### DIFF
--- a/docs/.plan-issue-8.md
+++ b/docs/.plan-issue-8.md
@@ -1,0 +1,412 @@
+# Execution plan — issue #8 locale-aware selectors
+
+## Intent
+
+Implement issue #8 with an **additive locale layer** that improves selector resilience on non-English LinkedIn sessions without restructuring the current selector architecture.
+This plan is based on `docs/.research-brief-issue-33.md` and is intentionally prescriptive about **seams and sequencing**, not exact helper names or the second locale to ship first.
+
+## Guardrails
+
+- Keep selectors **close to the feature modules** that already own them.
+- Add a **small shared locale dictionary + selector-builder layer** for text-bearing selectors instead of building a repo-wide selector registry.
+- Preserve current selector patterns: ordered candidate arrays, scoped locator probing, and structured `UI_CHANGED_SELECTOR_FAILED` telemetry.
+- Prefer **scoped role locators and stable structural selectors** when they already exist.
+- Treat **`aria-label` as locale-sensitive UI text**, not as a universally stable attribute.
+- Provide a **graceful English fallback** for uncovered locales.
+- Keep public API values canonical in English-like enums such as `like`, `support`, `public`, and `connections`.
+- Keep the selector audit JSON/report schema stable.
+
+## Recommended implementation shape
+
+### 1) Add one narrow locale helper layer in core
+
+Add a new focused helper module in `packages/core/src/` for selector-localized phrases.
+The exact filename can be chosen by the builder, but the shape should stay small and reusable.
+
+Recommended responsibilities:
+
+- define a `LinkedInSelectorLocale` type with default `en`
+- define semantic selector phrase keys such as `send`, `write_message`, `connect`, `comment`, `post`, `start_post`, `notifications`, `about`, `experience`, and `education`
+- store per-locale phrase lists keyed by semantic meaning, not by module name
+- expose builder helpers for:
+  - localized accessible-name regexes
+  - localized `aria-label` contains selectors
+  - locale-first-then-English fallback phrase lists
+  - selector-hint formatting that keeps existing selector keys readable
+
+What this helper should **not** do:
+
+- become a global selector registry
+- own feature-specific scoping rules
+- replace stable CSS, URL, or `data-*` selectors that already work well
+
+### 2) Add explicit selector-locale configuration
+
+Locale should be an explicit runtime input, not an inferred browser heuristic.
+
+Recommended config surface:
+
+- add selector-locale resolution to `packages/core/src/config.ts`
+- thread `selectorLocale` through `CreateCoreRuntimeOptions` and `CoreRuntime`
+- expose the setting through the CLI and MCP entry points
+- default to `en`
+- allow English fallback even when the requested locale is only partially covered
+
+A practical first-pass contract is:
+
+- runtime source of truth: `selectorLocale`
+- CLI/MCP: pass the configured locale through to runtime
+- diagnostics: optionally log page/browser language, but do not let it silently override explicit config
+
+### 3) Make selector audit locale-aware first
+
+`packages/core/src/selectorAudit.ts` is the safest first implementation target because it is read-only and already centralizes the current audit probes.
+
+Recommended changes:
+
+- build the audit registry from the shared locale phrases
+- keep existing page IDs and selector keys stable
+- keep `primary` / `secondary` / `tertiary` semantics stable
+- make each existing candidate factory consume localized phrases instead of hard-coded English strings
+- avoid duplicating strategies per phrase because the audit validator already rejects duplicate strategies in a selector group
+
+This slice should prove three things before mutation flows change:
+
+- the locale dictionary contract is workable
+- English fallback behaves as expected
+- selector audit remains a stable validation surface for operator workflows
+
+### 4) Retrofit the highest-risk mutation flows incrementally
+
+After audit, update the mutation/read flows in the following order:
+
+1. `packages/core/src/auth/sessionInspection.ts`
+2. `packages/core/src/linkedinInbox.ts`
+3. `packages/core/src/linkedinFollowups.ts`
+4. `packages/core/src/linkedinConnections.ts`
+5. `packages/core/src/linkedinFeed.ts`
+6. `packages/core/src/linkedinPosts.ts`
+7. `packages/core/src/linkedinProfile.ts`
+8. `packages/core/src/linkedinNotifications.ts`
+
+This order keeps the first implementation slices narrow and reduces the risk of non-English sessions failing before locale-aware selectors can even run.
+
+## Suggested delivery slices
+
+### Slice 0 — locale contract and inventory
+
+Goal: lock the helper contract before touching live mutation flows.
+
+- inventory the current text-bearing selectors by semantic phrase key
+- choose the first additional locale that the team can validate in a real LinkedIn session
+- define phrase coverage for the highest-risk keys first
+- document which selectors stay structural-only and need no locale dictionary entry
+
+Expected outcome:
+
+- a small phrase-key list that covers audit, auth, messaging, connections, feed, posts, profile, and notifications
+
+### Slice 1 — shared helpers and config plumbing
+
+Goal: add the runtime seam without changing behavior yet.
+
+Likely touch points:
+
+- `packages/core/src/config.ts`
+- `packages/core/src/runtime.ts`
+- `packages/core/src/index.ts`
+- `packages/cli/src/bin/linkedin.ts`
+- `packages/mcp/src/bin/linkedin-mcp.ts`
+- a new helper such as `packages/core/src/selectorLocale.ts`
+
+Implementation notes:
+
+- keep default behavior identical for English users
+- prefer one shared locale resolver over per-module environment reads
+- keep helper APIs narrow enough that feature modules still own their scoping and candidate ordering
+
+### Slice 2 — selector audit
+
+Goal: make the read-only audit accurately reflect locale coverage.
+
+Likely touch points:
+
+- `packages/core/src/selectorAudit.ts`
+- `packages/core/src/__tests__/selectorAudit.test.ts`
+- `packages/core/src/__tests__/selectorAuditTestUtils.ts`
+- the shared locale helper test file
+
+Implementation notes:
+
+- replace hard-coded English text probes with locale-aware phrase builders
+- preserve report schema and selector keys
+- keep existing structural candidates unchanged where they are already locale-safe
+
+### Slice 3 — auth and messaging
+
+Goal: remove the earliest false negatives and reuse one messaging selector vocabulary.
+
+Likely touch points:
+
+- `packages/core/src/auth/sessionInspection.ts`
+- `packages/core/src/linkedinInbox.ts`
+- `packages/core/src/linkedinFollowups.ts`
+- `packages/core/src/__tests__/sessionAuth.test.ts`
+- a new `packages/core/src/__tests__/linkedinInbox.test.ts` if targeted coverage is needed
+- `packages/core/src/__tests__/linkedinFollowups.test.ts`
+
+Implementation notes:
+
+- eliminate the English-only `Me` dependency in session inspection
+- reuse shared phrase builders for `write message` and `send`
+- keep structural fallbacks like `.msg-form__contenteditable[contenteditable='true']` and `button.msg-form__send-button`
+
+### Slice 4 — connections
+
+Goal: harden the highest-risk mutation flow.
+
+Likely touch points:
+
+- `packages/core/src/linkedinConnections.ts`
+- `packages/core/src/__tests__/linkedinConnections.test.ts`
+
+Implementation notes:
+
+- localize `Connect`, `More`, `Add a note`, `Send`, `Send without a note`, `Pending`, `Withdraw`, and invitation-state verification strings
+- preserve the current top-card and dialog scoping
+- keep stable selectors like `textarea[name='message']`, `textarea#custom-message`, and scoped menu/dialog containers
+
+### Slice 5 — feed and posts
+
+Goal: separate canonical API values from localized UI labels.
+
+Likely touch points:
+
+- `packages/core/src/linkedinFeed.ts`
+- `packages/core/src/linkedinPosts.ts`
+- `packages/core/src/__tests__/linkedinFeed.test.ts`
+- `packages/core/src/__tests__/linkedinPosts.test.ts`
+
+Implementation notes:
+
+- keep public reaction inputs canonical (`like`, `celebrate`, `support`, `love`, `insightful`, `funny`)
+- move reaction UI labels and menu aria labels into locale dictionaries
+- localize comment composer text, comment submit labels, post composer prompts, visibility labels, and done/save labels
+- preserve stable structural selectors such as reaction trigger buttons, comment button classes, comment submit button classes, `.ql-editor`, and generic contenteditable roots
+
+### Slice 6 — read-only extraction heuristics
+
+Goal: prevent silent partial-data regressions on non-English sessions.
+
+Likely touch points:
+
+- `packages/core/src/linkedinProfile.ts`
+- `packages/core/src/linkedinNotifications.ts`
+- `packages/core/src/__tests__/linkedinProfile.test.ts`
+- `packages/core/src/__tests__/linkedinNotifications.test.ts`
+
+Implementation notes:
+
+- replace English section-heading heuristics with localized heading sets where structural IDs are unavailable
+- replace notification type/read-state word checks with localized phrase sets where class/data signals are insufficient
+- prefer structural selectors and data attributes before localized text heuristics
+
+## Files likely to change
+
+Core runtime and config:
+
+- `packages/core/src/config.ts`
+- `packages/core/src/runtime.ts`
+- `packages/core/src/index.ts`
+- new helper module in `packages/core/src/` for selector locale phrases/builders
+
+Feature modules:
+
+- `packages/core/src/selectorAudit.ts`
+- `packages/core/src/auth/sessionInspection.ts`
+- `packages/core/src/linkedinInbox.ts`
+- `packages/core/src/linkedinFollowups.ts`
+- `packages/core/src/linkedinConnections.ts`
+- `packages/core/src/linkedinFeed.ts`
+- `packages/core/src/linkedinPosts.ts`
+- `packages/core/src/linkedinProfile.ts`
+- `packages/core/src/linkedinNotifications.ts`
+
+User-facing surfaces:
+
+- `packages/cli/src/bin/linkedin.ts`
+- `packages/mcp/src/bin/linkedin-mcp.ts`
+
+Tests:
+
+- `packages/core/src/__tests__/selectorAudit.test.ts`
+- `packages/core/src/__tests__/selectorAuditTestUtils.ts`
+- `packages/core/src/__tests__/sessionAuth.test.ts`
+- `packages/core/src/__tests__/linkedinConnections.test.ts`
+- `packages/core/src/__tests__/linkedinFeed.test.ts`
+- `packages/core/src/__tests__/linkedinFollowups.test.ts`
+- `packages/core/src/__tests__/linkedinNotifications.test.ts`
+- `packages/core/src/__tests__/linkedinPosts.test.ts`
+- `packages/core/src/__tests__/linkedinProfile.test.ts`
+- optionally `packages/core/src/__tests__/linkedinInbox.test.ts`
+- a new locale-helper unit test file
+
+## Selector inventory: locale-sensitive vs relatively stable
+
+### Needs locale support
+
+These selectors are text-bearing today and should be routed through the locale helper layer.
+
+| Module | Locale-sensitive selectors / heuristics | Notes |
+| --- | --- | --- |
+| `packages/core/src/selectorAudit.ts` | `start a post`, `messaging`, `write a message`, `connections`, `notifications`, `about`, `experience`, `education`, `resources`, `open to`, `ago` | Audit should become locale-aware before feature retrofits begin |
+| `packages/core/src/auth/sessionInspection.ts` | `button[aria-label*='Me']` | Fix early to avoid false unauthenticated states |
+| `packages/core/src/linkedinInbox.ts` | `write a message`, `message`, `send` | Shared messaging phrase set |
+| `packages/core/src/linkedinFollowups.ts` | `write a message`, `send` | Reuse the same messaging helpers |
+| `packages/core/src/linkedinConnections.ts` | `Connect`, `More`, `Add a note`, `Send`, `Send without a note`, `Pending`, `Withdraw`, `invitation sent`, `Accept`, `Ignore`, `Decline`, `Respond` | Highest mutation risk because text is used both to act and verify state |
+| `packages/core/src/linkedinFeed.ts` | reaction labels, reaction menu aria labels, `Comment`, `Add a comment`, `Post` | Keep canonical API inputs separate from UI labels |
+| `packages/core/src/linkedinPosts.ts` | `start a post`, `what do you want to talk about`, `Anyone`, `Connections only`, `Who can see your post`, `visibility`, `post settings`, `Done`, `Save`, `Post`, `Dismiss`, `Close`, `Discard`, `Leave` | Post-composer and visibility flows are label-heavy |
+| `packages/core/src/linkedinProfile.ts` | `about`, `experience`, `education`, `1st`/`2nd`/`3rd` degree parsing | Read-only extraction can silently degrade |
+| `packages/core/src/linkedinNotifications.ts` | `message`, `job`, `comment`, `reaction`, `like`, `mention`, `connection`, `invite`, `follow`, `unread`, `new`, `read` | Type and unread inference should no longer assume English |
+
+### Already relatively stable
+
+These selectors should stay in place and remain preferred when LinkedIn keeps them stable.
+They do **not** need dictionary entries unless future UI evidence proves otherwise.
+
+- `a[href*='/messaging/thread/']`
+- `a[href*='/in/']`
+- `button.msg-form__send-button`
+- `.msg-form__contenteditable[contenteditable='true']`
+- `textarea[name='message']`
+- `textarea#custom-message`
+- `button.social-actions-button.react-button__trigger`
+- `button.react-button__trigger`
+- `button.social-actions-button.comment-button`
+- `button[class*='comments-comment-box__submit-button']`
+- `.ql-editor[contenteditable='true']`
+- `[contenteditable='true'][role='textbox']`
+- `[role='dialog']` containers scoped by structure rather than labels
+- `div[data-urn]`
+- `.nt-card`, `.notification-card`
+- structural profile header containers, feed post containers, search result cards, and job cards/details surfaces
+- most of `packages/core/src/linkedinSearch.ts` and `packages/core/src/linkedinJobs.ts`, which are currently much more URL/CSS/data driven than text driven
+
+## Patterns to preserve
+
+- Keep **ordered candidate arrays** local to each feature module.
+- Preserve existing selector keys wherever possible so logs, audits, and failure artifacts stay comparable.
+- Generate localized text-bearing candidates from shared helpers, but keep feature-specific scoping local.
+- Scope broad text matching to a narrow root such as `topCardRoot`, `composerRoot`, `postRoot`, `main`, or dialog containers.
+- Prefer exact or anchored regexes for short, common labels such as `Send`, `More`, `Post`, and `Connect`.
+- Keep fallback behavior simple: locale-specific phrases first, English phrases second, then existing structural/broad fallbacks where needed.
+- Avoid cloning multiple candidate entries for each translated phrase when one candidate can hold a combined regex or localized selector list.
+
+## Risks to watch
+
+### 1) Candidate ordering drift
+
+Changing candidate order can change which selector wins, which selector key is reported, and whether selector audit records a fallback.
+
+Mitigation:
+
+- preserve current candidate order whenever possible
+- retrofit only the text-bearing candidate internals
+
+### 2) Over-broad localized matches
+
+Common words such as `Send`, `More`, `Comment`, and `Post` become riskier as phrase lists grow.
+
+Mitigation:
+
+- keep all text matches scoped to the smallest meaningful container
+- prefer exact or anchored regexes for short control labels
+
+### 3) Auth false negatives
+
+If `Me` remains English-only, non-English sessions may fail before the locale-aware selectors can help.
+
+Mitigation:
+
+- fix `packages/core/src/auth/sessionInspection.ts` in the first mutation slice
+
+### 4) Silent read-only regressions
+
+Profile extraction and notification classification can fail quietly by returning emptier results.
+
+Mitigation:
+
+- add targeted unit coverage for profile section extraction and notification classification
+- prefer structural selectors before localized text heuristics
+
+### 5) Audit output churn
+
+Selector audit is operator-facing.
+Large changes to keys, strategy names, or report shapes would create unnecessary maintenance noise.
+
+Mitigation:
+
+- keep report schema stable
+- keep selector keys stable
+- localize only the underlying phrase generation
+
+### 6) Canonical API values vs localized UI labels
+
+Reaction names and visibility options currently do double duty as both API values and UI labels.
+
+Mitigation:
+
+- keep public enums canonical
+- move UI labels and aria phrases into locale dictionaries only
+
+### 7) English-locked tests
+
+Current tests and fixtures likely assume English labels and selector hints.
+
+Mitigation:
+
+- add dictionary/helper tests
+- update service tests to assert fallback behavior and canonical outcomes, not only English strings
+- keep selector-audit fixture coverage explicit for both default English and one secondary locale
+
+## Validation plan
+
+Unit coverage should validate:
+
+- phrase resolution by locale
+- English fallback order for uncovered phrases
+- selector-builder output and regex escaping
+- selector-audit registry generation without duplicate-strategy regressions
+- canonical reaction/visibility normalization independent of UI locale
+- localized profile and notification heuristics where structural selectors are insufficient
+
+Before shipping the implementation work for issue #8:
+
+- run selector audit in English and one validated non-English locale
+- run service/unit coverage for auth, inbox/followups, connections, feed, posts, profile, notifications, and selector audit
+- keep any real LinkedIn write-flow verification within the repo safety rules:
+  - only message or connect with Simon Miller unless explicit approval says otherwise
+  - ask for approval before comments, likes, posts, or other public actions
+
+## Acceptance slice for issue #8
+
+A good first shippable implementation should do all of the following:
+
+1. add explicit selector-locale config with default `en`
+2. support English plus one additional validated locale
+3. make selector audit locale-aware without changing its report schema
+4. remove the English-only auth/session dependency
+5. update inbox/followups, connections, feed, and posts to use shared localized phrase builders
+6. harden profile and notifications heuristics where text assumptions remain necessary
+7. add unit coverage for dictionary resolution, fallback order, and selector-audit generation
+
+## Decisions left to the builder
+
+To keep this plan useful without over-constraining implementation, these choices are intentionally left open:
+
+- the exact helper filename and exported function names
+- the first non-English locale to support after `en`
+- whether the CLI/MCP surface uses a flag, env-only default, or both, as long as runtime locale remains explicit
+- whether some read-only heuristics can be replaced entirely by better structural selectors instead of localized text
+
+The main requirement is that the implementation stays **narrow, additive, and testable** while preserving today’s selector scoping, fallback ordering, and operator-facing telemetry.


### PR DESCRIPTION
## Summary
- add `docs/.plan-issue-8.md` for the phase-1 planning deliverable
- outline the additive locale dictionary, selector-builder, and config approach
- capture rollout order, selector inventory, risks, and validation guidance

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

Refs #8
Closes #44