### PR TITLE
test: harden E2E coverage and live-session safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Exposed tools:
 
 - `linkedin.session.status`
 - `linkedin.session.open_login`
+- `linkedin.session.health`
 - `linkedin.profile.view`
 - `linkedin.search`
 - `linkedin.inbox.list_threads`
@@ -262,56 +263,55 @@ npm run build
 
 ## E2E Testing (Real Browser)
 
-Unit tests use mocks. After all features are implemented, run E2E tests against a real authenticated LinkedIn session in a headless browser.
+Unit tests use mocks. The E2E suite validates the CLI, MCP tools, and selected
+two-phase commit flows against a real authenticated LinkedIn session.
+
+Run the default E2E runner:
+
+```bash
+npm run test:e2e
+```
+
+The runner now skips cleanly when no authenticated CDP session is available,
+which makes it safe to invoke in CI.
+
+See `docs/e2e-testing.md` for the full workflow, safe targets, and opt-in write
+flags.
 
 ### Prerequisites
 
-- Authenticated LinkedIn session in the openclaw browser profile (CDP port 18800)
-- Or: any Chromium instance with an active LinkedIn session exposed via CDP
+- Node.js 22+
+- `npm install`
+- Authenticated LinkedIn session in a dedicated Chromium instance exposed via
+  CDP (default: `http://localhost:18800`)
+- Optional: `LINKEDIN_CDP_URL` to point at a different CDP endpoint
 
-### E2E Test Plan
+### Safe defaults
 
-Connect the CLI to a live CDP session and exercise every feature against real LinkedIn:
+By default, the E2E suite only performs read-only operations, prepare-only
+two-phase commit steps, or safe `test.echo` confirmations for the generic
+confirm entrypoints. Real outbound confirms remain opt-in.
 
 ```bash
-# Status check (verify session is authenticated)
-npm exec -w @linkedin-assistant/cli -- linkedin status --profile default --cdp-url http://localhost:18800
+# Default run: safe coverage only
+npm run test:e2e
 
-# Profile viewing
-npm exec -w @linkedin-assistant/cli -- linkedin profile view --profile default --cdp-url http://localhost:18800
-npm exec -w @linkedin-assistant/cli -- linkedin profile view --profile default --cdp-url http://localhost:18800 --user "realsimonmiller"
-
-# Search (people, companies, jobs)
-npm exec -w @linkedin-assistant/cli -- linkedin search --profile default --cdp-url http://localhost:18800 --type people --query "Simon Miller"
-npm exec -w @linkedin-assistant/cli -- linkedin search --profile default --cdp-url http://localhost:18800 --type companies --query "Power International"
-npm exec -w @linkedin-assistant/cli -- linkedin search --profile default --cdp-url http://localhost:18800 --type jobs --query "engineering manager"
-
-# Connections
-npm exec -w @linkedin-assistant/cli -- linkedin connections list --profile default --cdp-url http://localhost:18800 --limit 10
-
-# Feed
-npm exec -w @linkedin-assistant/cli -- linkedin feed view --profile default --cdp-url http://localhost:18800 --limit 5
-
-# Inbox
-npm exec -w @linkedin-assistant/cli -- linkedin inbox list --profile default --cdp-url http://localhost:18800 --limit 10
-
-# Notifications (when implemented)
-npm exec -w @linkedin-assistant/cli -- linkedin notifications list --profile default --cdp-url http://localhost:18800 --limit 10
+# Raw Vitest E2E run when you already know the session is available
+npm run test:e2e:raw
 ```
 
-### E2E Acceptance Criteria
+### Opt-in writes
 
-- Each command returns structured JSON (not errors)
-- Profile view returns real profile data (name, headline, etc.)
-- Search returns real results matching the query
-- Connections list returns actual connections
-- Feed returns real posts
-- Inbox returns real message threads
-- No `AUTH_REQUIRED` or `UI_CHANGED_SELECTOR_FAILED` errors
-- Screenshots/trace artifacts are captured where applicable
+Use the flags documented in `docs/e2e-testing.md` for:
 
-### Test Account
+- `LINKEDIN_E2E_ENABLE_MESSAGE_CONFIRM=1`
+- `LINKEDIN_E2E_ENABLE_CONNECTION_CONFIRM=1`
+- `LINKEDIN_E2E_ENABLE_LIKE_CONFIRM=1`
+- `LINKEDIN_E2E_ENABLE_COMMENT_CONFIRM=1`
+- `LINKEDIN_ENABLE_POST_WRITE_E2E=1`
 
-- LinkedIn account: joakim@sigvardt.eu (authenticated in openclaw browser profile)
-- Safe interaction target: Simon Miller (linkedin.com/in/realsimonmiller)
-- **Do not** send unsolicited messages or connection requests during E2E testing without explicit approval
+### Safe targets
+
+- Safe message target: Simon Miller (`linkedin.com/in/realsimonmiller`)
+- Safe connection target: Simon Miller unless an explicitly approved alternative is provided
+- Public actions like likes, comments, and posts require explicit approval before enabling write confirms

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -1,0 +1,139 @@
+# E2E Testing
+
+The E2E suite exercises the CLI, the MCP tool surface, and the core two-phase
+commit flows against a real authenticated LinkedIn browser session.
+
+## Runner behavior
+
+Use the default runner from the repo root:
+
+```bash
+npm run test:e2e
+```
+
+The runner:
+
+1. Checks that a CDP endpoint is reachable.
+2. Verifies that the attached browser is already authenticated with LinkedIn.
+3. Builds the workspace.
+4. Runs the Vitest E2E suite.
+
+If no authenticated session is available, the runner prints a skip reason and
+exits successfully. This makes it safe for CI environments that do not have a
+LinkedIn browser session.
+
+To force the raw Vitest suite directly, use:
+
+```bash
+npm run test:e2e:raw
+```
+
+## Prerequisites
+
+- Node.js 22+
+- Installed dependencies via `npm install`
+- Playwright Chromium dependencies available for the existing toolchain
+- A dedicated Chromium session exposed over CDP and already logged into LinkedIn
+
+Environment variables:
+
+- `LINKEDIN_CDP_URL` — optional, defaults to `http://localhost:18800`
+- `LINKEDIN_E2E_PROFILE` — optional logical profile name, defaults to `default`
+
+## Safe defaults
+
+The default E2E suite is read-only or preview-only for all outbound actions.
+That means it can validate:
+
+- every CLI command
+- every MCP tool
+- prepare-only two-phase commit flows
+- confirm entrypoints using the built-in `test.echo` executor
+- failure paths like expired tokens, rate limits, and selector drift reporting
+
+By default, the suite does **not** send messages, likes, comments, posts, or
+connection changes.
+
+## Approved targets and opt-in writes
+
+Real outbound confirms are opt-in and must only be used with approved targets.
+
+### Messages
+
+Safe target: Simon Miller (`linkedin.com/in/realsimonmiller`)
+
+Enable:
+
+```bash
+LINKEDIN_E2E_ENABLE_MESSAGE_CONFIRM=1 npm run test:e2e
+```
+
+### Connections
+
+Safe target: Simon Miller unless an explicitly approved alternative is provided.
+
+Enable one confirm mode with a target that is already in the correct state:
+
+```bash
+LINKEDIN_E2E_ENABLE_CONNECTION_CONFIRM=1 \
+LINKEDIN_E2E_CONNECTION_CONFIRM_MODE=invite \
+LINKEDIN_E2E_CONNECTION_TARGET=realsimonmiller \
+npm run test:e2e
+```
+
+Supported modes:
+
+- `invite`
+- `accept`
+- `withdraw`
+
+### Likes
+
+Public actions require explicit approval before execution.
+
+```bash
+LINKEDIN_E2E_ENABLE_LIKE_CONFIRM=1 \
+LINKEDIN_E2E_LIKE_POST_URL='https://www.linkedin.com/feed/update/...' \
+npm run test:e2e
+```
+
+### Comments
+
+Public actions require explicit approval before execution.
+
+```bash
+LINKEDIN_E2E_ENABLE_COMMENT_CONFIRM=1 \
+LINKEDIN_E2E_COMMENT_POST_URL='https://www.linkedin.com/feed/update/...' \
+npm run test:e2e
+```
+
+### Posts
+
+Real post publishing is intentionally separate and already opt-in:
+
+```bash
+LINKEDIN_ENABLE_POST_WRITE_E2E=1 npm run test:e2e
+```
+
+## Coverage overview
+
+The E2E suite now covers:
+
+- CLI command groups: session, rate-limit, keepalive, inbox, connections,
+  followups, feed, post, notifications, jobs, profile, selector audit,
+  health, and confirm entrypoints
+- MCP tools: session status/open-login/health, inbox, profile, search,
+  connections, followups, feed, post prepare, notifications, jobs,
+  and actions confirm
+- Two-phase commit confirm flows for messages, connections, likes, and comments
+  behind explicit opt-in flags
+- Error paths for expired tokens, rate limits, and UI drift detection
+
+## Notes
+
+- Run the E2E suite against a dedicated browser session; many commands navigate
+  LinkedIn pages as part of the test flow.
+- Selector audit failures are surfaced as structured reports and do not require
+  outbound actions.
+- The confirm E2Es are intentionally split between safe default coverage and
+  explicit opt-in side effects.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint .",
     "typecheck": "tsc -b --pretty false --force",
     "test": "vitest run",
