### PR TITLE
feat: add draft quality evaluation harness

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -8,6 +8,7 @@ import { Command } from "commander";
 import {
   DEFAULT_FOLLOWUP_SINCE,
   clearRateLimitState,
+  evaluateDraftQuality,
   isInRateLimitCooldown,
   LINKEDIN_FEED_REACTION_TYPES,
   LINKEDIN_POST_VISIBILITY_TYPES,
@@ -15,14 +16,22 @@ import {
   createCoreRuntime,
   normalizeLinkedInFeedReaction,
   normalizeLinkedInPostVisibility,
+  parseDraftQualityCandidateSet,
+  parseDraftQualityDataset,
   resolveFollowupSinceWindow,
   redactStructuredValue,
   resolveConfigPaths,
   resolvePrivacyConfig,
   toLinkedInAssistantErrorPayload,
+  type DraftQualityReport,
   type SearchCategory,
   type SelectorAuditReport
 } from "@linkedin-assistant/core";
+import {
+  formatDraftQualityError,
+  formatDraftQualityReport,
+  resolveDraftQualityOutputMode
+} from "../draftQualityOutput.js";
 import {
   formatSelectorAuditError,
   formatSelectorAuditReport,
@@ -169,6 +178,62 @@ async function readJsonFile<T>(filePath: string): Promise<T | null> {
 
 async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
   await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+async function readJsonInputFile(filePath: string, label: string): Promise<unknown> {
+  const resolvedPath = path.resolve(filePath);
+  let raw: string;
+
+  try {
+    raw = await readFile(resolvedPath, "utf8");
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `Could not read ${label}.`,
+        {
+          path: resolvedPath,
+          cause: "ENOENT"
+        },
+        { cause: error }
+      );
+    }
+
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `Could not read ${label}.`,
+      {
+        path: resolvedPath,
+        cause: error instanceof Error ? error.message : String(error)
+      },
+      error instanceof Error ? { cause: error } : undefined
+    );
+  }
+
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch (error) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `Could not parse ${label} as JSON.`,
+      {
+        path: resolvedPath,
+        cause: error instanceof Error ? error.message : String(error)
+      },
+      error instanceof Error ? { cause: error } : undefined
+    );
+  }
+}
+
+async function writeOutputJsonFile(filePath: string, value: unknown): Promise<string> {
+  const resolvedPath = path.resolve(filePath);
+  await mkdir(path.dirname(resolvedPath), { recursive: true });
+  await writeJsonFile(resolvedPath, value);
+  return resolvedPath;
 }
 
 async function readKeepAlivePid(profileName: string): Promise<number | null> {
@@ -1525,6 +1590,72 @@ async function runSelectorAudit(input: {
   }
 }
 
+async function runDraftQualityAudit(input: {
+  datasetPath: string;
+  candidatesPath?: string;
+  json: boolean;
+  verbose: boolean;
+  outputPath?: string;
+}): Promise<void> {
+  const outputMode = resolveDraftQualityOutputMode(
+    { json: input.json },
+    Boolean(stdout.isTTY)
+  );
+
+  try {
+    const datasetPath = path.resolve(input.datasetPath);
+    const dataset = parseDraftQualityDataset(
+      await readJsonInputFile(datasetPath, "draft-quality dataset")
+    );
+    const candidatesPath = input.candidatesPath
+      ? path.resolve(input.candidatesPath)
+      : undefined;
+    const candidates = candidatesPath
+      ? parseDraftQualityCandidateSet(
+          await readJsonInputFile(candidatesPath, "draft-quality candidates file")
+        )
+      : undefined;
+    const report = await evaluateDraftQuality({
+      dataset,
+      ...(candidates ? { candidates } : {}),
+      dataset_path: datasetPath,
+      ...(candidatesPath ? { candidates_path: candidatesPath } : {})
+    });
+    const writtenReportPath = input.outputPath
+      ? await writeOutputJsonFile(input.outputPath, report)
+      : undefined;
+
+    if (outputMode === "json") {
+      printJson(report);
+    } else {
+      const redactedReport = redactStructuredValue(
+        report,
+        cliPrivacyConfig,
+        "cli"
+      ) as DraftQualityReport;
+      const output = formatDraftQualityReport(redactedReport, {
+        verbose: input.verbose
+      });
+
+      console.log(
+        writtenReportPath ? `${output}\nJSON report written to ${writtenReportPath}` : output
+      );
+    }
+
+    if (report.outcome === "fail") {
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    if (outputMode === "json") {
+      throw error;
+    }
+
+    const errorPayload = toLinkedInAssistantErrorPayload(error, cliPrivacyConfig);
+    process.stderr.write(`${formatDraftQualityError(errorPayload)}\n`);
+    process.exitCode = 1;
+  }
+}
+
 function readTargetProfileName(target: Record<string, unknown>): string | undefined {
   const value = target.profile_name;
   if (typeof value === "string" && value.trim().length > 0) {
@@ -1634,6 +1765,7 @@ async function main(): Promise<void> {
         "",
         "Diagnostics:",
         "  linkedin audit selectors --help",
+        "  linkedin audit draft-quality --help",
         `  ${SELECTOR_AUDIT_DOC_REFERENCE}`
       ].join("\n")
     );
@@ -2283,6 +2415,46 @@ async function main(): Promise<void> {
         progress: options.progress,
         verbose: options.verbose
       }, readCdpUrl());
+    });
+
+  auditCommand
+    .command("draft-quality")
+    .description("Evaluate draft replies against thread-specific quality expectations")
+    .requiredOption("--dataset <path>", "Path to the draft-quality dataset JSON file")
+    .option(
+      "--candidates <path>",
+      "Optional JSON file with external candidate drafts keyed by case_id"
+    )
+    .option("--json", "Print the full JSON report (recommended for automation)", false)
+    .option(
+      "--verbose",
+      "Show draft-by-draft detail in human-readable output",
+      false
+    )
+    .option("--output <path>", "Write the JSON report to a file")
+    .addHelpText(
+      "after",
+      [
+        "",
+        "The dataset can embed candidate_drafts or you can provide --candidates.",
+        "Interactive terminals default to a human-readable summary.",
+        "Use --json for automation and --output to persist the JSON report."
+      ].join("\n")
+    )
+    .action(async (options: {
+      dataset: string;
+      candidates?: string;
+      json: boolean;
+      verbose: boolean;
+      output?: string;
+    }) => {
+      await runDraftQualityAudit({
+        datasetPath: options.dataset,
+        json: options.json,
+        verbose: options.verbose,
+        ...(options.candidates ? { candidatesPath: options.candidates } : {}),
+        ...(options.output ? { outputPath: options.output } : {})
+      });
     });
 
   const actionsCommand = program

