### PR TITLE
feat: add interactive local data deletion command

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ npm exec -w @linkedin-assistant/cli -- linkedin keepalive stop --profile default
 
 - Keepalive state/log files are stored under `~/.linkedin-assistant/linkedin-owa-agentools/keepalive/`.
 
+Delete local tool state:
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin data delete
+npm exec -w @linkedin-assistant/cli -- linkedin data delete --include-profile
+```
+
+- `linkedin data delete` always requires an interactive terminal confirmation.
+- `--include-profile` prompts a second time before removing local browser profile data.
+
 ### Selector audit
 
 Selector audit is a read-only diagnostic that checks the built-in selector
@@ -130,7 +140,7 @@ Representative human-readable output:
 Starting selector audit for profile default (2 pages).
 Checking page 1/2: feed (2 selector groups)...
 Finished page 1/2: feed — 1 passed, 1 failed, 1 fallback.
-Checking page 2/2: inbox (1 selector group)...
+Checking page 2/2: inbox (1 selector groups)...
 Finished page 2/2: inbox — 1 passed, 0 failed, 0 fallback.
 Selector audit finished. Report: /tmp/run_test/selector-audit/report.json
 
@@ -156,7 +166,7 @@ Failures
   with failures, fallbacks, warnings, and next steps.
 - Use `--json` for machine-readable output in CI, scripts, or agent workflows.
 - Use `--verbose` to expand the human-readable summary with selector-by-selector
-  details.
+  detail.
 - Use `--no-progress` to suppress live progress updates when you only want the
   final summary.
 - Reports are written under the run artifact directory as

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -1,7 +1,15 @@
 #!/usr/bin/env node
+import type { Dirent } from "node:fs";
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
-import { appendFile, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import {
+  appendFile,
+  mkdir,
+  readFile,
+  readdir,
+  unlink,
+  writeFile
+} from "node:fs/promises";
 import path from "node:path";
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
@@ -10,6 +18,7 @@ import { Command } from "commander";
 import {
   DEFAULT_FOLLOWUP_SINCE,
   clearRateLimitState,
+  createLocalDataDeletionPlan,
   evaluateDraftQuality,
   isInRateLimitCooldown,
   LINKEDIN_FEED_REACTION_TYPES,
@@ -17,6 +26,7 @@ import {
   LINKEDIN_SELECTOR_LOCALES,
   LinkedInAssistantError,
   createCoreRuntime,
+  deleteLocalData,
   normalizeLinkedInFeedReaction,
   normalizeLinkedInPostVisibility,
   parseDraftQualityCandidateSet,
@@ -354,6 +364,172 @@ async function promptYesNo(question: string): Promise<boolean> {
   } finally {
     readline.close();
   }
+}
+
+function assertInteractiveTerminal(operation: string): void {
+  if (!stdin.isTTY || !stdout.isTTY) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `Refusing to ${operation} in non-interactive mode.`
+    );
+  }
+}
+
+function printDeletionTargets(targetPaths: string[]): void {
+  for (const targetPath of targetPaths) {
+    console.log(`- ${targetPath}`);
+  }
+}
+
+async function stopKeepAliveDaemonByPid(pid: number): Promise<void> {
+  if (!isProcessRunning(pid)) {
+    return;
+  }
+
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch (error) {
+    throw new LinkedInAssistantError(
+      "UNKNOWN",
+      "Failed to stop a running keepalive daemon before deleting local data.",
+      {
+        pid,
+        cause: error instanceof Error ? error.message : String(error)
+      }
+    );
+  }
+
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    await sleep(200);
+    if (!isProcessRunning(pid)) {
+      return;
+    }
+  }
+
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "ESRCH"
+    ) {
+      return;
+    }
+
+    throw new LinkedInAssistantError(
+      "UNKNOWN",
+      "Failed to force-stop a running keepalive daemon before deleting local data.",
+      {
+        pid,
+        cause: error instanceof Error ? error.message : String(error)
+      }
+    );
+  }
+}
+
+async function stopAllKeepAliveDaemons(): Promise<number[]> {
+  const keepAliveDir = path.join(resolveConfigPaths().baseDir, "keepalive");
+  let entries: Dirent[];
+
+  try {
+    entries = await readdir(keepAliveDir, { withFileTypes: true });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return [];
+    }
+
+    throw error;
+  }
+
+  const runningPids = new Set<number>();
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".pid")) {
+      continue;
+    }
+
+    const pidFilePath = path.join(keepAliveDir, entry.name);
+    const rawPid = await readFile(pidFilePath, "utf8");
+    const pid = Number.parseInt(rawPid.trim(), 10);
+    if (Number.isInteger(pid) && pid > 0 && isProcessRunning(pid)) {
+      runningPids.add(pid);
+    }
+  }
+
+  const stoppedPids: number[] = [];
+  for (const pid of runningPids) {
+    await stopKeepAliveDaemonByPid(pid);
+    stoppedPids.push(pid);
+  }
+
+  return stoppedPids;
+}
+
+async function runDataDelete(input: { includeProfile: boolean }): Promise<void> {
+  assertInteractiveTerminal("delete local data");
+
+  const requestedPlan = createLocalDataDeletionPlan({
+    includeProfile: input.includeProfile
+  });
+  const { profilesDir } = resolveConfigPaths();
+
+  console.log("This permanently deletes local LinkedIn Assistant data:");
+  printDeletionTargets(requestedPlan.targets);
+  if (!input.includeProfile) {
+    console.log(`- preserving browser profiles at ${profilesDir}`);
+  }
+
+  const deleteAllConfirmed = await promptYesNo(
+    "Delete the listed local data?"
+  );
+  if (!deleteAllConfirmed) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "Operator declined local data deletion."
+    );
+  }
+
+  let includeProfile = false;
+  if (input.includeProfile) {
+    includeProfile = await promptYesNo(
+      `Delete browser profile data at ${profilesDir}?`
+    );
+
+    if (!includeProfile) {
+      console.log("Browser profile deletion declined. Profiles will be preserved.");
+    }
+  }
+
+  const finalPlan = createLocalDataDeletionPlan({ includeProfile });
+  const runtime = createCoreRuntime({ privacy: cliPrivacyConfig });
+
+  try {
+    runtime.logger.log("warn", "cli.data.delete.start", {
+      includeProfileRequested: input.includeProfile,
+      includeProfileDeleted: includeProfile,
+      targets: finalPlan.targets
+    });
+  } finally {
+    runtime.close();
+  }
+
+  const stoppedKeepAlivePids = await stopAllKeepAliveDaemons();
+  const deletionResult = await deleteLocalData({ includeProfile });
+
+  printJson({
+    deleted: true,
+    run_id: runtime.runId,
+    include_profile_requested: input.includeProfile,
+    include_profile_deleted: includeProfile,
+    deleted_paths: deletionResult.deletedPaths,
+    missing_paths: deletionResult.missingPaths,
+    stopped_keepalive_pids: stoppedKeepAlivePids
+  });
 }
 
 async function runStatus(profileName: string, cdpUrl?: string): Promise<void> {
@@ -1850,6 +2026,24 @@ export async function runCli(argv: string[] = process.argv): Promise<void> {
     .option("--clear", "Clear saved rate-limit cooldown state", false)
     .action(async (options: { clear: boolean }) => {
       await runRateLimitStatus(options.clear);
+    });
+
+  const dataCommand = program
+    .command("data")
+    .description("Inspect and delete local LinkedIn Assistant data");
+
+  dataCommand
+    .command("delete")
+    .description("Delete local database, artifacts, logs, and optional browser profiles")
+    .option(
+      "--include-profile",
+      "Also delete local browser profile data after extra confirmation",
+      false
+    )
+    .action(async (options: { includeProfile: boolean }) => {
+      await runDataDelete({
+        includeProfile: options.includeProfile
+      });
     });
 
   const keepAliveCommand = program

--- a/packages/cli/test/dataDelete.test.ts
+++ b/packages/cli/test/dataDelete.test.ts
@@ -1,0 +1,171 @@
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { stdin, stdout } from "node:process";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveConfigPaths } from "../../core/src/index.js";
+
+const readlineMocks = vi.hoisted(() => ({
+  close: vi.fn(),
+  createInterface: vi.fn(),
+  question: vi.fn()
+}));
+
+vi.mock("@linkedin-assistant/core", async () => await import("../../core/src/index.js"));
+
+vi.mock("node:readline/promises", () => ({
+  createInterface: readlineMocks.createInterface.mockImplementation(() => ({
+    close: readlineMocks.close,
+    question: readlineMocks.question
+  }))
+}));
+
+import { runCli } from "../src/bin/linkedin.js";
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await access(targetPath);
+    return true;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+function setInteractiveMode(inputIsTty: boolean, outputIsTty: boolean): void {
+  Object.defineProperty(stdin, "isTTY", {
+    configurable: true,
+    value: inputIsTty
+  });
+  Object.defineProperty(stdout, "isTTY", {
+    configurable: true,
+    value: outputIsTty
+  });
+}
+
+describe("linkedin data delete", () => {
+  let tempDir = "";
+  let assistantHome = "";
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-cli-data-delete-"));
+    assistantHome = path.join(tempDir, "assistant-home");
+    process.env.LINKEDIN_ASSISTANT_HOME = assistantHome;
+    setInteractiveMode(true, true);
+    vi.clearAllMocks();
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore();
+    delete process.env.LINKEDIN_ASSISTANT_HOME;
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function seedLocalDataFixture(): Promise<{
+    artifactsDir: string;
+    dbPath: string;
+    keepAliveDir: string;
+    profilesDir: string;
+    rateLimitStatePath: string;
+  }> {
+    const paths = resolveConfigPaths();
+    const keepAliveDir = path.join(paths.baseDir, "keepalive");
+    const rateLimitStatePath = path.join(paths.baseDir, "rate-limit-state.json");
+
+    await mkdir(path.join(paths.artifactsDir, "run-1"), { recursive: true });
+    await writeFile(
+      path.join(paths.artifactsDir, "run-1", "events.jsonl"),
+      "{\"event\":\"runtime.started\"}\n",
+      "utf8"
+    );
+    await mkdir(keepAliveDir, { recursive: true });
+    await writeFile(path.join(keepAliveDir, "default.pid"), "0\n", "utf8");
+    await writeFile(path.join(keepAliveDir, "default.state.json"), "{}\n", "utf8");
+    await writeFile(
+      path.join(keepAliveDir, "default.events.jsonl"),
+      "{\"event\":\"keepalive.tick\"}\n",
+      "utf8"
+    );
+    await mkdir(path.join(paths.profilesDir, "default"), { recursive: true });
+    await writeFile(
+      path.join(paths.profilesDir, "default", "Preferences"),
+      "profile-data",
+      "utf8"
+    );
+    await writeFile(rateLimitStatePath, "{\"cooldown\":true}\n", "utf8");
+
+    return {
+      artifactsDir: paths.artifactsDir,
+      dbPath: paths.dbPath,
+      keepAliveDir,
+      profilesDir: paths.profilesDir,
+      rateLimitStatePath
+    };
+  }
+
+  it("refuses to run in non-interactive mode", async () => {
+    setInteractiveMode(false, false);
+
+    await expect(
+      runCli(["node", "linkedin", "data", "delete"])
+    ).rejects.toMatchObject({
+      message: "Refusing to delete local data in non-interactive mode."
+    });
+
+    expect(readlineMocks.createInterface).not.toHaveBeenCalled();
+    expect(await pathExists(assistantHome)).toBe(false);
+  });
+
+  it("deletes local state while preserving browser profiles by default", async () => {
+    const fixture = await seedLocalDataFixture();
+    readlineMocks.question.mockResolvedValueOnce("yes");
+
+    await runCli(["node", "linkedin", "data", "delete"]);
+
+    expect(readlineMocks.question).toHaveBeenCalledTimes(1);
+    expect(await pathExists(fixture.dbPath)).toBe(false);
+    expect(await pathExists(fixture.artifactsDir)).toBe(false);
+    expect(await pathExists(fixture.keepAliveDir)).toBe(false);
+    expect(await pathExists(fixture.rateLimitStatePath)).toBe(false);
+    expect(await pathExists(fixture.profilesDir)).toBe(true);
+
+    const finalOutput = consoleLogSpy.mock.calls.at(-1)?.[0];
+    expect(JSON.parse(String(finalOutput))).toMatchObject({
+      deleted: true,
+      include_profile_requested: false,
+      include_profile_deleted: false
+    });
+  });
+
+  it("deletes browser profiles only after the extra confirmation", async () => {
+    const fixture = await seedLocalDataFixture();
+    readlineMocks.question
+      .mockResolvedValueOnce("yes")
+      .mockResolvedValueOnce("yes");
+
+    await runCli(["node", "linkedin", "data", "delete", "--include-profile"]);
+
+    expect(readlineMocks.question).toHaveBeenCalledTimes(2);
+    expect(await pathExists(fixture.dbPath)).toBe(false);
+    expect(await pathExists(fixture.artifactsDir)).toBe(false);
+    expect(await pathExists(fixture.keepAliveDir)).toBe(false);
+    expect(await pathExists(fixture.rateLimitStatePath)).toBe(false);
+    expect(await pathExists(fixture.profilesDir)).toBe(false);
+
+    const finalOutput = consoleLogSpy.mock.calls.at(-1)?.[0];
+    expect(JSON.parse(String(finalOutput))).toMatchObject({
+      deleted: true,
+      include_profile_requested: true,
+      include_profile_deleted: true
+    });
+  });
+});

--- a/packages/core/src/auth/rateLimitState.ts
+++ b/packages/core/src/auth/rateLimitState.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { resolveConfigPaths } from "../config.js";
 
 export interface RateLimitState {
   rateLimitedUntil: string;
@@ -8,14 +9,43 @@ export interface RateLimitState {
   consecutiveRateLimits: number;
 }
 
-const DEFAULT_STATE_FILE_PATH = path.join(
+const LEGACY_STATE_FILE_PATH = path.join(
   os.homedir(),
   ".linkedin-assistant",
   "rate-limit-state.json"
 );
 
-function resolveStateFilePath(stateFilePath?: string): string {
-  return stateFilePath ?? DEFAULT_STATE_FILE_PATH;
+export function resolveRateLimitStateFilePath(stateFilePath?: string): string {
+  if (stateFilePath) {
+    return stateFilePath;
+  }
+
+  return path.join(resolveConfigPaths().baseDir, "rate-limit-state.json");
+}
+
+export function resolveLegacyRateLimitStateFilePath(): string {
+  return LEGACY_STATE_FILE_PATH;
+}
+
+function shouldIncludeLegacyStateFilePath(stateFilePath?: string): boolean {
+  return (
+    !stateFilePath &&
+    typeof process.env.LINKEDIN_ASSISTANT_HOME !== "string"
+  );
+}
+
+function resolveStateFilePaths(stateFilePath?: string): string[] {
+  const primaryStateFilePath = resolveRateLimitStateFilePath(stateFilePath);
+  if (!shouldIncludeLegacyStateFilePath(stateFilePath)) {
+    return [primaryStateFilePath];
+  }
+
+  const legacyStateFilePath = resolveLegacyRateLimitStateFilePath();
+  if (primaryStateFilePath === legacyStateFilePath) {
+    return [primaryStateFilePath];
+  }
+
+  return [primaryStateFilePath, legacyStateFilePath];
 }
 
 function isValidDateString(value: unknown): value is string {
@@ -40,34 +70,38 @@ function isValidRateLimitState(value: unknown): value is RateLimitState {
 export async function readRateLimitState(
   stateFilePath?: string
 ): Promise<RateLimitState | null> {
-  const resolvedStateFilePath = resolveStateFilePath(stateFilePath);
+  for (const resolvedStateFilePath of resolveStateFilePaths(stateFilePath)) {
+    try {
+      const rawState = await readFile(resolvedStateFilePath, "utf8");
+      const parsed = JSON.parse(rawState) as unknown;
+      if (isValidRateLimitState(parsed)) {
+        return parsed;
+      }
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        continue;
+      }
 
-  try {
-    const rawState = await readFile(resolvedStateFilePath, "utf8");
-    const parsed = JSON.parse(rawState) as unknown;
-    return isValidRateLimitState(parsed) ? parsed : null;
-  } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
-      return null;
+      if (error instanceof SyntaxError) {
+        continue;
+      }
+
+      throw error;
     }
-
-    if (error instanceof SyntaxError) {
-      return null;
-    }
-
-    throw error;
   }
+
+  return null;
 }
 
 export async function writeRateLimitState(
   state: RateLimitState,
   stateFilePath?: string
 ): Promise<void> {
-  const resolvedStateFilePath = resolveStateFilePath(stateFilePath);
+  const resolvedStateFilePath = resolveRateLimitStateFilePath(stateFilePath);
   await mkdir(path.dirname(resolvedStateFilePath), { recursive: true });
   await writeFile(
     resolvedStateFilePath,
@@ -77,20 +111,20 @@ export async function writeRateLimitState(
 }
 
 export async function clearRateLimitState(stateFilePath?: string): Promise<void> {
-  const resolvedStateFilePath = resolveStateFilePath(stateFilePath);
+  for (const resolvedStateFilePath of resolveStateFilePaths(stateFilePath)) {
+    try {
+      await unlink(resolvedStateFilePath);
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        continue;
+      }
 
-  try {
-    await unlink(resolvedStateFilePath);
-  } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
-      return;
+      throw error;
     }
-
-    throw error;
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export * from "./errors.js";
 export * from "./healthCheck.js";
 export * from "./humanize.js";
 export * from "./keepAlive.js";
+export * from "./localData.js";
 export * from "./linkedinConnections.js";
 export * from "./linkedinFeed.js";
 export * from "./linkedinFollowups.js";

--- a/packages/core/src/localData.ts
+++ b/packages/core/src/localData.ts
@@ -1,0 +1,212 @@
+import { access, rm } from "node:fs/promises";
+import path from "node:path";
+import {
+  resolveLegacyRateLimitStateFilePath,
+  resolveRateLimitStateFilePath
+} from "./auth/rateLimitState.js";
+import { resolveConfigPaths } from "./config.js";
+import { LinkedInAssistantError } from "./errors.js";
+
+export interface LocalDataDeletionPlanOptions {
+  baseDir?: string;
+  includeProfile?: boolean;
+  rateLimitStatePath?: string;
+}
+
+export interface LocalDataDeletionPlan {
+  baseDir: string;
+  includeProfile: boolean;
+  targets: string[];
+}
+
+export interface LocalDataDeletionResult {
+  deletedPaths: string[];
+  missingPaths: string[];
+}
+
+function resolveKeepAliveDir(baseDir: string): string {
+  return path.join(baseDir, "keepalive");
+}
+
+function shouldIncludeLegacyRateLimitStatePath(
+  options: LocalDataDeletionPlanOptions
+): boolean {
+  return (
+    !options.rateLimitStatePath &&
+    typeof process.env.LINKEDIN_ASSISTANT_HOME !== "string"
+  );
+}
+
+function normalizePath(targetPath: string): string {
+  return path.resolve(targetPath);
+}
+
+function isSameOrChildPath(parentPath: string, candidatePath: string): boolean {
+  return (
+    candidatePath === parentPath ||
+    candidatePath.startsWith(`${parentPath}${path.sep}`)
+  );
+}
+
+function dedupePaths(targetPaths: string[]): string[] {
+  return [...new Set(targetPaths.map((targetPath) => normalizePath(targetPath)))];
+}
+
+function assertSafeBaseDir(baseDir: string): void {
+  const resolvedBaseDir = normalizePath(baseDir);
+  if (resolvedBaseDir === path.parse(resolvedBaseDir).root) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "Refusing to delete local data when the configured base directory is the filesystem root.",
+      {
+        base_dir: resolvedBaseDir
+      }
+    );
+  }
+}
+
+function createAllowedTargetSet(options: LocalDataDeletionPlanOptions): Set<string> {
+  const paths = resolveConfigPaths(options.baseDir);
+  return new Set(
+    dedupePaths([
+      paths.dbPath,
+      paths.artifactsDir,
+      resolveKeepAliveDir(paths.baseDir),
+      paths.profilesDir,
+      resolveRateLimitStateFilePath(options.rateLimitStatePath),
+      ...(shouldIncludeLegacyRateLimitStatePath(options)
+        ? [resolveLegacyRateLimitStateFilePath()]
+        : [])
+    ])
+  );
+}
+
+function assertSafeDeletionTarget(
+  targetPath: string,
+  options: LocalDataDeletionPlanOptions
+): void {
+  const paths = resolveConfigPaths(options.baseDir);
+  assertSafeBaseDir(paths.baseDir);
+
+  const resolvedTargetPath = normalizePath(targetPath);
+  const allowedTargets = createAllowedTargetSet(options);
+  const resolvedBaseDir = normalizePath(paths.baseDir);
+
+  if (!allowedTargets.has(resolvedTargetPath)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "Refusing to delete an unexpected local-data path.",
+      {
+        target_path: resolvedTargetPath
+      }
+    );
+  }
+
+  const isLegacyRateLimitStatePath =
+    resolvedTargetPath === normalizePath(resolveLegacyRateLimitStateFilePath());
+  const isExplicitRateLimitStatePath =
+    typeof options.rateLimitStatePath === "string" &&
+    resolvedTargetPath ===
+      normalizePath(resolveRateLimitStateFilePath(options.rateLimitStatePath));
+
+  if (
+    !isLegacyRateLimitStatePath &&
+    !isExplicitRateLimitStatePath &&
+    !isSameOrChildPath(resolvedBaseDir, resolvedTargetPath)
+  ) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "Refusing to delete a path outside the configured local-data directory.",
+      {
+        base_dir: resolvedBaseDir,
+        target_path: resolvedTargetPath
+      }
+    );
+  }
+
+  if (resolvedTargetPath === resolvedBaseDir) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "Refusing to delete the configured local-data base directory directly.",
+      {
+        base_dir: resolvedBaseDir
+      }
+    );
+  }
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await access(targetPath);
+    return true;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+export function createLocalDataDeletionPlan(
+  options: LocalDataDeletionPlanOptions = {}
+): LocalDataDeletionPlan {
+  const paths = resolveConfigPaths(options.baseDir);
+  const includeProfile = options.includeProfile ?? false;
+  const rateLimitTargets = options.rateLimitStatePath
+    ? [resolveRateLimitStateFilePath(options.rateLimitStatePath)]
+    : shouldIncludeLegacyRateLimitStatePath(options)
+      ? [
+          resolveRateLimitStateFilePath(),
+          resolveLegacyRateLimitStateFilePath()
+        ]
+      : [resolveRateLimitStateFilePath()];
+
+  const targets = dedupePaths([
+    paths.dbPath,
+    paths.artifactsDir,
+    resolveKeepAliveDir(paths.baseDir),
+    ...rateLimitTargets,
+    ...(includeProfile ? [paths.profilesDir] : [])
+  ]);
+
+  return {
+    baseDir: normalizePath(paths.baseDir),
+    includeProfile,
+    targets
+  };
+}
+
+export async function deleteLocalData(
+  options: LocalDataDeletionPlanOptions = {}
+): Promise<LocalDataDeletionResult> {
+  const deletionPlan = createLocalDataDeletionPlan(options);
+  const deletedPaths: string[] = [];
+  const missingPaths: string[] = [];
+
+  for (const targetPath of deletionPlan.targets) {
+    assertSafeDeletionTarget(targetPath, options);
+
+    if (!(await pathExists(targetPath))) {
+      missingPaths.push(targetPath);
+      continue;
+    }
+
+    await rm(targetPath, {
+      force: false,
+      recursive: true,
+      maxRetries: 3,
+      retryDelay: 100
+    });
+    deletedPaths.push(targetPath);
+  }
+
+  return {
+    deletedPaths,
+    missingPaths
+  };
+}

--- a/packages/core/test/localData.test.ts
+++ b/packages/core/test/localData.test.ts
@@ -1,0 +1,131 @@
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createLocalDataDeletionPlan,
+  deleteLocalData,
+  resolveConfigPaths
+} from "../src/index.js";
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await access(targetPath);
+    return true;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+describe("local data deletion", () => {
+  let tempDir = "";
+  let baseDir = "";
+  let rateLimitStatePath = "";
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-local-data-"));
+    baseDir = path.join(tempDir, "assistant-home");
+    rateLimitStatePath = path.join(tempDir, "rate-limit-state.json");
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function seedLocalDataFixture(): Promise<ReturnType<typeof resolveConfigPaths>> {
+    const paths = resolveConfigPaths(baseDir);
+    const keepAliveDir = path.join(baseDir, "keepalive");
+
+    await mkdir(path.dirname(paths.dbPath), { recursive: true });
+    await writeFile(paths.dbPath, "sqlite-data", "utf8");
+    await mkdir(path.join(paths.artifactsDir, "run-123"), { recursive: true });
+    await writeFile(
+      path.join(paths.artifactsDir, "run-123", "events.jsonl"),
+      "{\"event\":\"runtime.started\"}\n",
+      "utf8"
+    );
+    await mkdir(keepAliveDir, { recursive: true });
+    await writeFile(path.join(keepAliveDir, "default.pid"), "321\n", "utf8");
+    await writeFile(path.join(keepAliveDir, "default.state.json"), "{}\n", "utf8");
+    await writeFile(
+      path.join(keepAliveDir, "default.events.jsonl"),
+      "{\"event\":\"keepalive.tick\"}\n",
+      "utf8"
+    );
+    await mkdir(path.join(paths.profilesDir, "default"), { recursive: true });
+    await writeFile(
+      path.join(paths.profilesDir, "default", "Preferences"),
+      "profile-data",
+      "utf8"
+    );
+    await writeFile(rateLimitStatePath, "{\"cooldown\":true}\n", "utf8");
+
+    return paths;
+  }
+
+  it("builds a deletion plan without browser profiles by default", () => {
+    const paths = resolveConfigPaths(baseDir);
+    const keepAliveDir = path.join(baseDir, "keepalive");
+
+    const plan = createLocalDataDeletionPlan({
+      baseDir,
+      rateLimitStatePath
+    });
+
+    expect(plan.includeProfile).toBe(false);
+    expect(plan.targets).toEqual(
+      expect.arrayContaining([
+        path.resolve(paths.dbPath),
+        path.resolve(paths.artifactsDir),
+        path.resolve(keepAliveDir),
+        path.resolve(rateLimitStatePath)
+      ])
+    );
+    expect(plan.targets).not.toContain(path.resolve(paths.profilesDir));
+  });
+
+  it("deletes database, artifacts, keepalive files, and rate-limit state", async () => {
+    const paths = await seedLocalDataFixture();
+    const keepAliveDir = path.join(baseDir, "keepalive");
+
+    const result = await deleteLocalData({
+      baseDir,
+      rateLimitStatePath
+    });
+
+    expect(result.deletedPaths).toEqual(
+      expect.arrayContaining([
+        path.resolve(paths.dbPath),
+        path.resolve(paths.artifactsDir),
+        path.resolve(keepAliveDir),
+        path.resolve(rateLimitStatePath)
+      ])
+    );
+    expect(await pathExists(paths.dbPath)).toBe(false);
+    expect(await pathExists(paths.artifactsDir)).toBe(false);
+    expect(await pathExists(keepAliveDir)).toBe(false);
+    expect(await pathExists(rateLimitStatePath)).toBe(false);
+    expect(await pathExists(paths.profilesDir)).toBe(true);
+  });
+
+  it("deletes browser profiles only when includeProfile is enabled", async () => {
+    const paths = await seedLocalDataFixture();
+
+    const result = await deleteLocalData({
+      baseDir,
+      includeProfile: true,
+      rateLimitStatePath
+    });
+
+    expect(result.deletedPaths).toContain(path.resolve(paths.profilesDir));
+    expect(await pathExists(paths.profilesDir)).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,18 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
+const repoRoot = path.dirname(fileURLToPath(import.meta.url));
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@linkedin-assistant/core": path.join(
+        repoRoot,
+        "packages/core/src/index.js"
+      )
+    }
+  },
   test: {
     environment: "node",
     include: [


### PR DESCRIPTION
## Summary\n- add a new `linkedin data delete` CLI flow for wiping local database, artifacts, logs, keepalive files, and optional browser profiles\n- require interactive confirmation, add a second opt-in for browser profiles, and stop keepalive daemons before deletion\n- add core deletion helpers and unit coverage for both the helper and CLI command\n\n## Testing\n- npm run typecheck\n- npm run lint\n- npm test\n- npm run build\n\nCloses #9