-    "test:e2e": "LINKEDIN_E2E=1 vitest run -c vitest.config.e2e.ts",
+    "test:e2e": "node ./scripts/run-e2e.js",
+    "test:e2e:raw": "LINKEDIN_E2E=1 vitest run -c vitest.config.e2e.ts",
     "build": "tsc -b --pretty false"
   },
   "devDependencies": {

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { appendFile, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { Command } from "commander";
 import {
   DEFAULT_FOLLOWUP_SINCE,
@@ -332,7 +334,7 @@ async function runKeepAliveStart(input: {
     await removeKeepAlivePid(input.profileName);
   }
 
-  const cliEntrypoint = process.argv[1];
+  const cliEntrypoint = resolveKeepAliveCliEntrypoint();
   if (!cliEntrypoint) {
     throw new LinkedInAssistantError(
       "UNKNOWN",
@@ -394,6 +396,23 @@ async function runKeepAliveStart(input: {
     pid: daemon.pid,
     state_path: getKeepAliveFiles(input.profileName).statePath
   });
+}
+
+function resolveKeepAliveCliEntrypoint(): string | undefined {
+  const overrideEntrypoint = process.env.LINKEDIN_CLI_ENTRYPOINT;
+  if (overrideEntrypoint && overrideEntrypoint.trim().length > 0) {
+    return overrideEntrypoint.trim();
+  }
+
+  const compiledEntrypoint = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../dist/bin/linkedin.js"
+  );
+  if (existsSync(compiledEntrypoint)) {
+    return compiledEntrypoint;
+  }
+
+  return process.argv[1];
 }
 
 async function runKeepAliveStatus(profileName: string): Promise<void> {
@@ -1617,7 +1636,10 @@ async function runConfirmAction(input: {
   }
 }
 
-async function main(): Promise<void> {
+export async function runCli(argv: string[] = process.argv): Promise<void> {
+  const originalArgv = process.argv;
+  process.argv = argv;
+
   const program = new Command();
 
   program
@@ -2322,11 +2344,26 @@ async function main(): Promise<void> {
       }
     });
 
-  await program.parseAsync(process.argv);
+  try {
+    await program.parseAsync(argv);
+  } finally {
+    process.argv = originalArgv;
+  }
 }
 
-main().catch((error: unknown) => {
-  const payload = toLinkedInAssistantErrorPayload(error, cliPrivacyConfig);
-  console.error(JSON.stringify(payload, null, 2));
-  process.exit(1);
-});
+function isDirectExecution(moduleUrl: string): boolean {
+  const entrypoint = process.argv[1];
+  if (!entrypoint) {
+    return false;
+  }
+
+  return pathToFileURL(entrypoint).href === moduleUrl;
+}
+
+if (isDirectExecution(import.meta.url)) {
+  runCli().catch((error: unknown) => {
+    const payload = toLinkedInAssistantErrorPayload(error, cliPrivacyConfig);
+    console.error(JSON.stringify(payload, null, 2));
+    process.exit(1);
+  });
+}

--- a/packages/core/src/__tests__/e2e/cli.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/cli.e2e.test.ts
@@ -1,0 +1,488 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  getCliCoverageFixtures,
+  getDefaultConnectionTarget,
+  getDefaultProfileName,
+  getLastJsonObject,
+  prepareEchoAction,
+  runCliCommand
+} from "./helpers.js";
+import {
+  cleanupRuntime,
+  getE2EAvailability,
+  getRuntime,
+  type E2EAvailability
+} from "./setup.js";
+
+describe.sequential("CLI E2E", () => {
+  let availability: E2EAvailability;
+  let fixtures: Awaited<ReturnType<typeof getCliCoverageFixtures>> | undefined;
+  const profileName = getDefaultProfileName();
+
+  beforeAll(async () => {
+    availability = await getE2EAvailability();
+    if (availability.canRun) {
+      fixtures = await getCliCoverageFixtures(getRuntime());
+    }
+  }, 180_000);
+
+  afterAll(() => {
+    cleanupRuntime();
+  });
+
+  it("covers session, health, rate-limit, login, and selector audit commands", async () => {
+    if (!availability.canRun || !fixtures) {
+      return;
+    }
+
+    const status = await runCliCommand(["status", "--profile", profileName]);
+    expect(status.error).toBeUndefined();
+    expect(status.exitCode).toBe(0);
+    expect(getLastJsonObject(status.stdout)).toMatchObject({
+      authenticated: true
+    });
+
+    const health = await runCliCommand(["health", "--profile", profileName]);
+    expect(health.error).toBeUndefined();
+    expect(health.exitCode).toBe(0);
+    expect(getLastJsonObject(health.stdout)).toMatchObject({
+      browser: {
+        healthy: true
+      },
+      session: {
+        authenticated: true
+      }
+    });
+
+    const rateLimitStatus = await runCliCommand(["rate-limit"]);
+    expect(rateLimitStatus.error).toBeUndefined();
+    expect(getLastJsonObject(rateLimitStatus.stdout)).toHaveProperty("active");
+
+    const rateLimitClear = await runCliCommand(["rate-limit", "--clear"]);
+    expect(rateLimitClear.error).toBeUndefined();
+    expect(getLastJsonObject(rateLimitClear.stdout)).toMatchObject({
+      cleared: true
+    });
+
+    const login = await runCliCommand([
+      "login",
+      "--profile",
+      profileName,
+      "--timeout-minutes",
+      "1"
+    ]);
+    expect(login.error).toBeUndefined();
+    expect(login.exitCode).toBe(0);
+    expect(getLastJsonObject(login.stdout)).toMatchObject({
+      authenticated: true,
+      timedOut: false
+    });
+
+    const audit = await runCliCommand([
+      "audit",
+      "selectors",
+      "--profile",
+      profileName,
+      "--json",
+      "--no-progress"
+    ]);
+    expect(audit.error).toBeUndefined();
+    const auditPayload = getLastJsonObject(audit.stdout);
+    expect(typeof auditPayload.total_count).toBe("number");
+    expect(typeof auditPayload.fail_count).toBe("number");
+    expect(typeof auditPayload.report_path).toBe("string");
+    const failCount = auditPayload.fail_count;
+    if (typeof failCount === "number" && failCount > 0) {
+      expect(audit.exitCode).toBe(1);
+    } else {
+      expect(audit.exitCode).toBe(0);
+    }
+  }, 240_000);
+
+  it("covers inbox commands and both confirm entrypoints", async () => {
+    if (!availability.canRun || !fixtures) {
+      return;
+    }
+
+    const inboxList = await runCliCommand([
+      "inbox",
+      "list",
+      "--profile",
+      profileName,
+      "--limit",
+      "5"
+    ]);
+    expect(inboxList.error).toBeUndefined();
+    expect(getLastJsonObject(inboxList.stdout)).toMatchObject({
+      profile_name: profileName,
+      count: expect.any(Number)
+    });
+
+    const inboxShow = await runCliCommand([
+      "inbox",
+      "show",
+      "--profile",
+      profileName,
+      "--thread",
+      fixtures.threadId,
+      "--limit",
+      "5"
+    ]);
+    expect(inboxShow.error).toBeUndefined();
+    expect(getLastJsonObject(inboxShow.stdout)).toMatchObject({
+      profile_name: profileName,
+      thread: {
+        thread_id: fixtures.threadId
+      }
+    });
+
+    const prepareReply = await runCliCommand([
+      "inbox",
+      "prepare-reply",
+      "--profile",
+      profileName,
+      "--thread",
+      fixtures.threadId,
+      "--text",
+      `CLI preview message [${Date.now()}]`
+    ]);
+    expect(prepareReply.error).toBeUndefined();
+    expect(getLastJsonObject(prepareReply.stdout)).toMatchObject({
+      profile_name: profileName,
+      preparedActionId: expect.stringMatching(/^pa_/),
+      confirmToken: expect.stringMatching(/^ct_/)
+    });
+
+    const runtime = getRuntime();
+    const confirmAction = prepareEchoAction(runtime, {
+      profileName,
+      summary: "CLI actions.confirm echo"
+    });
+    const actionsConfirm = await runCliCommand([
+      "actions",
+      "confirm",
+      "--profile",
+      profileName,
+      "--token",
+      confirmAction.confirmToken,
+      "--yes"
+    ]);
+    expect(actionsConfirm.error).toBeUndefined();
+    expect(actionsConfirm.exitCode).toBe(0);
+    expect(getLastJsonObject(actionsConfirm.stdout)).toMatchObject({
+      profile_name: profileName,
+      actionType: "test.echo",
+      result: {
+        echo: expect.any(String)
+      }
+    });
+
+    const confirmPost = prepareEchoAction(runtime, {
+      profileName,
+      summary: "CLI post.confirm echo"
+    });
+    const postConfirm = await runCliCommand([
+      "post",
+      "confirm",
+      "--profile",
+      profileName,
+      "--token",
+      confirmPost.confirmToken,
+      "--yes"
+    ]);
+    expect(postConfirm.error).toBeUndefined();
+    expect(postConfirm.exitCode).toBe(0);
+    expect(getLastJsonObject(postConfirm.stdout)).toMatchObject({
+      profile_name: profileName,
+      actionType: "test.echo",
+      result: {
+        echo: expect.any(String)
+      }
+    });
+  }, 180_000);
+
+  it("covers connections, followups, and keepalive commands", async () => {
+    if (!availability.canRun || !fixtures) {
+      return;
+    }
+
+    const connectionsList = await runCliCommand([
+      "connections",
+      "list",
+      "--profile",
+      profileName,
+      "--limit",
+      "5"
+    ]);
+    expect(connectionsList.error).toBeUndefined();
+    expect(getLastJsonObject(connectionsList.stdout)).toMatchObject({
+      profile_name: profileName,
+      count: expect.any(Number)
+    });
+
+    const pending = await runCliCommand([
+      "connections",
+      "pending",
+      "--profile",
+      profileName,
+      "--filter",
+      "all"
+    ]);
+    expect(pending.error).toBeUndefined();
+    expect(getLastJsonObject(pending.stdout)).toMatchObject({
+      profile_name: profileName,
+      filter: "all"
+    });
+
+    for (const command of ["invite", "accept", "withdraw"] as const) {
+      const prepared = await runCliCommand([
+        "connections",
+        command,
+        fixtures.connectionTarget,
+        "--profile",
+        profileName
+      ]);
+      expect(prepared.error).toBeUndefined();
+      expect(getLastJsonObject(prepared.stdout)).toMatchObject({
+        profile_name: profileName,
+        preparedActionId: expect.stringMatching(/^pa_/),
+        confirmToken: expect.stringMatching(/^ct_/)
+      });
+    }
+
+    const followupsList = await runCliCommand([
+      "followups",
+      "list",
+      "--profile",
+      profileName,
+      "--since",
+      "30d"
+    ]);
+    expect(followupsList.error).toBeUndefined();
+    expect(getLastJsonObject(followupsList.stdout)).toMatchObject({
+      profile_name: profileName,
+      accepted_connections: expect.any(Array)
+    });
+
+    const followupsPrepare = await runCliCommand([
+      "followups",
+      "prepare",
+      "--profile",
+      profileName,
+      "--since",
+      "30d"
+    ]);
+    expect(followupsPrepare.error).toBeUndefined();
+    expect(getLastJsonObject(followupsPrepare.stdout)).toMatchObject({
+      profile_name: profileName,
+      accepted_connections: expect.any(Array),
+      prepared_followups: expect.any(Array)
+    });
+
+    const keepaliveProfile = `e2e-keepalive-${Date.now()}`;
+    const keepaliveStart = await runCliCommand([
+      "keepalive",
+      "start",
+      "--profile",
+      keepaliveProfile,
+      "--interval-seconds",
+      "5",
+      "--jitter-seconds",
+      "0",
+      "--max-consecutive-failures",
+      "2"
+    ]);
+    expect(keepaliveStart.error).toBeUndefined();
+    expect(getLastJsonObject(keepaliveStart.stdout)).toMatchObject({
+      started: true,
+      profile_name: keepaliveProfile,
+      pid: expect.any(Number)
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+
+    const keepaliveStatus = await runCliCommand([
+      "keepalive",
+      "status",
+      "--profile",
+      keepaliveProfile
+    ]);
+    expect(keepaliveStatus.error).toBeUndefined();
+    expect(getLastJsonObject(keepaliveStatus.stdout)).toMatchObject({
+      profile_name: keepaliveProfile,
+      running: expect.any(Boolean)
+    });
+
+    const keepaliveStop = await runCliCommand([
+      "keepalive",
+      "stop",
+      "--profile",
+      keepaliveProfile
+    ]);
+    expect(keepaliveStop.error).toBeUndefined();
+    expect(getLastJsonObject(keepaliveStop.stdout)).toMatchObject({
+      stopped: true,
+      profile_name: keepaliveProfile
+    });
+  }, 180_000);
+
+  it("covers feed, post, profile, search, jobs, and notifications commands", async () => {
+    if (!availability.canRun || !fixtures) {
+      return;
+    }
+
+    const feedList = await runCliCommand([
+      "feed",
+      "list",
+      "--profile",
+      profileName,
+      "--limit",
+      "5"
+    ]);
+    expect(feedList.error).toBeUndefined();
+    expect(getLastJsonObject(feedList.stdout)).toMatchObject({
+      profile_name: profileName,
+      posts: expect.any(Array)
+    });
+
+    const feedView = await runCliCommand([
+      "feed",
+      "view",
+      fixtures.postUrl,
+      "--profile",
+      profileName
+    ]);
+    expect(feedView.error).toBeUndefined();
+    expect(getLastJsonObject(feedView.stdout)).toMatchObject({
+      profile_name: profileName,
+      post: {
+        post_url: fixtures.postUrl
+      }
+    });
+
+    const feedLike = await runCliCommand([
+      "feed",
+      "like",
+      fixtures.postUrl,
+      "--profile",
+      profileName,
+      "--reaction",
+      "like"
+    ]);
+    expect(feedLike.error).toBeUndefined();
+    expect(getLastJsonObject(feedLike.stdout)).toMatchObject({
+      profile_name: profileName,
+      preparedActionId: expect.stringMatching(/^pa_/),
+      confirmToken: expect.stringMatching(/^ct_/)
+    });
+
+    const feedComment = await runCliCommand([
+      "feed",
+      "comment",
+      fixtures.postUrl,
+      "--profile",
+      profileName,
+      "--text",
+      `CLI preview comment [${Date.now()}]`
+    ]);
+    expect(feedComment.error).toBeUndefined();
+    expect(getLastJsonObject(feedComment.stdout)).toMatchObject({
+      profile_name: profileName,
+      preparedActionId: expect.stringMatching(/^pa_/),
+      confirmToken: expect.stringMatching(/^ct_/)
+    });
+
+    const postPrepare = await runCliCommand([
+      "post",
+      "prepare",
+      "--profile",
+      profileName,
+      "--text",
+      `CLI preview post [${Date.now()}]`
+    ]);
+    expect(postPrepare.error).toBeUndefined();
+    expect(getLastJsonObject(postPrepare.stdout)).toMatchObject({
+      profile_name: profileName,
+      preparedActionId: expect.stringMatching(/^pa_/),
+      confirmToken: expect.stringMatching(/^ct_/)
+    });
+
+    const profileView = await runCliCommand([
+      "profile",
+      "view",
+      getDefaultConnectionTarget(),
+      "--profile",
+      profileName
+    ]);
+    expect(profileView.error).toBeUndefined();
+    expect(getLastJsonObject(profileView.stdout)).toMatchObject({
+      profile_name: profileName,
+      profile: {
+        profile_url: expect.stringContaining("linkedin.com")
+      }
+    });
+
+    const search = await runCliCommand([
+      "search",
+      "Simon Miller",
+      "--profile",
+      profileName,
+      "--category",
+      "people",
+      "--limit",
+      "5"
+    ]);
+    expect(search.error).toBeUndefined();
+    expect(getLastJsonObject(search.stdout)).toMatchObject({
+      profile_name: profileName,
+      category: "people",
+      results: expect.any(Array)
+    });
+
+    const jobsSearch = await runCliCommand([
+      "jobs",
+      "search",
+      "software engineer",
+      "--profile",
+      profileName,
+      "--location",
+      "Copenhagen",
+      "--limit",
+      "5"
+    ]);
+    expect(jobsSearch.error).toBeUndefined();
+    expect(getLastJsonObject(jobsSearch.stdout)).toMatchObject({
+      profile_name: profileName,
+      results: expect.any(Array)
+    });
+
+    const jobsView = await runCliCommand([
+      "jobs",
+      "view",
+      fixtures.jobId,
+      "--profile",
+      profileName
+    ]);
+    expect(jobsView.error).toBeUndefined();
+    expect(getLastJsonObject(jobsView.stdout)).toMatchObject({
+      profile_name: profileName,
+      job: {
+        job_id: fixtures.jobId
+      }
+    });
+
+    const notifications = await runCliCommand([
+      "notifications",
+      "list",
+      "--profile",
+      profileName,
+      "--limit",
+      "5"
+    ]);
+    expect(notifications.error).toBeUndefined();
+    expect(getLastJsonObject(notifications.stdout)).toMatchObject({
+      profile_name: profileName,
+      notifications: expect.any(Array)
+    });
+  }, 240_000);
+});

--- a/packages/core/src/__tests__/e2e/connections-write.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/connections-write.e2e.test.ts
@@ -1,0 +1,100 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  getConnectionConfirmMode,
+  getDefaultConnectionTarget,
+  getWriteConfirmGate
+} from "./helpers.js";
+import {
+  checkAuthenticated,
+  checkCdpAvailable,
+  cleanupRuntime,
+  getRuntime
+} from "./setup.js";
+
+const connectionConfirmMode = getConnectionConfirmMode();
+const connectionConfirmEnabled =
+  getWriteConfirmGate("LINKEDIN_E2E_ENABLE_CONNECTION_CONFIRM").enabled &&
+  ["invite", "accept", "withdraw"].includes(connectionConfirmMode);
+const connectionConfirmTest = connectionConfirmEnabled ? it : it.skip;
+
+describe("Connections Write E2E (2PC invitation flows)", () => {
+  let cdpOk = false;
+  let authOk = false;
+
+  beforeAll(async () => {
+    cdpOk = await checkCdpAvailable();
+    if (cdpOk) {
+      authOk = await checkAuthenticated();
+    }
+  });
+
+  afterAll(() => {
+    cleanupRuntime();
+  });
+
+  it("prepare returns valid previews for invite, accept, and withdraw", async () => {
+    if (!cdpOk || !authOk) return;
+    const runtime = getRuntime();
+    const targetProfile = getDefaultConnectionTarget();
+
+    const invite = runtime.connections.prepareSendInvitation({
+      targetProfile,
+      note: "E2E preview invite"
+    });
+    const accept = runtime.connections.prepareAcceptInvitation({
+      targetProfile
+    });
+    const withdraw = runtime.connections.prepareWithdrawInvitation({
+      targetProfile
+    });
+
+    for (const prepared of [invite, accept, withdraw]) {
+      expect(prepared.preparedActionId).toMatch(/^pa_/);
+      expect(prepared.confirmToken).toMatch(/^ct_/);
+      expect(prepared.preview).toHaveProperty("summary");
+      expect(prepared.preview).toHaveProperty("target");
+    }
+  });
+
+  connectionConfirmTest("confirms the configured connection flow via prepare → confirm", async () => {
+    if (!cdpOk || !authOk) return;
+    const runtime = getRuntime();
+    const targetProfile = getDefaultConnectionTarget();
+
+    const prepared =
+      connectionConfirmMode === "accept"
+        ? runtime.connections.prepareAcceptInvitation({ targetProfile })
+        : connectionConfirmMode === "withdraw"
+          ? runtime.connections.prepareWithdrawInvitation({ targetProfile })
+          : runtime.connections.prepareSendInvitation({
+              targetProfile,
+              note: "E2E connection invite"
+            });
+
+    const result = await runtime.twoPhaseCommit.confirmByToken({
+      confirmToken: prepared.confirmToken
+    });
+
+    expect(result.status).toBe("executed");
+    if (connectionConfirmMode === "accept") {
+      expect(result.actionType).toBe("connections.accept_invitation");
+      expect(result.result).toMatchObject({
+        status: "invitation_accepted"
+      });
+      return;
+    }
+
+    if (connectionConfirmMode === "withdraw") {
+      expect(result.actionType).toBe("connections.withdraw_invitation");
+      expect(result.result).toMatchObject({
+        status: "invitation_withdrawn"
+      });
+      return;
+    }
+
+    expect(result.actionType).toBe("connections.send_invitation");
+    expect(result.result).toMatchObject({
+      status: "invitation_sent"
+    });
+  }, 120_000);
+});

--- a/packages/core/src/__tests__/e2e/error-paths.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/error-paths.e2e.test.ts
@@ -1,0 +1,189 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { LinkedInAssistantError } from "../../errors.js";
+import { createCoreRuntime, type CoreRuntime } from "../../runtime.js";
+import {
+  LinkedInSelectorAuditService,
+  type SelectorAuditPageDefinition
+} from "../../selectorAudit.js";
+import { getFeedPost } from "./helpers.js";
+import {
+  checkAuthenticated,
+  checkCdpAvailable,
+  cleanupRuntime,
+  getCdpUrl
+} from "./setup.js";
+
+const LIKE_RATE_LIMIT_CONFIG = {
+  counterKey: "linkedin.feed.like_post",
+  windowSizeMs: 60 * 60 * 1000,
+  limit: 30
+} as const;
+
+async function createIsolatedRuntime(): Promise<{
+  runtime: CoreRuntime;
+  dispose: () => Promise<void>;
+}> {
+  const baseDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-e2e-"));
+  const runtime = createCoreRuntime({
+    baseDir,
+    cdpUrl: getCdpUrl()
+  });
+
+  return {
+    runtime,
+    dispose: async () => {
+      runtime.close();
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  };
+}
+
+async function expectAssistantError(
+  promise: Promise<unknown>,
+  expectedCode: string
+): Promise<LinkedInAssistantError> {
+  try {
+    await promise;
+    throw new Error(`Expected ${expectedCode} error.`);
+  } catch (error) {
+    expect(error).toBeInstanceOf(LinkedInAssistantError);
+    const assistantError = error as LinkedInAssistantError;
+    expect(assistantError.code).toBe(expectedCode);
+    return assistantError;
+  }
+}
+
+describe("E2E error paths", () => {
+  let cdpOk = false;
+  let authOk = false;
+
+  beforeAll(async () => {
+    cdpOk = await checkCdpAvailable();
+    if (cdpOk) {
+      authOk = await checkAuthenticated();
+    }
+  });
+
+  afterAll(() => {
+    cleanupRuntime();
+  });
+
+  it("rejects expired confirmation tokens before execution", async () => {
+    if (!cdpOk || !authOk) return;
+
+    const isolated = await createIsolatedRuntime();
+    try {
+      const post = await getFeedPost(isolated.runtime);
+      const prepared = isolated.runtime.feed.prepareLikePost({
+        postUrl: post.post_url,
+        reaction: "like"
+      });
+
+      const error = await expectAssistantError(
+        isolated.runtime.twoPhaseCommit.confirmByToken({
+          confirmToken: prepared.confirmToken,
+          nowMs: prepared.expiresAtMs + 1
+        }),
+        "ACTION_PRECONDITION_FAILED"
+      );
+      expect(error.message).toContain("expired");
+
+      const row = isolated.runtime.db.getPreparedActionById(prepared.preparedActionId);
+      expect(row?.status).toBe("prepared");
+    } finally {
+      await isolated.dispose();
+    }
+  }, 120_000);
+
+  it("surfaces rate limit failures without performing the action", async () => {
+    if (!cdpOk || !authOk) return;
+
+    const isolated = await createIsolatedRuntime();
+    try {
+      const post = await getFeedPost(isolated.runtime);
+      const prepared = isolated.runtime.feed.prepareLikePost({
+        postUrl: post.post_url,
+        reaction: "like"
+      });
+      const windowNow = Date.now();
+
+      for (let count = 0; count < LIKE_RATE_LIMIT_CONFIG.limit; count += 1) {
+        isolated.runtime.rateLimiter.consume({
+          ...LIKE_RATE_LIMIT_CONFIG,
+          nowMs: windowNow
+        });
+      }
+
+      const error = await expectAssistantError(
+        isolated.runtime.twoPhaseCommit.confirmByToken({
+          confirmToken: prepared.confirmToken,
+          nowMs: windowNow
+        }),
+        "RATE_LIMITED"
+      );
+      expect(error.details).toHaveProperty("rate_limit");
+
+      const row = isolated.runtime.db.getPreparedActionById(prepared.preparedActionId);
+      expect(row?.status).toBe("failed");
+      expect(row?.error_code).toBe("RATE_LIMITED");
+    } finally {
+      await isolated.dispose();
+    }
+  }, 120_000);
+
+  it("detects UI drift through selector audit failure artifacts", async () => {
+    if (!cdpOk || !authOk) return;
+
+    const isolated = await createIsolatedRuntime();
+    try {
+      const registry: SelectorAuditPageDefinition[] = [
+        {
+          page: "feed",
+          url: "https://www.linkedin.com/feed/",
+          selectors: [
+            {
+              key: "impossible_feed_selector",
+              description: "Deliberately impossible selector used to validate UI drift reporting.",
+              candidates: [
+                {
+                  key: "impossible-primary",
+                  strategy: "primary",
+                  selectorHint: "text=__linkedin_e2e_missing_selector__",
+                  locatorFactory: (page) =>
+                    page.locator("text=__linkedin_e2e_missing_selector__")
+                }
+              ]
+            }
+          ]
+        }
+      ];
+
+      const selectorAudit = new LinkedInSelectorAuditService(isolated.runtime, {
+        registry,
+        candidateTimeoutMs: 250,
+        pageReadyTimeoutMs: 1_000,
+        pageNavigationTimeoutMs: 15_000
+      });
+      const report = await selectorAudit.auditSelectors();
+
+      expect(report.outcome).toBe("fail");
+      expect(report.fail_count).toBe(1);
+      expect(report.failed_selectors).toHaveLength(1);
+      expect(report.failed_selectors[0]).toMatchObject({
+        page: "feed",
+        selector_key: "impossible_feed_selector"
+      });
+      expect(report.failed_selectors[0]?.failure_artifacts.screenshot_path).toEqual(
+        expect.any(String)
+      );
+      expect(report.failed_selectors[0]?.failure_artifacts.dom_snapshot_path).toEqual(
+        expect.any(String)
+      );
+    } finally {
+      await isolated.dispose();
+    }
+  }, 120_000);
+});

--- a/packages/core/src/__tests__/e2e/feed-like.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/feed-like.e2e.test.ts
@@ -1,0 +1,78 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  getFeedPost,
+  getOptInLikePostUrl,
+  getWriteConfirmGate
+} from "./helpers.js";
+import {
+  checkAuthenticated,
+  checkCdpAvailable,
+  cleanupRuntime,
+  getRuntime
+} from "./setup.js";
+
+const likeConfirmPostUrl = getOptInLikePostUrl();
+const likeConfirmTest =
+  getWriteConfirmGate("LINKEDIN_E2E_ENABLE_LIKE_CONFIRM").enabled &&
+  typeof likeConfirmPostUrl === "string" &&
+  likeConfirmPostUrl.length > 0
+    ? it
+    : it.skip;
+
+describe("Feed Like E2E (2PC like_post)", () => {
+  let cdpOk = false;
+  let authOk = false;
+
+  beforeAll(async () => {
+    cdpOk = await checkCdpAvailable();
+    if (cdpOk) {
+      authOk = await checkAuthenticated();
+    }
+  });
+
+  afterAll(() => {
+    cleanupRuntime();
+  });
+
+  it("prepare returns valid preview with rate limit info", async () => {
+    if (!cdpOk || !authOk) return;
+    const runtime = getRuntime();
+    const post = await getFeedPost(runtime);
+
+    const prepared = runtime.feed.prepareLikePost({
+      postUrl: post.post_url,
+      reaction: "like"
+    });
+
+    expect(prepared.preview).toHaveProperty("rate_limit");
+    const rateLimit = prepared.preview.rate_limit as Record<string, unknown>;
+    expect(rateLimit).toHaveProperty("counter_key", "linkedin.feed.like_post");
+    expect(typeof rateLimit.remaining).toBe("number");
+    expect(typeof rateLimit.allowed).toBe("boolean");
+  }, 60_000);
+
+  likeConfirmTest("likes a feed post via prepare → confirm", async () => {
+    if (!cdpOk || !authOk) return;
+    const runtime = getRuntime();
+    const postUrl = likeConfirmPostUrl!;
+    const prepared = runtime.feed.prepareLikePost({
+      postUrl,
+      reaction: "like",
+      operatorNote: "Automated E2E like write test"
+    });
+
+    expect(prepared.preparedActionId).toMatch(/^pa_/);
+    expect(prepared.confirmToken).toMatch(/^ct_/);
+
+    const result = await runtime.twoPhaseCommit.confirmByToken({
+      confirmToken: prepared.confirmToken
+    });
+
+    expect(result.status).toBe("executed");
+    expect(result.actionType).toBe("feed.like_post");
+    expect(result.result).toMatchObject({
+      reacted: true,
+      reaction: "like"
+    });
+  }, 120_000);
+});

--- a/packages/core/src/__tests__/e2e/feed-write.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/feed-write.e2e.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { getOptInCommentPostUrl, getWriteConfirmGate } from "./helpers.js";
 import {
   getRuntime,
   checkCdpAvailable,
@@ -6,12 +7,21 @@ import {
   cleanupRuntime
 } from "./setup.js";
 
+const commentConfirmPostUrl = getOptInCommentPostUrl();
+const commentConfirmTest =
+  getWriteConfirmGate("LINKEDIN_E2E_ENABLE_COMMENT_CONFIRM").enabled &&
+  typeof commentConfirmPostUrl === "string" &&
+  commentConfirmPostUrl.length > 0
+    ? it
+    : it.skip;
+
 /**
  * Feed Write E2E — two-phase commit comment on Joakim's own post.
  *
  * Flow: feed.viewFeed → feed.prepareCommentOnPost → twoPhaseCommit.confirmByToken
  *
- * Uses the first visible feed post (Joakim's own or any post in the feed).
+ * Requires LINKEDIN_E2E_ENABLE_COMMENT_CONFIRM=1 and
+ * LINKEDIN_E2E_COMMENT_POST_URL=<approved-post-url>.
  * Comments can be manually deleted afterwards.
  * Explicitly authorised by project owner (Joakim Sigvardt).
  */
@@ -30,29 +40,20 @@ describe("Feed Write E2E (2PC comment_on_post)", () => {
     cleanupRuntime();
   });
 
-  it("comments on a feed post via prepare → confirm", async () => {
+  commentConfirmTest("comments on a feed post via prepare → confirm", async () => {
     if (!cdpOk || !authOk) return;
     const runtime = getRuntime();
 
-    // Step 1: get feed posts and pick a target
-    const posts = await runtime.feed.viewFeed({ limit: 10 });
-    expect(posts.length).toBeGreaterThan(0);
+    const targetPostUrl = commentConfirmPostUrl!;
 
-    // Prefer Joakim's own post if visible; otherwise use the first post
-    const ownPost = posts.find((p) =>
-      /joakim\s*sigvardt/i.test(p.author_name)
-    );
-    const targetPost = ownPost ?? posts[0]!;
-
-    expect(targetPost.post_url).toBeTruthy();
-    expect(targetPost.post_id).toBeTruthy();
+    expect(targetPostUrl).toContain("linkedin.com");
 
     // Step 2: prepare a comment via 2PC
     const timestamp = new Date().toISOString();
     const commentText = `E2E test comment from linkedin-owa-agentools [${timestamp}]`;
 
     const prepared = runtime.feed.prepareCommentOnPost({
-      postUrl: targetPost.post_url,
+      postUrl: targetPostUrl,
       text: commentText,
       operatorNote: "Automated E2E feed write test"
     });

--- a/packages/core/src/__tests__/e2e/helpers.ts
+++ b/packages/core/src/__tests__/e2e/helpers.ts
@@ -1,0 +1,417 @@
+import type { CoreRuntime } from "../../runtime.js";
+import { TEST_ECHO_ACTION_TYPE } from "../../twoPhaseCommit.js";
+import { runCli } from "../../../../cli/src/bin/linkedin.js";
+import { handleToolCall } from "../../../../mcp/src/bin/linkedin-mcp.js";
+import {
+  LINKEDIN_ACTIONS_CONFIRM_TOOL,
+  LINKEDIN_CONNECTIONS_ACCEPT_TOOL,
+  LINKEDIN_CONNECTIONS_INVITE_TOOL,
+  LINKEDIN_CONNECTIONS_LIST_TOOL,
+  LINKEDIN_CONNECTIONS_PENDING_TOOL,
+  LINKEDIN_CONNECTIONS_WITHDRAW_TOOL,
+  LINKEDIN_FEED_COMMENT_TOOL,
+  LINKEDIN_FEED_LIKE_TOOL,
+  LINKEDIN_FEED_LIST_TOOL,
+  LINKEDIN_FEED_VIEW_POST_TOOL,
+  LINKEDIN_INBOX_GET_THREAD_TOOL,
+  LINKEDIN_INBOX_LIST_THREADS_TOOL,
+  LINKEDIN_INBOX_PREPARE_REPLY_TOOL,
+  LINKEDIN_JOBS_SEARCH_TOOL,
+  LINKEDIN_JOBS_VIEW_TOOL,
+  LINKEDIN_NETWORK_PREPARE_FOLLOWUP_AFTER_ACCEPT_TOOL,
+  LINKEDIN_NOTIFICATIONS_LIST_TOOL,
+  LINKEDIN_POST_PREPARE_CREATE_TOOL,
+  LINKEDIN_PROFILE_VIEW_TOOL,
+  LINKEDIN_SEARCH_TOOL,
+  LINKEDIN_SESSION_HEALTH_TOOL,
+  LINKEDIN_SESSION_OPEN_LOGIN_TOOL,
+  LINKEDIN_SESSION_STATUS_TOOL
+} from "../../../../mcp/src/index.js";
+import { getCdpUrl } from "./setup.js";
+
+export interface CapturedCommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  error?: unknown;
+}
+
+export interface MappedMcpResult {
+  payload: Record<string, unknown>;
+  isError: boolean;
+}
+
+export interface ConfirmGateConfig {
+  enabled: boolean;
+  reason: string;
+}
+
+const DEFAULT_PROFILE_NAME = process.env.LINKEDIN_E2E_PROFILE ?? "default";
+const DEFAULT_MESSAGE_TARGET_PATTERN =
+  process.env.LINKEDIN_E2E_MESSAGE_TARGET_PATTERN ?? "Simon Miller";
+const DEFAULT_CONNECTION_TARGET =
+  process.env.LINKEDIN_E2E_CONNECTION_TARGET ?? "realsimonmiller";
+const DEFAULT_LIKE_POST_URL = process.env.LINKEDIN_E2E_LIKE_POST_URL;
+const DEFAULT_COMMENT_POST_URL = process.env.LINKEDIN_E2E_COMMENT_POST_URL;
+const DEFAULT_CONNECTION_CONFIRM_MODE =
+  process.env.LINKEDIN_E2E_CONNECTION_CONFIRM_MODE ?? "";
+
+function readEnabledFlag(name: string): boolean {
+  const value = process.env[name];
+  return value === "1" || value === "true";
+}
+
+function coerceChunk(
+  chunk: string | Uint8Array,
+  encoding?: string | undefined
+): string {
+  if (typeof chunk === "string") {
+    return chunk;
+  }
+
+  return Buffer.from(chunk).toString(encoding);
+}
+
+function createWriteInterceptor(
+  chunks: string[]
+): typeof process.stdout.write {
+  return ((chunk, encoding, callback) => {
+    const resolvedEncoding = typeof encoding === "string" ? encoding : undefined;
+    chunks.push(coerceChunk(chunk, resolvedEncoding));
+
+    if (typeof encoding === "function") {
+      encoding();
+    }
+    if (typeof callback === "function") {
+      callback();
+    }
+
+    return true;
+  }) as typeof process.stdout.write;
+}
+
+function parseJsonObjects(text: string): Record<string, unknown>[] {
+  const objects: Record<string, unknown>[] = [];
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index]!;
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+
+    if (char === "{") {
+      if (depth === 0) {
+        start = index;
+      }
+      depth += 1;
+      continue;
+    }
+
+    if (char === "}") {
+      if (depth === 0) {
+        continue;
+      }
+      depth -= 1;
+      if (depth === 0 && start >= 0) {
+        const candidate = text.slice(start, index + 1);
+        try {
+          const parsed = JSON.parse(candidate) as unknown;
+          if (
+            typeof parsed === "object" &&
+            parsed !== null &&
+            !Array.isArray(parsed)
+          ) {
+            objects.push(parsed as Record<string, unknown>);
+          }
+        } catch {
+          // Ignore non-JSON brace blocks.
+        }
+        start = -1;
+      }
+    }
+  }
+
+  return objects;
+}
+
+export function getDefaultProfileName(): string {
+  return DEFAULT_PROFILE_NAME;
+}
+
+export function getDefaultConnectionTarget(): string {
+  return DEFAULT_CONNECTION_TARGET;
+}
+
+export function getDefaultMessageTargetPattern(): RegExp {
+  return new RegExp(DEFAULT_MESSAGE_TARGET_PATTERN, "i");
+}
+
+export function getWriteConfirmGate(name: string): ConfirmGateConfig {
+  const enabled = readEnabledFlag(name);
+  return {
+    enabled,
+    reason: enabled ? `${name} is enabled.` : `${name} is not enabled.`
+  };
+}
+
+export function getConnectionConfirmMode(): string {
+  return DEFAULT_CONNECTION_CONFIRM_MODE;
+}
+
+export function getOptInLikePostUrl(): string | undefined {
+  return DEFAULT_LIKE_POST_URL;
+}
+
+export function getOptInCommentPostUrl(): string | undefined {
+  return DEFAULT_COMMENT_POST_URL;
+}
+
+export async function runCliCommand(args: string[]): Promise<CapturedCommandResult> {
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+  const originalExitCode = process.exitCode;
+  let exitCode = 0;
+
+  process.stdout.write = createWriteInterceptor(stdoutChunks);
+  process.stderr.write = createWriteInterceptor(stderrChunks);
+  process.exitCode = 0;
+
+  let error: unknown;
+
+  try {
+    await runCli(["node", "linkedin", "--cdp-url", getCdpUrl(), ...args]);
+  } catch (caught) {
+    error = caught;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    exitCode = process.exitCode ?? 0;
+    process.exitCode = originalExitCode;
+  }
+
+  return {
+    stdout: stdoutChunks.join(""),
+    stderr: stderrChunks.join(""),
+    exitCode,
+    ...(error === undefined ? {} : { error })
+  };
+}
+
+export function getLastJsonObject(text: string): Record<string, unknown> {
+  const objects = parseJsonObjects(text);
+  const lastObject = objects.at(-1);
+  if (!lastObject) {
+    throw new Error(`No JSON object found in output:\n${text}`);
+  }
+  return lastObject;
+}
+
+export async function callMcpTool(
+  name: string,
+  args: Record<string, unknown> = {}
+): Promise<MappedMcpResult> {
+  const rawResult = await handleToolCall(name, {
+    cdpUrl: getCdpUrl(),
+    ...args
+  });
+  const content = rawResult.content[0];
+  if (!content) {
+    throw new Error(`Tool ${name} returned no content.`);
+  }
+
+  const payload = JSON.parse(content.text) as unknown;
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+    throw new Error(`Tool ${name} returned a non-object payload.`);
+  }
+
+  return {
+    payload: payload as Record<string, unknown>,
+    isError: "isError" in rawResult && rawResult.isError === true
+  };
+}
+
+export function prepareEchoAction(
+  runtime: CoreRuntime,
+  input: {
+    profileName?: string;
+    text?: string;
+    summary?: string;
+  } = {}
+): {
+  preparedActionId: string;
+  confirmToken: string;
+  expiresAtMs: number;
+  preview: Record<string, unknown>;
+} {
+  const profileName = input.profileName ?? DEFAULT_PROFILE_NAME;
+  const text = input.text ?? `echo-${Date.now()}`;
+  const target = {
+    profile_name: profileName
+  } satisfies Record<string, unknown>;
+
+  return runtime.twoPhaseCommit.prepare({
+    actionType: TEST_ECHO_ACTION_TYPE,
+    target,
+    payload: {
+      text
+    },
+    preview: {
+      summary: input.summary ?? `Echo action for ${profileName}`,
+      target,
+      outbound: {
+        text
+      }
+    }
+  });
+}
+
+export async function getMessageThread(runtime: CoreRuntime): Promise<{
+  thread_id: string;
+  title: string;
+  thread_url: string;
+}> {
+  const threads = await runtime.inbox.listThreads({
+    limit: 40,
+    profileName: DEFAULT_PROFILE_NAME
+  });
+
+  const match = threads.find((thread) => getDefaultMessageTargetPattern().test(thread.title));
+  if (!match) {
+    throw new Error(
+      `Could not find inbox thread matching ${DEFAULT_MESSAGE_TARGET_PATTERN}.`
+    );
+  }
+
+  return {
+    thread_id: match.thread_id,
+    title: match.title,
+    thread_url: match.thread_url
+  };
+}
+
+export async function getFeedPost(runtime: CoreRuntime): Promise<{
+  post_id: string;
+  post_url: string;
+  author_name: string;
+}> {
+  const posts = await runtime.feed.viewFeed({
+    profileName: DEFAULT_PROFILE_NAME,
+    limit: 10
+  });
+
+  const post = posts[0];
+  if (!post) {
+    throw new Error("No feed post was available for E2E coverage.");
+  }
+
+  return {
+    post_id: post.post_id,
+    post_url: post.post_url,
+    author_name: post.author_name
+  };
+}
+
+export async function getJob(runtime: CoreRuntime): Promise<{
+  job_id: string;
+  title: string;
+}> {
+  const search = await runtime.jobs.searchJobs({
+    profileName: DEFAULT_PROFILE_NAME,
+    query: "software engineer",
+    location: "Copenhagen",
+    limit: 5
+  });
+
+  const job = search.results[0];
+  if (!job) {
+    throw new Error("No LinkedIn job result was available for E2E coverage.");
+  }
+
+  return {
+    job_id: job.job_id,
+    title: job.title
+  };
+}
+
+export async function getCliCoverageFixtures(runtime: CoreRuntime): Promise<{
+  threadId: string;
+  threadUrl: string;
+  postUrl: string;
+  jobId: string;
+  connectionTarget: string;
+}> {
+  const thread = await getMessageThread(runtime);
+  const post = await getFeedPost(runtime);
+  const job = await getJob(runtime);
+
+  return {
+    threadId: thread.thread_id,
+    threadUrl: thread.thread_url,
+    postUrl: post.post_url,
+    jobId: job.job_id,
+    connectionTarget: DEFAULT_CONNECTION_TARGET
+  };
+}
+
+export async function prepareMessageReply(runtime: CoreRuntime): Promise<{
+  preparedActionId: string;
+  confirmToken: string;
+  expiresAtMs: number;
+  preview: Record<string, unknown>;
+}> {
+  const thread = await getMessageThread(runtime);
+  return runtime.inbox.prepareReply({
+    profileName: DEFAULT_PROFILE_NAME,
+    thread: thread.thread_id,
+    text: `E2E preview message [${new Date().toISOString()}]`
+  });
+}
+
+export const MCP_TOOL_NAMES = {
+  sessionStatus: LINKEDIN_SESSION_STATUS_TOOL,
+  sessionOpenLogin: LINKEDIN_SESSION_OPEN_LOGIN_TOOL,
+  sessionHealth: LINKEDIN_SESSION_HEALTH_TOOL,
+  inboxListThreads: LINKEDIN_INBOX_LIST_THREADS_TOOL,
+  inboxGetThread: LINKEDIN_INBOX_GET_THREAD_TOOL,
+  inboxPrepareReply: LINKEDIN_INBOX_PREPARE_REPLY_TOOL,
+  profileView: LINKEDIN_PROFILE_VIEW_TOOL,
+  search: LINKEDIN_SEARCH_TOOL,
+  connectionsList: LINKEDIN_CONNECTIONS_LIST_TOOL,
+  connectionsPending: LINKEDIN_CONNECTIONS_PENDING_TOOL,
+  connectionsInvite: LINKEDIN_CONNECTIONS_INVITE_TOOL,
+  connectionsAccept: LINKEDIN_CONNECTIONS_ACCEPT_TOOL,
+  connectionsWithdraw: LINKEDIN_CONNECTIONS_WITHDRAW_TOOL,
+  followupsPrepareAfterAccept: LINKEDIN_NETWORK_PREPARE_FOLLOWUP_AFTER_ACCEPT_TOOL,
+  feedList: LINKEDIN_FEED_LIST_TOOL,
+  feedViewPost: LINKEDIN_FEED_VIEW_POST_TOOL,
+  feedLike: LINKEDIN_FEED_LIKE_TOOL,
+  feedComment: LINKEDIN_FEED_COMMENT_TOOL,
+  postPrepareCreate: LINKEDIN_POST_PREPARE_CREATE_TOOL,
+  notificationsList: LINKEDIN_NOTIFICATIONS_LIST_TOOL,
+  jobsSearch: LINKEDIN_JOBS_SEARCH_TOOL,
+  jobsView: LINKEDIN_JOBS_VIEW_TOOL,
+  actionsConfirm: LINKEDIN_ACTIONS_CONFIRM_TOOL
+} as const;

--- a/packages/core/src/__tests__/e2e/inbox-write.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/inbox-write.e2e.test.ts
@@ -1,10 +1,17 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { getWriteConfirmGate } from "./helpers.js";
 import {
   getRuntime,
   checkCdpAvailable,
   checkAuthenticated,
   cleanupRuntime
 } from "./setup.js";
+
+const messageConfirmTest = getWriteConfirmGate(
+  "LINKEDIN_E2E_ENABLE_MESSAGE_CONFIRM"
+).enabled
+  ? it
+  : it.skip;
 
 /**
  * Inbox Write E2E — two-phase commit message send to Simon Miller.
@@ -13,6 +20,8 @@ import {
  * Explicitly authorised by project owner (Joakim Sigvardt).
  *
  * Flow: inbox.prepareReply → twoPhaseCommit.confirmByToken
+ *
+ * Opt in with LINKEDIN_E2E_ENABLE_MESSAGE_CONFIRM=1.
  */
 describe("Inbox Write E2E (2PC send_message)", () => {
   let cdpOk = false;
@@ -29,7 +38,7 @@ describe("Inbox Write E2E (2PC send_message)", () => {
     cleanupRuntime();
   });
 
-  it("sends a message to Simon Miller via prepare → confirm", async () => {
+  messageConfirmTest("sends a message to Simon Miller via prepare → confirm", async () => {
     if (!cdpOk || !authOk) return;
     const runtime = getRuntime();
 

--- a/packages/core/src/__tests__/e2e/mcp.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/mcp.e2e.test.ts
@@ -1,0 +1,315 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  callMcpTool,
+  getCliCoverageFixtures,
+  getDefaultConnectionTarget,
+  getDefaultProfileName,
+  MCP_TOOL_NAMES,
+  prepareEchoAction
+} from "./helpers.js";
+import {
+  cleanupRuntime,
+  getE2EAvailability,
+  getRuntime,
+  type E2EAvailability
+} from "./setup.js";
+
+describe.sequential("MCP E2E", () => {
+  let availability: E2EAvailability;
+  let fixtures: Awaited<ReturnType<typeof getCliCoverageFixtures>> | undefined;
+  const profileName = getDefaultProfileName();
+
+  beforeAll(async () => {
+    availability = await getE2EAvailability();
+    if (availability.canRun) {
+      fixtures = await getCliCoverageFixtures(getRuntime());
+    }
+  }, 180_000);
+
+  afterAll(() => {
+    cleanupRuntime();
+  });
+
+  it("covers session tools", async () => {
+    if (!availability.canRun || !fixtures) {
+      return;
+    }
+
+    const status = await callMcpTool(MCP_TOOL_NAMES.sessionStatus, {
+      profileName
+    });
+    expect(status.isError).toBe(false);
+    expect(status.payload).toMatchObject({
+      profile_name: profileName,
+      status: {
+        authenticated: true
+      }
+    });
+
+    const openLogin = await callMcpTool(MCP_TOOL_NAMES.sessionOpenLogin, {
+      profileName,
+      timeoutMs: 5_000
+    });
+    expect(openLogin.isError).toBe(false);
+    expect(openLogin.payload).toMatchObject({
+      profile_name: profileName,
+      status: {
+        authenticated: true,
+        timedOut: false
+      }
+    });
+
+    const health = await callMcpTool(MCP_TOOL_NAMES.sessionHealth, {
+      profileName
+    });
+    expect(health.isError).toBe(false);
+    expect(health.payload).toMatchObject({
+      profile_name: profileName,
+      browser: {
+        healthy: true
+      },
+      session: {
+        authenticated: true
+      }
+    });
+  }, 120_000);
+
+  it("covers inbox, connections, and followup tools", async () => {
+    if (!availability.canRun || !fixtures) {
+      return;
+    }
+
+    const inboxList = await callMcpTool(MCP_TOOL_NAMES.inboxListThreads, {
+      profileName,
+      limit: 5
+    });
+    expect(inboxList.isError).toBe(false);
+    expect(inboxList.payload).toMatchObject({
+      profile_name: profileName,
+      threads: expect.any(Array)
+    });
+
+    const inboxThread = await callMcpTool(MCP_TOOL_NAMES.inboxGetThread, {
+      profileName,
+      thread: fixtures.threadId,
+      limit: 5
+    });
+    expect(inboxThread.isError).toBe(false);
+    expect(inboxThread.payload).toMatchObject({
+      profile_name: profileName,
+      thread: {
+        thread_id: fixtures.threadId
+      }
+    });
+
+    const prepareReply = await callMcpTool(MCP_TOOL_NAMES.inboxPrepareReply, {
+      profileName,
+      thread: fixtures.threadId,
+      text: `MCP preview message [${Date.now()}]`
+    });
+    expect(prepareReply.isError).toBe(false);
+    expect(prepareReply.payload).toMatchObject({
+      profile_name: profileName,
+      preparedActionId: expect.stringMatching(/^pa_/),
+      confirmToken: expect.stringMatching(/^ct_/)
+    });
+
+    const connectionsList = await callMcpTool(MCP_TOOL_NAMES.connectionsList, {
+      profileName,
+      limit: 5
+    });
+    expect(connectionsList.isError).toBe(false);
+    expect(connectionsList.payload).toMatchObject({
+      profile_name: profileName,
+      connections: expect.any(Array)
+    });
+
+    const connectionsPending = await callMcpTool(MCP_TOOL_NAMES.connectionsPending, {
+      profileName,
+      filter: "all"
+    });
+    expect(connectionsPending.isError).toBe(false);
+    expect(connectionsPending.payload).toMatchObject({
+      profile_name: profileName,
+      invitations: expect.any(Array)
+    });
+
+    for (const toolName of [
+      MCP_TOOL_NAMES.connectionsInvite,
+      MCP_TOOL_NAMES.connectionsAccept,
+      MCP_TOOL_NAMES.connectionsWithdraw
+    ] as const) {
+      const targetProfile = getDefaultConnectionTarget();
+      const prepared = await callMcpTool(toolName, {
+        profileName,
+        targetProfile
+      });
+      expect(prepared.isError).toBe(false);
+      expect(prepared.payload).toMatchObject({
+        profile_name: profileName,
+        preparedActionId: expect.stringMatching(/^pa_/),
+        confirmToken: expect.stringMatching(/^ct_/)
+      });
+    }
+
+    const followups = await callMcpTool(MCP_TOOL_NAMES.followupsPrepareAfterAccept, {
+      profileName,
+      since: "30d"
+    });
+    expect(followups.isError).toBe(false);
+    expect(followups.payload).toMatchObject({
+      profile_name: profileName,
+      accepted_connections: expect.any(Array),
+      prepared_followups: expect.any(Array)
+    });
+  }, 180_000);
+
+  it("covers feed, post, actions confirm, and notifications tools", async () => {
+    if (!availability.canRun || !fixtures) {
+      return;
+    }
+
+    const feedList = await callMcpTool(MCP_TOOL_NAMES.feedList, {
+      profileName,
+      limit: 5
+    });
+    expect(feedList.isError).toBe(false);
+    expect(feedList.payload).toMatchObject({
+      profile_name: profileName,
+      posts: expect.any(Array)
+    });
+
+    const feedView = await callMcpTool(MCP_TOOL_NAMES.feedViewPost, {
+      profileName,
+      postUrl: fixtures.postUrl
+    });
+    expect(feedView.isError).toBe(false);
+    expect(feedView.payload).toMatchObject({
+      profile_name: profileName,
+      post: {
+        post_url: fixtures.postUrl
+      }
+    });
+
+    const feedLike = await callMcpTool(MCP_TOOL_NAMES.feedLike, {
+      profileName,
+      postUrl: fixtures.postUrl,
+      reaction: "like"
+    });
+    expect(feedLike.isError).toBe(false);
+    expect(feedLike.payload).toMatchObject({
+      profile_name: profileName,
+      preparedActionId: expect.stringMatching(/^pa_/),
+      confirmToken: expect.stringMatching(/^ct_/)
+    });
+
+    const feedComment = await callMcpTool(MCP_TOOL_NAMES.feedComment, {
+      profileName,
+      postUrl: fixtures.postUrl,
+      text: `MCP preview comment [${Date.now()}]`
+    });
+    expect(feedComment.isError).toBe(false);
+    expect(feedComment.payload).toMatchObject({
+      profile_name: profileName,
+      preparedActionId: expect.stringMatching(/^pa_/),
+      confirmToken: expect.stringMatching(/^ct_/)
+    });
+
+    const postPrepare = await callMcpTool(MCP_TOOL_NAMES.postPrepareCreate, {
+      profileName,
+      text: `MCP preview post [${Date.now()}]`,
+      visibility: "public"
+    });
+    expect(postPrepare.isError).toBe(false);
+    expect(postPrepare.payload).toMatchObject({
+      profile_name: profileName,
+      preparedActionId: expect.stringMatching(/^pa_/),
+      confirmToken: expect.stringMatching(/^ct_/)
+    });
+
+    const runtime = getRuntime();
+    const preparedConfirm = prepareEchoAction(runtime, {
+      profileName,
+      summary: "MCP actions.confirm echo"
+    });
+    const confirm = await callMcpTool(MCP_TOOL_NAMES.actionsConfirm, {
+      profileName,
+      token: preparedConfirm.confirmToken
+    });
+    expect(confirm.isError).toBe(false);
+    expect(confirm.payload).toMatchObject({
+      profile_name: profileName,
+      result: {
+        actionType: "test.echo",
+        result: {
+          echo: expect.any(String)
+        }
+      }
+    });
+
+    const notifications = await callMcpTool(MCP_TOOL_NAMES.notificationsList, {
+      profileName,
+      limit: 5
+    });
+    expect(notifications.isError).toBe(false);
+    expect(notifications.payload).toMatchObject({
+      profile_name: profileName,
+      notifications: expect.any(Array)
+    });
+  }, 180_000);
+
+  it("covers profile, search, and jobs tools", async () => {
+    if (!availability.canRun || !fixtures) {
+      return;
+    }
+
+    const profile = await callMcpTool(MCP_TOOL_NAMES.profileView, {
+      profileName,
+      target: getDefaultConnectionTarget()
+    });
+    expect(profile.isError).toBe(false);
+    expect(profile.payload).toMatchObject({
+      profile_name: profileName,
+      profile: {
+        profile_url: expect.stringContaining("linkedin.com")
+      }
+    });
+
+    const search = await callMcpTool(MCP_TOOL_NAMES.search, {
+      profileName,
+      query: "Simon Miller",
+      category: "people",
+      limit: 5
+    });
+    expect(search.isError).toBe(false);
+    expect(search.payload).toMatchObject({
+      profile_name: profileName,
+      category: "people",
+      results: expect.any(Array)
+    });
+
+    const jobsSearch = await callMcpTool(MCP_TOOL_NAMES.jobsSearch, {
+      profileName,
+      query: "software engineer",
+      location: "Copenhagen",
+      limit: 5
+    });
+    expect(jobsSearch.isError).toBe(false);
+    expect(jobsSearch.payload).toMatchObject({
+      profile_name: profileName,
+      results: expect.any(Array)
+    });
+
+    const jobView = await callMcpTool(MCP_TOOL_NAMES.jobsView, {
+      profileName,
+      jobId: fixtures.jobId
+    });
+    expect(jobView.isError).toBe(false);
+    expect(jobView.payload).toMatchObject({
+      profile_name: profileName,
+      job: {
+        job_id: fixtures.jobId
+      }
+    });
+  }, 180_000);
+});

--- a/packages/core/src/__tests__/e2e/setup.ts
+++ b/packages/core/src/__tests__/e2e/setup.ts
@@ -3,6 +3,14 @@ import { createCoreRuntime, type CoreRuntime } from "../../runtime.js";
 const CDP_URL = process.env.LINKEDIN_CDP_URL ?? "http://localhost:18800";
 
 let sharedRuntime: CoreRuntime | undefined;
+let sharedAvailability: E2EAvailability | undefined;
+
+export interface E2EAvailability {
+  cdpAvailable: boolean;
+  authenticated: boolean;
+  canRun: boolean;
+  reason: string;
+}
 
 export function getRuntime(): CoreRuntime {
   if (!sharedRuntime) {
@@ -34,9 +42,39 @@ export async function checkAuthenticated(): Promise<boolean> {
   }
 }
 
+export async function getE2EAvailability(): Promise<E2EAvailability> {
+  if (sharedAvailability) {
+    return sharedAvailability;
+  }
+
+  const cdpAvailable = await checkCdpAvailable();
+  if (!cdpAvailable) {
+    sharedAvailability = {
+      cdpAvailable,
+      authenticated: false,
+      canRun: false,
+      reason: `No CDP endpoint is reachable at ${CDP_URL}.`
+    };
+    return sharedAvailability;
+  }
+
+  const authenticated = await checkAuthenticated();
+  sharedAvailability = {
+    cdpAvailable,
+    authenticated,
+    canRun: cdpAvailable && authenticated,
+    reason: authenticated
+      ? `Authenticated LinkedIn session detected via ${CDP_URL}.`
+      : `LinkedIn session is not authenticated via ${CDP_URL}.`
+  };
+
+  return sharedAvailability;
+}
+
 export function cleanupRuntime(): void {
   if (sharedRuntime) {
     sharedRuntime.close();
     sharedRuntime = undefined;
   }
+  sharedAvailability = undefined;
 }

--- a/packages/mcp/src/bin/linkedin-mcp.ts
+++ b/packages/mcp/src/bin/linkedin-mcp.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { pathToFileURL } from "node:url";
 import {
   DEFAULT_FOLLOWUP_SINCE,
   LINKEDIN_FEED_REACTION_TYPES,
@@ -41,12 +42,17 @@ import {
   LINKEDIN_NOTIFICATIONS_LIST_TOOL,
   LINKEDIN_POST_PREPARE_CREATE_TOOL,
   LINKEDIN_SEARCH_TOOL,
+  LINKEDIN_SESSION_HEALTH_TOOL,
   LINKEDIN_SESSION_OPEN_LOGIN_TOOL,
   LINKEDIN_SESSION_STATUS_TOOL
 } from "../index.js";
 
 type ToolArgs = Record<string, unknown>;
 type ToolResult = { content: Array<{ type: "text"; text: string }> };
+type ToolErrorResult = {
+  isError: true;
+  content: Array<{ type: "text"; text: string }>;
+};
 
 const mcpPrivacyConfig = resolvePrivacyConfig();
 const SELECTOR_AUDIT_DOC_PATH = "docs/selector-audit.md";
@@ -136,10 +142,7 @@ function toToolResult(payload: unknown): ToolResult {
   };
 }
 
-function toErrorResult(error: unknown): {
-  isError: true;
-  content: Array<{ type: "text"; text: string }>;
-} {
+function toErrorResult(error: unknown): ToolErrorResult {
   return {
     isError: true,
     content: [
@@ -243,6 +246,36 @@ async function handleSessionOpenLogin(args: ToolArgs): Promise<ToolResult> {
       run_id: runtime.runId,
       profile_name: profileName,
       status
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function handleSessionHealth(args: ToolArgs): Promise<ToolResult> {
+  const runtime = createRuntime(args);
+
+  try {
+    const profileName = readString(args, "profileName", "default");
+
+    runtime.logger.log("info", "mcp.session.health.start", {
+      profileName
+    });
+
+    const health = await runtime.healthCheck({
+      profileName
+    });
+
+    runtime.logger.log("info", "mcp.session.health.done", {
+      profileName,
+      browserHealthy: health.browser.healthy,
+      authenticated: health.session.authenticated
+    });
+
+    return toToolResult({
+      run_id: runtime.runId,
+      profile_name: profileName,
+      ...health
     });
   } finally {
     runtime.close();
@@ -1026,6 +1059,20 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         }
       },
       {
+        name: LINKEDIN_SESSION_HEALTH_TOOL,
+        description: "Check browser connectivity and LinkedIn session health for a profile.",
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+          properties: withCdpSchemaProperties({
+            profileName: {
+              type: "string",
+              description: "Persistent Playwright profile name. Defaults to default."
+            }
+          })
+        }
+      },
+      {
         name: LINKEDIN_INBOX_LIST_THREADS_TOOL,
         description: withSelectorAuditHint(
           "List LinkedIn inbox threads for a profile."
@@ -1539,116 +1586,137 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
   };
 });
 
+export async function handleToolCall(
+  name: string,
+  args: ToolArgs = {}
+): Promise<ToolResult | ToolErrorResult> {
+  try {
+    if (name === LINKEDIN_SESSION_STATUS_TOOL) {
+      return await handleSessionStatus(args);
+    }
+
+    if (name === LINKEDIN_SESSION_OPEN_LOGIN_TOOL) {
+      return await handleSessionOpenLogin(args);
+    }
+
+    if (name === LINKEDIN_SESSION_HEALTH_TOOL) {
+      return await handleSessionHealth(args);
+    }
+
+    if (name === LINKEDIN_INBOX_LIST_THREADS_TOOL) {
+      return await handleListThreads(args);
+    }
+
+    if (name === LINKEDIN_INBOX_GET_THREAD_TOOL) {
+      return await handleGetThread(args);
+    }
+
+    if (name === LINKEDIN_INBOX_PREPARE_REPLY_TOOL) {
+      return await handlePrepareReply(args);
+    }
+
+    if (name === LINKEDIN_PROFILE_VIEW_TOOL) {
+      return await handleProfileView(args);
+    }
+
+    if (name === LINKEDIN_SEARCH_TOOL) {
+      return await handleSearch(args);
+    }
+
+    if (name === LINKEDIN_CONNECTIONS_LIST_TOOL) {
+      return await handleConnectionsList(args);
+    }
+
+    if (name === LINKEDIN_CONNECTIONS_PENDING_TOOL) {
+      return await handleConnectionsPending(args);
+    }
+
+    if (name === LINKEDIN_CONNECTIONS_INVITE_TOOL) {
+      return await handleConnectionsInvite(args);
+    }
+
+    if (name === LINKEDIN_CONNECTIONS_ACCEPT_TOOL) {
+      return await handleConnectionsAccept(args);
+    }
+
+    if (name === LINKEDIN_CONNECTIONS_WITHDRAW_TOOL) {
+      return await handleConnectionsWithdraw(args);
+    }
+
+    if (name === LINKEDIN_NETWORK_PREPARE_FOLLOWUP_AFTER_ACCEPT_TOOL) {
+      return await handlePrepareFollowupAfterAccept(args);
+    }
+
+    if (name === LINKEDIN_FEED_LIST_TOOL) {
+      return await handleFeedList(args);
+    }
+
+    if (name === LINKEDIN_FEED_VIEW_POST_TOOL) {
+      return await handleFeedViewPost(args);
+    }
+
+    if (name === LINKEDIN_FEED_LIKE_TOOL) {
+      return await handleFeedLike(args);
+    }
+
+    if (name === LINKEDIN_FEED_COMMENT_TOOL) {
+      return await handleFeedComment(args);
+    }
+
+    if (name === LINKEDIN_POST_PREPARE_CREATE_TOOL) {
+      return await handlePostPrepareCreate(args);
+    }
+
+    if (name === LINKEDIN_NOTIFICATIONS_LIST_TOOL) {
+      return await handleNotificationsList(args);
+    }
+
+    if (name === LINKEDIN_JOBS_SEARCH_TOOL) {
+      return await handleJobsSearch(args);
+    }
+
+    if (name === LINKEDIN_JOBS_VIEW_TOOL) {
+      return await handleJobsView(args);
+    }
+
+    if (name === LINKEDIN_ACTIONS_CONFIRM_TOOL) {
+      return await handleConfirm(args);
+    }
+
+    return toErrorResult(`Unknown tool: ${name}`);
+  } catch (error) {
+    return toErrorResult(error);
+  }
+}
+
 server.setRequestHandler(
   CallToolRequestSchema,
   async (request: CallToolRequest) => {
     const name = request.params.name;
     const args = (request.params.arguments ?? {}) as ToolArgs;
-
-    try {
-      if (name === LINKEDIN_SESSION_STATUS_TOOL) {
-        return await handleSessionStatus(args);
-      }
-
-      if (name === LINKEDIN_SESSION_OPEN_LOGIN_TOOL) {
-        return await handleSessionOpenLogin(args);
-      }
-
-      if (name === LINKEDIN_INBOX_LIST_THREADS_TOOL) {
-        return await handleListThreads(args);
-      }
-
-      if (name === LINKEDIN_INBOX_GET_THREAD_TOOL) {
-        return await handleGetThread(args);
-      }
-
-      if (name === LINKEDIN_INBOX_PREPARE_REPLY_TOOL) {
-        return await handlePrepareReply(args);
-      }
-
-      if (name === LINKEDIN_PROFILE_VIEW_TOOL) {
-        return await handleProfileView(args);
-      }
-
-      if (name === LINKEDIN_SEARCH_TOOL) {
-        return await handleSearch(args);
-      }
-
-      if (name === LINKEDIN_CONNECTIONS_LIST_TOOL) {
-        return await handleConnectionsList(args);
-      }
-
-      if (name === LINKEDIN_CONNECTIONS_PENDING_TOOL) {
-        return await handleConnectionsPending(args);
-      }
-
-      if (name === LINKEDIN_CONNECTIONS_INVITE_TOOL) {
-        return await handleConnectionsInvite(args);
-      }
-
-      if (name === LINKEDIN_CONNECTIONS_ACCEPT_TOOL) {
-        return await handleConnectionsAccept(args);
-      }
-
-      if (name === LINKEDIN_CONNECTIONS_WITHDRAW_TOOL) {
-        return await handleConnectionsWithdraw(args);
-      }
-
-      if (name === LINKEDIN_NETWORK_PREPARE_FOLLOWUP_AFTER_ACCEPT_TOOL) {
-        return await handlePrepareFollowupAfterAccept(args);
-      }
-
-      if (name === LINKEDIN_FEED_LIST_TOOL) {
-        return await handleFeedList(args);
-      }
-
-      if (name === LINKEDIN_FEED_VIEW_POST_TOOL) {
-        return await handleFeedViewPost(args);
-      }
-
-      if (name === LINKEDIN_FEED_LIKE_TOOL) {
-        return await handleFeedLike(args);
-      }
-
-      if (name === LINKEDIN_FEED_COMMENT_TOOL) {
-        return await handleFeedComment(args);
-      }
-
-      if (name === LINKEDIN_POST_PREPARE_CREATE_TOOL) {
-        return await handlePostPrepareCreate(args);
-      }
-
-      if (name === LINKEDIN_NOTIFICATIONS_LIST_TOOL) {
-        return await handleNotificationsList(args);
-      }
-
-      if (name === LINKEDIN_JOBS_SEARCH_TOOL) {
-        return await handleJobsSearch(args);
-      }
-
-      if (name === LINKEDIN_JOBS_VIEW_TOOL) {
-        return await handleJobsView(args);
-      }
-
-      if (name === LINKEDIN_ACTIONS_CONFIRM_TOOL) {
-        return await handleConfirm(args);
-      }
-
-      return toErrorResult(`Unknown tool: ${name}`);
-    } catch (error) {
-      return toErrorResult(error);
-    }
+    return handleToolCall(name, args);
   }
 );
 
-async function main(): Promise<void> {
+export async function startLinkedInMcpServer(): Promise<void> {
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }
 
-main().catch((error: unknown) => {
-  console.error(
-    JSON.stringify(toLinkedInAssistantErrorPayload(error, mcpPrivacyConfig), null, 2)
-  );
-  process.exit(1);
-});
+function isDirectExecution(moduleUrl: string): boolean {
+  const entrypoint = process.argv[1];
+  if (!entrypoint) {
+    return false;
+  }
+
+  return pathToFileURL(entrypoint).href === moduleUrl;
+}
+
+if (isDirectExecution(import.meta.url)) {
+  startLinkedInMcpServer().catch((error: unknown) => {
+    console.error(
+      JSON.stringify(toLinkedInAssistantErrorPayload(error, mcpPrivacyConfig), null, 2)
+    );
+    process.exit(1);
+  });
+}

--- a/scripts/run-e2e.js
+++ b/scripts/run-e2e.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright-core";
+
+const DEFAULT_CDP_URL = "http://localhost:18800";
+const LINKEDIN_FEED_URL = "https://www.linkedin.com/feed/";
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const vitestEntrypoint = path.join(projectRoot, "node_modules", "vitest", "vitest.mjs");
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+
+function log(message) {
+  process.stdout.write(`${message}\n`);
+}
+
+function summarizeError(error) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+async function detectAuthenticatedSession(cdpUrl) {
+  try {
+    const response = await fetch(`${cdpUrl}/json/version`);
+    if (!response.ok) {
+      return {
+        ok: false,
+        reason: `CDP endpoint responded with HTTP ${response.status}.`
+      };
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      reason: `CDP endpoint is unavailable at ${cdpUrl}: ${summarizeError(error)}`
+    };
+  }
+
+  try {
+    const browser = await chromium.connectOverCDP(cdpUrl);
+
+    try {
+      const context = browser.contexts()[0];
+      if (!context) {
+        return {
+          ok: false,
+          reason: "Connected browser has no contexts to inspect."
+        };
+      }
+
+      const page = await context.newPage();
+      try {
+        await page.goto(LINKEDIN_FEED_URL, {
+          waitUntil: "domcontentloaded",
+          timeout: 15_000
+        });
+
+        const currentUrl = page.url();
+        const authenticated =
+          currentUrl.includes("linkedin.com") &&
+          !currentUrl.includes("/login") &&
+          !currentUrl.includes("/checkpoint");
+
+        if (!authenticated) {
+          return {
+            ok: false,
+            reason: `LinkedIn session is not authenticated (landed on ${currentUrl}).`
+          };
+        }
+
+        return {
+          ok: true,
+          reason: `Authenticated LinkedIn session detected at ${currentUrl}.`
+        };
+      } finally {
+        await page.close().catch(() => undefined);
+      }
+    } finally {
+      await browser.close().catch(() => undefined);
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      reason: `Could not verify LinkedIn authentication over CDP: ${summarizeError(error)}`
+    };
+  }
+}
+
+async function main() {
+  const cdpUrl = process.env.LINKEDIN_CDP_URL ?? DEFAULT_CDP_URL;
+  const availability = await detectAuthenticatedSession(cdpUrl);
+
+  if (!availability.ok) {
+    log(`[e2e] Skipping LinkedIn E2E suite: ${availability.reason}`);
+    process.exit(0);
+  }
+
+  log(`[e2e] ${availability.reason}`);
+  log("[e2e] Building workspace before running E2E tests.");
+
+  const build = spawn(npmCommand, ["run", "build"], {
+    cwd: projectRoot,
+    stdio: "inherit",
+    env: process.env
+  });
+
+  const buildCode = await new Promise((resolve, reject) => {
+    build.on("exit", (code) => resolve(code ?? 1));
+    build.on("error", reject);
+  });
+
+  if (buildCode !== 0) {
+    log(`[e2e] Build failed with exit code ${buildCode}.`);
+    process.exit(Number(buildCode));
+  }
+
+  log("[e2e] Running Vitest E2E suite.");
+
+  const child = spawn(
+    process.execPath,
+    [vitestEntrypoint, "run", "-c", "vitest.config.e2e.ts"],
+    {
+      cwd: projectRoot,
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        LINKEDIN_E2E: process.env.LINKEDIN_E2E ?? "1",
+        LINKEDIN_CDP_URL: cdpUrl
+      }
+    }
+  );
+
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 1);
+  });
+
+  child.on("error", (error) => {
+    log(`[e2e] Failed to start Vitest: ${summarizeError(error)}`);
+    process.exit(1);
+  });
+}
+
+void main();

--- a/vitest.config.e2e.ts
+++ b/vitest.config.e2e.ts
@@ -1,6 +1,15 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
+const rootDir = path.dirname(fileURLToPath(import.meta.url));
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@linkedin-assistant/core": path.resolve(rootDir, "packages/core/src/index.ts")
+    }
+  },
   test: {
     environment: "node",
     include: ["packages/core/src/__tests__/e2e/**/*.e2e.test.ts"],


### PR DESCRIPTION
## Summary
- add direct E2E coverage for every CLI command group and MCP tool
- add opt-in real confirm coverage for messages, connections, likes, and comments
- add deterministic E2E error-path coverage plus a skip-aware E2E runner and docs

## Validation
- npm run lint
- npm run typecheck
- npm test
- npm run build
- npm run test:e2e
- npm run test:e2e:raw

Closes #11