--- a/packages/cli/src/draftQualityOutput.ts
+++ b/packages/cli/src/draftQualityOutput.ts
@@ -1,0 +1,234 @@
+import type {
+  DraftQualityCaseResult,
+  DraftQualityHardFailure,
+  DraftQualityReport,
+  LinkedInAssistantErrorPayload
+} from "@linkedin-assistant/core";
+
+export type DraftQualityOutputMode = "human" | "json";
+
+export interface FormatDraftQualityReportOptions {
+  verbose?: boolean;
+}
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatStatus(passed: boolean): string {
+  return passed ? "PASS" : "FAIL";
+}
+
+function appendSection(lines: string[], title: string, entries: string[]): void {
+  if (entries.length === 0) {
+    return;
+  }
+
+  lines.push("");
+  lines.push(title);
+  lines.push(...entries);
+}
+
+function formatSourceCounts(report: DraftQualityReport): string | null {
+  const entries = Object.entries(report.summary.source_counts)
+    .filter(([, count]) => count > 0)
+    .map(([source, count]) => `${source}=${count}`);
+
+  return entries.length > 0 ? entries.join(" | ") : null;
+}
+
+function formatLengthExpectation(result: DraftQualityCaseResult): string {
+  const details = result.metrics.length.details;
+  const range = `${details.min_words}-${details.max_words} words`;
+  const sentenceLimit =
+    details.max_sentences === null ? "" : `, <= ${details.max_sentences} sentences`;
+
+  return `${details.word_count} words / ${details.sentence_count} sentences (expected ${range}${sentenceLimit})`;
+}
+
+function formatHardFailures(hardFailures: DraftQualityHardFailure[]): string | null {
+  if (hardFailures.length === 0) {
+    return null;
+  }
+
+  return hardFailures.map((failure) => failure.message).join(" | ");
+}
+
+function formatFailureBlock(result: DraftQualityCaseResult): string[] {
+  const lines = [`- ${result.case_id}/${result.draft_id} (${result.draft_source})`];
+  const missingPoints = result.metrics.relevance.details.missing_point_ids;
+  const toneMissing = result.metrics.tone.details.missing;
+  const toneForbidden = result.metrics.tone.details.forbidden_triggered;
+  const hardFailures = formatHardFailures(result.overall.hard_failures);
+
+  if (result.case_scenario) {
+    lines.push(`  Scenario: ${result.case_scenario}`);
+  }
+
+  if (result.overall.failed_metrics.length > 0) {
+    lines.push(`  Overall: failed ${result.overall.failed_metrics.join(", ")}`);
+  }
+
+  if (!result.metrics.relevance.passed) {
+    lines.push(
+      `  Relevance: missing points ${
+        missingPoints.length > 0 ? missingPoints.join(", ") : "none"
+      }`
+    );
+  }
+
+  if (result.metrics.relevance.details.off_topic_signals.length > 0) {
+    lines.push(
+      `  Relevance notes: ${result.metrics.relevance.details.off_topic_signals.join(" | ")}`
+    );
+  }
+
+  if (!result.metrics.tone.passed) {
+    const toneDetails: string[] = [];
+    if (toneMissing.length > 0) {
+      toneDetails.push(`missing ${toneMissing.join(", ")}`);
+    }
+    if (toneForbidden.length > 0) {
+      toneDetails.push(`forbidden ${toneForbidden.join(", ")}`);
+    }
+    lines.push(`  Tone: ${toneDetails.join("; ")}`);
+  }
+
+  if (!result.metrics.length.passed) {
+    lines.push(`  Length: ${formatLengthExpectation(result)}`);
+  }
+
+  if (hardFailures) {
+    lines.push(`  Hard checks: ${hardFailures}`);
+  }
+
+  if (result.notes.length > 0) {
+    lines.push(`  Notes: ${result.notes.join(" | ")}`);
+  }
+
+  return lines;
+}
+
+function formatDraftDetail(result: DraftQualityCaseResult): string[] {
+  const lines = [
+    `- ${formatStatus(result.overall.passed)} ${result.case_id}/${result.draft_id} (${result.draft_source})`
+  ];
+  const toneDetails = result.metrics.tone.details;
+  const matchedTones =
+    toneDetails.matched.length > 0 ? toneDetails.matched.join(", ") : "none";
+  const optionalTones =
+    toneDetails.optional_matched.length > 0
+      ? `; optional ${toneDetails.optional_matched.join(", ")}`
+      : "";
+  const hardFailures = formatHardFailures(result.overall.hard_failures);
+
+  lines.push(
+    `  Relevance: ${formatStatus(result.metrics.relevance.passed)} ${
+      result.metrics.relevance.details.covered_point_ids.length
+    }/${result.metrics.relevance.details.total_required_points} required points covered`
+  );
+  lines.push(
+    `  Tone: ${formatStatus(result.metrics.tone.passed)} matched ${matchedTones}${optionalTones}`
+  );
+  lines.push(`  Length: ${formatStatus(result.metrics.length.passed)} ${formatLengthExpectation(result)}`);
+
+  if (hardFailures) {
+    lines.push(`  Hard checks: ${hardFailures}`);
+  }
+
+  if (result.notes.length > 0) {
+    lines.push(`  Notes: ${result.notes.join(" | ")}`);
+  }
+
+  return lines;
+}
+
+export function resolveDraftQualityOutputMode(
+  input: { json?: boolean },
+  interactiveTerminal: boolean
+): DraftQualityOutputMode {
+  if (input.json) {
+    return "json";
+  }
+
+  return interactiveTerminal ? "human" : "json";
+}
+
+export function formatDraftQualityReport(
+  report: DraftQualityReport,
+  options: FormatDraftQualityReportOptions = {}
+): string {
+  const lines = [`Draft Quality Evaluation: ${report.outcome.toUpperCase()}`];
+
+  lines.push(`Run: ${report.run_id}`);
+  if (report.dataset_path) {
+    lines.push(`Dataset: ${report.dataset_path}`);
+  }
+  if (report.candidates_path) {
+    lines.push(`Candidates: ${report.candidates_path}`);
+  }
+
+  lines.push(
+    `Summary: Evaluated ${report.summary.total_drafts} drafts across ${report.summary.evaluated_case_count}/${report.summary.total_cases} cases. ${report.summary.passed_drafts} passed. ${report.summary.failed_drafts} failed. Pass rate ${formatPercent(report.summary.pass_rate)}.`
+  );
+  lines.push(
+    `Metric Averages: relevance ${formatPercent(report.summary.metric_averages.relevance)} | tone ${formatPercent(report.summary.metric_averages.tone)} | length ${formatPercent(report.summary.metric_averages.length)}`
+  );
+
+  const sources = formatSourceCounts(report);
+  if (sources) {
+    lines.push(`Sources: ${sources}`);
+  }
+
+  appendSection(
+    lines,
+    "Warnings",
+    report.warnings.map((warning) => `- ${warning}`)
+  );
+
+  appendSection(
+    lines,
+    "Failures",
+    report.cases
+      .filter((result) => !result.overall.passed)
+      .flatMap((result) => formatFailureBlock(result))
+  );
+
+  if (options.verbose) {
+    appendSection(
+      lines,
+      "Draft Details",
+      report.cases.flatMap((result) => formatDraftDetail(result))
+    );
+  }
+
+  return lines.join("\n");
+}
+
+function readString(payload: Record<string, unknown>, key: string): string | null {
+  const value = payload[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export function formatDraftQualityError(error: LinkedInAssistantErrorPayload): string {
+  const lines = [`Draft quality evaluation failed: ${error.message}`];
+  const location = readString(error.details, "location") ?? readString(error.details, "path");
+  const field = readString(error.details, "field");
+  const caseId = readString(error.details, "case_id");
+  const draftId = readString(error.details, "draft_id");
+
+  if (location) {
+    lines.push(`Location: ${location}`);
+  }
+  if (field) {
+    lines.push(`Field: ${field}`);
+  }
+  if (caseId) {
+    lines.push(`Case: ${caseId}`);
+  }
+  if (draftId) {
+    lines.push(`Draft: ${draftId}`);
+  }
+
+  return lines.join("\n");
+}

--- a/packages/cli/test/draftQualityOutput.test.ts
+++ b/packages/cli/test/draftQualityOutput.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "vitest";
+import type { DraftQualityReport, LinkedInAssistantErrorPayload } from "@linkedin-assistant/core";
+import {
+  formatDraftQualityError,
+  formatDraftQualityReport,
+  resolveDraftQualityOutputMode
+} from "../src/draftQualityOutput.js";
+
+function createDraftQualityReportFixture(): DraftQualityReport {
+  return {
+    run_id: "run_dq_test",
+    generated_at: "2026-03-08T12:00:00.000Z",
+    outcome: "fail",
+    dataset_path: "packages/core/test/fixtures/draft-quality/smoke-dataset.json",
+    candidates_path: "packages/core/test/fixtures/draft-quality/smoke-candidates.json",
+    summary: {
+      total_cases: 2,
+      evaluated_case_count: 2,
+      skipped_case_count: 0,
+      total_drafts: 2,
+      passed_drafts: 1,
+      failed_drafts: 1,
+      pass_rate: 0.5,
+      metric_averages: {
+        relevance: 0.75,
+        tone: 0.833,
+        length: 1
+      },
+      source_counts: {
+        manual: 1,
+        model: 1,
+        imported: 0,
+        synthetic: 0
+      }
+    },
+    warnings: ["Case skipped_case_001 has no candidate drafts and was skipped."],
+    cases: [
+      {
+        case_id: "followup_meeting_request_001",
+        draft_id: "baseline_manual",
+        draft_source: "manual",
+        overall: {
+          passed: true,
+          score: 1,
+          failed_metrics: [],
+          hard_failures: []
+        },
+        metrics: {
+          relevance: {
+            passed: true,
+            score: 1,
+            mode: "deterministic",
+            details: {
+              total_required_points: 2,
+              covered_point_ids: ["acknowledge_busyness", "propose_next_week"],
+              missing_point_ids: [],
+              point_matches: [
+                {
+                  point_id: "acknowledge_busyness",
+                  matched_aliases: ["packed"]
+                },
+                {
+                  point_id: "propose_next_week",
+                  matched_aliases: ["next week"]
+                }
+              ],
+              off_topic_signals: [],
+              forbidden_phrase_hits: [],
+              judge_rationale: []
+            }
+          },
+          tone: {
+            passed: true,
+            score: 1,
+            mode: "deterministic",
+            details: {
+              required: ["warm", "professional", "concise"],
+              matched: ["warm", "professional", "concise"],
+              missing: [],
+              optional_matched: [],
+              forbidden_requested: ["pushy", "robotic"],
+              forbidden_triggered: [],
+              evidence: [
+                {
+                  tone: "warm",
+                  signals: ["thanks"]
+                }
+              ],
+              judge_rationale: []
+            }
+          },
+          length: {
+            passed: true,
+            score: 1,
+            mode: "deterministic",
+            details: {
+              word_count: 24,
+              sentence_count: 2,
+              min_words: 20,
+              max_words: 50,
+              target_words: 35,
+              max_sentences: 2,
+              distance_from_target: 11
+            }
+          }
+        },
+        notes: ["Synthetic calibration baseline."],
+        case_channel: "linkedin_inbox",
+        case_scenario: "Warm follow-up when the contact is busy this week"
+      },
+      {
+        case_id: "followup_meeting_request_001",
+        draft_id: "too_pushy",
+        draft_source: "model",
+        overall: {
+          passed: false,
+          score: 0.561,
+          failed_metrics: ["relevance", "tone"],
+          hard_failures: [
+            {
+              kind: "forbidden_phrase",
+              message: "Draft used forbidden phrases: just circling back",
+              values: ["just circling back"]
+            }
+          ]
+        },
+        metrics: {
+          relevance: {
+            passed: false,
+            score: 0.5,
+            mode: "deterministic",
+            details: {
+              total_required_points: 2,
+              covered_point_ids: ["propose_next_week"],
+              missing_point_ids: ["acknowledge_busyness"],
+              point_matches: [
+                {
+                  point_id: "acknowledge_busyness",
+                  matched_aliases: []
+                },
+                {
+                  point_id: "propose_next_week",
+                  matched_aliases: ["next week"]
+                }
+              ],
+              off_topic_signals: ["Draft missed every required point for the active thread."],
+              forbidden_phrase_hits: ["just circling back"],
+              judge_rationale: []
+            }
+          },
+          tone: {
+            passed: false,
+            score: 0.667,
+            mode: "deterministic",
+            details: {
+              required: ["warm", "professional", "concise"],
+              matched: ["concise"],
+              missing: ["warm", "professional"],
+              optional_matched: [],
+              forbidden_requested: ["pushy", "robotic"],
+              forbidden_triggered: ["pushy"],
+              evidence: [
+                {
+                  tone: "pushy",
+                  signals: ["just circling back", "repeated exclamation marks"]
+                }
+              ],
+              judge_rationale: []
+            }
+          },
+          length: {
+            passed: true,
+            score: 1,
+            mode: "deterministic",
+            details: {
+              word_count: 21,
+              sentence_count: 2,
+              min_words: 20,
+              max_words: 50,
+              target_words: 35,
+              max_sentences: 2,
+              distance_from_target: 14
+            }
+          }
+        },
+        notes: ["Keep the reply low-pressure and kind."],
+        case_channel: "linkedin_inbox",
+        case_scenario: "Warm follow-up when the contact is busy this week"
+      }
+    ]
+  };
+}
+
+describe("draft quality output helpers", () => {
+  it("defaults to human output in interactive terminals unless JSON is forced", () => {
+    expect(resolveDraftQualityOutputMode({ json: false }, true)).toBe("human");
+    expect(resolveDraftQualityOutputMode({ json: false }, false)).toBe("json");
+    expect(resolveDraftQualityOutputMode({ json: true }, true)).toBe("json");
+  });
+
+  it("renders a scannable human-readable report", () => {
+    const output = formatDraftQualityReport(createDraftQualityReportFixture());
+
+    expect(output).toContain("Draft Quality Evaluation: FAIL");
+    expect(output).toContain(
+      "Summary: Evaluated 2 drafts across 2/2 cases. 1 passed. 1 failed. Pass rate 50.0%."
+    );
+    expect(output).toContain(
+      "Metric Averages: relevance 75.0% | tone 83.3% | length 100.0%"
+    );
+    expect(output).toContain("Warnings");
+    expect(output).toContain("Failures");
+    expect(output).toContain("Hard checks: Draft used forbidden phrases: just circling back");
+  });
+
+  it("adds per-draft detail in verbose mode", () => {
+    const output = formatDraftQualityReport(createDraftQualityReportFixture(), {
+      verbose: true
+    });
+
+    expect(output).toContain("Draft Details");
+    expect(output).toContain(
+      "PASS followup_meeting_request_001/baseline_manual (manual)"
+    );
+    expect(output).toContain(
+      "FAIL followup_meeting_request_001/too_pushy (model)"
+    );
+    expect(output).toContain("Tone: FAIL matched concise");
+  });
+
+  it("formats friendly human-readable errors", () => {
+    const error: LinkedInAssistantErrorPayload = {
+      code: "ACTION_PRECONDITION_FAILED",
+      message: "Draft-quality dataset must contain at least one case.",
+      details: {
+        location: "dataset.cases"
+      }
+    };
+
+    const output = formatDraftQualityError(error);
+
+    expect(output).toContain(
+      "Draft quality evaluation failed: Draft-quality dataset must contain at least one case."
+    );
+    expect(output).toContain("Location: dataset.cases");
+  });
+});

--- a/packages/core/src/draftQualityEval.ts
+++ b/packages/core/src/draftQualityEval.ts
@@ -1,0 +1,1613 @@
+import { LinkedInAssistantError } from "./errors.js";
+import { createRunId } from "./run.js";
+import {
+  DRAFT_QUALITY_DRAFT_SOURCES,
+  DRAFT_QUALITY_SCHEMA_VERSION,
+  DRAFT_QUALITY_TONE_LABELS,
+  type DraftQualityCandidateDraft,
+  type DraftQualityCandidateSet,
+  type DraftQualityCase,
+  type DraftQualityCaseResult,
+  type DraftQualityDraftSource,
+  type DraftQualityExpectations,
+  type DraftQualityExternalCandidateDraft,
+  type DraftQualityHardFailure,
+  type DraftQualityJsonObject,
+  type DraftQualityJsonValue,
+  type DraftQualityJudgeMetricFeedback,
+  type DraftQualityLengthDetails,
+  type DraftQualityLengthExpectations,
+  type DraftQualityMetricResult,
+  type DraftQualityParticipant,
+  type DraftQualityParticipantRole,
+  type DraftQualityReport,
+  type DraftQualityRelevanceDetails,
+  type DraftQualityRequiredPoint,
+  type DraftQualityThread,
+  type DraftQualityThreadMessage,
+  type DraftQualityToneDetails,
+  type DraftQualityToneEvidence,
+  type DraftQualityToneExpectations,
+  type DraftQualityToneLabel,
+  type DraftQualityMessageDirection,
+  type DraftQualityDataset,
+  type EvaluateDraftQualityInput
+} from "./draftQualityTypes.js";
+
+const NON_WORD_PATTERN = /[^\p{L}\p{N}]+/gu;
+const SENTENCE_SPLIT_PATTERN = /[.!?]+/;
+
+const STOP_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "at",
+  "be",
+  "but",
+  "for",
+  "from",
+  "have",
+  "i",
+  "if",
+  "in",
+  "is",
+  "it",
+  "just",
+  "me",
+  "my",
+  "of",
+  "on",
+  "or",
+  "our",
+  "so",
+  "that",
+  "the",
+  "their",
+  "this",
+  "to",
+  "up",
+  "we",
+  "with",
+  "you",
+  "your"
+]);
+
+const WARM_SIGNALS = [
+  "thanks",
+  "thank you",
+  "appreciate",
+  "happy to",
+  "glad",
+  "understand",
+  "totally understand",
+  "no worries",
+  "hope"
+] as const;
+
+const PROFESSIONAL_SIGNALS = [
+  "thank you",
+  "thanks",
+  "appreciate",
+  "happy to",
+  "please",
+  "let me know",
+  "would you",
+  "could you",
+  "i can send"
+] as const;
+
+const FRIENDLY_SIGNALS = [
+  "thanks",
+  "thank you",
+  "happy to",
+  "glad",
+  "great",
+  "hope"
+] as const;
+
+const CURIOUS_SIGNALS = [
+  "curious",
+  "would you be open",
+  "would you be interested",
+  "could you",
+  "what works",
+  "when would"
+] as const;
+
+const APPRECIATIVE_SIGNALS = [
+  "thanks",
+  "thank you",
+  "appreciate",
+  "grateful"
+] as const;
+
+const DIRECT_SIGNALS = [
+  "let me know",
+  "can we",
+  "could we",
+  "would next week",
+  "are you available",
+  "open to",
+  "happy to reconnect",
+  "i can send",
+  "send a one page overview",
+  "send a one-page overview"
+] as const;
+
+const EMPATHETIC_SIGNALS = [
+  "understand",
+  "totally understand",
+  "no worries",
+  "sorry",
+  "appreciate"
+] as const;
+
+const PUSHY_SIGNALS = [
+  "just circling back",
+  "circling back",
+  "following up again",
+  "asap",
+  "urgent",
+  "please respond",
+  "bumping",
+  "kind reminder",
+  "checking again"
+] as const;
+
+const ROBOTIC_SIGNALS = [
+  "as an ai",
+  "i am an ai",
+  "furthermore",
+  "hereby",
+  "leverage",
+  "synergy",
+  "dear sir",
+  "dear madam",
+  "your prompt"
+] as const;
+
+const CASUAL_SIGNALS = [
+  "hey",
+  "awesome",
+  "super",
+  "lol",
+  "haha",
+  "gonna",
+  "wanna",
+  "cheers"
+] as const;
+
+interface ToneContext {
+  original_text: string;
+  normalized_text: string;
+  word_count: number;
+  sentence_count: number;
+  length_expectations: DraftQualityLengthExpectations;
+}
+
+interface DeterministicDraftEvaluation {
+  relevance: DraftQualityMetricResult<DraftQualityRelevanceDetails>;
+  tone: DraftQualityMetricResult<DraftQualityToneDetails>;
+  length: DraftQualityMetricResult<DraftQualityLengthDetails>;
+  hard_failures: DraftQualityHardFailure[];
+}
+
+function createInputError(
+  message: string,
+  details: Record<string, unknown> = {}
+): LinkedInAssistantError {
+  return new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    message,
+    details
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function readValue(
+  record: Record<string, unknown>,
+  keys: readonly string[]
+): unknown {
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(record, key)) {
+      return record[key];
+    }
+  }
+
+  return undefined;
+}
+
+function readOptionalString(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+  location: string
+): string | undefined {
+  const value = readValue(record, keys);
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    throw createInputError(`Expected ${location}.${keys[0]} to be a string.`, {
+      location,
+      field: keys[0]
+    });
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw createInputError(`Expected ${location}.${keys[0]} to be non-empty.`, {
+      location,
+      field: keys[0]
+    });
+  }
+
+  return trimmed;
+}
+
+function readRequiredString(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+  location: string
+): string {
+  const value = readOptionalString(record, keys, location);
+  if (value === undefined) {
+    throw createInputError(`Missing required field ${location}.${keys[0]}.`, {
+      location,
+      field: keys[0]
+    });
+  }
+
+  return value;
+}
+
+function readOptionalArray(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+  location: string
+): unknown[] | undefined {
+  const value = readValue(record, keys);
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!Array.isArray(value)) {
+    throw createInputError(`Expected ${location}.${keys[0]} to be an array.`, {
+      location,
+      field: keys[0]
+    });
+  }
+
+  return value;
+}
+
+function readRequiredArray(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+  location: string
+): unknown[] {
+  const value = readOptionalArray(record, keys, location);
+  if (value === undefined) {
+    throw createInputError(`Missing required field ${location}.${keys[0]}.`, {
+      location,
+      field: keys[0]
+    });
+  }
+
+  return value;
+}
+
+function readOptionalNumber(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+  location: string
+): number | undefined {
+  const value = readValue(record, keys);
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw createInputError(`Expected ${location}.${keys[0]} to be a number.`, {
+      location,
+      field: keys[0]
+    });
+  }
+
+  return value;
+}
+
+function readOptionalObject(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+  location: string
+): Record<string, unknown> | undefined {
+  const value = readValue(record, keys);
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const parsed = asRecord(value);
+  if (!parsed) {
+    throw createInputError(`Expected ${location}.${keys[0]} to be an object.`, {
+      location,
+      field: keys[0]
+    });
+  }
+
+  return parsed;
+}
+
+function parseJsonValue(value: unknown, location: string): DraftQualityJsonValue {
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    value === null
+  ) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item, index) => parseJsonValue(item, `${location}[${index}]`));
+  }
+
+  const record = asRecord(value);
+  if (!record) {
+    throw createInputError(`Expected ${location} to be JSON-serializable.`, {
+      location
+    });
+  }
+
+  const parsed: DraftQualityJsonObject = {};
+  for (const [key, entry] of Object.entries(record)) {
+    parsed[key] = parseJsonValue(entry, `${location}.${key}`);
+  }
+  return parsed;
+}
+
+function parseMetadataObject(
+  record: Record<string, unknown> | undefined,
+  location: string
+): DraftQualityJsonObject | undefined {
+  if (!record) {
+    return undefined;
+  }
+
+  return parseJsonValue(record, location) as DraftQualityJsonObject;
+}
+
+function parseInteger(
+  value: number,
+  location: string,
+  field: string,
+  minimum: number
+): number {
+  if (!Number.isInteger(value) || value < minimum) {
+    throw createInputError(
+      `Expected ${location}.${field} to be an integer greater than or equal to ${minimum}.`,
+      {
+        location,
+        field,
+        minimum
+      }
+    );
+  }
+
+  return value;
+}
+
+function isToneLabel(value: string): value is DraftQualityToneLabel {
+  return (DRAFT_QUALITY_TONE_LABELS as readonly string[]).includes(value);
+}
+
+function isDraftSource(value: string): value is DraftQualityDraftSource {
+  return (DRAFT_QUALITY_DRAFT_SOURCES as readonly string[]).includes(value);
+}
+
+function uniqueStrings<T extends string>(values: readonly T[]): T[] {
+  const seen = new Set<string>();
+  const uniqueValues: T[] = [];
+
+  for (const value of values) {
+    if (seen.has(value)) {
+      continue;
+    }
+
+    seen.add(value);
+    uniqueValues.push(value);
+  }
+
+  return uniqueValues;
+}
+
+function parseStringList(values: unknown[], location: string): string[] {
+  const parsedValues = values.map((value, index) => {
+    if (typeof value !== "string") {
+      throw createInputError(`Expected ${location}[${index}] to be a string.`, {
+        location,
+        index
+      });
+    }
+
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      throw createInputError(`Expected ${location}[${index}] to be non-empty.`, {
+        location,
+        index
+      });
+    }
+
+    return trimmed;
+  });
+
+  return uniqueStrings(parsedValues);
+}
+
+function parseToneLabels(values: unknown[], location: string): DraftQualityToneLabel[] {
+  const parsedValues = parseStringList(values, location);
+  return parsedValues.map((value) => {
+    if (!isToneLabel(value)) {
+      throw createInputError(`Unsupported tone label "${value}" at ${location}.`, {
+        location,
+        tone_label: value,
+        supported_tone_labels: DRAFT_QUALITY_TONE_LABELS
+      });
+    }
+
+    return value;
+  });
+}
+
+function parseParticipantRole(
+  value: string | undefined,
+  location: string
+): DraftQualityParticipantRole | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === "assistant" || value === "contact" || value === "other") {
+    return value;
+  }
+
+  throw createInputError(`Unsupported participant role "${value}" at ${location}.`, {
+    location,
+    participant_role: value
+  });
+}
+
+function parseMessageDirection(
+  value: string,
+  location: string
+): DraftQualityMessageDirection {
+  if (value === "inbound" || value === "outbound") {
+    return value;
+  }
+
+  throw createInputError(`Unsupported message direction "${value}" at ${location}.`, {
+    location,
+    direction: value
+  });
+}
+
+function parseDraftSource(
+  value: string,
+  location: string
+): DraftQualityDraftSource {
+  if (isDraftSource(value)) {
+    return value;
+  }
+
+  throw createInputError(`Unsupported draft source "${value}" at ${location}.`, {
+    location,
+    draft_source: value,
+    supported_sources: DRAFT_QUALITY_DRAFT_SOURCES
+  });
+}
+
+function parseParticipant(value: unknown, location: string): DraftQualityParticipant {
+  const record = asRecord(value);
+  if (!record) {
+    throw createInputError(`Expected ${location} to be an object.`, { location });
+  }
+
+  const id = readRequiredString(record, ["id"], location);
+  const name = readRequiredString(record, ["name"], location);
+  const role = parseParticipantRole(
+    readOptionalString(record, ["role"], location),
+    `${location}.role`
+  );
+
+  return {
+    id,
+    name,
+    ...(role ? { role } : {})
+  };
+}
+
+function parseThreadMessage(
+  value: unknown,
+  location: string
+): DraftQualityThreadMessage {
+  const record = asRecord(value);
+  if (!record) {
+    throw createInputError(`Expected ${location} to be an object.`, { location });
+  }
+
+  const id = readRequiredString(record, ["id"], location);
+  const author = readRequiredString(record, ["author"], location);
+  const direction = parseMessageDirection(
+    readRequiredString(record, ["direction"], location),
+    `${location}.direction`
+  );
+  const text = readRequiredString(record, ["text"], location);
+  const participantId = readOptionalString(
+    record,
+    ["participant_id", "participantId"],
+    location
+  );
+  const createdAt = readOptionalString(record, ["created_at", "createdAt"], location);
+
+  return {
+    id,
+    author,
+    direction,
+    text,
+    ...(participantId ? { participant_id: participantId } : {}),
+    ...(createdAt ? { created_at: createdAt } : {})
+  };
+}
+
+function parseThread(value: unknown, location: string): DraftQualityThread {
+  const record = asRecord(value);
+  if (!record) {
+    throw createInputError(`Expected ${location} to be an object.`, { location });
+  }
+
+  const participants = readRequiredArray(record, ["participants"], location).map(
+    (entry, index) => parseParticipant(entry, `${location}.participants[${index}]`)
+  );
+  const messages = readRequiredArray(record, ["messages"], location).map(
+    (entry, index) => parseThreadMessage(entry, `${location}.messages[${index}]`)
+  );
+
+  if (participants.length === 0) {
+    throw createInputError(`Expected ${location}.participants to include at least one participant.`, {
+      location
+    });
+  }
+
+  if (messages.length === 0) {
+    throw createInputError(`Expected ${location}.messages to include at least one message.`, {
+      location
+    });
+  }
+
+  return {
+    participants,
+    messages
+  };
+}
+
+function parseRequiredPoint(
+  value: unknown,
+  location: string
+): DraftQualityRequiredPoint {
+  const record = asRecord(value);
+  if (!record) {
+    throw createInputError(`Expected ${location} to be an object.`, { location });
+  }
+
+  const id = readRequiredString(record, ["id"], location);
+  const description = readOptionalString(record, ["description"], location);
+  const aliasValues = readRequiredArray(record, ["aliases", "match_any", "matchAny"], location);
+  const aliases = parseStringList(aliasValues, `${location}.aliases`);
+
+  if (aliases.length === 0) {
+    throw createInputError(`Expected ${location}.aliases to include at least one phrase.`, {
+      location,
+      point_id: id
+    });
+  }
+
+  return {
+    id,
+    aliases,
+    ...(description ? { description } : {})
+  };
+}
+
+function parseLengthExpectations(
+  value: unknown,
+  location: string
+): DraftQualityLengthExpectations {
+  const record = asRecord(value);
+  if (!record) {
+    throw createInputError(`Expected ${location} to be an object.`, { location });
+  }
+
+  const minWords = parseInteger(
+    readOptionalNumber(record, ["min_words", "minWords"], location) ?? NaN,
+    location,
+    "min_words",
+    0
+  );
+  const maxWords = parseInteger(
+    readOptionalNumber(record, ["max_words", "maxWords"], location) ?? NaN,
+    location,
+    "max_words",
+    1
+  );
+  const targetWordsValue = readOptionalNumber(
+    record,
+    ["target_words", "targetWords"],
+    location
+  );
+  const maxSentencesValue = readOptionalNumber(
+    record,
+    ["max_sentences", "maxSentences"],
+    location
+  );
+
+  if (minWords > maxWords) {
+    throw createInputError(
+      `${location}.min_words must be less than or equal to ${location}.max_words.`,
+      { location }
+    );
+  }
+
+  const targetWords =
+    targetWordsValue === undefined
+      ? undefined
+      : parseInteger(targetWordsValue, location, "target_words", 0);
+  const maxSentences =
+    maxSentencesValue === undefined
+      ? undefined
+      : parseInteger(maxSentencesValue, location, "max_sentences", 1);
+
+  if (targetWords !== undefined && (targetWords < minWords || targetWords > maxWords)) {
+    throw createInputError(
+      `${location}.target_words must stay within the configured word-count range.`,
+      { location, min_words: minWords, max_words: maxWords, target_words: targetWords }
+    );
+  }
+
+  return {
+    min_words: minWords,
+    max_words: maxWords,
+    ...(targetWords !== undefined ? { target_words: targetWords } : {}),
+    ...(maxSentences !== undefined ? { max_sentences: maxSentences } : {})
+  };
+}
+
+function parseToneExpectations(
+  value: unknown,
+  location: string
+): DraftQualityToneExpectations {
+  const record = asRecord(value);
+  if (!record) {
+    throw createInputError(`Expected ${location} to be an object.`, { location });
+  }
+
+  const required = parseToneLabels(
+    readOptionalArray(record, ["required"], location) ?? [],
+    `${location}.required`
+  );
+  const forbidden = parseToneLabels(
+    readOptionalArray(record, ["forbidden"], location) ?? [],
+    `${location}.forbidden`
+  );
+  const optional = parseToneLabels(
+    readOptionalArray(record, ["optional"], location) ?? [],
+    `${location}.optional`
+  ).filter((label) => !required.includes(label) && !forbidden.includes(label));
+
+  const conflictingLabels = required.filter((label) => forbidden.includes(label));
+  if (conflictingLabels.length > 0) {
+    throw createInputError(
+      `${location} includes tone labels that are both required and forbidden.`,
+      {
+        location,
+        conflicting_tone_labels: conflictingLabels
+      }
+    );
+  }
+
+  return {
+    required,
+    optional,
+    forbidden
+  };
+}
+
+function parseExpectations(
+  value: unknown,
+  location: string
+): DraftQualityExpectations {
+  const record = asRecord(value);
+  if (!record) {
+    throw createInputError(`Expected ${location} to be an object.`, { location });
+  }
+
+  const tone = parseToneExpectations(
+    readValue(record, ["tone"]),
+    `${location}.tone`
+  );
+  const length = parseLengthExpectations(
+    readValue(record, ["length"]),
+    `${location}.length`
+  );
+  const requiredPoints = readRequiredArray(
+    record,
+    ["required_points", "requiredPoints"],
+    location
+  ).map((entry, index) => parseRequiredPoint(entry, `${location}.required_points[${index}]`));
+  const forbiddenPhrases = parseStringList(
+    readOptionalArray(record, ["forbidden_phrases", "forbiddenPhrases"], location) ?? [],
+    `${location}.forbidden_phrases`
+  );
+  const manualNotes = parseStringList(
+    readOptionalArray(record, ["manual_notes", "manualNotes"], location) ?? [],
+    `${location}.manual_notes`
+  );
+
+  const seenPointIds = new Set<string>();
+  for (const point of requiredPoints) {
+    if (seenPointIds.has(point.id)) {
+      throw createInputError(`Duplicate required point id "${point.id}" in ${location}.`, {
+        location,
+        point_id: point.id
+      });
+    }
+    seenPointIds.add(point.id);
+  }
+
+  return {
+    tone,
+    length,
+    required_points: requiredPoints,
+    forbidden_phrases: forbiddenPhrases,
+    manual_notes: manualNotes
+  };
+}
+
+function parseCandidateDraft(
+  value: unknown,
+  location: string
+): DraftQualityCandidateDraft {
+  const record = asRecord(value);
+  if (!record) {
+    throw createInputError(`Expected ${location} to be an object.`, { location });
+  }
+
+  const id = readRequiredString(record, ["id"], location);
+  const source = parseDraftSource(
+    readRequiredString(record, ["source"], location),
+    `${location}.source`
+  );
+  const text = readRequiredString(record, ["text"], location);
+  const label = readOptionalString(record, ["label"], location);
+  const metadata = parseMetadataObject(
+    readOptionalObject(record, ["metadata"], location),
+    `${location}.metadata`
+  );
+
+  return {
+    id,
+    source,
+    text,
+    ...(label ? { label } : {}),
+    ...(metadata ? { metadata } : {})
+  };
+}
+
+function parseExternalCandidateDraft(
+  value: unknown,
+  location: string
+): DraftQualityExternalCandidateDraft {
+  const record = asRecord(value);
+  if (!record) {
+    throw createInputError(`Expected ${location} to be an object.`, { location });
+  }
+
+  const caseId = readRequiredString(record, ["case_id", "caseId"], location);
+  const draft = parseCandidateDraft(record, location);
+
+  return {
+    case_id: caseId,
+    ...draft
+  };
+}
+
+function parseSchemaVersion(
+  record: Record<string, unknown>,
+  location: string
+): typeof DRAFT_QUALITY_SCHEMA_VERSION {
+  const version = readOptionalNumber(record, ["schema_version", "schemaVersion"], location);
+  if (version === undefined) {
+    return DRAFT_QUALITY_SCHEMA_VERSION;
+  }
+
+  if (version !== DRAFT_QUALITY_SCHEMA_VERSION) {
+    throw createInputError(`Unsupported schema version ${String(version)} at ${location}.`, {
+      location,
+      schema_version: version,
+      supported_schema_version: DRAFT_QUALITY_SCHEMA_VERSION
+    });
+  }
+
+  return DRAFT_QUALITY_SCHEMA_VERSION;
+}
+
+function assertUniqueDraftIds(
+  drafts: DraftQualityCandidateDraft[],
+  location: string,
+  caseId: string
+): void {
+  const seen = new Set<string>();
+  for (const draft of drafts) {
+    if (seen.has(draft.id)) {
+      throw createInputError(
+        `Duplicate draft id "${draft.id}" found for case "${caseId}".`,
+        {
+          location,
+          case_id: caseId,
+          draft_id: draft.id
+        }
+      );
+    }
+    seen.add(draft.id);
+  }
+}
+
+function parseCase(value: unknown, location: string): DraftQualityCase {
+  const record = asRecord(value);
+  if (!record) {
+    throw createInputError(`Expected ${location} to be an object.`, { location });
+  }
+
+  const id = readRequiredString(record, ["id"], location);
+  const channel = readOptionalString(record, ["channel"], location);
+  const scenario = readOptionalString(record, ["scenario"], location);
+  const thread = parseThread(readValue(record, ["thread"]), `${location}.thread`);
+  const expectations = parseExpectations(
+    readValue(record, ["expectations"]),
+    `${location}.expectations`
+  );
+  const candidateDrafts = (
+    readOptionalArray(record, ["candidate_drafts", "candidateDrafts"], location) ?? []
+  ).map((entry, index) => parseCandidateDraft(entry, `${location}.candidate_drafts[${index}]`));
+  const metadata = parseMetadataObject(
+    readOptionalObject(record, ["metadata"], location),
+    `${location}.metadata`
+  );
+
+  assertUniqueDraftIds(candidateDrafts, `${location}.candidate_drafts`, id);
+
+  return {
+    id,
+    thread,
+    expectations,
+    candidate_drafts: candidateDrafts,
+    ...(channel ? { channel } : {}),
+    ...(scenario ? { scenario } : {}),
+    ...(metadata ? { metadata } : {})
+  };
+}
+
+export function parseDraftQualityDataset(value: unknown): DraftQualityDataset {
+  const record = asRecord(value);
+  if (!record) {
+    throw createInputError("Draft-quality dataset must be a JSON object.");
+  }
+
+  const schemaVersion = parseSchemaVersion(record, "dataset");
+  const name = readOptionalString(record, ["name"], "dataset");
+  const metadata = parseMetadataObject(
+    readOptionalObject(record, ["metadata"], "dataset"),
+    "dataset.metadata"
+  );
+  const cases = readRequiredArray(record, ["cases"], "dataset").map((entry, index) =>
+    parseCase(entry, `dataset.cases[${index}]`)
+  );
+
+  if (cases.length === 0) {
+    throw createInputError("Draft-quality dataset must contain at least one case.", {
+      location: "dataset.cases"
+    });
+  }
+
+  const seenCaseIds = new Set<string>();
+  for (const draftCase of cases) {
+    if (seenCaseIds.has(draftCase.id)) {
+      throw createInputError(`Duplicate case id "${draftCase.id}" in dataset.`, {
+        case_id: draftCase.id
+      });
+    }
+    seenCaseIds.add(draftCase.id);
+  }
+
+  return {
+    schema_version: schemaVersion,
+    cases,
+    ...(name ? { name } : {}),
+    ...(metadata ? { metadata } : {})
+  };
+}
+
+export function parseDraftQualityCandidateSet(value: unknown): DraftQualityCandidateSet {
+  const record = asRecord(value);
+  if (!record) {
+    throw createInputError("Draft-quality candidates file must be a JSON object.");
+  }
+
+  const schemaVersion = parseSchemaVersion(record, "candidates");
+  const metadata = parseMetadataObject(
+    readOptionalObject(record, ["metadata"], "candidates"),
+    "candidates.metadata"
+  );
+  const drafts = readRequiredArray(
+    record,
+    ["drafts", "candidates", "candidate_drafts", "candidateDrafts"],
+    "candidates"
+  ).map((entry, index) => parseExternalCandidateDraft(entry, `candidates.drafts[${index}]`));
+
+  const seenDraftKeys = new Set<string>();
+  for (const draft of drafts) {
+    const draftKey = `${draft.case_id}::${draft.id}`;
+    if (seenDraftKeys.has(draftKey)) {
+      throw createInputError(
+        `Duplicate draft id "${draft.id}" found for case "${draft.case_id}" in candidates file.`,
+        {
+          case_id: draft.case_id,
+          draft_id: draft.id
+        }
+      );
+    }
+
+    seenDraftKeys.add(draftKey);
+  }
+
+  return {
+    schema_version: schemaVersion,
+    drafts,
+    ...(metadata ? { metadata } : {})
+  };
+}
+
+function normalizeText(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(NON_WORD_PATTERN, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+function tokenizeText(value: string): string[] {
+  const normalized = normalizeText(value);
+  return normalized.length === 0 ? [] : normalized.split(" ");
+}
+
+function countWords(value: string): number {
+  return tokenizeText(value).length;
+}
+
+function countSentences(value: string): number {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return 0;
+  }
+
+  const segments = trimmed
+    .split(SENTENCE_SPLIT_PATTERN)
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+
+  return segments.length === 0 ? 1 : segments.length;
+}
+
+function containsNormalizedPhrase(haystack: string, needle: string): boolean {
+  const normalizedHaystack = normalizeText(haystack);
+  const normalizedNeedle = normalizeText(needle);
+
+  if (normalizedHaystack.length === 0 || normalizedNeedle.length === 0) {
+    return false;
+  }
+
+  return ` ${normalizedHaystack} `.includes(` ${normalizedNeedle} `);
+}
+
+function matchSignalPhrases(text: string, phrases: readonly string[]): string[] {
+  return uniqueStrings(phrases.filter((phrase) => containsNormalizedPhrase(text, phrase)));
+}
+
+function clampScore(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  if (value <= 0) {
+    return 0;
+  }
+
+  if (value >= 1) {
+    return 1;
+  }
+
+  return value;
+}
+
+function roundScore(value: number): number {
+  return Math.round(clampScore(value) * 1_000) / 1_000;
+}
+
+function detectToneEvidence(
+  tone: DraftQualityToneLabel,
+  context: ToneContext
+): string[] {
+  switch (tone) {
+    case "warm":
+      return matchSignalPhrases(context.original_text, WARM_SIGNALS);
+    case "professional": {
+      const blockers = matchSignalPhrases(context.original_text, CASUAL_SIGNALS);
+      if (blockers.length > 0 || /!{2,}/.test(context.original_text)) {
+        return [];
+      }
+
+      return matchSignalPhrases(context.original_text, PROFESSIONAL_SIGNALS);
+    }
+    case "friendly":
+      return matchSignalPhrases(context.original_text, FRIENDLY_SIGNALS);
+    case "concise": {
+      const wordThreshold =
+        context.length_expectations.target_words ??
+        Math.min(context.length_expectations.max_words, 30);
+      const sentenceThreshold = Math.min(
+        context.length_expectations.max_sentences ?? 2,
+        2
+      );
+
+      if (
+        context.word_count <= wordThreshold &&
+        context.sentence_count <= sentenceThreshold
+      ) {
+        return [
+          `${context.word_count} words within concise threshold ${wordThreshold}`,
+          `${context.sentence_count} sentences within concise threshold ${sentenceThreshold}`
+        ];
+      }
+
+      return [];
+    }
+    case "curious": {
+      const evidence = matchSignalPhrases(context.original_text, CURIOUS_SIGNALS);
+      if (context.original_text.includes("?")) {
+        evidence.push("question mark");
+      }
+      return uniqueStrings(evidence);
+    }
+    case "appreciative":
+      return matchSignalPhrases(context.original_text, APPRECIATIVE_SIGNALS);
+    case "direct":
+      return matchSignalPhrases(context.original_text, DIRECT_SIGNALS);
+    case "empathetic":
+      return matchSignalPhrases(context.original_text, EMPATHETIC_SIGNALS);
+    case "pushy": {
+      const evidence = matchSignalPhrases(context.original_text, PUSHY_SIGNALS);
+      if (/!{2,}/.test(context.original_text)) {
+        evidence.push("repeated exclamation marks");
+      }
+      return uniqueStrings(evidence);
+    }
+    case "robotic":
+      return matchSignalPhrases(context.original_text, ROBOTIC_SIGNALS);
+    case "casual":
+      return matchSignalPhrases(context.original_text, CASUAL_SIGNALS);
+  }
+}
+
+function evaluateLength(
+  expectations: DraftQualityLengthExpectations,
+  draftText: string
+): DraftQualityMetricResult<DraftQualityLengthDetails> {
+  const wordCount = countWords(draftText);
+  const sentenceCount = countSentences(draftText);
+  let score = 1;
+
+  if (wordCount < expectations.min_words && expectations.min_words > 0) {
+    score = Math.min(score, wordCount / expectations.min_words);
+  }
+
+  if (wordCount > expectations.max_words && wordCount > 0) {
+    score = Math.min(score, expectations.max_words / wordCount);
+  }
+
+  if (
+    expectations.max_sentences !== undefined &&
+    sentenceCount > expectations.max_sentences &&
+    sentenceCount > 0
+  ) {
+    score = Math.min(score, expectations.max_sentences / sentenceCount);
+  }
+
+  return {
+    passed:
+      wordCount >= expectations.min_words &&
+      wordCount <= expectations.max_words &&
+      (expectations.max_sentences === undefined ||
+        sentenceCount <= expectations.max_sentences),
+    score: roundScore(score),
+    mode: "deterministic",
+    details: {
+      word_count: wordCount,
+      sentence_count: sentenceCount,
+      min_words: expectations.min_words,
+      max_words: expectations.max_words,
+      target_words: expectations.target_words ?? null,
+      max_sentences: expectations.max_sentences ?? null,
+      distance_from_target:
+        expectations.target_words === undefined
+          ? null
+          : Math.abs(wordCount - expectations.target_words)
+    }
+  };
+}
+
+function extractLatestInboundMessage(thread: DraftQualityThread): DraftQualityThreadMessage | null {
+  for (let index = thread.messages.length - 1; index >= 0; index -= 1) {
+    const candidate = thread.messages[index];
+    if (candidate && candidate.direction === "inbound") {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function extractKeywords(value: string): string[] {
+  const tokens = tokenizeText(value);
+  const filteredTokens = tokens.filter(
+    (token) => token.length >= 4 && !STOP_WORDS.has(token)
+  );
+  return uniqueStrings(filteredTokens).slice(0, 6);
+}
+
+function buildOffTopicSignals(
+  thread: DraftQualityThread,
+  draftText: string,
+  totalRequiredPoints: number,
+  coveredPointCount: number
+): string[] {
+  const signals: string[] = [];
+  const latestInbound = extractLatestInboundMessage(thread);
+
+  if (totalRequiredPoints > 0 && coveredPointCount === 0) {
+    signals.push("Draft missed every required point for the active thread.");
+  }
+
+  if (!latestInbound) {
+    return signals;
+  }
+
+  const latestKeywords = extractKeywords(latestInbound.text);
+  if (latestKeywords.length === 0) {
+    return signals;
+  }
+
+  const draftTokens = new Set(tokenizeText(draftText));
+  const overlappingKeywords = latestKeywords.filter((keyword) => draftTokens.has(keyword));
+
+  if (overlappingKeywords.length === 0) {
+    signals.push(
+      `Draft shares no keywords with the latest inbound message (${latestKeywords.join(", ")}).`
+    );
+  } else if (overlappingKeywords.length === 1 && latestKeywords.length >= 3) {
+    signals.push(
+      `Draft only overlaps one latest-message keyword (${overlappingKeywords[0]}).`
+    );
+  }
+
+  return signals;
+}
+
+function evaluateRelevance(
+  expectations: DraftQualityExpectations,
+  thread: DraftQualityThread,
+  draftText: string,
+  forbiddenPhraseHits: string[]
+): DraftQualityMetricResult<DraftQualityRelevanceDetails> {
+  const pointMatches = expectations.required_points.map((point) => {
+    const matchedAliases = point.aliases.filter((alias) =>
+      containsNormalizedPhrase(draftText, alias)
+    );
+
+    return {
+      point_id: point.id,
+      matched_aliases: uniqueStrings(matchedAliases)
+    };
+  });
+
+  const coveredPointIds = pointMatches
+    .filter((pointMatch) => pointMatch.matched_aliases.length > 0)
+    .map((pointMatch) => pointMatch.point_id);
+  const missingPointIds = pointMatches
+    .filter((pointMatch) => pointMatch.matched_aliases.length === 0)
+    .map((pointMatch) => pointMatch.point_id);
+  const totalRequiredPoints = expectations.required_points.length;
+
+  return {
+    passed: missingPointIds.length === 0,
+    score: totalRequiredPoints === 0 ? 1 : roundScore(coveredPointIds.length / totalRequiredPoints),
+    mode: "deterministic",
+    details: {
+      total_required_points: totalRequiredPoints,
+      covered_point_ids: coveredPointIds,
+      missing_point_ids: missingPointIds,
+      point_matches: pointMatches,
+      off_topic_signals: buildOffTopicSignals(
+        thread,
+        draftText,
+        totalRequiredPoints,
+        coveredPointIds.length
+      ),
+      forbidden_phrase_hits: forbiddenPhraseHits,
+      judge_rationale: []
+    }
+  };
+}
+
+function evaluateTone(
+  expectations: DraftQualityExpectations,
+  draftText: string,
+  length: DraftQualityMetricResult<DraftQualityLengthDetails>
+): DraftQualityMetricResult<DraftQualityToneDetails> {
+  const context: ToneContext = {
+    original_text: draftText,
+    normalized_text: normalizeText(draftText),
+    word_count: length.details.word_count,
+    sentence_count: length.details.sentence_count,
+    length_expectations: expectations.length
+  };
+  const labelsToInspect = uniqueStrings([
+    ...expectations.tone.required,
+    ...expectations.tone.optional,
+    ...expectations.tone.forbidden
+  ]);
+  const evidenceByTone = new Map<DraftQualityToneLabel, string[]>();
+
+  for (const tone of labelsToInspect) {
+    evidenceByTone.set(tone, detectToneEvidence(tone, context));
+  }
+
+  const matchedRequired = expectations.tone.required.filter(
+    (tone) => (evidenceByTone.get(tone)?.length ?? 0) > 0
+  );
+  const missingRequired = expectations.tone.required.filter(
+    (tone) => (evidenceByTone.get(tone)?.length ?? 0) === 0
+  );
+  const optionalMatched = expectations.tone.optional.filter(
+    (tone) => (evidenceByTone.get(tone)?.length ?? 0) > 0
+  );
+  const forbiddenTriggered = expectations.tone.forbidden.filter(
+    (tone) => (evidenceByTone.get(tone)?.length ?? 0) > 0
+  );
+
+  const evidence: DraftQualityToneEvidence[] = labelsToInspect
+    .map((tone) => {
+      const signals = evidenceByTone.get(tone) ?? [];
+      if (signals.length === 0) {
+        return null;
+      }
+
+      return {
+        tone,
+        signals
+      };
+    })
+    .filter((entry): entry is DraftQualityToneEvidence => entry !== null);
+
+  return {
+    passed: missingRequired.length === 0 && forbiddenTriggered.length === 0,
+    score:
+      expectations.tone.required.length === 0
+        ? 1
+        : roundScore(matchedRequired.length / expectations.tone.required.length),
+    mode: "deterministic",
+    details: {
+      required: expectations.tone.required,
+      matched: matchedRequired,
+      missing: missingRequired,
+      optional_matched: optionalMatched,
+      forbidden_requested: expectations.tone.forbidden,
+      forbidden_triggered: forbiddenTriggered,
+      evidence,
+      judge_rationale: []
+    }
+  };
+}
+
+function mergeJudgeMetric<TDetails extends { judge_rationale: string[] }>(
+  metric: DraftQualityMetricResult<TDetails>,
+  feedback: DraftQualityJudgeMetricFeedback | undefined
+): DraftQualityMetricResult<TDetails> {
+  if (!feedback) {
+    return metric;
+  }
+
+  const mergedRationale = uniqueStrings([
+    ...metric.details.judge_rationale,
+    ...(feedback.rationale ?? [])
+  ]);
+
+  return {
+    passed: metric.passed && (feedback.passed ?? true),
+    score:
+      typeof feedback.score === "number"
+        ? roundScore((metric.score + clampScore(feedback.score)) / 2)
+        : metric.score,
+    mode: "hybrid",
+    details: {
+      ...metric.details,
+      judge_rationale: mergedRationale
+    }
+  };
+}
+
+function createForbiddenPhraseFailures(forbiddenPhraseHits: string[]): DraftQualityHardFailure[] {
+  if (forbiddenPhraseHits.length === 0) {
+    return [];
+  }
+
+  return [
+    {
+      kind: "forbidden_phrase",
+      message: `Draft used forbidden phrases: ${forbiddenPhraseHits.join(", ")}`,
+      values: forbiddenPhraseHits
+    }
+  ];
+}
+
+function evaluateDeterministicDraft(
+  draftCase: DraftQualityCase,
+  draft: DraftQualityCandidateDraft
+): DeterministicDraftEvaluation {
+  const forbiddenPhraseHits = uniqueStrings(
+    draftCase.expectations.forbidden_phrases.filter((phrase) =>
+      containsNormalizedPhrase(draft.text, phrase)
+    )
+  );
+  const length = evaluateLength(draftCase.expectations.length, draft.text);
+  const relevance = evaluateRelevance(
+    draftCase.expectations,
+    draftCase.thread,
+    draft.text,
+    forbiddenPhraseHits
+  );
+  const tone = evaluateTone(draftCase.expectations, draft.text, length);
+
+  return {
+    relevance,
+    tone,
+    length,
+    hard_failures: createForbiddenPhraseFailures(forbiddenPhraseHits)
+  };
+}
+
+function createOverallResult(input: {
+  relevance: DraftQualityMetricResult<DraftQualityRelevanceDetails>;
+  tone: DraftQualityMetricResult<DraftQualityToneDetails>;
+  length: DraftQualityMetricResult<DraftQualityLengthDetails>;
+  hard_failures: DraftQualityHardFailure[];
+}) {
+  const failedMetrics: Array<"relevance" | "tone" | "length"> = [];
+
+  if (!input.relevance.passed) {
+    failedMetrics.push("relevance");
+  }
+
+  if (!input.tone.passed) {
+    failedMetrics.push("tone");
+  }
+
+  if (!input.length.passed) {
+    failedMetrics.push("length");
+  }
+
+  return {
+    passed: failedMetrics.length === 0 && input.hard_failures.length === 0,
+    score: roundScore(
+      (input.relevance.score + input.tone.score + input.length.score) / 3
+    ),
+    failed_metrics: failedMetrics,
+    hard_failures: input.hard_failures
+  };
+}
+
+function buildCandidateLookup(
+  dataset: DraftQualityDataset,
+  candidates?: DraftQualityCandidateSet
+): Map<string, DraftQualityCandidateDraft[]> {
+  const draftsByCaseId = new Map<string, DraftQualityCandidateDraft[]>();
+  const seenDraftKeys = new Set<string>();
+  const knownCaseIds = new Set(dataset.cases.map((draftCase) => draftCase.id));
+
+  for (const draftCase of dataset.cases) {
+    const caseDrafts = [...draftCase.candidate_drafts];
+    draftsByCaseId.set(draftCase.id, caseDrafts);
+    for (const draft of caseDrafts) {
+      seenDraftKeys.add(`${draftCase.id}::${draft.id}`);
+    }
+  }
+
+  for (const externalDraft of candidates?.drafts ?? []) {
+    if (!knownCaseIds.has(externalDraft.case_id)) {
+      throw createInputError(
+        `Candidates file references unknown case "${externalDraft.case_id}".`,
+        {
+          case_id: externalDraft.case_id,
+          draft_id: externalDraft.id
+        }
+      );
+    }
+
+    const draftKey = `${externalDraft.case_id}::${externalDraft.id}`;
+    if (seenDraftKeys.has(draftKey)) {
+      throw createInputError(
+        `Duplicate draft id "${externalDraft.id}" found for case "${externalDraft.case_id}" across dataset and candidates inputs.`,
+        {
+          case_id: externalDraft.case_id,
+          draft_id: externalDraft.id
+        }
+      );
+    }
+
+    seenDraftKeys.add(draftKey);
+    const caseDrafts = draftsByCaseId.get(externalDraft.case_id);
+    if (!caseDrafts) {
+      throw createInputError(
+        `No case bucket found for external draft "${externalDraft.id}".`,
+        {
+          case_id: externalDraft.case_id,
+          draft_id: externalDraft.id
+        }
+      );
+    }
+
+    caseDrafts.push({
+      id: externalDraft.id,
+      source: externalDraft.source,
+      text: externalDraft.text,
+      ...(externalDraft.label ? { label: externalDraft.label } : {}),
+      ...(externalDraft.metadata ? { metadata: externalDraft.metadata } : {})
+    });
+  }
+
+  return draftsByCaseId;
+}
+
+function createSourceCounts(): Record<DraftQualityDraftSource, number> {
+  return {
+    manual: 0,
+    model: 0,
+    imported: 0,
+    synthetic: 0
+  };
+}
+
+export async function evaluateDraftQuality(
+  input: EvaluateDraftQualityInput
+): Promise<DraftQualityReport> {
+  const now = input.now ?? new Date();
+  const runId = input.run_id ?? createRunId(now);
+  const draftsByCaseId = buildCandidateLookup(input.dataset, input.candidates);
+  const sourceCounts = createSourceCounts();
+  const warnings: string[] = [];
+  const caseResults: DraftQualityCaseResult[] = [];
+
+  for (const draftCase of input.dataset.cases) {
+    const drafts = draftsByCaseId.get(draftCase.id) ?? [];
+
+    if (drafts.length === 0) {
+      warnings.push(`Case ${draftCase.id} has no candidate drafts and was skipped.`);
+      continue;
+    }
+
+    for (const draft of drafts) {
+      sourceCounts[draft.source] += 1;
+
+      const deterministic = evaluateDeterministicDraft(draftCase, draft);
+      let relevance = deterministic.relevance;
+      let tone = deterministic.tone;
+      const length = deterministic.length;
+      const notes = [...draftCase.expectations.manual_notes];
+
+      if (input.judge) {
+        const judgeResult = await input.judge.evaluate({
+          draft_case: draftCase,
+          draft,
+          deterministic
+        });
+        relevance = mergeJudgeMetric(relevance, judgeResult.relevance);
+        tone = mergeJudgeMetric(tone, judgeResult.tone);
+        notes.push(...(judgeResult.notes ?? []));
+      }
+
+      caseResults.push({
+        case_id: draftCase.id,
+        draft_id: draft.id,
+        draft_source: draft.source,
+        overall: createOverallResult({
+          relevance,
+          tone,
+          length,
+          hard_failures: deterministic.hard_failures
+        }),
+        metrics: {
+          relevance,
+          tone,
+          length
+        },
+        notes: uniqueStrings(notes),
+        ...(draftCase.channel ? { case_channel: draftCase.channel } : {}),
+        ...(draftCase.scenario ? { case_scenario: draftCase.scenario } : {}),
+        ...(draft.label ? { draft_label: draft.label } : {})
+      });
+    }
+  }
+
+  if (caseResults.length === 0) {
+    throw createInputError(
+      "No candidate drafts were found. Provide embedded candidate_drafts or a separate candidates file.",
+      {
+        dataset_case_count: input.dataset.cases.length,
+        candidates_supplied: Boolean(input.candidates)
+      }
+    );
+  }
+
+  const passedDrafts = caseResults.filter((result) => result.overall.passed).length;
+  const failedDrafts = caseResults.length - passedDrafts;
+  const totalMetricScores = caseResults.reduce(
+    (totals, result) => {
+      totals.relevance += result.metrics.relevance.score;
+      totals.tone += result.metrics.tone.score;
+      totals.length += result.metrics.length.score;
+      return totals;
+    },
+    { relevance: 0, tone: 0, length: 0 }
+  );
+
+  return {
+    run_id: runId,
+    generated_at: now.toISOString(),
+    outcome: failedDrafts === 0 ? "pass" : "fail",
+    summary: {
+      total_cases: input.dataset.cases.length,
+      evaluated_case_count: input.dataset.cases.length - warnings.length,
+      skipped_case_count: warnings.length,
+      total_drafts: caseResults.length,
+      passed_drafts: passedDrafts,
+      failed_drafts: failedDrafts,
+      pass_rate: roundScore(passedDrafts / caseResults.length),
+      metric_averages: {
+        relevance: roundScore(totalMetricScores.relevance / caseResults.length),
+        tone: roundScore(totalMetricScores.tone / caseResults.length),
+        length: roundScore(totalMetricScores.length / caseResults.length)
+      },
+      source_counts: sourceCounts
+    },
+    warnings,
+    cases: caseResults,
+    ...(input.dataset_path ? { dataset_path: input.dataset_path } : {}),
+    ...(input.candidates_path ? { candidates_path: input.candidates_path } : {})
+  };
+}

--- a/packages/core/src/draftQualityTypes.ts
+++ b/packages/core/src/draftQualityTypes.ts
@@ -1,0 +1,272 @@
+export const DRAFT_QUALITY_SCHEMA_VERSION = 1 as const;
+
+export const DRAFT_QUALITY_TONE_LABELS = [
+  "warm",
+  "professional",
+  "friendly",
+  "concise",
+  "curious",
+  "appreciative",
+  "direct",
+  "empathetic",
+  "pushy",
+  "robotic",
+  "casual"
+] as const;
+
+export type DraftQualityToneLabel =
+  (typeof DRAFT_QUALITY_TONE_LABELS)[number];
+
+export const DRAFT_QUALITY_DRAFT_SOURCES = [
+  "manual",
+  "model",
+  "imported",
+  "synthetic"
+] as const;
+
+export type DraftQualityDraftSource =
+  (typeof DRAFT_QUALITY_DRAFT_SOURCES)[number];
+
+export type DraftQualityMetricMode = "deterministic" | "judge" | "hybrid";
+
+export type DraftQualityJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | DraftQualityJsonObject
+  | DraftQualityJsonValue[];
+
+export interface DraftQualityJsonObject {
+  [key: string]: DraftQualityJsonValue;
+}
+
+export type DraftQualityParticipantRole = "assistant" | "contact" | "other";
+
+export type DraftQualityMessageDirection = "inbound" | "outbound";
+
+export interface DraftQualityParticipant {
+  id: string;
+  name: string;
+  role?: DraftQualityParticipantRole;
+}
+
+export interface DraftQualityThreadMessage {
+  id: string;
+  author: string;
+  direction: DraftQualityMessageDirection;
+  text: string;
+  participant_id?: string;
+  created_at?: string;
+}
+
+export interface DraftQualityThread {
+  participants: DraftQualityParticipant[];
+  messages: DraftQualityThreadMessage[];
+}
+
+export interface DraftQualityRequiredPoint {
+  id: string;
+  aliases: string[];
+  description?: string;
+}
+
+export interface DraftQualityToneExpectations {
+  required: DraftQualityToneLabel[];
+  optional: DraftQualityToneLabel[];
+  forbidden: DraftQualityToneLabel[];
+}
+
+export interface DraftQualityLengthExpectations {
+  min_words: number;
+  max_words: number;
+  target_words?: number;
+  max_sentences?: number;
+}
+
+export interface DraftQualityExpectations {
+  tone: DraftQualityToneExpectations;
+  length: DraftQualityLengthExpectations;
+  required_points: DraftQualityRequiredPoint[];
+  forbidden_phrases: string[];
+  manual_notes: string[];
+}
+
+export interface DraftQualityCandidateDraft {
+  id: string;
+  source: DraftQualityDraftSource;
+  text: string;
+  label?: string;
+  metadata?: DraftQualityJsonObject;
+}
+
+export interface DraftQualityExternalCandidateDraft
+  extends DraftQualityCandidateDraft {
+  case_id: string;
+}
+
+export interface DraftQualityCase {
+  id: string;
+  thread: DraftQualityThread;
+  expectations: DraftQualityExpectations;
+  candidate_drafts: DraftQualityCandidateDraft[];
+  channel?: string;
+  scenario?: string;
+  metadata?: DraftQualityJsonObject;
+}
+
+export interface DraftQualityDataset {
+  schema_version: typeof DRAFT_QUALITY_SCHEMA_VERSION;
+  cases: DraftQualityCase[];
+  name?: string;
+  metadata?: DraftQualityJsonObject;
+}
+
+export interface DraftQualityCandidateSet {
+  schema_version: typeof DRAFT_QUALITY_SCHEMA_VERSION;
+  drafts: DraftQualityExternalCandidateDraft[];
+  metadata?: DraftQualityJsonObject;
+}
+
+export interface DraftQualityPointMatch {
+  point_id: string;
+  matched_aliases: string[];
+}
+
+export interface DraftQualityRelevanceDetails {
+  total_required_points: number;
+  covered_point_ids: string[];
+  missing_point_ids: string[];
+  point_matches: DraftQualityPointMatch[];
+  off_topic_signals: string[];
+  forbidden_phrase_hits: string[];
+  judge_rationale: string[];
+}
+
+export interface DraftQualityToneEvidence {
+  tone: DraftQualityToneLabel;
+  signals: string[];
+}
+
+export interface DraftQualityToneDetails {
+  required: DraftQualityToneLabel[];
+  matched: DraftQualityToneLabel[];
+  missing: DraftQualityToneLabel[];
+  optional_matched: DraftQualityToneLabel[];
+  forbidden_requested: DraftQualityToneLabel[];
+  forbidden_triggered: DraftQualityToneLabel[];
+  evidence: DraftQualityToneEvidence[];
+  judge_rationale: string[];
+}
+
+export interface DraftQualityLengthDetails {
+  word_count: number;
+  sentence_count: number;
+  min_words: number;
+  max_words: number;
+  target_words: number | null;
+  max_sentences: number | null;
+  distance_from_target: number | null;
+}
+
+export interface DraftQualityMetricResult<TDetails> {
+  passed: boolean;
+  score: number;
+  mode: DraftQualityMetricMode;
+  details: TDetails;
+}
+
+export interface DraftQualityHardFailure {
+  kind: "forbidden_phrase";
+  message: string;
+  values: string[];
+}
+
+export interface DraftQualityOverallResult {
+  passed: boolean;
+  score: number;
+  failed_metrics: Array<"relevance" | "tone" | "length">;
+  hard_failures: DraftQualityHardFailure[];
+}
+
+export interface DraftQualityCaseResult {
+  case_id: string;
+  draft_id: string;
+  draft_source: DraftQualityDraftSource;
+  overall: DraftQualityOverallResult;
+  metrics: {
+    relevance: DraftQualityMetricResult<DraftQualityRelevanceDetails>;
+    tone: DraftQualityMetricResult<DraftQualityToneDetails>;
+    length: DraftQualityMetricResult<DraftQualityLengthDetails>;
+  };
+  notes: string[];
+  case_channel?: string;
+  case_scenario?: string;
+  draft_label?: string;
+}
+
+export interface DraftQualityMetricAverages {
+  relevance: number;
+  tone: number;
+  length: number;
+}
+
+export interface DraftQualityReportSummary {
+  total_cases: number;
+  evaluated_case_count: number;
+  skipped_case_count: number;
+  total_drafts: number;
+  passed_drafts: number;
+  failed_drafts: number;
+  pass_rate: number;
+  metric_averages: DraftQualityMetricAverages;
+  source_counts: Record<DraftQualityDraftSource, number>;
+}
+
+export interface DraftQualityReport {
+  run_id: string;
+  generated_at: string;
+  outcome: "pass" | "fail";
+  summary: DraftQualityReportSummary;
+  warnings: string[];
+  cases: DraftQualityCaseResult[];
+  dataset_path?: string;
+  candidates_path?: string;
+}
+
+export interface DraftQualityJudgeMetricFeedback {
+  passed?: boolean;
+  score?: number;
+  rationale?: string[];
+}
+
+export interface DraftQualityJudgeInput {
+  draft_case: DraftQualityCase;
+  draft: DraftQualityCandidateDraft;
+  deterministic: {
+    relevance: DraftQualityMetricResult<DraftQualityRelevanceDetails>;
+    tone: DraftQualityMetricResult<DraftQualityToneDetails>;
+    length: DraftQualityMetricResult<DraftQualityLengthDetails>;
+    hard_failures: DraftQualityHardFailure[];
+  };
+}
+
+export interface DraftQualityJudgeResult {
+  relevance?: DraftQualityJudgeMetricFeedback;
+  tone?: DraftQualityJudgeMetricFeedback;
+  notes?: string[];
+}
+
+export interface DraftQualityJudge {
+  evaluate(input: DraftQualityJudgeInput): Promise<DraftQualityJudgeResult>;
+}
+
+export interface EvaluateDraftQualityInput {
+  dataset: DraftQualityDataset;
+  candidates?: DraftQualityCandidateSet;
+  judge?: DraftQualityJudge;
+  now?: Date;
+  run_id?: string;
+  dataset_path?: string;
+  candidates_path?: string;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,8 @@ export * from "./connectionPool.js";
 export * from "./config.js";
 export * from "./confirmArtifacts.js";
 export * from "./db/database.js";
+export * from "./draftQualityEval.js";
+export * from "./draftQualityTypes.js";
 export * from "./errors.js";
 export * from "./healthCheck.js";
 export * from "./humanize.js";

--- a/packages/core/test/draftQualityEval.test.ts
+++ b/packages/core/test/draftQualityEval.test.ts
@@ -1,0 +1,315 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  LinkedInAssistantError,
+  evaluateDraftQuality,
+  parseDraftQualityCandidateSet,
+  parseDraftQualityDataset,
+  type DraftQualityJudge
+} from "../src/index.js";
+
+const FIXED_DATE = new Date("2026-03-08T12:00:00.000Z");
+
+function readFixture(fileName: string): unknown {
+  const fixtureUrl = new URL(`./fixtures/draft-quality/${fileName}`, import.meta.url);
+  return JSON.parse(readFileSync(fixtureUrl, "utf8")) as unknown;
+}
+
+function createInlineDataset(): unknown {
+  return {
+    schemaVersion: 1,
+    cases: [
+      {
+        id: "inline_case_001",
+        channel: "linkedin_inbox",
+        scenario: "Short warm acknowledgement",
+        thread: {
+          participants: [
+            {
+              id: "assistant",
+              name: "You",
+              role: "assistant"
+            },
+            {
+              id: "contact",
+              name: "Taylor",
+              role: "contact"
+            }
+          ],
+          messages: [
+            {
+              id: "m1",
+              author: "Taylor",
+              direction: "inbound",
+              text: "Thanks for the context — could you follow up next week?"
+            }
+          ]
+        },
+        expectations: {
+          tone: {
+            required: ["warm"],
+            forbidden: ["pushy"]
+          },
+          length: {
+            minWords: 4,
+            maxWords: 20,
+            targetWords: 10
+          },
+          requiredPoints: [
+            {
+              id: "say_thanks",
+              aliases: ["thanks", "thank you"]
+            }
+          ],
+          manualNotes: ["This fixture uses camelCase input keys."]
+        },
+        candidateDrafts: [
+          {
+            id: "manual_ok",
+            source: "manual",
+            text: "Thanks again for the quick reply."
+          }
+        ]
+      }
+    ]
+  };
+}
+
+describe("draft quality evaluator", () => {
+  it("evaluates embedded and external drafts from the smoke fixtures", async () => {
+    const dataset = parseDraftQualityDataset(readFixture("smoke-dataset.json"));
+    const candidates = parseDraftQualityCandidateSet(readFixture("smoke-candidates.json"));
+
+    const report = await evaluateDraftQuality({
+      dataset,
+      candidates,
+      now: FIXED_DATE,
+      run_id: "run_fixture",
+      dataset_path: "fixtures/smoke-dataset.json",
+      candidates_path: "fixtures/smoke-candidates.json"
+    });
+
+    expect(report.run_id).toBe("run_fixture");
+    expect(report.summary.total_cases).toBe(2);
+    expect(report.summary.evaluated_case_count).toBe(2);
+    expect(report.summary.skipped_case_count).toBe(0);
+    expect(report.summary.total_drafts).toBe(3);
+    expect(report.summary.passed_drafts).toBe(2);
+    expect(report.summary.failed_drafts).toBe(1);
+    expect(report.summary.pass_rate).toBeCloseTo(0.667, 3);
+    expect(report.summary.metric_averages.relevance).toBeCloseTo(0.833, 3);
+    expect(report.summary.metric_averages.tone).toBeCloseTo(0.778, 3);
+    expect(report.summary.metric_averages.length).toBeCloseTo(0.817, 3);
+    expect(report.summary.source_counts.manual).toBe(1);
+    expect(report.summary.source_counts.model).toBe(2);
+
+    const baselineDraft = report.cases.find(
+      (result) => result.case_id === "followup_meeting_request_001" && result.draft_id === "baseline_manual"
+    );
+    expect(baselineDraft?.overall.passed).toBe(true);
+
+    const timelineDraft = report.cases.find(
+      (result) => result.case_id === "timeline_clarification_001" && result.draft_id === "model_candidate"
+    );
+    expect(timelineDraft?.overall.passed).toBe(true);
+    expect(timelineDraft?.metrics.tone.details.matched).toEqual(
+      expect.arrayContaining(["professional", "direct"])
+    );
+
+    const failingDraft = report.cases.find(
+      (result) => result.case_id === "followup_meeting_request_001" && result.draft_id === "too_pushy"
+    );
+    expect(failingDraft?.overall.passed).toBe(false);
+    expect(failingDraft?.overall.failed_metrics).toEqual([
+      "relevance",
+      "tone",
+      "length"
+    ]);
+    expect(failingDraft?.overall.hard_failures[0]?.kind).toBe("forbidden_phrase");
+    expect(failingDraft?.overall.hard_failures[0]?.values).toEqual([
+      "just circling back"
+    ]);
+    expect(failingDraft?.metrics.relevance.details.missing_point_ids).toEqual([
+      "acknowledge_busyness"
+    ]);
+    expect(failingDraft?.metrics.tone.details.forbidden_triggered).toEqual(["pushy"]);
+    expect(failingDraft?.metrics.length.passed).toBe(false);
+  });
+
+  it("parses camelCase dataset fields and carries manual notes into the report", async () => {
+    const dataset = parseDraftQualityDataset(createInlineDataset());
+
+    expect(dataset.cases[0]?.candidate_drafts).toHaveLength(1);
+    expect(dataset.cases[0]?.expectations.length.min_words).toBe(4);
+
+    const report = await evaluateDraftQuality({
+      dataset,
+      now: FIXED_DATE,
+      run_id: "run_inline"
+    });
+
+    expect(report.summary.total_drafts).toBe(1);
+    expect(report.cases[0]?.overall.passed).toBe(true);
+    expect(report.cases[0]?.notes).toContain(
+      "This fixture uses camelCase input keys."
+    );
+  });
+
+  it("preserves deterministic failures even when a judge is optimistic", async () => {
+    const dataset = parseDraftQualityDataset({
+      schemaVersion: 1,
+      cases: [
+        {
+          id: "judge_case_001",
+          thread: {
+            participants: [
+              {
+                id: "assistant",
+                name: "You",
+                role: "assistant"
+              },
+              {
+                id: "contact",
+                name: "Alex",
+                role: "contact"
+              }
+            ],
+            messages: [
+              {
+                id: "m1",
+                author: "Alex",
+                direction: "inbound",
+                text: "Could you reconnect next week?"
+              }
+            ]
+          },
+          expectations: {
+            tone: {
+              required: ["warm"],
+              forbidden: ["pushy"]
+            },
+            length: {
+              minWords: 2,
+              maxWords: 20,
+              targetWords: 6
+            },
+            requiredPoints: [
+              {
+                id: "mention_next_week",
+                aliases: ["next week"]
+              }
+            ]
+          },
+          candidateDrafts: [
+            {
+              id: "model_guess",
+              source: "model",
+              text: "Following up soon."
+            }
+          ]
+        }
+      ]
+    });
+
+    const judge: DraftQualityJudge = {
+      evaluate: async () => ({
+        relevance: {
+          passed: true,
+          score: 1,
+          rationale: ["Judge thought the reply still addressed the schedule."]
+        },
+        tone: {
+          passed: true,
+          score: 1,
+          rationale: ["Judge heard a friendly tone."]
+        },
+        notes: ["Judge note"]
+      })
+    };
+
+    const report = await evaluateDraftQuality({
+      dataset,
+      judge,
+      now: FIXED_DATE,
+      run_id: "run_judge"
+    });
+
+    const result = report.cases[0];
+    expect(result?.metrics.relevance.mode).toBe("hybrid");
+    expect(result?.metrics.relevance.passed).toBe(false);
+    expect(result?.metrics.relevance.details.judge_rationale).toContain(
+      "Judge thought the reply still addressed the schedule."
+    );
+    expect(result?.metrics.tone.mode).toBe("hybrid");
+    expect(result?.metrics.tone.passed).toBe(false);
+    expect(result?.overall.passed).toBe(false);
+    expect(result?.notes).toContain("Judge note");
+  });
+
+  it("rejects unsupported tone labels and duplicate external draft identifiers", () => {
+    expect(() =>
+      parseDraftQualityDataset({
+        schemaVersion: 1,
+        cases: [
+          {
+            id: "invalid_case",
+            thread: {
+              participants: [
+                {
+                  id: "assistant",
+                  name: "You",
+                  role: "assistant"
+                }
+              ],
+              messages: [
+                {
+                  id: "m1",
+                  author: "You",
+                  direction: "outbound",
+                  text: "Hello"
+                }
+              ]
+            },
+            expectations: {
+              tone: {
+                required: ["uplifting"]
+              },
+              length: {
+                minWords: 1,
+                maxWords: 10
+              },
+              requiredPoints: []
+            },
+            candidateDrafts: [
+              {
+                id: "draft_1",
+                source: "manual",
+                text: "Hello"
+              }
+            ]
+          }
+        ]
+      })
+    ).toThrowError(LinkedInAssistantError);
+
+    expect(() =>
+      parseDraftQualityCandidateSet({
+        schema_version: 1,
+        drafts: [
+          {
+            case_id: "case_1",
+            id: "duplicate",
+            source: "model",
+            text: "One"
+          },
+          {
+            case_id: "case_1",
+            id: "duplicate",
+            source: "model",
+            text: "Two"
+          }
+        ]
+      })
+    ).toThrowError(LinkedInAssistantError);
+  });
+});

--- a/packages/core/test/fixtures/draft-quality/smoke-candidates.json
+++ b/packages/core/test/fixtures/draft-quality/smoke-candidates.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "drafts": [
+    {
+      "case_id": "timeline_clarification_001",
+      "id": "model_candidate",
+      "source": "model",
+      "text": "Thanks for checking. We are planning a small pilot in Q3, and I can send a one-page overview if that would be helpful."
+    },
+    {
+      "case_id": "followup_meeting_request_001",
+      "id": "too_pushy",
+      "source": "model",
+      "text": "Just circling back. Please respond ASAP about next week!!!"
+    }
+  ]
+}

--- a/packages/core/test/fixtures/draft-quality/smoke-dataset.json
+++ b/packages/core/test/fixtures/draft-quality/smoke-dataset.json
@@ -1,0 +1,125 @@
+{
+  "schemaVersion": 1,
+  "name": "draft-quality-smoke",
+  "cases": [
+    {
+      "id": "followup_meeting_request_001",
+      "channel": "linkedin_inbox",
+      "scenario": "Warm follow-up when the contact is busy this week",
+      "thread": {
+        "participants": [
+          {
+            "id": "assistant",
+            "name": "You",
+            "role": "assistant"
+          },
+          {
+            "id": "contact",
+            "name": "Pat Morgan",
+            "role": "contact"
+          }
+        ],
+        "messages": [
+          {
+            "id": "m1",
+            "author": "You",
+            "direction": "outbound",
+            "text": "Thanks again for connecting. Would you be open to a quick intro call next week?"
+          },
+          {
+            "id": "m2",
+            "author": "Pat Morgan",
+            "direction": "inbound",
+            "text": "Thanks for reaching out. This week is packed on my side, so I cannot commit to a call right now."
+          }
+        ]
+      },
+      "expectations": {
+        "tone": {
+          "required": ["warm", "professional", "concise"],
+          "forbidden": ["pushy", "robotic"]
+        },
+        "length": {
+          "minWords": 20,
+          "maxWords": 50,
+          "targetWords": 35,
+          "maxSentences": 2
+        },
+        "requiredPoints": [
+          {
+            "id": "acknowledge_busyness",
+            "aliases": ["packed", "busy", "totally understand", "no worries"]
+          },
+          {
+            "id": "propose_next_week",
+            "aliases": ["next week", "another time", "when your schedule opens up"]
+          }
+        ],
+        "forbiddenPhrases": ["just circling back", "as an AI"],
+        "manualNotes": ["Keep the reply low-pressure and kind."]
+      },
+      "candidateDrafts": [
+        {
+          "id": "baseline_manual",
+          "source": "manual",
+          "text": "Thanks for the reply — totally understand that this week is packed. Happy to reconnect next week if that is easier for you."
+        }
+      ],
+      "metadata": {
+        "difficulty": "normal",
+        "source": "synthetic"
+      }
+    },
+    {
+      "id": "timeline_clarification_001",
+      "channel": "linkedin_inbox",
+      "scenario": "Direct answer about pilot timing with an offer to send context",
+      "thread": {
+        "participants": [
+          {
+            "id": "assistant",
+            "name": "You",
+            "role": "assistant"
+          },
+          {
+            "id": "contact",
+            "name": "Jordan Lee",
+            "role": "contact"
+          }
+        ],
+        "messages": [
+          {
+            "id": "m1",
+            "author": "Jordan Lee",
+            "direction": "inbound",
+            "text": "Can you clarify whether the pilot is still on track for Q3, and do you have a short overview you can send?"
+          }
+        ]
+      },
+      "expectations": {
+        "tone": {
+          "required": ["professional", "direct"],
+          "forbidden": ["pushy", "casual"]
+        },
+        "length": {
+          "minWords": 12,
+          "maxWords": 35,
+          "targetWords": 24,
+          "maxSentences": 2
+        },
+        "requiredPoints": [
+          {
+            "id": "mention_q3_pilot",
+            "aliases": ["pilot in q3", "small pilot in q3", "q3 pilot"]
+          },
+          {
+            "id": "offer_overview",
+            "aliases": ["one-page overview", "short overview", "send an overview"]
+          }
+        ],
+        "forbiddenPhrases": ["urgent", "ASAP"],
+        "manualNotes": ["Answer the question directly before offering the follow-up asset."]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a pure core draft-quality evaluator with dataset parsing, relevance/tone/length scoring, and an optional judge seam
- add synthetic smoke fixtures plus unit tests and human-readable output formatters for local/manual review
- add `linkedin audit draft-quality` so operators can evaluate embedded or external candidate drafts from JSON files

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #10