### PR TITLE
feat: add locale-aware selector fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Default tool-owned state home (profiles, DB, artifacts):
 - `~/.linkedin-assistant/linkedin-owa-agentools`
 - Override with `LINKEDIN_ASSISTANT_HOME=/custom/path`
 - Confirm-failure trace size cap: `LINKEDIN_ASSISTANT_CONFIRM_TRACE_MAX_BYTES` (defaults to `26214400`)
+- Selector locale for UI-text fallbacks: `LINKEDIN_ASSISTANT_SELECTOR_LOCALE` (defaults to `en`; supports `en`, `da`)
 
 Privacy / redaction controls:
 
@@ -116,6 +117,9 @@ npm exec -w @linkedin-assistant/cli -- linkedin audit selectors --profile defaul
 # Audit an attached logged-in browser instead of the tool-owned profile
 npm exec -w @linkedin-assistant/cli -- linkedin audit selectors --profile default --cdp-url http://127.0.0.1:18800
 
+# Force Danish selector fallbacks with English as a safety net
+npm exec -w @linkedin-assistant/cli -- linkedin audit selectors --profile default --selector-locale da
+
 # Show command help and doc reference
 npm exec -w @linkedin-assistant/cli -- linkedin audit selectors --help
 ```
@@ -158,9 +162,9 @@ Failures
 - Reports are written under the run artifact directory as
   `selector-audit/report.json`; screenshots, DOM snapshots, and accessibility
   snapshots are captured only for failures.
-- The CLI has no selector-audit-specific env vars today; configuration is via
-  `--profile`, optional `--cdp-url`, and the programmatic core service options
-  documented in `docs/selector-audit.md`.
+- Selector audit also supports `--selector-locale <locale>` for localized UI
+  text fallbacks, and the default can be set with
+  `LINKEDIN_ASSISTANT_SELECTOR_LOCALE`.
 
 Inbox MVP commands:
 

--- a/docs/selector-audit.md
+++ b/docs/selector-audit.md
@@ -30,6 +30,9 @@ npm exec -w @linkedin-assistant/cli -- linkedin audit selectors --profile defaul
 # Attach to an existing authenticated browser session
 npm exec -w @linkedin-assistant/cli -- linkedin audit selectors --profile default --cdp-url http://127.0.0.1:18800
 
+# Prefer Danish selectors first, then fall back to English phrases
+npm exec -w @linkedin-assistant/cli -- linkedin audit selectors --profile default --selector-locale da
+
 # Show built-in help and doc pointer
 npm exec -w @linkedin-assistant/cli -- linkedin audit selectors --help
 ```
@@ -120,9 +123,11 @@ Available switches:
 - `--verbose`: add selector-by-selector detail to human output
 - `--no-progress`: suppress live progress lines in human output
 - `--cdp-url <url>`: attach to an existing authenticated browser session
+- `--selector-locale <locale>`: use locale-aware UI text fallbacks (`en`, `da`)
 
-There are no selector-audit-specific environment variables today. General tool
-state and artifacts still follow `LINKEDIN_ASSISTANT_HOME`.
+You can also set `LINKEDIN_ASSISTANT_SELECTOR_LOCALE` to change the default
+selector locale. General tool state and artifacts still follow
+`LINKEDIN_ASSISTANT_HOME`.
 
 ### Core API
 

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -11,6 +11,7 @@ import {
   isInRateLimitCooldown,
   LINKEDIN_FEED_REACTION_TYPES,
   LINKEDIN_POST_VISIBILITY_TYPES,
+  LINKEDIN_SELECTOR_LOCALES,
   LinkedInAssistantError,
   createCoreRuntime,
   normalizeLinkedInFeedReaction,
@@ -34,6 +35,7 @@ const cliPrivacyConfig = resolvePrivacyConfig();
 const SELECTOR_AUDIT_DOC_PATH = "docs/selector-audit.md";
 const SELECTOR_AUDIT_DOC_REFERENCE =
   `See ${SELECTOR_AUDIT_DOC_PATH} for sample output, configuration, and troubleshooting.`;
+let cliSelectorLocale: string | undefined;
 
 function coercePositiveInt(value: string, label: string): number {
   const parsed = Number.parseInt(value, 10);
@@ -95,8 +97,15 @@ function createRuntime(cdpUrl?: string) {
   }
   return createCoreRuntime(
     cdpUrl
-      ? { cdpUrl, privacy: cliPrivacyConfig }
-      : { privacy: cliPrivacyConfig }
+      ? {
+          cdpUrl,
+          privacy: cliPrivacyConfig,
+          ...(cliSelectorLocale ? { selectorLocale: cliSelectorLocale } : {})
+        }
+      : {
+          privacy: cliPrivacyConfig,
+          ...(cliSelectorLocale ? { selectorLocale: cliSelectorLocale } : {})
+        }
   );
 }
 
@@ -344,6 +353,9 @@ async function runKeepAliveStart(input: {
   if (cdpUrl) {
     daemonArgs.push("--cdp-url", cdpUrl);
   }
+  if (cliSelectorLocale) {
+    daemonArgs.push("--selector-locale", cliSelectorLocale);
+  }
   daemonArgs.push(
     "keepalive",
     "__run",
@@ -500,7 +512,16 @@ async function runKeepAliveDaemon(input: {
   jitterSeconds: number;
   maxConsecutiveFailures: number;
 }, cdpUrl?: string): Promise<void> {
-  const runtime = createCoreRuntime(cdpUrl ? { cdpUrl } : {});
+  const runtime = createCoreRuntime(
+    cdpUrl
+      ? {
+          cdpUrl,
+          ...(cliSelectorLocale ? { selectorLocale: cliSelectorLocale } : {})
+        }
+      : {
+          ...(cliSelectorLocale ? { selectorLocale: cliSelectorLocale } : {})
+        }
+  );
   const profileName = input.profileName;
   let stopRequested = false;
   let consecutiveFailures = 0;
@@ -1628,6 +1649,10 @@ async function main(): Promise<void> {
       "--cdp-url <url>",
       "Connect to existing browser via CDP endpoint (e.g., http://127.0.0.1:18800)"
     )
+    .option(
+      "--selector-locale <locale>",
+      `Selector locale for LinkedIn UI text fallbacks (${LINKEDIN_SELECTOR_LOCALES.join(", ")})`
+    )
     .addHelpText(
       "after",
       [
@@ -1644,6 +1669,18 @@ async function main(): Promise<void> {
       ? options.cdpUrl.trim()
       : undefined;
   };
+
+  const readSelectorLocale = (): string | undefined => {
+    const options = program.opts<{ selectorLocale?: string }>();
+    return typeof options.selectorLocale === "string" &&
+      options.selectorLocale.trim().length > 0
+      ? options.selectorLocale.trim()
+      : undefined;
+  };
+
+  program.hook("preAction", () => {
+    cliSelectorLocale = readSelectorLocale();
+  });
 
   program
     .command("status")

--- a/packages/core/src/__tests__/selectorAudit.test.ts
+++ b/packages/core/src/__tests__/selectorAudit.test.ts
@@ -45,6 +45,15 @@ describe("createLinkedInSelectorAuditRegistry", () => {
       }
     }
   });
+
+  it("builds locale-aware selector hints with english fallback", () => {
+    const registry = createLinkedInSelectorAuditRegistry("da");
+    const feedDefinition = registry.find((pageDefinition) => pageDefinition.page === "feed");
+    const primaryCandidate = feedDefinition?.selectors[0]?.candidates[0];
+
+    expect(primaryCandidate?.selectorHint).toContain("Start et opslag");
+    expect(primaryCandidate?.selectorHint).toContain("Start a post");
+  });
 });
 
 describe("LinkedInSelectorAuditService", () => {

--- a/packages/core/src/__tests__/selectorLocale.test.ts
+++ b/packages/core/src/__tests__/selectorLocale.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLinkedInAriaLabelContainsSelector,
+  buildLinkedInSelectorPhraseRegex,
+  getLinkedInSelectorPhrases,
+  resolveLinkedInSelectorLocale
+} from "../selectorLocale.js";
+
+describe("resolveLinkedInSelectorLocale", () => {
+  it("normalizes region-specific locales to the supported base locale", () => {
+    expect(resolveLinkedInSelectorLocale("da-DK")).toBe("da");
+    expect(resolveLinkedInSelectorLocale("EN_us")).toBe("en");
+  });
+
+  it("falls back to english for unsupported locales", () => {
+    expect(resolveLinkedInSelectorLocale("fr")).toBe("en");
+    expect(resolveLinkedInSelectorLocale(undefined)).toBe("en");
+  });
+});
+
+describe("getLinkedInSelectorPhrases", () => {
+  it("returns locale-specific phrases before english fallbacks", () => {
+    expect(getLinkedInSelectorPhrases("connect", "da")).toEqual([
+      "Opret forbindelse",
+      "Forbind",
+      "Connect"
+    ]);
+  });
+
+  it("deduplicates english fallback phrases when the locale already shares them", () => {
+    expect(getLinkedInSelectorPhrases("send", "da")).toEqual(["Send"]);
+  });
+});
+
+describe("buildLinkedInSelectorPhraseRegex", () => {
+  it("matches both localized phrases and english fallback phrases", () => {
+    const regex = buildLinkedInSelectorPhraseRegex("connect", "da", {
+      exact: true
+    });
+
+    expect(regex.test("Opret forbindelse")).toBe(true);
+    expect(regex.test("Connect")).toBe(true);
+    expect(regex.test("Invite to connect")).toBe(false);
+  });
+});
+
+describe("buildLinkedInAriaLabelContainsSelector", () => {
+  it("builds locale-aware aria-label selectors with english fallback", () => {
+    const selector = buildLinkedInAriaLabelContainsSelector(
+      "button",
+      "comment",
+      "da"
+    );
+
+    expect(selector).toContain('button[aria-label*="Kommenter" i]');
+    expect(selector).toContain('button[aria-label*="Comment" i]');
+  });
+});

--- a/packages/core/src/auth/session.ts
+++ b/packages/core/src/auth/session.ts
@@ -7,6 +7,10 @@ import {
   isRateLimitedChallengeUrl
 } from "./sessionInspection.js";
 import {
+  DEFAULT_LINKEDIN_SELECTOR_LOCALE,
+  type LinkedInSelectorLocale
+} from "../selectorLocale.js";
+import {
   clearRateLimitState,
   isInRateLimitCooldown,
   recordRateLimit,
@@ -90,7 +94,9 @@ async function sleep(ms: number): Promise<void> {
 export class LinkedInAuthService {
   constructor(
     private readonly profileManager: ProfileManager,
-    private readonly cdpUrl?: string
+    private readonly cdpUrl?: string,
+    private readonly selectorLocale: LinkedInSelectorLocale =
+      DEFAULT_LINKEDIN_SELECTOR_LOCALE
   ) {}
 
   async status(options: SessionOptions = {}): Promise<SessionStatus> {
@@ -110,7 +116,9 @@ export class LinkedInAuthService {
         await page.goto("https://www.linkedin.com/feed/", {
           waitUntil: "domcontentloaded"
         });
-        const status = await inspectLinkedInSession(page);
+        const status = await inspectLinkedInSession(page, {
+          selectorLocale: this.selectorLocale
+        });
         if (status.authenticated) {
           await clearRateLimitState();
         }
@@ -226,7 +234,9 @@ export class LinkedInAuthService {
 
         const currentUrl = page.url();
         if (!currentUrl.includes("/login") && !currentUrl.includes("/checkpoint")) {
-          const earlyStatus = await inspectLinkedInSession(page);
+          const earlyStatus = await inspectLinkedInSession(page, {
+            selectorLocale: this.selectorLocale
+          });
           if (earlyStatus.authenticated) {
             await clearRateLimitState();
             return {
@@ -259,7 +269,9 @@ export class LinkedInAuthService {
         let mfaCodeSubmitted = false;
 
         while (Date.now() < deadline) {
-          const status = await inspectLinkedInSession(page);
+          const status = await inspectLinkedInSession(page, {
+            selectorLocale: this.selectorLocale
+          });
 
           if (status.authenticated) {
             await clearRateLimitState();
@@ -454,7 +466,9 @@ export class LinkedInAuthService {
           }
         }
 
-        const finalStatus = await inspectLinkedInSession(page);
+        const finalStatus = await inspectLinkedInSession(page, {
+          selectorLocale: this.selectorLocale
+        });
         if (finalStatus.authenticated) {
           await clearRateLimitState();
         }
@@ -492,7 +506,9 @@ export class LinkedInAuthService {
           waitUntil: "domcontentloaded"
         });
 
-        let status = await inspectLinkedInSession(page);
+        let status = await inspectLinkedInSession(page, {
+          selectorLocale: this.selectorLocale
+        });
         const deadline = Date.now() + timeoutMs;
 
         while (!status.authenticated && Date.now() < deadline) {
@@ -505,7 +521,9 @@ export class LinkedInAuthService {
             };
           }
 
-          status = await inspectLinkedInSession(page);
+          status = await inspectLinkedInSession(page, {
+            selectorLocale: this.selectorLocale
+          });
         }
 
         if (status.authenticated) {

--- a/packages/core/src/auth/sessionInspection.ts
+++ b/packages/core/src/auth/sessionInspection.ts
@@ -1,4 +1,9 @@
 import type { Page } from "playwright-core";
+import {
+  DEFAULT_LINKEDIN_SELECTOR_LOCALE,
+  buildLinkedInAriaLabelContainsSelector,
+  type LinkedInSelectorLocale
+} from "../selectorLocale.js";
 
 export interface LinkedInSessionInspection {
   authenticated: boolean;
@@ -10,8 +15,13 @@ export interface LinkedInSessionInspection {
 const LOGIN_FORM_SELECTOR = "input[name='session_key'], input#username";
 const CHECKPOINT_FORM_SELECTOR = "form[action*='checkpoint']";
 const AUTH_NAV_SELECTOR = "nav.global-nav";
-const AUTH_PROFILE_SELECTOR =
-  "button[aria-label*='Me'], [data-control-name='nav.settings_view_profile']";
+
+function createAuthProfileSelector(selectorLocale: LinkedInSelectorLocale): string {
+  return [
+    buildLinkedInAriaLabelContainsSelector("button", "me", selectorLocale),
+    "[data-control-name='nav.settings_view_profile']"
+  ].join(", ");
+}
 
 async function isVisibleSafe(page: Page, selector: string): Promise<boolean> {
   try {
@@ -56,8 +66,11 @@ async function hasSessionCookie(page: Page): Promise<boolean> {
 }
 
 export async function inspectLinkedInSession(
-  page: Page
+  page: Page,
+  options: { selectorLocale?: LinkedInSelectorLocale } = {}
 ): Promise<LinkedInSessionInspection> {
+  const selectorLocale =
+    options.selectorLocale ?? DEFAULT_LINKEDIN_SELECTOR_LOCALE;
   const checkedAt = new Date().toISOString();
   const currentUrl = page.url();
 
@@ -88,7 +101,10 @@ export async function inspectLinkedInSession(
   }
 
   const navVisible = await isVisibleSafe(page, AUTH_NAV_SELECTOR);
-  const profileMenuVisible = await isVisibleSafe(page, AUTH_PROFILE_SELECTOR);
+  const profileMenuVisible = await isVisibleSafe(
+    page,
+    createAuthProfileSelector(selectorLocale)
+  );
   const sessionCookiePresent = await hasSessionCookie(page);
 
   if (navVisible || profileMenuVisible || sessionCookiePresent) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,6 +1,11 @@
 import { mkdirSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import {
+  DEFAULT_LINKEDIN_SELECTOR_LOCALE,
+  resolveLinkedInSelectorLocale,
+  type LinkedInSelectorLocale
+} from "./selectorLocale.js";
 
 export const DEFAULT_LINKEDIN_ASSISTANT_HOME = path.join(
   os.homedir(),
@@ -20,6 +25,9 @@ export const DEFAULT_CONFIRM_TRACE_MAX_BYTES = 25 * 1024 * 1024;
 export interface ConfirmFailureArtifactConfig {
   traceMaxBytes: number;
 }
+
+export const LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV =
+  "LINKEDIN_ASSISTANT_SELECTOR_LOCALE";
 
 function parsePositiveInteger(
   value: string | undefined,
@@ -64,4 +72,13 @@ export function resolveConfirmFailureArtifactConfig(): ConfirmFailureArtifactCon
       DEFAULT_CONFIRM_TRACE_MAX_BYTES
     )
   };
+}
+
+export function resolveLinkedInSelectorLocaleConfig(
+  selectorLocale?: string | LinkedInSelectorLocale
+): LinkedInSelectorLocale {
+  return resolveLinkedInSelectorLocale(
+    selectorLocale ?? process.env[LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV],
+    DEFAULT_LINKEDIN_SELECTOR_LOCALE
+  );
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,5 +24,6 @@ export * from "./profileManager.js";
 export * from "./rateLimiter.js";
 export * from "./run.js";
 export * from "./runtime.js";
+export * from "./selectorLocale.js";
 export * from "./selectorAudit.js";
 export * from "./twoPhaseCommit.js";

--- a/packages/core/src/linkedinConnections.ts
+++ b/packages/core/src/linkedinConnections.ts
@@ -11,6 +11,13 @@ import {
   normalizeLinkedInProfileUrl,
   resolveProfileUrl
 } from "./linkedinProfile.js";
+import type { LinkedInSelectorLocale } from "./selectorLocale.js";
+import {
+  buildLinkedInAriaLabelContainsSelector,
+  buildLinkedInSelectorPhraseRegex,
+  formatLinkedInSelectorRegexHint,
+  getLinkedInSelectorPhrases
+} from "./selectorLocale.js";
 import type { TwoPhaseCommitService } from "./twoPhaseCommit.js";
 import type { ArtifactHelpers } from "./artifacts.js";
 
@@ -70,6 +77,7 @@ export interface LinkedInConnectionsExecutorRuntime {
   db: AssistantDatabase;
   auth: LinkedInAuthService;
   cdpUrl?: string | undefined;
+  selectorLocale: LinkedInSelectorLocale;
   profileManager: ProfileManager;
   logger: JsonEventLogger;
   artifacts: ArtifactHelpers;
@@ -269,7 +277,8 @@ async function scrapeConnections(
 
 async function scrapePendingInvitations(
   page: Page,
-  sentOrReceived: "sent" | "received"
+  sentOrReceived: "sent" | "received",
+  selectorLocale: LinkedInSelectorLocale
 ): Promise<LinkedInPendingInvitation[]> {
   // Wait for invitation cards
   await page
@@ -278,9 +287,55 @@ async function scrapePendingInvitations(
     .waitFor({ state: "visible", timeout: 5_000 })
     .catch(() => undefined);
 
-  const invitations = await page.evaluate((direction: string) => {
+  const sentSignals = getLinkedInSelectorPhrases(
+    ["withdraw", "invitation_sent"],
+    selectorLocale
+  );
+  const receivedSignals = getLinkedInSelectorPhrases(
+    ["accept", "ignore", "decline", "respond"],
+    selectorLocale
+  );
+  const headlineNoiseSignals = getLinkedInSelectorPhrases(
+    [
+      "accept",
+      "decline",
+      "ignore",
+      "invitation",
+      "invitation_sent",
+      "respond",
+      "withdraw"
+    ],
+    selectorLocale
+  );
+
+  const invitations = await page.evaluate(
+    ({ direction, sentSignals, receivedSignals, headlineNoiseSignals }) => {
     const normalize = (v: string | null | undefined): string =>
       (v ?? "").replace(/\s+/g, " ").trim();
+
+      const containsAny = (value: string, phrases: string[]): boolean => {
+        const normalizedValue = normalize(value).toLowerCase();
+        return phrases.some((phrase) =>
+          normalizedValue.includes(normalize(phrase).toLowerCase())
+        );
+      };
+
+      const escapeRegExp = (value: string): string =>
+        value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+      const stripPhrases = (value: string, phrases: string[]): string => {
+        return phrases.reduce((stripped, phrase) => {
+          const normalizedPhrase = normalize(phrase);
+          if (!normalizedPhrase) {
+            return stripped;
+          }
+
+          return stripped.replace(
+            new RegExp(escapeRegExp(normalizedPhrase), "giu"),
+            " "
+          );
+        }, normalize(value));
+      };
 
     const legacyCards = Array.from(
       document.querySelectorAll(
@@ -297,10 +352,10 @@ async function scrapePendingInvitations(
       }
 
       if (direction === "sent") {
-        return /withdraw|sent/.test(text);
+        return containsAny(text, sentSignals);
       }
 
-      return /accept|ignore|decline|respond/.test(text);
+      return containsAny(text, receivedSignals);
     });
 
     const cards = legacyCards.length > 0 ? legacyCards : modernCards;
@@ -324,9 +379,10 @@ async function scrapePendingInvitations(
       const headlineEl =
         card.querySelector(".invitation-card__subtitle") ??
         card.querySelector(".entity-result__primary-subtitle");
-      let headline = normalize(headlineEl?.textContent)
-        .replace(/\b(sent|withdraw|accept|ignore)\b/gi, "")
-        .trim();
+      let headline = stripPhrases(
+        normalize(headlineEl?.textContent),
+        headlineNoiseSignals
+      ).trim();
 
       if (!headline) {
         const fallbackLine = Array.from(card.querySelectorAll("p, span"))
@@ -334,7 +390,7 @@ async function scrapePendingInvitations(
           .find((line) => {
             if (!line) return false;
             if (line === fullName) return false;
-            if (/sent|withdraw|accept|ignore|invitation/i.test(line)) return false;
+            if (containsAny(line, headlineNoiseSignals)) return false;
             return true;
           });
         headline = fallbackLine ?? "";
@@ -347,7 +403,14 @@ async function scrapePendingInvitations(
         sent_or_received: direction as "sent" | "received"
       };
     });
-  }, sentOrReceived);
+    },
+    {
+      direction: sentOrReceived,
+      sentSignals,
+      receivedSignals,
+      headlineNoiseSignals
+    }
+  );
 
   return invitations.map((inv) => ({
     vanity_name: extractVanityName(inv.profile_url),
@@ -411,62 +474,166 @@ async function executeSendInvitation(
       await page.goto(profileUrl, { waitUntil: "domcontentloaded" });
       await waitForNetworkIdleBestEffort(page);
 
+      const connectExactRegex = buildLinkedInSelectorPhraseRegex(
+        "connect",
+        runtime.selectorLocale,
+        { exact: true }
+      );
+      const connectExactRegexHint = formatLinkedInSelectorRegexHint(
+        "connect",
+        runtime.selectorLocale,
+        { exact: true }
+      );
+      const connectTextRegex = buildLinkedInSelectorPhraseRegex(
+        "connect",
+        runtime.selectorLocale
+      );
+      const connectTextRegexHint = formatLinkedInSelectorRegexHint(
+        "connect",
+        runtime.selectorLocale
+      );
+      const connectAriaSelector = buildLinkedInAriaLabelContainsSelector(
+        "button",
+        "connect",
+        runtime.selectorLocale
+      );
+      const moreExactRegex = buildLinkedInSelectorPhraseRegex(
+        "more",
+        runtime.selectorLocale,
+        { exact: true }
+      );
+      const moreExactRegexHint = formatLinkedInSelectorRegexHint(
+        "more",
+        runtime.selectorLocale,
+        { exact: true }
+      );
+      const moreActionsAriaSelector = buildLinkedInAriaLabelContainsSelector(
+        "button",
+        "more_actions",
+        runtime.selectorLocale
+      );
+      const addNoteRegex = buildLinkedInSelectorPhraseRegex(
+        "add_note",
+        runtime.selectorLocale
+      );
+      const addNoteRegexHint = formatLinkedInSelectorRegexHint(
+        "add_note",
+        runtime.selectorLocale
+      );
+      const addNoteAriaSelector = buildLinkedInAriaLabelContainsSelector(
+        "button",
+        "add_note",
+        runtime.selectorLocale
+      );
+      const invitationAriaSelector = buildLinkedInAriaLabelContainsSelector(
+        "textarea",
+        "invitation",
+        runtime.selectorLocale
+      );
+      const sendExactRegex = buildLinkedInSelectorPhraseRegex(
+        "send",
+        runtime.selectorLocale,
+        { exact: true }
+      );
+      const sendExactRegexHint = formatLinkedInSelectorRegexHint(
+        "send",
+        runtime.selectorLocale,
+        { exact: true }
+      );
+      const sendTextRegex = buildLinkedInSelectorPhraseRegex(
+        "send",
+        runtime.selectorLocale
+      );
+      const sendTextRegexHint = formatLinkedInSelectorRegexHint(
+        "send",
+        runtime.selectorLocale
+      );
+      const sendWithoutNoteRegex = buildLinkedInSelectorPhraseRegex(
+        "send_without_note",
+        runtime.selectorLocale
+      );
+      const sendWithoutNoteRegexHint = formatLinkedInSelectorRegexHint(
+        "send_without_note",
+        runtime.selectorLocale
+      );
+      const sendAriaSelector = buildLinkedInAriaLabelContainsSelector(
+        "button",
+        "send",
+        runtime.selectorLocale
+      );
+      const pendingRegex = buildLinkedInSelectorPhraseRegex(
+        ["pending", "withdraw"],
+        runtime.selectorLocale
+      );
+      const pendingRegexHint = formatLinkedInSelectorRegexHint(
+        ["pending", "withdraw"],
+        runtime.selectorLocale
+      );
+      const withdrawAriaSelector = buildLinkedInAriaLabelContainsSelector(
+        "button",
+        "withdraw",
+        runtime.selectorLocale
+      );
+      const invitationSentRegex = buildLinkedInSelectorPhraseRegex(
+        "invitation_sent",
+        runtime.selectorLocale
+      );
+      const invitationSentRegexHint = formatLinkedInSelectorRegexHint(
+        "invitation_sent",
+        runtime.selectorLocale
+      );
+
       const topCardRoot = page.locator("main .pv-top-card, main").first();
 
       const connectCandidates: VisibleLocatorCandidate[] = [
         {
           key: "topcard-connect-role",
-          selectorHint: "topCard.getByRole(button, /^connect$/i)",
+          selectorHint: `topCard.getByRole(button, ${connectExactRegexHint})`,
           locatorFactory: () =>
             topCardRoot.getByRole("button", {
-              name: /^connect$/i
+              name: connectExactRegex
             })
         },
         {
-          key: "topcard-connect-aria-invite",
-          selectorHint: "topCard button[aria-label*='Invite'][aria-label*='connect']",
-          locatorFactory: () =>
-            topCardRoot.locator(
-              "button[aria-label*='Invite' i][aria-label*='connect' i]"
-            )
+          key: "topcard-connect-aria",
+          selectorHint: `topCard ${connectAriaSelector}`,
+          locatorFactory: () => topCardRoot.locator(connectAriaSelector)
         },
         {
           key: "page-connect-role",
-          selectorHint: "page.getByRole(button, /^connect$/i)",
+          selectorHint: `page.getByRole(button, ${connectExactRegexHint})`,
           locatorFactory: (targetPage) =>
             targetPage.getByRole("button", {
-              name: /^connect$/i
+              name: connectExactRegex
             })
         },
         {
           key: "page-connect-aria",
-          selectorHint: "button[aria-label*='connect']",
-          locatorFactory: (targetPage) =>
-            targetPage.locator("button[aria-label*='connect' i]")
+          selectorHint: connectAriaSelector,
+          locatorFactory: (targetPage) => targetPage.locator(connectAriaSelector)
         }
       ];
 
       const moreCandidates: VisibleLocatorCandidate[] = [
         {
           key: "topcard-more-role",
-          selectorHint: "topCard.getByRole(button, /^more$/i)",
+          selectorHint: `topCard.getByRole(button, ${moreExactRegexHint})`,
           locatorFactory: () =>
             topCardRoot.getByRole("button", {
-              name: /^more$/i
+              name: moreExactRegex
             })
         },
         {
           key: "topcard-more-actions-aria",
-          selectorHint: "topCard button[aria-label='More actions']",
-          locatorFactory: () =>
-            topCardRoot.locator("button[aria-label='More actions']")
+          selectorHint: `topCard ${moreActionsAriaSelector}`,
+          locatorFactory: () => topCardRoot.locator(moreActionsAriaSelector)
         },
         {
           key: "page-more-role",
-          selectorHint: "page.getByRole(button, /^more$/i)",
+          selectorHint: `page.getByRole(button, ${moreExactRegexHint})`,
           locatorFactory: (targetPage) =>
             targetPage.getByRole("button", {
-              name: /^more$/i
+              name: moreExactRegex
             })
         }
       ];
@@ -474,26 +641,26 @@ async function executeSendInvitation(
       const menuConnectCandidates: VisibleLocatorCandidate[] = [
         {
           key: "menu-connect-roleitem",
-          selectorHint: "[role='menuitem'] hasText /^connect$/i",
+          selectorHint: `[role='menuitem'] hasText ${connectExactRegexHint}`,
           locatorFactory: (targetPage) =>
             targetPage.locator("[role='menuitem']").filter({
-              hasText: /^connect$/i
+              hasText: connectExactRegex
             })
         },
         {
           key: "menu-connect-dropdown-item",
-          selectorHint: ".artdeco-dropdown__content-inner [role='button'] hasText /^connect$/i",
+          selectorHint: `.artdeco-dropdown__content-inner [role='button'] hasText ${connectExactRegexHint}`,
           locatorFactory: (targetPage) =>
             targetPage.locator(".artdeco-dropdown__content-inner [role='button']").filter({
-              hasText: /^connect$/i
+              hasText: connectExactRegex
             })
         },
         {
           key: "menu-connect-li-text",
-          selectorHint: ".artdeco-dropdown__content-inner li:has-text('Connect')",
+          selectorHint: `.artdeco-dropdown__content-inner li hasText ${connectTextRegexHint}`,
           locatorFactory: (targetPage) =>
             targetPage.locator(".artdeco-dropdown__content-inner li").filter({
-              hasText: /^connect$/i
+              hasText: connectTextRegex
             })
         }
       ];
@@ -535,13 +702,14 @@ async function executeSendInvitation(
       const addNoteCandidates: VisibleLocatorCandidate[] = [
         {
           key: "add-note-text",
-          selectorHint: "button:has-text('Add a note')",
-          locatorFactory: (targetPage) => targetPage.locator("button:has-text('Add a note')")
+          selectorHint: `button hasText ${addNoteRegexHint}`,
+          locatorFactory: (targetPage) =>
+            targetPage.locator("button").filter({ hasText: addNoteRegex })
         },
         {
           key: "add-note-aria",
-          selectorHint: "button[aria-label*='Add a note']",
-          locatorFactory: (targetPage) => targetPage.locator("button[aria-label*='Add a note']")
+          selectorHint: addNoteAriaSelector,
+          locatorFactory: (targetPage) => targetPage.locator(addNoteAriaSelector)
         }
       ];
 
@@ -558,9 +726,8 @@ async function executeSendInvitation(
         },
         {
           key: "note-textarea-aria",
-          selectorHint: "textarea[aria-label*='invitation']",
-          locatorFactory: (targetPage) =>
-            targetPage.locator("textarea[aria-label*='invitation' i]")
+          selectorHint: invitationAriaSelector,
+          locatorFactory: (targetPage) => targetPage.locator(invitationAriaSelector)
         },
         {
           key: "note-textarea-fallback",
@@ -598,27 +765,28 @@ async function executeSendInvitation(
       const sendCandidates: VisibleLocatorCandidate[] = [
         {
           key: "send-text",
-          selectorHint: "button:has-text('Send')",
-          locatorFactory: (targetPage) => targetPage.locator("button:has-text('Send')")
+          selectorHint: `button hasText ${sendTextRegexHint}`,
+          locatorFactory: (targetPage) =>
+            targetPage.locator("button").filter({ hasText: sendTextRegex })
         },
         {
           key: "send-role",
-          selectorHint: "getByRole(button, /^send$/i)",
+          selectorHint: `getByRole(button, ${sendExactRegexHint})`,
           locatorFactory: (targetPage) =>
             targetPage.getByRole("button", {
-              name: /^send$/i
+              name: sendExactRegex
             })
         },
         {
           key: "send-aria",
-          selectorHint: "button[aria-label*='Send']",
-          locatorFactory: (targetPage) => targetPage.locator("button[aria-label*='Send' i]")
+          selectorHint: sendAriaSelector,
+          locatorFactory: (targetPage) => targetPage.locator(sendAriaSelector)
         },
         {
           key: "send-without-note",
-          selectorHint: "button:has-text('Send without a note')",
+          selectorHint: `button hasText ${sendWithoutNoteRegexHint}`,
           locatorFactory: (targetPage) =>
-            targetPage.locator("button:has-text('Send without a note')")
+            targetPage.locator("button").filter({ hasText: sendWithoutNoteRegex })
         }
       ];
 
@@ -639,23 +807,22 @@ async function executeSendInvitation(
       const pendingCandidates: VisibleLocatorCandidate[] = [
         {
           key: "pending-text",
-          selectorHint: "topCard.getByRole(button, /pending|withdraw/i)",
+          selectorHint: `topCard.getByRole(button, ${pendingRegexHint})`,
           locatorFactory: () =>
             topCardRoot.getByRole("button", {
-              name: /pending|withdraw/i
+              name: pendingRegex
             })
         },
         {
           key: "pending-aria",
-          selectorHint: "topCard button[aria-label*='Withdraw']",
-          locatorFactory: () =>
-            topCardRoot.locator("button[aria-label*='Withdraw' i]")
+          selectorHint: `topCard ${withdrawAriaSelector}`,
+          locatorFactory: () => topCardRoot.locator(withdrawAriaSelector)
         },
         {
           key: "pending-invitations-sent-text",
-          selectorHint: "page text=/invitation sent/i",
+          selectorHint: `page hasText ${invitationSentRegexHint}`,
           locatorFactory: (targetPage) =>
-            targetPage.locator(":text-matches('invitation sent', 'i')")
+            targetPage.locator("body").filter({ hasText: invitationSentRegex })
         }
       ];
 
@@ -748,10 +915,18 @@ async function executeAcceptInvitation(
       await page.goto(INVITATIONS_RECEIVED_URL, { waitUntil: "domcontentloaded" });
       await waitForNetworkIdleBestEffort(page);
 
+      const acceptRegex = buildLinkedInSelectorPhraseRegex(
+        "accept",
+        runtime.selectorLocale,
+        { exact: true }
+      );
+
       // Find the invitation card for the target
       const acceptBtn = page.locator(
-        `li:has(a[href*="${targetProfile}"]) button:has-text("Accept")`
-      ).first();
+        `li:has(a[href*="${targetProfile}"]) button`
+      ).filter({
+        hasText: acceptRegex
+      }).first();
 
       if (await acceptBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
         await acceptBtn.click();
@@ -818,17 +993,26 @@ async function executeWithdrawInvitation(
       await page.goto(INVITATIONS_SENT_URL, { waitUntil: "domcontentloaded" });
       await waitForNetworkIdleBestEffort(page);
 
+      const withdrawRegex = buildLinkedInSelectorPhraseRegex(
+        "withdraw",
+        runtime.selectorLocale,
+        { exact: true }
+      );
+
       const withdrawBtn = page.locator(
-        `li:has(a[href*="${targetProfile}"]) button:has-text("Withdraw")`
-      ).first();
+        `li:has(a[href*="${targetProfile}"]) button`
+      ).filter({
+        hasText: withdrawRegex
+      }).first();
 
       if (await withdrawBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
         await withdrawBtn.click();
         await page.waitForTimeout(1000);
         // Confirm withdrawal dialog
-        const confirmBtn = page.locator(
-          "button:has-text('Withdraw')"
-        ).last();
+        const confirmBtn = page
+          .locator("button")
+          .filter({ hasText: withdrawRegex })
+          .last();
         if (await confirmBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
           await confirmBtn.click();
           await page.waitForTimeout(2000);
@@ -1002,7 +1186,11 @@ export class LinkedInConnectionsService {
               waitUntil: "domcontentloaded"
             });
             await waitForNetworkIdleBestEffort(page);
-            return scrapePendingInvitations(page, "received");
+            return scrapePendingInvitations(
+              page,
+              "received",
+              this.runtime.selectorLocale
+            );
           }
         );
         results.push(...received);
@@ -1021,7 +1209,11 @@ export class LinkedInConnectionsService {
               waitUntil: "domcontentloaded"
             });
             await waitForNetworkIdleBestEffort(page);
-            return scrapePendingInvitations(page, "sent");
+            return scrapePendingInvitations(
+              page,
+              "sent",
+              this.runtime.selectorLocale
+            );
           }
         );
 

--- a/packages/core/src/linkedinFeed.ts
+++ b/packages/core/src/linkedinFeed.ts
@@ -10,6 +10,16 @@ import type { JsonEventLogger } from "./logging.js";
 import type { ProfileManager } from "./profileManager.js";
 import type { RateLimiter, RateLimiterState } from "./rateLimiter.js";
 import type {
+  LinkedInSelectorLocale,
+  LinkedInSelectorPhraseKey
+} from "./selectorLocale.js";
+import {
+  buildLinkedInAriaLabelContainsSelector,
+  buildLinkedInSelectorPhraseRegex,
+  formatLinkedInSelectorRegexHint,
+  valueContainsLinkedInSelectorPhrase
+} from "./selectorLocale.js";
+import type {
   ActionExecutor,
   ActionExecutorInput,
   ActionExecutorResult,
@@ -56,6 +66,7 @@ export interface CommentOnPostInput {
 export interface LinkedInFeedExecutorRuntime {
   auth: LinkedInAuthService;
   cdpUrl?: string | undefined;
+  selectorLocale: LinkedInSelectorLocale;
   profileManager: ProfileManager;
   logger: JsonEventLogger;
   rateLimiter: RateLimiter;
@@ -802,7 +813,22 @@ interface ReactionButtonState {
   buttonText: string;
 }
 
-function inferReactionFromText(value: string): LinkedInFeedReaction | null {
+const REACTION_SELECTOR_KEYS: Record<
+  LinkedInFeedReaction,
+  LinkedInSelectorPhraseKey
+> = {
+  like: "like",
+  celebrate: "celebrate",
+  support: "support",
+  love: "love",
+  insightful: "insightful",
+  funny: "funny"
+};
+
+function inferReactionFromText(
+  value: string,
+  selectorLocale: LinkedInSelectorLocale
+): LinkedInFeedReaction | null {
   const normalized = normalizeText(value).toLowerCase();
   if (!normalized) {
     return null;
@@ -810,7 +836,13 @@ function inferReactionFromText(value: string): LinkedInFeedReaction | null {
 
   for (const reaction of LINKEDIN_FEED_REACTION_TYPES) {
     const ui = LINKEDIN_FEED_REACTION_MAP[reaction];
-    if (normalized.includes(ui.label.toLowerCase())) {
+    if (
+      valueContainsLinkedInSelectorPhrase(
+        normalized,
+        REACTION_SELECTOR_KEYS[reaction],
+        selectorLocale
+      )
+    ) {
       return reaction;
     }
     if (normalized.includes(ui.iconType.toLowerCase())) {
@@ -821,7 +853,10 @@ function inferReactionFromText(value: string): LinkedInFeedReaction | null {
   return null;
 }
 
-async function getReactionButtonState(reactButton: Locator): Promise<ReactionButtonState> {
+async function getReactionButtonState(
+  reactButton: Locator,
+  selectorLocale: LinkedInSelectorLocale
+): Promise<ReactionButtonState> {
   const ariaPressed = normalizeText(await reactButton.getAttribute("aria-pressed")).toLowerCase();
   const className = normalizeText(await reactButton.getAttribute("class"));
   const ariaLabel = normalizeText(await reactButton.getAttribute("aria-label"));
@@ -832,8 +867,8 @@ async function getReactionButtonState(reactButton: Locator): Promise<ReactionBut
     className.toLowerCase().includes("react-button--active") ||
     /remove\s+your\s+reaction|unreact|reacted|undo/i.test(ariaLabel);
 
-  const reactionFromLabel = inferReactionFromText(ariaLabel);
-  const reactionFromText = inferReactionFromText(buttonText);
+  const reactionFromLabel = inferReactionFromText(ariaLabel, selectorLocale);
+  const reactionFromText = inferReactionFromText(buttonText, selectorLocale);
 
   return {
     reacted,
@@ -846,9 +881,10 @@ async function getReactionButtonState(reactButton: Locator): Promise<ReactionBut
 
 async function isDesiredReactionActive(
   reactButton: Locator,
-  desiredReaction: LinkedInFeedReaction
+  desiredReaction: LinkedInFeedReaction,
+  selectorLocale: LinkedInSelectorLocale
 ): Promise<boolean> {
-  const state = await getReactionButtonState(reactButton);
+  const state = await getReactionButtonState(reactButton, selectorLocale);
   if (!state.reacted) {
     return false;
   }
@@ -864,9 +900,30 @@ async function isDesiredReactionActive(
 async function selectReactionFromMenu(
   page: Page,
   reactButton: Locator,
-  reaction: LinkedInFeedReaction
+  reaction: LinkedInFeedReaction,
+  selectorLocale: LinkedInSelectorLocale
 ): Promise<string> {
-  const reactionUi = LINKEDIN_FEED_REACTION_MAP[reaction];
+  const reactionKey = REACTION_SELECTOR_KEYS[reaction];
+  const reactionLabelRegex = buildLinkedInSelectorPhraseRegex(
+    reactionKey,
+    selectorLocale,
+    { exact: true }
+  );
+  const reactionLabelRegexHint = formatLinkedInSelectorRegexHint(
+    reactionKey,
+    selectorLocale,
+    { exact: true }
+  );
+  const reactionAriaSelector = buildLinkedInAriaLabelContainsSelector(
+    "button.reactions-menu__reaction-index",
+    reactionKey,
+    selectorLocale
+  );
+  const reactionFallbackAriaSelector = buildLinkedInAriaLabelContainsSelector(
+    "button",
+    reactionKey,
+    selectorLocale
+  );
   await reactButton.hover({ timeout: 5_000 });
 
   const menu = page.locator("span.reactions-menu--active").first();
@@ -880,26 +937,22 @@ async function selectReactionFromMenu(
 
   const candidateButtons: SelectorCandidate[] = [
     {
-      key: "menu-reaction-aria",
-      selectorHint: `button.reactions-menu__reaction-index[aria-label='${reactionUi.menuAriaLabel}']`,
-      locatorFactory: () =>
-        menu.locator(
-          `button.reactions-menu__reaction-index[aria-label="${reactionUi.menuAriaLabel}"]`
-        )
-    },
-    {
       key: "menu-reaction-text",
-      selectorHint: `button.reactions-menu__reaction-index hasText=${reactionUi.label}`,
+      selectorHint: `button.reactions-menu__reaction-index hasText ${reactionLabelRegexHint}`,
       locatorFactory: () =>
         menu
           .locator("button.reactions-menu__reaction-index")
-          .filter({ hasText: new RegExp(`^${reactionUi.label}$`, "i") })
+          .filter({ hasText: reactionLabelRegex })
+    },
+    {
+      key: "menu-reaction-aria",
+      selectorHint: reactionAriaSelector,
+      locatorFactory: () => menu.locator(reactionAriaSelector)
     },
     {
       key: "menu-reaction-fallback",
-      selectorHint: `button[aria-label*='${reactionUi.label}']`,
-      locatorFactory: () =>
-        menu.locator(`button[aria-label*="${reactionUi.label}"]`)
+      selectorHint: reactionFallbackAriaSelector,
+      locatorFactory: () => menu.locator(reactionFallbackAriaSelector)
     }
   ];
 
@@ -977,7 +1030,25 @@ async function findTargetPostLocator(page: Page, postUrl: string): Promise<Targe
   };
 }
 
-async function expandCommentsForPost(page: Page, postRoot: Locator): Promise<string | null> {
+async function expandCommentsForPost(
+  page: Page,
+  postRoot: Locator,
+  selectorLocale: LinkedInSelectorLocale
+): Promise<string | null> {
+  const commentRegex = buildLinkedInSelectorPhraseRegex(
+    "comment",
+    selectorLocale
+  );
+  const commentRegexHint = formatLinkedInSelectorRegexHint(
+    "comment",
+    selectorLocale
+  );
+  const commentAriaSelector = buildLinkedInAriaLabelContainsSelector(
+    "button",
+    "comment",
+    selectorLocale
+  );
+
   const candidates: SelectorCandidate[] = [
     {
       key: "post-social-action-comment",
@@ -986,15 +1057,15 @@ async function expandCommentsForPost(page: Page, postRoot: Locator): Promise<str
     },
     {
       key: "post-aria-comment-button",
-      selectorHint: "button[aria-label*='Comment']",
-      locatorFactory: () => postRoot.locator("button[aria-label*='Comment']")
+      selectorHint: commentAriaSelector,
+      locatorFactory: () => postRoot.locator(commentAriaSelector)
     },
     {
       key: "post-role-button-comment",
-      selectorHint: "getByRole(button, /comment/i)",
+      selectorHint: `getByRole(button, ${commentRegexHint})`,
       locatorFactory: () =>
         postRoot.getByRole("button", {
-          name: /comment/i
+          name: commentRegex
         })
     }
   ];
@@ -1114,6 +1185,19 @@ export class LikePostActionExecutor
           await waitForPostSurface(page);
 
           let targetPost = await findTargetPostLocator(page, postUrl);
+          const likeOrReactRegex = buildLinkedInSelectorPhraseRegex(
+            ["like", "react"],
+            runtime.selectorLocale
+          );
+          const likeOrReactRegexHint = formatLinkedInSelectorRegexHint(
+            ["like", "react"],
+            runtime.selectorLocale
+          );
+          const likeReactAriaSelector = buildLinkedInAriaLabelContainsSelector(
+            "button",
+            ["like", "react", "reaction"],
+            runtime.selectorLocale
+          );
 
           const resolveReactionButton = async (postRoot: Locator) =>
             findVisibleLocatorOrThrow(
@@ -1134,19 +1218,15 @@ export class LikePostActionExecutor
                 },
                 {
                   key: "post-aria-like-button",
-                  selectorHint:
-                    "button[aria-label*='Like'], button[aria-label*='React'], button[aria-label*='reaction']",
-                  locatorFactory: () =>
-                    postRoot.locator(
-                      "button[aria-label*='Like'], button[aria-label*='React'], button[aria-label*='reaction']"
-                    )
+                  selectorHint: likeReactAriaSelector,
+                  locatorFactory: () => postRoot.locator(likeReactAriaSelector)
                 },
                 {
                   key: "post-role-button-like",
-                  selectorHint: "getByRole(button, /like|react/i)",
+                  selectorHint: `getByRole(button, ${likeOrReactRegexHint})`,
                   locatorFactory: () =>
                     postRoot.getByRole("button", {
-                      name: /\blike\b|\breact\b/i
+                      name: likeOrReactRegex
                     })
                 }
               ],
@@ -1156,7 +1236,8 @@ export class LikePostActionExecutor
           let reactButton = await resolveReactionButton(targetPost.locator);
           const wasAlreadyReacted = await isDesiredReactionActive(
             reactButton.locator,
-            reaction
+            reaction,
+            runtime.selectorLocale
           );
           let reactionSelectorKey: string | null = null;
 
@@ -1165,7 +1246,12 @@ export class LikePostActionExecutor
             if (reaction === "like") {
               await reactButton.locator.click({ timeout: 5_000 });
               verifiedReaction = await waitForCondition(
-                async () => isDesiredReactionActive(reactButton.locator, reaction),
+                async () =>
+                  isDesiredReactionActive(
+                    reactButton.locator,
+                    reaction,
+                    runtime.selectorLocale
+                  ),
                 6_000
               );
 
@@ -1174,10 +1260,16 @@ export class LikePostActionExecutor
                   reactionSelectorKey = await selectReactionFromMenu(
                     page,
                     reactButton.locator,
-                    reaction
+                    reaction,
+                    runtime.selectorLocale
                   );
                   verifiedReaction = await waitForCondition(
-                    async () => isDesiredReactionActive(reactButton.locator, reaction),
+                    async () =>
+                      isDesiredReactionActive(
+                        reactButton.locator,
+                        reaction,
+                        runtime.selectorLocale
+                      ),
                     6_000
                   );
                 } catch {
@@ -1188,10 +1280,16 @@ export class LikePostActionExecutor
               reactionSelectorKey = await selectReactionFromMenu(
                 page,
                 reactButton.locator,
-                reaction
+                reaction,
+                runtime.selectorLocale
               );
               verifiedReaction = await waitForCondition(
-                async () => isDesiredReactionActive(reactButton.locator, reaction),
+                async () =>
+                  isDesiredReactionActive(
+                    reactButton.locator,
+                    reaction,
+                    runtime.selectorLocale
+                  ),
                 8_000
               );
             }
@@ -1202,11 +1300,18 @@ export class LikePostActionExecutor
             await waitForPostSurface(page);
             targetPost = await findTargetPostLocator(page, postUrl);
             reactButton = await resolveReactionButton(targetPost.locator);
-            verifiedReaction = await isDesiredReactionActive(reactButton.locator, reaction);
+            verifiedReaction = await isDesiredReactionActive(
+              reactButton.locator,
+              reaction,
+              runtime.selectorLocale
+            );
           }
 
           if (!verifiedReaction) {
-            const currentReactionState = await getReactionButtonState(reactButton.locator);
+            const currentReactionState = await getReactionButtonState(
+              reactButton.locator,
+              runtime.selectorLocale
+            );
             throw new LinkedInAssistantError(
               "UNKNOWN",
               "Reaction action could not be verified on the target post.",
@@ -1330,6 +1435,42 @@ export class CommentOnPostActionExecutor
           await waitForPostSurface(page);
 
           let targetPost = await findTargetPostLocator(page, postUrl);
+          const commentRegex = buildLinkedInSelectorPhraseRegex(
+            "comment",
+            runtime.selectorLocale
+          );
+          const commentRegexHint = formatLinkedInSelectorRegexHint(
+            "comment",
+            runtime.selectorLocale
+          );
+          const commentAriaSelector = buildLinkedInAriaLabelContainsSelector(
+            "button",
+            "comment",
+            runtime.selectorLocale
+          );
+          const commentComposerRegex = buildLinkedInSelectorPhraseRegex(
+            ["add_comment", "comment"],
+            runtime.selectorLocale
+          );
+          const commentComposerRegexHint = formatLinkedInSelectorRegexHint(
+            ["add_comment", "comment"],
+            runtime.selectorLocale
+          );
+          const postRegex = buildLinkedInSelectorPhraseRegex(
+            "post",
+            runtime.selectorLocale,
+            { exact: true }
+          );
+          const postRegexHint = formatLinkedInSelectorRegexHint(
+            "post",
+            runtime.selectorLocale,
+            { exact: true }
+          );
+          const commentSubmitAriaSelector = buildLinkedInAriaLabelContainsSelector(
+            "button",
+            ["post_comment", "post"],
+            runtime.selectorLocale
+          );
 
           const commentTrigger = await findVisibleLocatorOrThrow(
             page,
@@ -1342,16 +1483,16 @@ export class CommentOnPostActionExecutor
               },
               {
                 key: "post-aria-comment-button",
-                selectorHint: "button[aria-label*='Comment']",
+                selectorHint: commentAriaSelector,
                 locatorFactory: () =>
-                  targetPost.locator.locator("button[aria-label*='Comment']")
+                  targetPost.locator.locator(commentAriaSelector)
               },
               {
                 key: "post-role-button-comment",
-                selectorHint: "getByRole(button, /comment/i)",
+                selectorHint: `getByRole(button, ${commentRegexHint})`,
                 locatorFactory: () =>
                   targetPost.locator.getByRole("button", {
-                    name: /comment/i
+                    name: commentRegex
                   })
               },
               {
@@ -1385,10 +1526,10 @@ export class CommentOnPostActionExecutor
               },
               {
                 key: "post-role-textbox-comment",
-                selectorHint: "getByRole(textbox, /add a comment|comment/i)",
+                selectorHint: `getByRole(textbox, ${commentComposerRegexHint})`,
                 locatorFactory: () =>
                   targetPost.locator.getByRole("textbox", {
-                    name: /add a comment|comment/i
+                    name: commentComposerRegex
                   })
               },
               {
@@ -1428,27 +1569,25 @@ export class CommentOnPostActionExecutor
               },
               {
                 key: "comment-submit-role-post",
-                selectorHint: "getByRole(button, /^post$/i)",
+                selectorHint: `getByRole(button, ${postRegexHint})`,
                 locatorFactory: () =>
                   composerRoot.getByRole("button", {
-                    name: /^post$/i
+                    name: postRegex
                   })
               },
               {
                 key: "comment-submit-role-comment",
-                selectorHint: "getByRole(button, /^comment$/i)",
+                selectorHint: `getByRole(button, ${commentRegexHint})`,
                 locatorFactory: () =>
                   composerRoot.getByRole("button", {
-                    name: /^comment$/i
+                    name: commentRegex
                   })
               },
               {
                 key: "comment-submit-aria",
-                selectorHint: "button[aria-label*='Post comment'], button[aria-label*='Post']",
+                selectorHint: commentSubmitAriaSelector,
                 locatorFactory: () =>
-                  composerRoot.locator(
-                    "button[aria-label*='Post comment'], button[aria-label*='Post']"
-                  )
+                  composerRoot.locator(commentSubmitAriaSelector)
               },
               {
                 key: "comment-submit-post-root-fallback",
@@ -1489,7 +1628,11 @@ export class CommentOnPostActionExecutor
           await page.reload({ waitUntil: "domcontentloaded" });
           await waitForPostSurface(page);
           targetPost = await findTargetPostLocator(page, postUrl);
-          const reopenCommentKey = await expandCommentsForPost(page, targetPost.locator);
+          const reopenCommentKey = await expandCommentsForPost(
+            page,
+            targetPost.locator,
+            runtime.selectorLocale
+          );
 
           const commentVerified = await waitForCondition(
             async () => isCommentVisibleInPost(targetPost.locator, text),

--- a/packages/core/src/linkedinFollowups.ts
+++ b/packages/core/src/linkedinFollowups.ts
@@ -22,6 +22,12 @@ import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
 import type { RateLimiter, RateLimiterState } from "./rateLimiter.js";
+import type { LinkedInSelectorLocale } from "./selectorLocale.js";
+import {
+  buildLinkedInAriaLabelContainsSelector,
+  buildLinkedInSelectorPhraseRegex,
+  formatLinkedInSelectorRegexHint
+} from "./selectorLocale.js";
 import type {
   ActionExecutor,
   ActionExecutorInput,
@@ -104,6 +110,7 @@ export interface LinkedInFollowupsExecutorRuntime {
   db: AssistantDatabase;
   auth: LinkedInAuthService;
   cdpUrl?: string | undefined;
+  selectorLocale: LinkedInSelectorLocale;
   profileManager: ProfileManager;
   artifacts: ArtifactHelpers;
   rateLimiter: RateLimiter;
@@ -458,65 +465,129 @@ async function findVisibleLocatorOrThrow(
   );
 }
 
-function profileMessageButtonCandidates(root: Locator): SelectorCandidate[] {
+function profileMessageButtonCandidates(
+  root: Locator,
+  selectorLocale: LinkedInSelectorLocale
+): SelectorCandidate[] {
+  const messageExactRegex = buildLinkedInSelectorPhraseRegex(
+    "message",
+    selectorLocale,
+    { exact: true }
+  );
+  const messageExactRegexHint = formatLinkedInSelectorRegexHint(
+    "message",
+    selectorLocale,
+    { exact: true }
+  );
+  const messageTextRegex = buildLinkedInSelectorPhraseRegex(
+    "message",
+    selectorLocale
+  );
+  const messageTextRegexHint = formatLinkedInSelectorRegexHint(
+    "message",
+    selectorLocale
+  );
+  const messageAriaSelector = buildLinkedInAriaLabelContainsSelector(
+    "button",
+    "message",
+    selectorLocale
+  );
+
   return [
     {
       key: "topcard-message-role",
-      selectorHint: "topCard.getByRole(button, /^message$/i)",
+      selectorHint: `topCard.getByRole(button, ${messageExactRegexHint})`,
       locatorFactory: () =>
         root.getByRole("button", {
-          name: /^message$/i
+          name: messageExactRegex
         })
     },
     {
       key: "topcard-message-text",
-      selectorHint: "topCard button:has-text('Message')",
-      locatorFactory: () => root.locator("button:has-text('Message')")
+      selectorHint: `topCard button hasText ${messageTextRegexHint}`,
+      locatorFactory: () => root.locator("button").filter({ hasText: messageTextRegex })
     },
     {
       key: "topcard-message-aria",
-      selectorHint: "topCard button[aria-label*='Message']",
-      locatorFactory: () => root.locator("button[aria-label*='Message' i]")
+      selectorHint: `topCard ${messageAriaSelector}`,
+      locatorFactory: () => root.locator(messageAriaSelector)
     },
     {
       key: "page-message-role",
-      selectorHint: "page.getByRole(button, /^message$/i)",
+      selectorHint: `page.getByRole(button, ${messageExactRegexHint})`,
       locatorFactory: (page) =>
         page.getByRole("button", {
-          name: /^message$/i
+          name: messageExactRegex
         })
     }
   ];
 }
 
 async function findProfileMessageTrigger(
-  page: Page
+  page: Page,
+  selectorLocale: LinkedInSelectorLocale
 ): Promise<{ locator: Locator; key: string } | null> {
   const topCardRoot = page.locator("main .pv-top-card, main").first();
-  const direct = await findVisibleLocator(page, profileMessageButtonCandidates(topCardRoot));
+  const direct = await findVisibleLocator(
+    page,
+    profileMessageButtonCandidates(topCardRoot, selectorLocale)
+  );
   if (direct) {
     return direct;
   }
 
+  const moreExactRegex = buildLinkedInSelectorPhraseRegex(
+    "more",
+    selectorLocale,
+    { exact: true }
+  );
+  const moreExactRegexHint = formatLinkedInSelectorRegexHint(
+    "more",
+    selectorLocale,
+    { exact: true }
+  );
+  const moreActionsAriaSelector = buildLinkedInAriaLabelContainsSelector(
+    "button",
+    "more_actions",
+    selectorLocale
+  );
+  const messageMenuExactRegex = buildLinkedInSelectorPhraseRegex(
+    "message",
+    selectorLocale,
+    { exact: true }
+  );
+  const messageMenuExactRegexHint = formatLinkedInSelectorRegexHint(
+    "message",
+    selectorLocale,
+    { exact: true }
+  );
+  const messageMenuTextRegex = buildLinkedInSelectorPhraseRegex(
+    "message",
+    selectorLocale
+  );
+  const messageMenuTextRegexHint = formatLinkedInSelectorRegexHint(
+    "message",
+    selectorLocale
+  );
+
   const moreCandidates: SelectorCandidate[] = [
     {
       key: "topcard-more-role",
-      selectorHint: "topCard.getByRole(button, /^more$/i)",
+      selectorHint: `topCard.getByRole(button, ${moreExactRegexHint})`,
       locatorFactory: () =>
         topCardRoot.getByRole("button", {
-          name: /^more$/i
+          name: moreExactRegex
         })
     },
     {
       key: "topcard-more-aria",
-      selectorHint: "topCard button[aria-label*='More actions']",
-      locatorFactory: () =>
-        topCardRoot.locator("button[aria-label*='More actions' i]")
+      selectorHint: `topCard ${moreActionsAriaSelector}`,
+      locatorFactory: () => topCardRoot.locator(moreActionsAriaSelector)
     },
     {
       key: "page-more-aria",
-      selectorHint: "page button[aria-label*='More actions']",
-      locatorFactory: (page) => page.locator("button[aria-label*='More actions' i]")
+      selectorHint: `page ${moreActionsAriaSelector}`,
+      locatorFactory: (page) => page.locator(moreActionsAriaSelector)
     }
   ];
 
@@ -531,21 +602,23 @@ async function findProfileMessageTrigger(
   const menuCandidates: SelectorCandidate[] = [
     {
       key: "menuitem-message-role",
-      selectorHint: "page.getByRole(menuitem, /^message$/i)",
+      selectorHint: `page.getByRole(menuitem, ${messageMenuExactRegexHint})`,
       locatorFactory: (page) =>
         page.getByRole("menuitem", {
-          name: /^message$/i
+          name: messageMenuExactRegex
         })
     },
     {
       key: "menu-message-text",
-      selectorHint: "[role='menu'] :text-is('Message')",
-      locatorFactory: (page) => page.locator("[role='menu'] :text-is('Message')")
+      selectorHint: `[role='menu'] hasText ${messageMenuTextRegexHint}`,
+      locatorFactory: (page) =>
+        page.locator("[role='menu']").filter({ hasText: messageMenuTextRegex })
     },
     {
       key: "menu-message-button-fallback",
-      selectorHint: "div[role='button']:has-text('Message')",
-      locatorFactory: (page) => page.locator("div[role='button']:has-text('Message')")
+      selectorHint: `div[role='button'] hasText ${messageMenuTextRegexHint}`,
+      locatorFactory: (page) =>
+        page.locator("div[role='button']").filter({ hasText: messageMenuTextRegex })
     }
   ];
 
@@ -603,14 +676,15 @@ async function extractProfileSummary(page: Page): Promise<{
 
 async function probeAcceptedConnection(
   page: Page,
-  profileUrl: string
+  profileUrl: string,
+  selectorLocale: LinkedInSelectorLocale
 ): Promise<AcceptanceProbeResult | null> {
   await page.goto(profileUrl, { waitUntil: "domcontentloaded" });
   await waitForNetworkIdleBestEffort(page);
   await page.waitForTimeout(500);
 
   const summary = await extractProfileSummary(page);
-  const messageTrigger = await findProfileMessageTrigger(page);
+  const messageTrigger = await findProfileMessageTrigger(page, selectorLocale);
   if (!messageTrigger) {
     return null;
   }
@@ -757,7 +831,10 @@ export class FollowupAfterAcceptActionExecutor
           await page.goto(profileUrl, { waitUntil: "domcontentloaded" });
           await waitForNetworkIdleBestEffort(page);
 
-          const messageTrigger = await findProfileMessageTrigger(page);
+          const messageTrigger = await findProfileMessageTrigger(
+            page,
+            runtime.selectorLocale
+          );
           if (!messageTrigger) {
             throw new LinkedInAssistantError(
               "ACTION_PRECONDITION_FAILED",
@@ -790,19 +867,54 @@ export class FollowupAfterAcceptActionExecutor
             );
           }
 
+          const composerNameRegex = buildLinkedInSelectorPhraseRegex(
+            ["write_message", "message"],
+            runtime.selectorLocale
+          );
+          const composerNameRegexHint = formatLinkedInSelectorRegexHint(
+            ["write_message", "message"],
+            runtime.selectorLocale
+          );
+          const placeholderRegex = buildLinkedInSelectorPhraseRegex(
+            "write_message",
+            runtime.selectorLocale
+          );
+          const placeholderRegexHint = formatLinkedInSelectorRegexHint(
+            "write_message",
+            runtime.selectorLocale
+          );
+          const sendButtonRegex = buildLinkedInSelectorPhraseRegex(
+            "send",
+            runtime.selectorLocale,
+            { exact: true }
+          );
+          const sendButtonRegexHint = formatLinkedInSelectorRegexHint(
+            "send",
+            runtime.selectorLocale,
+            { exact: true }
+          );
+          const dialogSendRegex = buildLinkedInSelectorPhraseRegex(
+            "send",
+            runtime.selectorLocale
+          );
+          const dialogSendRegexHint = formatLinkedInSelectorRegexHint(
+            "send",
+            runtime.selectorLocale
+          );
+
           const composerSelectors: SelectorCandidate[] = [
             {
               key: "role-textbox-write-message",
-              selectorHint: "getByRole(textbox, /write a message|message/i)",
+              selectorHint: `getByRole(textbox, ${composerNameRegexHint})`,
               locatorFactory: (page) =>
                 page.getByRole("textbox", {
-                  name: /write a message|message/i
+                  name: composerNameRegex
                 })
             },
             {
               key: "placeholder-write-message",
-              selectorHint: "getByPlaceholder(/write a message/i)",
-              locatorFactory: (page) => page.getByPlaceholder(/write a message/i)
+              selectorHint: `getByPlaceholder(${placeholderRegexHint})`,
+              locatorFactory: (page) => page.getByPlaceholder(placeholderRegex)
             },
             {
               key: "msg-contenteditable",
@@ -830,9 +942,9 @@ export class FollowupAfterAcceptActionExecutor
           const sendButtonSelectors: SelectorCandidate[] = [
             {
               key: "role-button-send",
-              selectorHint: "getByRole(button, /send/i)",
+              selectorHint: `getByRole(button, ${sendButtonRegexHint})`,
               locatorFactory: (page) =>
-                page.getByRole("button", { name: /send/i })
+                page.getByRole("button", { name: sendButtonRegex })
             },
             {
               key: "msg-form-send-button",
@@ -841,9 +953,11 @@ export class FollowupAfterAcceptActionExecutor
             },
             {
               key: "dialog-send-button",
-              selectorHint: "[role='dialog'] button:has-text('Send')",
+              selectorHint: `[role='dialog'] button hasText ${dialogSendRegexHint}`,
               locatorFactory: (page) =>
-                page.locator("[role='dialog'] button:has-text('Send')")
+                page.locator("[role='dialog'] button").filter({
+                  hasText: dialogSendRegex
+                })
             }
           ];
 
@@ -1062,7 +1176,11 @@ export class LinkedInFollowupsService {
 
         for (const state of candidates) {
           try {
-            const probe = await probeAcceptedConnection(page, state.profile_url);
+            const probe = await probeAcceptedConnection(
+              page,
+              state.profile_url,
+              this.runtime.selectorLocale
+            );
             if (!probe) {
               continue;
             }
@@ -1129,7 +1247,11 @@ export class LinkedInFollowupsService {
           }
 
           try {
-            const probe = await probeAcceptedConnection(page, state.profile_url);
+            const probe = await probeAcceptedConnection(
+              page,
+              state.profile_url,
+              this.runtime.selectorLocale
+            );
             if (!probe) {
               this.runtime.logger.log(
                 "warn",

--- a/packages/core/src/linkedinInbox.ts
+++ b/packages/core/src/linkedinInbox.ts
@@ -20,6 +20,11 @@ import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
 import type { RateLimiter, RateLimiterState } from "./rateLimiter.js";
+import type { LinkedInSelectorLocale } from "./selectorLocale.js";
+import {
+  buildLinkedInSelectorPhraseRegex,
+  formatLinkedInSelectorRegexHint
+} from "./selectorLocale.js";
 import type {
   ActionExecutor,
   ActionExecutorRegistry,
@@ -130,6 +135,7 @@ export interface LinkedInMessagingRuntime {
   db: AssistantDatabase;
   auth: LinkedInAuthService;
   cdpUrl?: string | undefined;
+  selectorLocale: LinkedInSelectorLocale;
   profileManager: ProfileManager;
   artifacts: ArtifactHelpers;
   confirmFailureArtifacts: ConfirmFailureArtifactConfig;
@@ -1386,20 +1392,47 @@ class SendMessageActionExecutor
             );
           }
 
+          const composerNameRegex = buildLinkedInSelectorPhraseRegex(
+            ["write_message", "message"],
+            runtime.selectorLocale
+          );
+          const composerNameRegexHint = formatLinkedInSelectorRegexHint(
+            ["write_message", "message"],
+            runtime.selectorLocale
+          );
+          const writeMessagePlaceholderRegex = buildLinkedInSelectorPhraseRegex(
+            "write_message",
+            runtime.selectorLocale
+          );
+          const writeMessagePlaceholderRegexHint = formatLinkedInSelectorRegexHint(
+            "write_message",
+            runtime.selectorLocale
+          );
+          const sendButtonRegex = buildLinkedInSelectorPhraseRegex(
+            "send",
+            runtime.selectorLocale,
+            { exact: true }
+          );
+          const sendButtonRegexHint = formatLinkedInSelectorRegexHint(
+            "send",
+            runtime.selectorLocale,
+            { exact: true }
+          );
+
           const composerSelectors: SelectorCandidate[] = [
             {
               key: "role-textbox-write-message",
-              selectorHint: "getByRole(textbox, /write a message|message/i)",
+              selectorHint: `getByRole(textbox, ${composerNameRegexHint})`,
               locatorFactory: (targetPage) =>
                 targetPage.getByRole("textbox", {
-                  name: /write a message|message/i
+                  name: composerNameRegex
                 })
             },
             {
               key: "placeholder-write-message",
-              selectorHint: "getByPlaceholder(/write a message/i)",
+              selectorHint: `getByPlaceholder(${writeMessagePlaceholderRegexHint})`,
               locatorFactory: (targetPage) =>
-                targetPage.getByPlaceholder(/write a message/i)
+                targetPage.getByPlaceholder(writeMessagePlaceholderRegex)
             },
             {
               key: "msg-contenteditable",
@@ -1429,9 +1462,9 @@ class SendMessageActionExecutor
           const sendButtonSelectors: SelectorCandidate[] = [
             {
               key: "role-button-send",
-              selectorHint: "getByRole(button, /send/i)",
+              selectorHint: `getByRole(button, ${sendButtonRegexHint})`,
               locatorFactory: (targetPage) =>
-                targetPage.getByRole("button", { name: /send/i })
+                targetPage.getByRole("button", { name: sendButtonRegex })
             },
             {
               key: "msg-form-send-button",

--- a/packages/core/src/linkedinPosts.ts
+++ b/packages/core/src/linkedinPosts.ts
@@ -18,6 +18,15 @@ import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
 import type { RateLimiter, RateLimiterState } from "./rateLimiter.js";
 import type {
+  LinkedInSelectorLocale,
+  LinkedInSelectorPhraseKey
+} from "./selectorLocale.js";
+import {
+  buildLinkedInAriaLabelContainsSelector,
+  buildLinkedInSelectorPhraseRegex,
+  formatLinkedInSelectorRegexHint
+} from "./selectorLocale.js";
+import type {
   ActionExecutor,
   ActionExecutorInput,
   ActionExecutorResult,
@@ -87,6 +96,7 @@ export interface PrepareCreatePostInput {
 export interface LinkedInPostsExecutorRuntime {
   auth: LinkedInAuthService;
   cdpUrl?: string | undefined;
+  selectorLocale: LinkedInSelectorLocale;
   profileManager: ProfileManager;
   logger: JsonEventLogger;
   rateLimiter: RateLimiter;
@@ -1114,7 +1124,6 @@ async function findOptionalScopedLocator(
 async function waitForFeedSurface(page: Page): Promise<void> {
   const candidates = [
     page.locator(".share-box-feed-entry").first(),
-    page.getByRole("button", { name: /start a post/i }).first(),
     page.locator(".feed-shared-update-v2, .occludable-update, main").first(),
     page.locator("main").first()
   ];
@@ -1137,20 +1146,44 @@ async function waitForFeedSurface(page: Page): Promise<void> {
   );
 }
 
-function createComposeTriggerCandidates(): SelectorCandidate[] {
+function createComposeTriggerCandidates(
+  selectorLocale: LinkedInSelectorLocale
+): SelectorCandidate[] {
+  const startPostExactRegex = buildLinkedInSelectorPhraseRegex(
+    "start_post",
+    selectorLocale,
+    { exact: true }
+  );
+  const startPostExactRegexHint = formatLinkedInSelectorRegexHint(
+    "start_post",
+    selectorLocale,
+    { exact: true }
+  );
+  const startPostTextRegex = buildLinkedInSelectorPhraseRegex(
+    "start_post",
+    selectorLocale
+  );
+  const startPostTextRegexHint = formatLinkedInSelectorRegexHint(
+    "start_post",
+    selectorLocale
+  );
+  const startPostAriaSelector = buildLinkedInAriaLabelContainsSelector(
+    ["button", "[role='button']"],
+    "start_post",
+    selectorLocale
+  );
+
   return [
     {
       key: "role-button-start-post",
-      selectorHint: "getByRole(button, /start a post/i)",
-      locatorFactory: (page) => page.getByRole("button", { name: /start a post/i })
+      selectorHint: `getByRole(button, ${startPostExactRegexHint})`,
+      locatorFactory: (page) =>
+        page.getByRole("button", { name: startPostExactRegex })
     },
     {
       key: "aria-start-post",
-      selectorHint: "button[aria-label*='Start a post' i]",
-      locatorFactory: (page) =>
-        page.locator(
-          "button[aria-label*='start a post' i], [role='button'][aria-label*='start a post' i]"
-        )
+      selectorHint: startPostAriaSelector,
+      locatorFactory: (page) => page.locator(startPostAriaSelector)
     },
     {
       key: "share-box-trigger",
@@ -1160,14 +1193,37 @@ function createComposeTriggerCandidates(): SelectorCandidate[] {
     },
     {
       key: "text-start-post",
-      selectorHint: "button, [role='button'] hasText /start a post/i",
+      selectorHint: `button, [role='button'] hasText ${startPostTextRegexHint}`,
       locatorFactory: (page) =>
-        page.locator("button, [role='button']").filter({ hasText: /start a post/i })
+        page
+          .locator("button, [role='button']")
+          .filter({ hasText: startPostTextRegex })
     }
   ];
 }
 
-function createComposerRootCandidates(): SelectorCandidate[] {
+function createComposerRootCandidates(
+  selectorLocale: LinkedInSelectorLocale
+): SelectorCandidate[] {
+  const postExactRegex = buildLinkedInSelectorPhraseRegex(
+    "post",
+    selectorLocale,
+    { exact: true }
+  );
+  const postExactRegexHint = formatLinkedInSelectorRegexHint(
+    "post",
+    selectorLocale,
+    { exact: true }
+  );
+  const composerPromptRegex = buildLinkedInSelectorPhraseRegex(
+    "what_do_you_want_to_talk_about",
+    selectorLocale
+  );
+  const composerPromptRegexHint = formatLinkedInSelectorRegexHint(
+    "what_do_you_want_to_talk_about",
+    selectorLocale
+  );
+
   return [
     {
       key: "dialog-with-textbox",
@@ -1179,19 +1235,19 @@ function createComposerRootCandidates(): SelectorCandidate[] {
     },
     {
       key: "dialog-with-post-button",
-      selectorHint: "[role='dialog'] has getByRole(button, /^post$/i)",
+      selectorHint: `[role='dialog'] has getByRole(button, ${postExactRegexHint})`,
       locatorFactory: (page) =>
         page
           .locator("[role='dialog']")
-          .filter({ has: page.getByRole("button", { name: /^post$/i }) })
+          .filter({ has: page.getByRole("button", { name: postExactRegex }) })
     },
     {
       key: "dialog-with-prompt",
-      selectorHint: "[role='dialog'] hasText /what do you want to talk about/i",
+      selectorHint: `[role='dialog'] hasText ${composerPromptRegexHint}`,
       locatorFactory: (page) =>
         page
           .locator("[role='dialog']")
-          .filter({ has: page.getByText(/what do you want to talk about/i) })
+          .filter({ has: page.getByText(composerPromptRegex) })
     },
     {
       key: "share-box-open",
@@ -1202,14 +1258,25 @@ function createComposerRootCandidates(): SelectorCandidate[] {
   ];
 }
 
-function createComposerInputCandidates(): ScopedSelectorCandidate[] {
+function createComposerInputCandidates(
+  selectorLocale: LinkedInSelectorLocale
+): ScopedSelectorCandidate[] {
+  const composerInputRegex = buildLinkedInSelectorPhraseRegex(
+    ["what_do_you_want_to_talk_about", "start_post"],
+    selectorLocale
+  );
+  const composerInputRegexHint = formatLinkedInSelectorRegexHint(
+    ["what_do_you_want_to_talk_about", "start_post"],
+    selectorLocale
+  );
+
   return [
     {
       key: "role-textbox-prompt",
-      selectorHint: "getByRole(textbox, /what do you want to talk about|start a post/i)",
+      selectorHint: `getByRole(textbox, ${composerInputRegexHint})`,
       locatorFactory: (root) =>
         root.getByRole("textbox", {
-          name: /what do you want to talk about|start a post/i
+          name: composerInputRegex
         })
     },
     {
@@ -1235,59 +1302,113 @@ function createComposerInputCandidates(): ScopedSelectorCandidate[] {
   ];
 }
 
-function createVisibilityButtonCandidates(): ScopedSelectorCandidate[] {
+function createVisibilityButtonCandidates(
+  selectorLocale: LinkedInSelectorLocale
+): ScopedSelectorCandidate[] {
+  const visibilityRegex = buildLinkedInSelectorPhraseRegex(
+    [
+      "anyone",
+      "connections_only",
+      "who_can_see_your_post",
+      "visibility",
+      "post_settings"
+    ],
+    selectorLocale
+  );
+  const visibilityRegexHint = formatLinkedInSelectorRegexHint(
+    [
+      "anyone",
+      "connections_only",
+      "who_can_see_your_post",
+      "visibility",
+      "post_settings"
+    ],
+    selectorLocale
+  );
+  const visibilityAriaSelector = buildLinkedInAriaLabelContainsSelector(
+    "button",
+    [
+      "anyone",
+      "connections_only",
+      "who_can_see_your_post",
+      "visibility",
+      "post_settings"
+    ],
+    selectorLocale
+  );
+  const visibilityTextRegex = buildLinkedInSelectorPhraseRegex(
+    ["anyone", "connections_only"],
+    selectorLocale
+  );
+  const visibilityTextRegexHint = formatLinkedInSelectorRegexHint(
+    ["anyone", "connections_only"],
+    selectorLocale
+  );
+
   return [
     {
       key: "role-button-visibility",
-      selectorHint:
-        "getByRole(button, /anyone|connections only|who can see your post|visibility|post settings/i)",
+      selectorHint: `getByRole(button, ${visibilityRegexHint})`,
       locatorFactory: (root) =>
         root.getByRole("button", {
-          name: /anyone|connections only|who can see your post|visibility|post settings/i
+          name: visibilityRegex
         })
     },
     {
       key: "aria-label-visibility",
-      selectorHint:
-        "button[aria-label*=anyone|connections only|visibility|post settings]",
-      locatorFactory: (root) =>
-        root.locator(
-          "button[aria-label*='Anyone' i], button[aria-label*='Connections only' i], button[aria-label*='Who can see your post' i], button[aria-label*='visibility' i], button[aria-label*='post settings' i]"
-        )
+      selectorHint: visibilityAriaSelector,
+      locatorFactory: (root) => root.locator(visibilityAriaSelector)
     },
     {
       key: "button-text-visibility",
-      selectorHint: "button hasText /anyone|connections only/i",
-      locatorFactory: (root) => root.locator("button").filter({ hasText: /anyone|connections only/i })
+      selectorHint: `button hasText ${visibilityTextRegexHint}`,
+      locatorFactory: (root) =>
+        root.locator("button").filter({ hasText: visibilityTextRegex })
     }
   ];
 }
 
-function createVisibilityOptionCandidates(
+function getVisibilityPhraseKey(
   visibility: LinkedInPostVisibility
+): LinkedInSelectorPhraseKey {
+  return visibility === "connections" ? "connections_only" : "anyone";
+}
+
+function createVisibilityOptionCandidates(
+  visibility: LinkedInPostVisibility,
+  selectorLocale: LinkedInSelectorLocale
 ): SelectorCandidate[] {
-  const audienceLabel = LINKEDIN_POST_VISIBILITY_MAP[visibility].audienceLabel;
-  const labelRegex = new RegExp(`^${escapeRegExp(audienceLabel)}$`, "i");
+  const visibilityPhraseKey = getVisibilityPhraseKey(visibility);
+  const labelRegex = buildLinkedInSelectorPhraseRegex(
+    visibilityPhraseKey,
+    selectorLocale,
+    { exact: true }
+  );
+  const labelRegexHint = formatLinkedInSelectorRegexHint(
+    visibilityPhraseKey,
+    selectorLocale,
+    { exact: true }
+  );
 
   return [
     {
       key: "role-radio-visibility-option",
-      selectorHint: `getByRole(radio, ${audienceLabel})`,
+      selectorHint: `getByRole(radio, ${labelRegexHint})`,
       locatorFactory: (page) => page.getByRole("radio", { name: labelRegex })
     },
     {
       key: "role-button-visibility-option",
-      selectorHint: `getByRole(button, ${audienceLabel})`,
+      selectorHint: `getByRole(button, ${labelRegexHint})`,
       locatorFactory: (page) => page.getByRole("button", { name: labelRegex })
     },
     {
       key: "label-visibility-option",
-      selectorHint: `label hasText ${audienceLabel}`,
+      selectorHint: `label hasText ${labelRegexHint}`,
       locatorFactory: (page) => page.locator("label").filter({ hasText: labelRegex })
     },
     {
       key: "generic-visibility-option",
-      selectorHint: `[role='radio'], button, label, li hasText ${audienceLabel}`,
+      selectorHint: `[role='radio'], button, label, li hasText ${labelRegexHint}`,
       locatorFactory: (page) =>
         page
           .locator("[role='radio'], button, label, li")
@@ -1296,27 +1417,51 @@ function createVisibilityOptionCandidates(
   ];
 }
 
-function createVisibilityDoneButtonCandidates(): SelectorCandidate[] {
+function createVisibilityDoneButtonCandidates(
+  selectorLocale: LinkedInSelectorLocale
+): SelectorCandidate[] {
+  const doneRegex = buildLinkedInSelectorPhraseRegex(
+    ["done", "save"],
+    selectorLocale
+  );
+  const doneRegexHint = formatLinkedInSelectorRegexHint(
+    ["done", "save"],
+    selectorLocale
+  );
+
   return [
     {
       key: "role-button-done",
-      selectorHint: "getByRole(button, /done|save/i)",
-      locatorFactory: (page) => page.getByRole("button", { name: /done|save/i })
+      selectorHint: `getByRole(button, ${doneRegexHint})`,
+      locatorFactory: (page) => page.getByRole("button", { name: doneRegex })
     },
     {
       key: "button-text-done",
-      selectorHint: "button hasText /done|save/i",
-      locatorFactory: (page) => page.locator("button").filter({ hasText: /done|save/i })
+      selectorHint: `button hasText ${doneRegexHint}`,
+      locatorFactory: (page) => page.locator("button").filter({ hasText: doneRegex })
     }
   ];
 }
 
-function createPublishButtonCandidates(): ScopedSelectorCandidate[] {
+function createPublishButtonCandidates(
+  selectorLocale: LinkedInSelectorLocale
+): ScopedSelectorCandidate[] {
+  const postExactRegex = buildLinkedInSelectorPhraseRegex(
+    "post",
+    selectorLocale,
+    { exact: true }
+  );
+  const postExactRegexHint = formatLinkedInSelectorRegexHint(
+    "post",
+    selectorLocale,
+    { exact: true }
+  );
+
   return [
     {
       key: "role-button-post",
-      selectorHint: "getByRole(button, /^post$/i)",
-      locatorFactory: (root) => root.getByRole("button", { name: /^post$/i })
+      selectorHint: `getByRole(button, ${postExactRegexHint})`,
+      locatorFactory: (root) => root.getByRole("button", { name: postExactRegex })
     },
     {
       key: "share-actions-primary",
@@ -1331,41 +1476,66 @@ function createPublishButtonCandidates(): ScopedSelectorCandidate[] {
   ];
 }
 
-function createComposerCloseButtonCandidates(): ScopedSelectorCandidate[] {
+function createComposerCloseButtonCandidates(
+  selectorLocale: LinkedInSelectorLocale
+): ScopedSelectorCandidate[] {
+  const closeRegex = buildLinkedInSelectorPhraseRegex(
+    ["dismiss", "close"],
+    selectorLocale
+  );
+  const closeRegexHint = formatLinkedInSelectorRegexHint(
+    ["dismiss", "close"],
+    selectorLocale
+  );
+  const closeAriaSelector = buildLinkedInAriaLabelContainsSelector(
+    "button",
+    ["dismiss", "close"],
+    selectorLocale
+  );
+
   return [
     {
       key: "role-button-dismiss",
-      selectorHint: "getByRole(button, /dismiss|close/i)",
-      locatorFactory: (root) => root.getByRole("button", { name: /dismiss|close/i })
+      selectorHint: `getByRole(button, ${closeRegexHint})`,
+      locatorFactory: (root) => root.getByRole("button", { name: closeRegex })
     },
     {
       key: "aria-dismiss-close",
-      selectorHint: "button[aria-label*=dismiss|close]",
-      locatorFactory: (root) =>
-        root.locator(
-          "button[aria-label*='dismiss' i], button[aria-label*='close' i]"
-        )
+      selectorHint: closeAriaSelector,
+      locatorFactory: (root) => root.locator(closeAriaSelector)
     }
   ];
 }
 
-function createDiscardDialogCandidates(): SelectorCandidate[] {
+function createDiscardDialogCandidates(
+  selectorLocale: LinkedInSelectorLocale
+): SelectorCandidate[] {
+  const discardRegex = buildLinkedInSelectorPhraseRegex(
+    ["discard", "leave"],
+    selectorLocale
+  );
+  const discardRegexHint = formatLinkedInSelectorRegexHint(
+    ["discard", "leave"],
+    selectorLocale
+  );
+
   return [
     {
       key: "role-button-discard",
-      selectorHint: "getByRole(button, /discard|leave/i)",
-      locatorFactory: (page) => page.getByRole("button", { name: /discard|leave/i })
+      selectorHint: `getByRole(button, ${discardRegexHint})`,
+      locatorFactory: (page) => page.getByRole("button", { name: discardRegex })
     },
     {
       key: "button-text-discard",
-      selectorHint: "button hasText /discard|leave/i",
-      locatorFactory: (page) => page.locator("button").filter({ hasText: /discard|leave/i })
+      selectorHint: `button hasText ${discardRegexHint}`,
+      locatorFactory: (page) => page.locator("button").filter({ hasText: discardRegex })
     }
   ];
 }
 
 async function openPostComposer(
   page: Page,
+  selectorLocale: LinkedInSelectorLocale,
   artifactPaths: string[]
 ): Promise<{ composerRoot: Locator; triggerKey: string; rootKey: string }> {
   await page.goto(LINKEDIN_FEED_URL, { waitUntil: "domcontentloaded" });
@@ -1374,7 +1544,7 @@ async function openPostComposer(
 
   const trigger = await findVisibleLocatorOrThrow(
     page,
-    createComposeTriggerCandidates(),
+    createComposeTriggerCandidates(selectorLocale),
     "post_composer_trigger",
     artifactPaths
   );
@@ -1382,7 +1552,7 @@ async function openPostComposer(
 
   const root = await findVisibleLocatorOrThrow(
     page,
-    createComposerRootCandidates(),
+    createComposerRootCandidates(selectorLocale),
     "post_composer_root",
     artifactPaths
   );
@@ -1394,10 +1564,14 @@ async function openPostComposer(
   };
 }
 
-async function closeComposerBestEffort(page: Page, composerRoot: Locator): Promise<void> {
+async function closeComposerBestEffort(
+  page: Page,
+  composerRoot: Locator,
+  selectorLocale: LinkedInSelectorLocale
+): Promise<void> {
   const closeButton = await findOptionalScopedLocator(
     composerRoot,
-    createComposerCloseButtonCandidates()
+    createComposerCloseButtonCandidates(selectorLocale)
   );
 
   try {
@@ -1412,7 +1586,7 @@ async function closeComposerBestEffort(page: Page, composerRoot: Locator): Promi
 
   const discardButton = await findOptionalVisibleLocator(
     page,
-    createDiscardDialogCandidates()
+    createDiscardDialogCandidates(selectorLocale)
   );
   if (discardButton) {
     await discardButton.locator.click({ timeout: 2_000 }).catch(() => undefined);
@@ -1424,12 +1598,13 @@ async function closeComposerBestEffort(page: Page, composerRoot: Locator): Promi
 async function setComposerText(
   page: Page,
   composerRoot: Locator,
+  selectorLocale: LinkedInSelectorLocale,
   text: string,
   artifactPaths: string[]
 ): Promise<string> {
   const composerInput = await findVisibleScopedLocatorOrThrow(
     composerRoot,
-    createComposerInputCandidates(),
+    createComposerInputCandidates(selectorLocale),
     "post_composer_input",
     artifactPaths,
     page.url()
@@ -1462,13 +1637,14 @@ async function readLocatorDetails(locator: Locator): Promise<string> {
 async function setPostVisibility(
   page: Page,
   composerRoot: Locator,
+  selectorLocale: LinkedInSelectorLocale,
   visibility: LinkedInPostVisibility,
   artifactPaths: string[]
 ): Promise<string> {
   const audienceLabel = LINKEDIN_POST_VISIBILITY_MAP[visibility].audienceLabel;
   const visibilityButton = await findVisibleScopedLocatorOrThrow(
     composerRoot,
-    createVisibilityButtonCandidates(),
+    createVisibilityButtonCandidates(selectorLocale),
     "post_visibility_button",
     artifactPaths,
     page.url()
@@ -1483,7 +1659,7 @@ async function setPostVisibility(
 
   const option = await findVisibleLocatorOrThrow(
     page,
-    createVisibilityOptionCandidates(visibility),
+    createVisibilityOptionCandidates(visibility, selectorLocale),
     "post_visibility_option",
     artifactPaths
   );
@@ -1491,7 +1667,7 @@ async function setPostVisibility(
 
   const doneButton = await findOptionalVisibleLocator(
     page,
-    createVisibilityDoneButtonCandidates()
+    createVisibilityDoneButtonCandidates(selectorLocale)
   );
   if (doneButton) {
     await doneButton.locator.click({ timeout: 5_000 });
@@ -1500,7 +1676,7 @@ async function setPostVisibility(
   const updated = await waitForCondition(async () => {
     const nextButton = await findOptionalScopedLocator(
       composerRoot,
-      createVisibilityButtonCandidates()
+      createVisibilityButtonCandidates(selectorLocale)
     );
     if (!nextButton) {
       return false;
@@ -1668,6 +1844,7 @@ export class LinkedInPostsService {
 
             const { composerRoot, triggerKey, rootKey } = await openPostComposer(
               page,
+              this.runtime.selectorLocale,
               artifactPaths
             );
 
@@ -1681,7 +1858,11 @@ export class LinkedInPostsService {
             });
             artifactPaths.push(screenshotPath);
 
-            await closeComposerBestEffort(page, composerRoot);
+            await closeComposerBestEffort(
+              page,
+              composerRoot,
+              this.runtime.selectorLocale
+            );
 
             const rateLimitState = this.runtime.rateLimiter.peek(
               CREATE_POST_RATE_LIMIT_CONFIG
@@ -1843,15 +2024,23 @@ class CreatePostActionExecutor
 
           const { composerRoot, triggerKey, rootKey } = await openPostComposer(
             page,
+            runtime.selectorLocale,
             artifactPaths
           );
           const visibilityKey = await setPostVisibility(
             page,
             composerRoot,
+            runtime.selectorLocale,
             visibility,
             artifactPaths
           );
-          const inputKey = await setComposerText(page, composerRoot, text, artifactPaths);
+          const inputKey = await setComposerText(
+            page,
+            composerRoot,
+            runtime.selectorLocale,
+            text,
+            artifactPaths
+          );
 
           const prePublishScreenshot = `linkedin/screenshot-post-confirm-before-${Date.now()}.png`;
           await captureScreenshotArtifact(runtime, page, prePublishScreenshot, {
@@ -1867,7 +2056,7 @@ class CreatePostActionExecutor
 
           const publishButton = await findVisibleScopedLocatorOrThrow(
             composerRoot,
-            createPublishButtonCandidates(),
+            createPublishButtonCandidates(runtime.selectorLocale),
             "post_publish_button",
             artifactPaths,
             page.url()

--- a/packages/core/src/linkedinProfile.ts
+++ b/packages/core/src/linkedinProfile.ts
@@ -4,6 +4,8 @@ import { LinkedInAssistantError, asLinkedInAssistantError } from "./errors.js";
 import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
+import type { LinkedInSelectorLocale } from "./selectorLocale.js";
+import { getLinkedInSelectorPhrases } from "./selectorLocale.js";
 
 export interface LinkedInExperience {
   title: string;
@@ -40,6 +42,7 @@ export interface ViewProfileInput {
 export interface LinkedInProfileRuntime {
   auth: LinkedInAuthService;
   cdpUrl?: string | undefined;
+  selectorLocale: LinkedInSelectorLocale;
   profileManager: ProfileManager;
   logger: JsonEventLogger;
 }
@@ -118,8 +121,11 @@ async function getOrCreatePage(context: BrowserContext): Promise<Page> {
 }
 
 /* eslint-disable no-undef -- DOM types (ParentNode, Element) are valid inside page.evaluate() */
-async function extractProfileData(page: Page): Promise<LinkedInProfile> {
-  const extracted = await page.evaluate(() => {
+async function extractProfileData(
+  page: Page,
+  selectorLocale: LinkedInSelectorLocale
+): Promise<LinkedInProfile> {
+  const extracted = await page.evaluate((sectionLabels) => {
     const normalize = (value: string | null | undefined): string =>
       (value ?? "").replace(/\s+/g, " ").trim();
     const emptyProfile = {
@@ -162,7 +168,15 @@ async function extractProfileData(page: Page): Promise<LinkedInProfile> {
       return [];
     };
 
-    const findSectionRoot = (id: string, label: string): Element | null => {
+    const includesAnyLabel = (
+      value: string,
+      labels: string[]
+    ): boolean => {
+      const normalizedValue = normalize(value).toLowerCase();
+      return labels.some((label) => normalizedValue.includes(normalize(label).toLowerCase()));
+    };
+
+    const findSectionRoot = (id: string, labels: string[]): Element | null => {
       const byId = globalThis.document.querySelector(`#${id}`);
       if (byId) {
         return byId.closest("section") ?? byId;
@@ -175,7 +189,7 @@ async function extractProfileData(page: Page): Promise<LinkedInProfile> {
         const heading = normalize(
           section.querySelector("h2, h3, .pvs-header__title")?.textContent
         );
-        if (heading.toLowerCase().includes(label.toLowerCase())) {
+        if (includesAnyLabel(heading, labels)) {
           return section;
         }
       }
@@ -282,7 +296,7 @@ async function extractProfileData(page: Page): Promise<LinkedInProfile> {
           const heading = normalize(
             section.querySelector("h2, h3, .pvs-header__title")?.textContent
           );
-          if (!heading || !heading.toLowerCase().includes("about")) {
+          if (!heading || !includesAnyLabel(heading, sectionLabels.about)) {
             continue;
           }
 
@@ -313,7 +327,10 @@ async function extractProfileData(page: Page): Promise<LinkedInProfile> {
         connectionDegree = degreeMatch ? normalize(degreeMatch[1]) : "";
       }
 
-      const experienceSection = findSectionRoot("experience", "experience");
+      const experienceSection = findSectionRoot(
+        "experience",
+        sectionLabels.experience
+      );
       const experience = collectSectionItems(experienceSection)
         .map((item) => {
           const lines = pickList(
@@ -404,7 +421,10 @@ async function extractProfileData(page: Page): Promise<LinkedInProfile> {
             item.description
         );
 
-      const educationSection = findSectionRoot("education", "education");
+      const educationSection = findSectionRoot(
+        "education",
+        sectionLabels.education
+      );
       const education = collectSectionItems(educationSection)
         .map((item) => {
           const lines = pickList(
@@ -474,6 +494,10 @@ async function extractProfileData(page: Page): Promise<LinkedInProfile> {
     } catch {
       return emptyProfile;
     }
+  }, {
+    about: getLinkedInSelectorPhrases("about", selectorLocale),
+    experience: getLinkedInSelectorPhrases("experience", selectorLocale),
+    education: getLinkedInSelectorPhrases("education", selectorLocale)
   });
 
   return {
@@ -531,7 +555,7 @@ export class LinkedInProfileService {
             .first()
             .waitFor({ state: "visible", timeout: 10_000 })
             .catch(() => undefined);
-          return extractProfileData(page);
+          return extractProfileData(page, this.runtime.selectorLocale);
         }
       );
     } catch (error) {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -3,6 +3,7 @@ import {
   ensureConfigPaths,
   resolveConfigPaths,
   resolveConfirmFailureArtifactConfig,
+  resolveLinkedInSelectorLocaleConfig,
   type ConfigPaths,
   type ConfirmFailureArtifactConfig
 } from "./config.js";
@@ -65,6 +66,7 @@ import {
 } from "./twoPhaseCommit.js";
 import { resolvePrivacyConfig, type PrivacyConfig } from "./privacy.js";
 import { LinkedInSelectorAuditService } from "./selectorAudit.js";
+import type { LinkedInSelectorLocale } from "./selectorLocale.js";
 
 export interface CreateCoreRuntimeOptions {
   baseDir?: string;
@@ -72,12 +74,14 @@ export interface CreateCoreRuntimeOptions {
   runId?: string;
   cdpUrl?: string | undefined;
   privacy?: Partial<PrivacyConfig>;
+  selectorLocale?: string | LinkedInSelectorLocale;
 }
 
 export interface CoreRuntime {
   paths: ConfigPaths;
   runId: string;
   cdpUrl?: string | undefined;
+  selectorLocale: LinkedInSelectorLocale;
   confirmFailureArtifacts: ConfirmFailureArtifactConfig;
   privacy: PrivacyConfig;
   postSafetyLint: LinkedInPostSafetyLintConfig;
@@ -110,6 +114,9 @@ export function createCoreRuntime(
   ensureConfigPaths(paths);
   const privacy = resolvePrivacyConfig(options.privacy);
   const postSafetyLint = resolveLinkedInPostSafetyLintConfig(paths.baseDir);
+  const selectorLocale = resolveLinkedInSelectorLocaleConfig(
+    options.selectorLocale
+  );
 
   const db = new AssistantDatabase(options.dbPath ?? paths.dbPath);
   const runId = options.runId ?? createRunId();
@@ -155,6 +162,7 @@ export function createCoreRuntime(
     paths,
     runId,
     cdpUrl: options.cdpUrl,
+    selectorLocale,
     confirmFailureArtifacts,
     privacy,
     postSafetyLint,
@@ -164,7 +172,11 @@ export function createCoreRuntime(
     twoPhaseCommit,
     rateLimiter: new RateLimiter(db),
     profileManager,
-    auth: new LinkedInAuthService(profileManager, options.cdpUrl),
+    auth: new LinkedInAuthService(
+      profileManager,
+      options.cdpUrl,
+      selectorLocale
+    ),
     profile: undefined as unknown as LinkedInProfileService,
     search: undefined as unknown as LinkedInSearchService,
     jobs: undefined as unknown as LinkedInJobsService,
@@ -216,7 +228,8 @@ export function createCoreRuntime(
 
   logger.log("info", "runtime.started", {
     runId,
-    baseDir: paths.baseDir
+    baseDir: paths.baseDir,
+    selector_locale: selectorLocale
   });
 
   return runtime;

--- a/packages/core/src/selectorAudit.ts
+++ b/packages/core/src/selectorAudit.ts
@@ -12,6 +12,13 @@ import { LinkedInAssistantError } from "./errors.js";
 import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
+import {
+  DEFAULT_LINKEDIN_SELECTOR_LOCALE,
+  buildLinkedInAriaLabelContainsSelector,
+  buildLinkedInSelectorPhraseRegex,
+  formatLinkedInSelectorRegexHint,
+  type LinkedInSelectorLocale
+} from "./selectorLocale.js";
 
 /**
  * Canonical LinkedIn page identifiers covered by the built-in selector audit.
@@ -211,6 +218,7 @@ export interface LinkedInSelectorAuditRuntime {
   runId: string;
   auth: LinkedInAuthService;
   cdpUrl?: string | undefined;
+  selectorLocale?: LinkedInSelectorLocale;
   profileManager: ProfileManager;
   logger: JsonEventLogger;
   artifacts: ArtifactHelpers;
@@ -279,7 +287,81 @@ function createSelectorAuditSelectorDefinition(
   };
 }
 
-function createDefaultSelectorAuditRegistry(): SelectorAuditPageDefinition[] {
+function createDefaultSelectorAuditRegistry(
+  selectorLocale: LinkedInSelectorLocale = DEFAULT_LINKEDIN_SELECTOR_LOCALE
+): SelectorAuditPageDefinition[] {
+  const startPostExactRegex = buildLinkedInSelectorPhraseRegex(
+    "start_post",
+    selectorLocale,
+    { exact: true }
+  );
+  const startPostRegexHint = formatLinkedInSelectorRegexHint(
+    "start_post",
+    selectorLocale,
+    { exact: true }
+  );
+  const startPostTextRegex = buildLinkedInSelectorPhraseRegex(
+    "start_post",
+    selectorLocale
+  );
+  const startPostTextRegexHint = formatLinkedInSelectorRegexHint(
+    "start_post",
+    selectorLocale
+  );
+  const startPostAriaSelector = buildLinkedInAriaLabelContainsSelector(
+    ["button", "[role='button']"],
+    "start_post",
+    selectorLocale
+  );
+  const inboxSurfaceRegex = buildLinkedInSelectorPhraseRegex(
+    ["messaging", "write_message"],
+    selectorLocale
+  );
+  const inboxSurfaceRegexHint = formatLinkedInSelectorRegexHint(
+    ["messaging", "write_message"],
+    selectorLocale
+  );
+  const profileSurfaceRegex = buildLinkedInSelectorPhraseRegex(
+    ["about", "experience", "education", "resources", "open_to"],
+    selectorLocale
+  );
+  const profileSurfaceRegexHint = formatLinkedInSelectorRegexHint(
+    ["about", "experience", "education", "resources", "open_to"],
+    selectorLocale
+  );
+  const connectionsHeadingRegex = buildLinkedInSelectorPhraseRegex(
+    "connections",
+    selectorLocale
+  );
+  const connectionsHeadingRegexHint = formatLinkedInSelectorRegexHint(
+    "connections",
+    selectorLocale
+  );
+  const connectionsSurfaceRegex = buildLinkedInSelectorPhraseRegex(
+    ["connections", "message", "remove_connection"],
+    selectorLocale
+  );
+  const connectionsSurfaceRegexHint = formatLinkedInSelectorRegexHint(
+    ["connections", "message", "remove_connection"],
+    selectorLocale
+  );
+  const notificationsHeadingRegex = buildLinkedInSelectorPhraseRegex(
+    "notifications",
+    selectorLocale
+  );
+  const notificationsHeadingRegexHint = formatLinkedInSelectorRegexHint(
+    "notifications",
+    selectorLocale
+  );
+  const notificationsSurfaceRegex = buildLinkedInSelectorPhraseRegex(
+    ["notifications", "time_ago"],
+    selectorLocale
+  );
+  const notificationsSurfaceRegexHint = formatLinkedInSelectorRegexHint(
+    ["notifications", "time_ago"],
+    selectorLocale
+  );
+
   return [
     {
       page: "feed",
@@ -291,26 +373,25 @@ function createDefaultSelectorAuditRegistry(): SelectorAuditPageDefinition[] {
           {
             primary: {
               key: "role-button-start-post",
-              selectorHint: "getByRole(button, /start a post/i)",
+              selectorHint: `getByRole(button, ${startPostRegexHint})`,
               locatorFactory: (page) =>
-                page.getByRole("button", { name: /start a post/i })
+                page.getByRole("button", { name: startPostExactRegex })
             },
             secondary: {
               key: "aria-or-share-box-start-post",
-              selectorHint:
-                "button[aria-label*='start a post' i], .share-box-feed-entry__trigger, .share-box__open",
+              selectorHint: `${startPostAriaSelector}, .share-box-feed-entry__trigger, .share-box__open`,
               locatorFactory: (page) =>
                 page.locator(
-                  "button[aria-label*='start a post' i], [role='button'][aria-label*='start a post' i], .share-box-feed-entry__trigger, .share-box__open"
+                  `${startPostAriaSelector}, .share-box-feed-entry__trigger, .share-box__open`
                 )
             },
             tertiary: {
               key: "text-start-post",
-              selectorHint: "button, [role='button'] hasText /start a post/i",
+              selectorHint: `button, [role='button'] hasText ${startPostTextRegexHint}`,
               locatorFactory: (page) =>
                 page
                   .locator("button, [role='button']")
-                  .filter({ hasText: /start a post/i })
+                  .filter({ hasText: startPostTextRegex })
             }
           }
         )
@@ -343,10 +424,10 @@ function createDefaultSelectorAuditRegistry(): SelectorAuditPageDefinition[] {
             },
             tertiary: {
               key: "main-text-messaging",
-              selectorHint: "main hasText /messaging|write a message/i",
+              selectorHint: `main hasText ${inboxSurfaceRegexHint}`,
               locatorFactory: (page) =>
                 page.locator("main").filter({
-                  hasText: /messaging|write a message/i
+                  hasText: inboxSurfaceRegex
                 })
             }
           }
@@ -371,10 +452,10 @@ function createDefaultSelectorAuditRegistry(): SelectorAuditPageDefinition[] {
           },
           tertiary: {
             key: "main-text-profile-sections",
-            selectorHint: "main hasText /about|experience|education|resources|open to/i",
+            selectorHint: `main hasText ${profileSurfaceRegexHint}`,
             locatorFactory: (page) =>
               page.locator("main").filter({
-                hasText: /about|experience|education|resources|open to/i
+                hasText: profileSurfaceRegex
               })
           }
         })
@@ -390,9 +471,9 @@ function createDefaultSelectorAuditRegistry(): SelectorAuditPageDefinition[] {
           {
             primary: {
               key: "role-heading-connections",
-              selectorHint: "getByRole(heading, /connections/i)",
+              selectorHint: `getByRole(heading, ${connectionsHeadingRegexHint})`,
               locatorFactory: (page) =>
-                page.getByRole("heading", { name: /connections/i })
+                page.getByRole("heading", { name: connectionsHeadingRegex })
             },
             secondary: {
               key: "connection-card",
@@ -405,10 +486,10 @@ function createDefaultSelectorAuditRegistry(): SelectorAuditPageDefinition[] {
             },
             tertiary: {
               key: "main-text-connections",
-              selectorHint: "main hasText /connections|message|remove connection/i",
+              selectorHint: `main hasText ${connectionsSurfaceRegexHint}`,
               locatorFactory: (page) =>
                 page.locator("main").filter({
-                  hasText: /connections|message|remove connection/i
+                  hasText: connectionsSurfaceRegex
                 })
             }
           }
@@ -425,9 +506,9 @@ function createDefaultSelectorAuditRegistry(): SelectorAuditPageDefinition[] {
           {
             primary: {
               key: "role-heading-notifications",
-              selectorHint: "getByRole(heading, /notifications/i)",
+              selectorHint: `getByRole(heading, ${notificationsHeadingRegexHint})`,
               locatorFactory: (page) =>
-                page.getByRole("heading", { name: /notifications/i })
+                page.getByRole("heading", { name: notificationsHeadingRegex })
             },
             secondary: {
               key: "notification-card",
@@ -437,9 +518,9 @@ function createDefaultSelectorAuditRegistry(): SelectorAuditPageDefinition[] {
             },
             tertiary: {
               key: "main-text-notifications",
-              selectorHint: "main hasText /notifications|ago/i",
+              selectorHint: `main hasText ${notificationsSurfaceRegexHint}`,
               locatorFactory: (page) =>
-                page.locator("main").filter({ hasText: /notifications|ago/i })
+                page.locator("main").filter({ hasText: notificationsSurfaceRegex })
             }
           }
         )
@@ -1086,7 +1167,10 @@ export class LinkedInSelectorAuditService {
     options: LinkedInSelectorAuditServiceOptions = {}
   ) {
     this.registry = validateSelectorAuditRegistry(
-      options.registry ?? createDefaultSelectorAuditRegistry()
+      options.registry ??
+        createDefaultSelectorAuditRegistry(
+          this.runtime.selectorLocale ?? DEFAULT_LINKEDIN_SELECTOR_LOCALE
+        )
     );
     this.candidateTimeoutMs = validateTimeoutOption(
       options.candidateTimeoutMs,
@@ -1620,6 +1704,8 @@ export class LinkedInSelectorAuditService {
  * Callers can inspect or clone this registry before passing a customized copy
  * to {@link LinkedInSelectorAuditServiceOptions.registry}.
  */
-export function createLinkedInSelectorAuditRegistry(): SelectorAuditPageDefinition[] {
-  return createDefaultSelectorAuditRegistry();
+export function createLinkedInSelectorAuditRegistry(
+  selectorLocale: LinkedInSelectorLocale = DEFAULT_LINKEDIN_SELECTOR_LOCALE
+): SelectorAuditPageDefinition[] {
+  return createDefaultSelectorAuditRegistry(selectorLocale);
 }

--- a/packages/core/src/selectorLocale.ts
+++ b/packages/core/src/selectorLocale.ts
@@ -1,0 +1,339 @@
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function escapeCssAttributeValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function normalizePhrase(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function dedupePhrases(values: readonly string[]): string[] {
+  const normalizedValues: string[] = [];
+  const seen = new Set<string>();
+
+  for (const value of values) {
+    const normalized = normalizePhrase(value);
+    if (!normalized) {
+      continue;
+    }
+
+    const dedupeKey = normalized.toLowerCase();
+    if (seen.has(dedupeKey)) {
+      continue;
+    }
+
+    seen.add(dedupeKey);
+    normalizedValues.push(normalized);
+  }
+
+  return normalizedValues;
+}
+
+export const LINKEDIN_SELECTOR_LOCALES = ["en", "da"] as const;
+export type LinkedInSelectorLocale =
+  (typeof LINKEDIN_SELECTOR_LOCALES)[number];
+
+export const DEFAULT_LINKEDIN_SELECTOR_LOCALE: LinkedInSelectorLocale = "en";
+
+export type LinkedInSelectorPhraseKey =
+  | "accept"
+  | "add_comment"
+  | "add_note"
+  | "anyone"
+  | "about"
+  | "celebrate"
+  | "close"
+  | "comment"
+  | "connect"
+  | "connections"
+  | "connections_only"
+  | "decline"
+  | "discard"
+  | "dismiss"
+  | "done"
+  | "education"
+  | "experience"
+  | "funny"
+  | "ignore"
+  | "insightful"
+  | "invitation"
+  | "invitation_sent"
+  | "invite"
+  | "leave"
+  | "like"
+  | "love"
+  | "me"
+  | "message"
+  | "messaging"
+  | "more"
+  | "more_actions"
+  | "notifications"
+  | "open_to"
+  | "pending"
+  | "post"
+  | "post_comment"
+  | "post_settings"
+  | "react"
+  | "reaction"
+  | "remove_connection"
+  | "resources"
+  | "respond"
+  | "save"
+  | "send"
+  | "send_without_note"
+  | "start_post"
+  | "support"
+  | "time_ago"
+  | "visibility"
+  | "what_do_you_want_to_talk_about"
+  | "who_can_see_your_post"
+  | "withdraw"
+  | "write_message";
+
+type SelectorPhraseDictionary = Record<
+  LinkedInSelectorPhraseKey,
+  readonly string[]
+>;
+
+const ENGLISH_SELECTOR_PHRASES: SelectorPhraseDictionary = {
+  accept: ["Accept"],
+  add_comment: ["Add a comment"],
+  add_note: ["Add a note"],
+  anyone: ["Anyone"],
+  about: ["About"],
+  celebrate: ["Celebrate"],
+  close: ["Close"],
+  comment: ["Comment"],
+  connect: ["Connect"],
+  connections: ["Connections"],
+  connections_only: ["Connections only"],
+  decline: ["Decline"],
+  discard: ["Discard"],
+  dismiss: ["Dismiss"],
+  done: ["Done"],
+  education: ["Education"],
+  experience: ["Experience"],
+  funny: ["Funny"],
+  ignore: ["Ignore"],
+  insightful: ["Insightful"],
+  invitation: ["Invitation"],
+  invitation_sent: ["Invitation sent"],
+  invite: ["Invite"],
+  leave: ["Leave"],
+  like: ["Like"],
+  love: ["Love"],
+  me: ["Me"],
+  message: ["Message"],
+  messaging: ["Messaging", "Messages"],
+  more: ["More"],
+  more_actions: ["More actions"],
+  notifications: ["Notifications"],
+  open_to: ["Open to"],
+  pending: ["Pending"],
+  post: ["Post"],
+  post_comment: ["Post comment"],
+  post_settings: ["Post settings"],
+  react: ["React"],
+  reaction: ["Reaction", "Reactions"],
+  remove_connection: ["Remove connection"],
+  resources: ["Resources"],
+  respond: ["Respond"],
+  save: ["Save"],
+  send: ["Send"],
+  send_without_note: ["Send without a note"],
+  start_post: ["Start a post"],
+  support: ["Support"],
+  time_ago: ["ago"],
+  visibility: ["Visibility"],
+  what_do_you_want_to_talk_about: ["What do you want to talk about?"],
+  who_can_see_your_post: ["Who can see your post?"],
+  withdraw: ["Withdraw"],
+  write_message: ["Write a message"]
+};
+
+const DANISH_SELECTOR_PHRASES: SelectorPhraseDictionary = {
+  ...ENGLISH_SELECTOR_PHRASES,
+  accept: ["Accepter"],
+  add_comment: ["Tilføj en kommentar", "Skriv en kommentar"],
+  add_note: ["Tilføj en note", "Tilføj en bemærkning"],
+  anyone: ["Alle"],
+  about: ["Om"],
+  celebrate: ["Fejr"],
+  close: ["Luk"],
+  comment: ["Kommenter", "Kommentar"],
+  connect: ["Opret forbindelse", "Forbind"],
+  connections: ["Forbindelser"],
+  connections_only: ["Kun forbindelser"],
+  decline: ["Afvis"],
+  discard: ["Kassér", "Fjern"],
+  dismiss: ["Luk"],
+  done: ["Færdig", "Udført"],
+  education: ["Uddannelse"],
+  experience: ["Erfaring"],
+  funny: ["Sjov"],
+  ignore: ["Ignorer"],
+  insightful: ["Indsigtsfuld", "Indsigt"],
+  invitation: ["Invitation", "Invitering"],
+  invitation_sent: ["Invitation sendt"],
+  invite: ["Inviter"],
+  leave: ["Forlad"],
+  like: ["Synes godt om"],
+  love: ["Elsker"],
+  me: ["Mig"],
+  message: ["Besked", "Meddelelse"],
+  messaging: ["Beskeder"],
+  more: ["Mere"],
+  more_actions: ["Flere handlinger", "Mere"],
+  notifications: ["Notifikationer", "Meddelelser"],
+  open_to: ["Åben for", "Åben over for"],
+  pending: ["Afventer"],
+  post: ["Slå op", "Opslag"],
+  post_comment: ["Slå kommentar op", "Send kommentar"],
+  post_settings: ["Opslagsindstillinger", "Indstillinger for opslag"],
+  react: ["Reager"],
+  reaction: ["Reaktion", "Reaktioner"],
+  remove_connection: ["Fjern forbindelse", "Fjern kontakt"],
+  resources: ["Ressourcer"],
+  respond: ["Svar"],
+  save: ["Gem"],
+  send: ["Send"],
+  send_without_note: ["Send uden note", "Send uden en note"],
+  start_post: ["Start et opslag", "Start et indlæg"],
+  support: ["Støt", "Støtter"],
+  time_ago: ["siden"],
+  visibility: ["Synlighed"],
+  what_do_you_want_to_talk_about: [
+    "Hvad vil du tale om?",
+    "Hvad vil du skrive om?"
+  ],
+  who_can_see_your_post: ["Hvem kan se dit opslag?"],
+  withdraw: ["Træk tilbage", "Tilbagetræk"],
+  write_message: ["Skriv en besked", "Skriv en meddelelse"]
+};
+
+const LINKEDIN_SELECTOR_PHRASES: Record<
+  LinkedInSelectorLocale,
+  SelectorPhraseDictionary
+> = {
+  en: ENGLISH_SELECTOR_PHRASES,
+  da: DANISH_SELECTOR_PHRASES
+};
+
+export function resolveLinkedInSelectorLocale(
+  value: string | LinkedInSelectorLocale | undefined,
+  fallback: LinkedInSelectorLocale = DEFAULT_LINKEDIN_SELECTOR_LOCALE
+): LinkedInSelectorLocale {
+  if (!value) {
+    return fallback;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return fallback;
+  }
+
+  const baseLocale = normalized.split(/[-_]/u)[0];
+  return LINKEDIN_SELECTOR_LOCALES.includes(
+    baseLocale as LinkedInSelectorLocale
+  )
+    ? (baseLocale as LinkedInSelectorLocale)
+    : fallback;
+}
+
+interface SelectorPhraseOptions {
+  includeEnglishFallback?: boolean;
+}
+
+interface SelectorRegexOptions extends SelectorPhraseOptions {
+  exact?: boolean;
+}
+
+function normalizePhraseKeys(
+  keys: LinkedInSelectorPhraseKey | readonly LinkedInSelectorPhraseKey[]
+): LinkedInSelectorPhraseKey[] {
+  return Array.isArray(keys)
+    ? [...keys]
+    : [keys as LinkedInSelectorPhraseKey];
+}
+
+export function getLinkedInSelectorPhrases(
+  keys: LinkedInSelectorPhraseKey | readonly LinkedInSelectorPhraseKey[],
+  locale: LinkedInSelectorLocale,
+  options: SelectorPhraseOptions = {}
+): string[] {
+  const includeEnglishFallback = options.includeEnglishFallback ?? true;
+  const normalizedKeys = normalizePhraseKeys(keys);
+  const localeDictionary = LINKEDIN_SELECTOR_PHRASES[locale];
+
+  const localizedValues = normalizedKeys.flatMap(
+    (key) => localeDictionary[key] ?? []
+  );
+
+  if (!includeEnglishFallback || locale === "en") {
+    return dedupePhrases(localizedValues);
+  }
+
+  const englishValues = normalizedKeys.flatMap(
+    (key) => ENGLISH_SELECTOR_PHRASES[key] ?? []
+  );
+  return dedupePhrases([...localizedValues, ...englishValues]);
+}
+
+export function buildLinkedInSelectorPhraseRegex(
+  keys: LinkedInSelectorPhraseKey | readonly LinkedInSelectorPhraseKey[],
+  locale: LinkedInSelectorLocale,
+  options: SelectorRegexOptions = {}
+): RegExp {
+  const phrases = getLinkedInSelectorPhrases(keys, locale, options);
+  const body = phrases.map((phrase) => escapeRegExp(phrase)).join("|") || "^$";
+  const pattern = options.exact ? `^(?:${body})$` : `(?:${body})`;
+  return new RegExp(pattern, "i");
+}
+
+export function formatLinkedInSelectorRegexHint(
+  keys: LinkedInSelectorPhraseKey | readonly LinkedInSelectorPhraseKey[],
+  locale: LinkedInSelectorLocale,
+  options: SelectorRegexOptions = {}
+): string {
+  const phrases = getLinkedInSelectorPhrases(keys, locale, options);
+  const body = phrases.map((phrase) => escapeRegExp(phrase)).join("|") || "^$";
+  return options.exact ? `/^(?:${body})$/i` : `/${body}/i`;
+}
+
+export function buildLinkedInAriaLabelContainsSelector(
+  roots: string | readonly string[],
+  keys: LinkedInSelectorPhraseKey | readonly LinkedInSelectorPhraseKey[],
+  locale: LinkedInSelectorLocale,
+  attributeName: string = "aria-label",
+  options: SelectorPhraseOptions = {}
+): string {
+  const selectors = Array.isArray(roots) ? roots : [roots];
+  const phrases = getLinkedInSelectorPhrases(keys, locale, options);
+
+  return selectors
+    .flatMap((root) =>
+      phrases.map(
+        (phrase) => `${root}[${attributeName}*="${escapeCssAttributeValue(phrase)}" i]`
+      )
+    )
+    .join(", ");
+}
+
+export function valueContainsLinkedInSelectorPhrase(
+  value: string | null | undefined,
+  keys: LinkedInSelectorPhraseKey | readonly LinkedInSelectorPhraseKey[],
+  locale: LinkedInSelectorLocale,
+  options: SelectorPhraseOptions = {}
+): boolean {
+  const normalizedValue = normalizePhrase(value ?? "").toLowerCase();
+  if (!normalizedValue) {
+    return false;
+  }
+
+  return getLinkedInSelectorPhrases(keys, locale, options).some((phrase) =>
+    normalizedValue.includes(phrase.toLowerCase())
+  );
+}

--- a/packages/mcp/src/bin/linkedin-mcp.ts
+++ b/packages/mcp/src/bin/linkedin-mcp.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_FOLLOWUP_SINCE,
   LINKEDIN_FEED_REACTION_TYPES,
   LINKEDIN_POST_VISIBILITY_TYPES,
+  LINKEDIN_SELECTOR_LOCALES,
   LinkedInAssistantError,
   createCoreRuntime,
   normalizeLinkedInFeedReaction,
@@ -169,21 +170,37 @@ const cdpUrlInputSchemaProperty = {
     "Connect to an existing browser via CDP endpoint (for example http://127.0.0.1:18800)."
 } as const;
 
+const selectorLocaleInputSchemaProperty = {
+  type: "string",
+  description: `Selector locale for LinkedIn UI text fallbacks (${LINKEDIN_SELECTOR_LOCALES.join(
+    ", "
+  )}). Defaults to en.`
+} as const;
+
 function withCdpSchemaProperties(
   properties: Record<string, unknown>
 ): Record<string, unknown> {
   return {
     ...properties,
-    cdpUrl: cdpUrlInputSchemaProperty
+    cdpUrl: cdpUrlInputSchemaProperty,
+    selectorLocale: selectorLocaleInputSchemaProperty
   };
 }
 
 function createRuntime(args: ToolArgs) {
   const cdpUrl = readString(args, "cdpUrl", "");
+  const selectorLocale = readString(args, "selectorLocale", "");
   return createCoreRuntime(
     cdpUrl
-      ? { cdpUrl, privacy: mcpPrivacyConfig }
-      : { privacy: mcpPrivacyConfig }
+      ? {
+          cdpUrl,
+          privacy: mcpPrivacyConfig,
+          ...(selectorLocale ? { selectorLocale } : {})
+        }
+      : {
+          privacy: mcpPrivacyConfig,
+          ...(selectorLocale ? { selectorLocale } : {})
+        }
   );
 }
 


### PR DESCRIPTION
## Summary\n- add a shared selector-locale dictionary/helper layer with Danish support and English fallback\n- thread selector locale through core runtime plus CLI/MCP entry points\n- update selector audit and locale-sensitive inbox/connections/feed/posts/profile/auth selectors to use locale-aware fallbacks\n- add unit coverage for locale parsing/fallback behavior and document the new flag/env var\n\n## Validation\n- npm run typecheck\n- npm test\n- npm run lint\n- npm run build\n\nCloses #8