### PR TITLE
refactor: simplify E2E hardening scaffolding

### DIFF
--- a/packages/core/src/__tests__/e2e/auth.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/auth.e2e.test.ts
@@ -1,44 +1,27 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  getRuntime,
-  checkCdpAvailable,
-  checkAuthenticated,
-  cleanupRuntime
-} from "./setup.js";
+import { describe, expect, it } from "vitest";
+import { setupE2ESuite } from "./setup.js";
 
 describe("Auth E2E", () => {
-  let cdpOk = false;
-  let authOk = false;
-
-  beforeAll(async () => {
-    cdpOk = await checkCdpAvailable();
-    if (cdpOk) {
-      authOk = await checkAuthenticated();
-    }
-  });
-
-  afterAll(() => {
-    cleanupRuntime();
-  });
+  const e2e = setupE2ESuite();
 
   it("status returns authenticated: true", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const status = await runtime.auth.status();
     expect(status.authenticated).toBe(true);
   });
 
   it("ensureAuthenticated does not throw", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     await expect(runtime.auth.ensureAuthenticated()).resolves.toMatchObject({
       authenticated: true
     });
   });
 
   it("current URL contains linkedin.com", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const status = await runtime.auth.status();
     expect(status.currentUrl).toContain("linkedin.com");
   });

--- a/packages/core/src/__tests__/e2e/cli.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/cli.e2e.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   getCliCoverageFixtures,
   getDefaultConnectionTarget,
@@ -7,31 +7,17 @@ import {
   prepareEchoAction,
   runCliCommand
 } from "./helpers.js";
-import {
-  cleanupRuntime,
-  getE2EAvailability,
-  getRuntime,
-  type E2EAvailability
-} from "./setup.js";
+import { setupE2ESuite } from "./setup.js";
 
 describe.sequential("CLI E2E", () => {
-  let availability: E2EAvailability;
-  let fixtures: Awaited<ReturnType<typeof getCliCoverageFixtures>> | undefined;
+  const e2e = setupE2ESuite({
+    fixtures: getCliCoverageFixtures,
+    timeoutMs: 180_000
+  });
   const profileName = getDefaultProfileName();
 
-  beforeAll(async () => {
-    availability = await getE2EAvailability();
-    if (availability.canRun) {
-      fixtures = await getCliCoverageFixtures(getRuntime());
-    }
-  }, 180_000);
-
-  afterAll(() => {
-    cleanupRuntime();
-  });
-
   it("covers session, health, rate-limit, login, and selector audit commands", async () => {
-    if (!availability.canRun || !fixtures) {
+    if (!e2e.canRun()) {
       return;
     }
 
@@ -100,9 +86,10 @@ describe.sequential("CLI E2E", () => {
   }, 240_000);
 
   it("covers inbox commands and both confirm entrypoints", async () => {
-    if (!availability.canRun || !fixtures) {
+    if (!e2e.canRun()) {
       return;
     }
+    const fixtures = e2e.fixtures();
 
     const inboxList = await runCliCommand([
       "inbox",
@@ -153,7 +140,7 @@ describe.sequential("CLI E2E", () => {
       confirmToken: expect.stringMatching(/^ct_/)
     });
 
-    const runtime = getRuntime();
+    const runtime = e2e.runtime();
     const confirmAction = prepareEchoAction(runtime, {
       profileName,
       summary: "CLI actions.confirm echo"
@@ -202,9 +189,10 @@ describe.sequential("CLI E2E", () => {
   }, 180_000);
 
   it("covers connections, followups, and keepalive commands", async () => {
-    if (!availability.canRun || !fixtures) {
+    if (!e2e.canRun()) {
       return;
     }
+    const fixtures = e2e.fixtures();
 
     const connectionsList = await runCliCommand([
       "connections",
@@ -327,9 +315,10 @@ describe.sequential("CLI E2E", () => {
   }, 180_000);
 
   it("covers feed, post, profile, search, jobs, and notifications commands", async () => {
-    if (!availability.canRun || !fixtures) {
+    if (!e2e.canRun()) {
       return;
     }
+    const fixtures = e2e.fixtures();
 
     const feedList = await runCliCommand([
       "feed",

--- a/packages/core/src/__tests__/e2e/connections-write.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/connections-write.e2e.test.ts
@@ -1,40 +1,24 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
+  expectPreparedAction,
   getConnectionConfirmMode,
   getDefaultConnectionTarget,
-  getWriteConfirmGate
+  isOptInEnabled
 } from "./helpers.js";
-import {
-  checkAuthenticated,
-  checkCdpAvailable,
-  cleanupRuntime,
-  getRuntime
-} from "./setup.js";
+import { setupE2ESuite } from "./setup.js";
 
 const connectionConfirmMode = getConnectionConfirmMode();
 const connectionConfirmEnabled =
-  getWriteConfirmGate("LINKEDIN_E2E_ENABLE_CONNECTION_CONFIRM").enabled &&
+  isOptInEnabled("LINKEDIN_E2E_ENABLE_CONNECTION_CONFIRM") &&
   ["invite", "accept", "withdraw"].includes(connectionConfirmMode);
 const connectionConfirmTest = connectionConfirmEnabled ? it : it.skip;
 
 describe("Connections Write E2E (2PC invitation flows)", () => {
-  let cdpOk = false;
-  let authOk = false;
-
-  beforeAll(async () => {
-    cdpOk = await checkCdpAvailable();
-    if (cdpOk) {
-      authOk = await checkAuthenticated();
-    }
-  });
-
-  afterAll(() => {
-    cleanupRuntime();
-  });
+  const e2e = setupE2ESuite();
 
   it("prepare returns valid previews for invite, accept, and withdraw", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const targetProfile = getDefaultConnectionTarget();
 
     const invite = runtime.connections.prepareSendInvitation({
@@ -49,16 +33,13 @@ describe("Connections Write E2E (2PC invitation flows)", () => {
     });
 
     for (const prepared of [invite, accept, withdraw]) {
-      expect(prepared.preparedActionId).toMatch(/^pa_/);
-      expect(prepared.confirmToken).toMatch(/^ct_/);
-      expect(prepared.preview).toHaveProperty("summary");
-      expect(prepared.preview).toHaveProperty("target");
+      expectPreparedAction(prepared);
     }
   });
 
   connectionConfirmTest("confirms the configured connection flow via prepare → confirm", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const targetProfile = getDefaultConnectionTarget();
 
     const prepared =

--- a/packages/core/src/__tests__/e2e/connections.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/connections.e2e.test.ts
@@ -1,29 +1,12 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  getRuntime,
-  checkCdpAvailable,
-  checkAuthenticated,
-  cleanupRuntime
-} from "./setup.js";
+import { describe, expect, it } from "vitest";
+import { setupE2ESuite } from "./setup.js";
 
 describe("Connections E2E", () => {
-  let cdpOk = false;
-  let authOk = false;
-
-  beforeAll(async () => {
-    cdpOk = await checkCdpAvailable();
-    if (cdpOk) {
-      authOk = await checkAuthenticated();
-    }
-  });
-
-  afterAll(() => {
-    cleanupRuntime();
-  });
+  const e2e = setupE2ESuite();
 
   it("list connections returns array with name, profile_url", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const connections = await runtime.connections.listConnections();
 
     expect(Array.isArray(connections)).toBe(true);
@@ -35,8 +18,8 @@ describe("Connections E2E", () => {
   });
 
   it("list with limit 5 returns <= 5 results", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const connections = await runtime.connections.listConnections({ limit: 5 });
 
     expect(connections.length).toBeLessThanOrEqual(5);

--- a/packages/core/src/__tests__/e2e/error-paths.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/error-paths.e2e.test.ts
@@ -1,7 +1,7 @@
 import os from "node:os";
 import path from "node:path";
 import { mkdtemp, rm } from "node:fs/promises";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { LinkedInAssistantError } from "../../errors.js";
 import { createCoreRuntime, type CoreRuntime } from "../../runtime.js";
 import {
@@ -9,12 +9,7 @@ import {
   type SelectorAuditPageDefinition
 } from "../../selectorAudit.js";
 import { getFeedPost } from "./helpers.js";
-import {
-  checkAuthenticated,
-  checkCdpAvailable,
-  cleanupRuntime,
-  getCdpUrl
-} from "./setup.js";
+import { getCdpUrl, setupE2ESuite } from "./setup.js";
 
 const LIKE_RATE_LIMIT_CONFIG = {
   counterKey: "linkedin.feed.like_post",
@@ -57,22 +52,10 @@ async function expectAssistantError(
 }
 
 describe("E2E error paths", () => {
-  let cdpOk = false;
-  let authOk = false;
-
-  beforeAll(async () => {
-    cdpOk = await checkCdpAvailable();
-    if (cdpOk) {
-      authOk = await checkAuthenticated();
-    }
-  });
-
-  afterAll(() => {
-    cleanupRuntime();
-  });
+  const e2e = setupE2ESuite();
 
   it("rejects expired confirmation tokens before execution", async () => {
-    if (!cdpOk || !authOk) return;
+    if (!e2e.canRun()) return;
 
     const isolated = await createIsolatedRuntime();
     try {
@@ -99,7 +82,7 @@ describe("E2E error paths", () => {
   }, 120_000);
 
   it("surfaces rate limit failures without performing the action", async () => {
-    if (!cdpOk || !authOk) return;
+    if (!e2e.canRun()) return;
 
     const isolated = await createIsolatedRuntime();
     try {
@@ -135,7 +118,7 @@ describe("E2E error paths", () => {
   }, 120_000);
 
   it("detects UI drift through selector audit failure artifacts", async () => {
-    if (!cdpOk || !authOk) return;
+    if (!e2e.canRun()) return;
 
     const isolated = await createIsolatedRuntime();
     try {

--- a/packages/core/src/__tests__/e2e/feed-like.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/feed-like.e2e.test.ts
@@ -1,42 +1,27 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
+  expectPreparedAction,
+  expectRateLimitPreview,
   getFeedPost,
   getOptInLikePostUrl,
-  getWriteConfirmGate
+  isOptInEnabled
 } from "./helpers.js";
-import {
-  checkAuthenticated,
-  checkCdpAvailable,
-  cleanupRuntime,
-  getRuntime
-} from "./setup.js";
+import { setupE2ESuite } from "./setup.js";
 
 const likeConfirmPostUrl = getOptInLikePostUrl();
 const likeConfirmTest =
-  getWriteConfirmGate("LINKEDIN_E2E_ENABLE_LIKE_CONFIRM").enabled &&
+  isOptInEnabled("LINKEDIN_E2E_ENABLE_LIKE_CONFIRM") &&
   typeof likeConfirmPostUrl === "string" &&
   likeConfirmPostUrl.length > 0
     ? it
     : it.skip;
 
 describe("Feed Like E2E (2PC like_post)", () => {
-  let cdpOk = false;
-  let authOk = false;
-
-  beforeAll(async () => {
-    cdpOk = await checkCdpAvailable();
-    if (cdpOk) {
-      authOk = await checkAuthenticated();
-    }
-  });
-
-  afterAll(() => {
-    cleanupRuntime();
-  });
+  const e2e = setupE2ESuite();
 
   it("prepare returns valid preview with rate limit info", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const post = await getFeedPost(runtime);
 
     const prepared = runtime.feed.prepareLikePost({
@@ -44,16 +29,12 @@ describe("Feed Like E2E (2PC like_post)", () => {
       reaction: "like"
     });
 
-    expect(prepared.preview).toHaveProperty("rate_limit");
-    const rateLimit = prepared.preview.rate_limit as Record<string, unknown>;
-    expect(rateLimit).toHaveProperty("counter_key", "linkedin.feed.like_post");
-    expect(typeof rateLimit.remaining).toBe("number");
-    expect(typeof rateLimit.allowed).toBe("boolean");
+    expectRateLimitPreview(prepared.preview, "linkedin.feed.like_post");
   }, 60_000);
 
   likeConfirmTest("likes a feed post via prepare → confirm", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const postUrl = likeConfirmPostUrl!;
     const prepared = runtime.feed.prepareLikePost({
       postUrl,
@@ -61,8 +42,7 @@ describe("Feed Like E2E (2PC like_post)", () => {
       operatorNote: "Automated E2E like write test"
     });
 
-    expect(prepared.preparedActionId).toMatch(/^pa_/);
-    expect(prepared.confirmToken).toMatch(/^ct_/);
+    expectPreparedAction(prepared);
 
     const result = await runtime.twoPhaseCommit.confirmByToken({
       confirmToken: prepared.confirmToken

--- a/packages/core/src/__tests__/e2e/feed-write.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/feed-write.e2e.test.ts
@@ -1,15 +1,17 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { getOptInCommentPostUrl, getWriteConfirmGate } from "./helpers.js";
+import { describe, expect, it } from "vitest";
 import {
-  getRuntime,
-  checkCdpAvailable,
-  checkAuthenticated,
-  cleanupRuntime
-} from "./setup.js";
+  expectPreparedAction,
+  expectPreparedOutboundText,
+  expectRateLimitPreview,
+  getFeedPost,
+  getOptInCommentPostUrl,
+  isOptInEnabled
+} from "./helpers.js";
+import { setupE2ESuite } from "./setup.js";
 
 const commentConfirmPostUrl = getOptInCommentPostUrl();
 const commentConfirmTest =
-  getWriteConfirmGate("LINKEDIN_E2E_ENABLE_COMMENT_CONFIRM").enabled &&
+  isOptInEnabled("LINKEDIN_E2E_ENABLE_COMMENT_CONFIRM") &&
   typeof commentConfirmPostUrl === "string" &&
   commentConfirmPostUrl.length > 0
     ? it
@@ -26,29 +28,16 @@ const commentConfirmTest =
  * Explicitly authorised by project owner (Joakim Sigvardt).
  */
 describe("Feed Write E2E (2PC comment_on_post)", () => {
-  let cdpOk = false;
-  let authOk = false;
-
-  beforeAll(async () => {
-    cdpOk = await checkCdpAvailable();
-    if (cdpOk) {
-      authOk = await checkAuthenticated();
-    }
-  });
-
-  afterAll(() => {
-    cleanupRuntime();
-  });
+  const e2e = setupE2ESuite();
 
   commentConfirmTest("comments on a feed post via prepare → confirm", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
 
     const targetPostUrl = commentConfirmPostUrl!;
 
     expect(targetPostUrl).toContain("linkedin.com");
 
-    // Step 2: prepare a comment via 2PC
     const timestamp = new Date().toISOString();
     const commentText = `E2E test comment from linkedin-owa-agentools [${timestamp}]`;
 
@@ -58,20 +47,9 @@ describe("Feed Write E2E (2PC comment_on_post)", () => {
       operatorNote: "Automated E2E feed write test"
     });
 
-    expect(prepared.preparedActionId).toBeTruthy();
-    expect(prepared.preparedActionId).toMatch(/^pa_/);
-    expect(prepared.confirmToken).toBeTruthy();
-    expect(prepared.confirmToken).toMatch(/^ct_/);
-    expect(prepared.expiresAtMs).toBeGreaterThan(Date.now());
-    expect(prepared.preview).toBeDefined();
-    expect(prepared.preview).toHaveProperty("summary");
-    expect(prepared.preview).toHaveProperty("target");
-    expect(prepared.preview).toHaveProperty("outbound");
+    expectPreparedAction(prepared);
+    expectPreparedOutboundText(prepared, commentText);
 
-    const outbound = prepared.preview.outbound as { text: string };
-    expect(outbound.text).toBe(commentText);
-
-    // Step 3: confirm the action (execute the comment)
     const result = await runtime.twoPhaseCommit.confirmByToken({
       confirmToken: prepared.confirmToken
     });
@@ -84,24 +62,14 @@ describe("Feed Write E2E (2PC comment_on_post)", () => {
   }, 120_000);
 
   it("prepare returns valid preview with rate limit info", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
-
-    const posts = await runtime.feed.viewFeed({ limit: 5 });
-    if (posts.length === 0) return;
-
-    const targetPost = posts[0]!;
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
+    const targetPost = await getFeedPost(runtime);
     const prepared = runtime.feed.prepareCommentOnPost({
       postUrl: targetPost.post_url,
       text: "E2E preview-only test (will not confirm)"
     });
 
-    expect(prepared.preview).toHaveProperty("rate_limit");
-    const rateLimit = prepared.preview.rate_limit as Record<string, unknown>;
-    expect(rateLimit).toHaveProperty("counter_key", "linkedin.feed.comment_on_post");
-    expect(typeof rateLimit.remaining).toBe("number");
-    expect(typeof rateLimit.allowed).toBe("boolean");
-
-    // Intentionally not confirmed; will expire naturally.
+    expectRateLimitPreview(prepared.preview, "linkedin.feed.comment_on_post");
   }, 60_000);
 });

--- a/packages/core/src/__tests__/e2e/feed.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/feed.e2e.test.ts
@@ -1,29 +1,12 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  getRuntime,
-  checkCdpAvailable,
-  checkAuthenticated,
-  cleanupRuntime
-} from "./setup.js";
+import { describe, expect, it } from "vitest";
+import { setupE2ESuite } from "./setup.js";
 
 describe("Feed E2E", () => {
-  let cdpOk = false;
-  let authOk = false;
-
-  beforeAll(async () => {
-    cdpOk = await checkCdpAvailable();
-    if (cdpOk) {
-      authOk = await checkAuthenticated();
-    }
-  });
-
-  afterAll(() => {
-    cleanupRuntime();
-  });
+  const e2e = setupE2ESuite();
 
   it("view feed returns posts array with author, text", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const posts = await runtime.feed.viewFeed({ limit: 5 });
 
     expect(Array.isArray(posts)).toBe(true);
@@ -35,8 +18,8 @@ describe("Feed E2E", () => {
   });
 
   it("view feed with limit respects parameter", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const posts = await runtime.feed.viewFeed({ limit: 3 });
 
     expect(posts.length).toBeLessThanOrEqual(3);

--- a/packages/core/src/__tests__/e2e/health.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/health.e2e.test.ts
@@ -1,11 +1,5 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  getRuntime,
-  getCdpUrl,
-  checkCdpAvailable,
-  checkAuthenticated,
-  cleanupRuntime
-} from "./setup.js";
+import { describe, expect, it } from "vitest";
+import { getCdpUrl, setupE2ESuite } from "./setup.js";
 import { CDPConnectionPool } from "../../connectionPool.js";
 import {
   SessionKeepAliveService,
@@ -13,23 +7,11 @@ import {
 } from "../../keepAlive.js";
 
 describe("Health E2E", () => {
-  let cdpOk = false;
-  let authOk = false;
-
-  beforeAll(async () => {
-    cdpOk = await checkCdpAvailable();
-    if (cdpOk) {
-      authOk = await checkAuthenticated();
-    }
-  });
-
-  afterAll(() => {
-    cleanupRuntime();
-  });
+  const e2e = setupE2ESuite();
 
   it("browser health returns healthy: true", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const health = await runtime.healthCheck();
 
     expect(health.browser.healthy).toBe(true);
@@ -38,8 +20,8 @@ describe("Health E2E", () => {
   });
 
   it("session health returns authenticated: true", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const health = await runtime.healthCheck();
 
     expect(health.session.authenticated).toBe(true);
@@ -48,22 +30,10 @@ describe("Health E2E", () => {
 });
 
 describe("KeepAlive E2E", () => {
-  let cdpOk = false;
-  let authOk = false;
-
-  beforeAll(async () => {
-    cdpOk = await checkCdpAvailable();
-    if (cdpOk) {
-      authOk = await checkAuthenticated();
-    }
-  });
-
-  afterAll(() => {
-    cleanupRuntime();
-  });
+  const e2e = setupE2ESuite();
 
   it("starts, emits health-event, and stops cleanly", async () => {
-    if (!cdpOk || !authOk) return;
+    if (!e2e.canRun()) return;
 
     const pool = new CDPConnectionPool({ idleTimeoutMs: 60_000 });
     const service = new SessionKeepAliveService(pool, {

--- a/packages/core/src/__tests__/e2e/helpers.ts
+++ b/packages/core/src/__tests__/e2e/helpers.ts
@@ -2,6 +2,7 @@ import type { CoreRuntime } from "../../runtime.js";
 import { TEST_ECHO_ACTION_TYPE } from "../../twoPhaseCommit.js";
 import { runCli } from "../../../../cli/src/bin/linkedin.js";
 import { handleToolCall } from "../../../../mcp/src/bin/linkedin-mcp.js";
+import { expect } from "vitest";
 import {
   LINKEDIN_ACTIONS_CONFIRM_TOOL,
   LINKEDIN_CONNECTIONS_ACCEPT_TOOL,
@@ -41,9 +42,11 @@ export interface MappedMcpResult {
   isError: boolean;
 }
 
-export interface ConfirmGateConfig {
-  enabled: boolean;
-  reason: string;
+export interface PreparedActionResult {
+  preparedActionId: string;
+  confirmToken: string;
+  expiresAtMs?: number;
+  preview: Record<string, unknown>;
 }
 
 const DEFAULT_PROFILE_NAME = process.env.LINKEDIN_E2E_PROFILE ?? "default";
@@ -167,12 +170,8 @@ export function getDefaultMessageTargetPattern(): RegExp {
   return new RegExp(DEFAULT_MESSAGE_TARGET_PATTERN, "i");
 }
 
-export function getWriteConfirmGate(name: string): ConfirmGateConfig {
-  const enabled = readEnabledFlag(name);
-  return {
-    enabled,
-    reason: enabled ? `${name} is enabled.` : `${name} is not enabled.`
-  };
+export function isOptInEnabled(name: string): boolean {
+  return readEnabledFlag(name);
 }
 
 export function getConnectionConfirmMode(): string {
@@ -251,6 +250,45 @@ export async function callMcpTool(
     payload: payload as Record<string, unknown>,
     isError: "isError" in rawResult && rawResult.isError === true
   };
+}
+
+function asRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+
+  return value as Record<string, unknown>;
+}
+
+export function expectPreparedAction(prepared: PreparedActionResult): void {
+  expect(prepared.preparedActionId).toMatch(/^pa_/);
+  expect(prepared.confirmToken).toMatch(/^ct_/);
+  if (typeof prepared.expiresAtMs === "number") {
+    expect(prepared.expiresAtMs).toBeGreaterThan(Date.now());
+  }
+  expect(prepared.preview).toHaveProperty("summary");
+  expect(prepared.preview).toHaveProperty("target");
+}
+
+export function expectPreparedOutboundText(
+  prepared: PreparedActionResult,
+  text: string
+): void {
+  const outbound = asRecord(prepared.preview.outbound, "prepared.preview.outbound");
+
+  expect(outbound.text).toBe(text);
+}
+
+export function expectRateLimitPreview(
+  preview: Record<string, unknown>,
+  counterKey: string
+): void {
+  expect(preview).toHaveProperty("rate_limit");
+
+  const rateLimit = asRecord(preview.rate_limit, "prepared.preview.rate_limit");
+  expect(rateLimit).toHaveProperty("counter_key", counterKey);
+  expect(typeof rateLimit.remaining).toBe("number");
+  expect(typeof rateLimit.allowed).toBe("boolean");
 }
 
 export function prepareEchoAction(
@@ -358,7 +396,6 @@ export async function getJob(runtime: CoreRuntime): Promise<{
 
 export async function getCliCoverageFixtures(runtime: CoreRuntime): Promise<{
   threadId: string;
-  threadUrl: string;
   postUrl: string;
   jobId: string;
   connectionTarget: string;
@@ -369,25 +406,10 @@ export async function getCliCoverageFixtures(runtime: CoreRuntime): Promise<{
 
   return {
     threadId: thread.thread_id,
-    threadUrl: thread.thread_url,
     postUrl: post.post_url,
     jobId: job.job_id,
     connectionTarget: DEFAULT_CONNECTION_TARGET
   };
-}
-
-export async function prepareMessageReply(runtime: CoreRuntime): Promise<{
-  preparedActionId: string;
-  confirmToken: string;
-  expiresAtMs: number;
-  preview: Record<string, unknown>;
-}> {
-  const thread = await getMessageThread(runtime);
-  return runtime.inbox.prepareReply({
-    profileName: DEFAULT_PROFILE_NAME,
-    thread: thread.thread_id,
-    text: `E2E preview message [${new Date().toISOString()}]`
-  });
 }
 
 export const MCP_TOOL_NAMES = {

--- a/packages/core/src/__tests__/e2e/inbox-write.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/inbox-write.e2e.test.ts
@@ -1,15 +1,14 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { getWriteConfirmGate } from "./helpers.js";
+import { describe, expect, it } from "vitest";
 import {
-  getRuntime,
-  checkCdpAvailable,
-  checkAuthenticated,
-  cleanupRuntime
-} from "./setup.js";
+  expectPreparedAction,
+  expectPreparedOutboundText,
+  expectRateLimitPreview,
+  getMessageThread,
+  isOptInEnabled
+} from "./helpers.js";
+import { setupE2ESuite } from "./setup.js";
 
-const messageConfirmTest = getWriteConfirmGate(
-  "LINKEDIN_E2E_ENABLE_MESSAGE_CONFIRM"
-).enabled
+const messageConfirmTest = isOptInEnabled("LINKEDIN_E2E_ENABLE_MESSAGE_CONFIRM")
   ? it
   : it.skip;
 
@@ -24,34 +23,14 @@ const messageConfirmTest = getWriteConfirmGate(
  * Opt in with LINKEDIN_E2E_ENABLE_MESSAGE_CONFIRM=1.
  */
 describe("Inbox Write E2E (2PC send_message)", () => {
-  let cdpOk = false;
-  let authOk = false;
-
-  beforeAll(async () => {
-    cdpOk = await checkCdpAvailable();
-    if (cdpOk) {
-      authOk = await checkAuthenticated();
-    }
-  });
-
-  afterAll(() => {
-    cleanupRuntime();
-  });
+  const e2e = setupE2ESuite();
 
   messageConfirmTest("sends a message to Simon Miller via prepare → confirm", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
 
-    // Step 1: find Simon Miller's thread
-    const threads = await runtime.inbox.listThreads({ limit: 40 });
-    const simonThread = threads.find((t) =>
-      /simon\s*miller/i.test(t.title)
-    );
+    const simonThread = await getMessageThread(runtime);
 
-    expect(simonThread).toBeDefined();
-    if (!simonThread) return; // type guard
-
-    // Step 2: prepare a reply via 2PC
     const timestamp = new Date().toISOString();
     const messageText = `E2E test message from linkedin-owa-agentools [${timestamp}]`;
 
@@ -61,20 +40,9 @@ describe("Inbox Write E2E (2PC send_message)", () => {
       operatorNote: "Automated E2E write test"
     });
 
-    expect(prepared.preparedActionId).toBeTruthy();
-    expect(prepared.preparedActionId).toMatch(/^pa_/);
-    expect(prepared.confirmToken).toBeTruthy();
-    expect(prepared.confirmToken).toMatch(/^ct_/);
-    expect(prepared.expiresAtMs).toBeGreaterThan(Date.now());
-    expect(prepared.preview).toBeDefined();
-    expect(prepared.preview).toHaveProperty("summary");
-    expect(prepared.preview).toHaveProperty("target");
-    expect(prepared.preview).toHaveProperty("outbound");
+    expectPreparedAction(prepared);
+    expectPreparedOutboundText(prepared, messageText);
 
-    const outbound = prepared.preview.outbound as { text: string };
-    expect(outbound.text).toBe(messageText);
-
-    // Step 3: confirm the action (execute the send)
     const result = await runtime.twoPhaseCommit.confirmByToken({
       confirmToken: prepared.confirmToken
     });
@@ -86,26 +54,15 @@ describe("Inbox Write E2E (2PC send_message)", () => {
   }, 120_000);
 
   it("prepare returns valid preview with rate limit info", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
-
-    const threads = await runtime.inbox.listThreads({ limit: 40 });
-    const simonThread = threads.find((t) =>
-      /simon\s*miller/i.test(t.title)
-    );
-    if (!simonThread) return;
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
+    const simonThread = await getMessageThread(runtime);
 
     const prepared = await runtime.inbox.prepareReply({
       thread: simonThread.thread_id,
       text: "E2E preview-only test (will not confirm)"
     });
 
-    expect(prepared.preview).toHaveProperty("rate_limit");
-    const rateLimit = prepared.preview.rate_limit as Record<string, unknown>;
-    expect(rateLimit).toHaveProperty("counter_key", "linkedin.messaging.send_message");
-    expect(typeof rateLimit.remaining).toBe("number");
-    expect(typeof rateLimit.allowed).toBe("boolean");
-
-    // We intentionally do NOT confirm this one; it will expire naturally.
+    expectRateLimitPreview(prepared.preview, "linkedin.messaging.send_message");
   }, 60_000);
 });

--- a/packages/core/src/__tests__/e2e/inbox.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/inbox.e2e.test.ts
@@ -1,29 +1,12 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  getRuntime,
-  checkCdpAvailable,
-  checkAuthenticated,
-  cleanupRuntime
-} from "./setup.js";
+import { describe, expect, it } from "vitest";
+import { setupE2ESuite } from "./setup.js";
 
 describe("Inbox E2E", () => {
-  let cdpOk = false;
-  let authOk = false;
-
-  beforeAll(async () => {
-    cdpOk = await checkCdpAvailable();
-    if (cdpOk) {
-      authOk = await checkAuthenticated();
-    }
-  });
-
-  afterAll(() => {
-    cleanupRuntime();
-  });
+  const e2e = setupE2ESuite();
 
   it("list threads returns array with thread_id, title", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const threads = await runtime.inbox.listThreads({ limit: 20 });
 
     expect(Array.isArray(threads)).toBe(true);
@@ -35,8 +18,8 @@ describe("Inbox E2E", () => {
   });
 
   it("list with limit respects parameter", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const threads = await runtime.inbox.listThreads({ limit: 5 });
 
     expect(threads.length).toBeLessThanOrEqual(5);

--- a/packages/core/src/__tests__/e2e/jobs.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/jobs.e2e.test.ts
@@ -1,29 +1,12 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  getRuntime,
-  checkCdpAvailable,
-  checkAuthenticated,
-  cleanupRuntime
-} from "./setup.js";
+import { describe, expect, it } from "vitest";
+import { setupE2ESuite } from "./setup.js";
 
 describe("Jobs E2E", () => {
-  let cdpOk = false;
-  let authOk = false;
-
-  beforeAll(async () => {
-    cdpOk = await checkCdpAvailable();
-    if (cdpOk) {
-      authOk = await checkAuthenticated();
-    }
-  });
-
-  afterAll(() => {
-    cleanupRuntime();
-  });
+  const e2e = setupE2ESuite();
 
   it("search jobs returns structured results with count", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const result = await runtime.jobs.searchJobs({
       query: "software engineer",
       limit: 5

--- a/packages/core/src/__tests__/e2e/mcp.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/mcp.e2e.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   callMcpTool,
   getCliCoverageFixtures,
@@ -7,31 +7,17 @@ import {
   MCP_TOOL_NAMES,
   prepareEchoAction
 } from "./helpers.js";
-import {
-  cleanupRuntime,
-  getE2EAvailability,
-  getRuntime,
-  type E2EAvailability
-} from "./setup.js";
+import { setupE2ESuite } from "./setup.js";
 
 describe.sequential("MCP E2E", () => {
-  let availability: E2EAvailability;
-  let fixtures: Awaited<ReturnType<typeof getCliCoverageFixtures>> | undefined;
+  const e2e = setupE2ESuite({
+    fixtures: getCliCoverageFixtures,
+    timeoutMs: 180_000
+  });
   const profileName = getDefaultProfileName();
 
-  beforeAll(async () => {
-    availability = await getE2EAvailability();
-    if (availability.canRun) {
-      fixtures = await getCliCoverageFixtures(getRuntime());
-    }
-  }, 180_000);
-
-  afterAll(() => {
-    cleanupRuntime();
-  });
-
   it("covers session tools", async () => {
-    if (!availability.canRun || !fixtures) {
+    if (!e2e.canRun()) {
       return;
     }
 
@@ -75,9 +61,10 @@ describe.sequential("MCP E2E", () => {
   }, 120_000);
 
   it("covers inbox, connections, and followup tools", async () => {
-    if (!availability.canRun || !fixtures) {
+    if (!e2e.canRun()) {
       return;
     }
+    const fixtures = e2e.fixtures();
 
     const inboxList = await callMcpTool(MCP_TOOL_NAMES.inboxListThreads, {
       profileName,
@@ -165,9 +152,10 @@ describe.sequential("MCP E2E", () => {
   }, 180_000);
 
   it("covers feed, post, actions confirm, and notifications tools", async () => {
-    if (!availability.canRun || !fixtures) {
+    if (!e2e.canRun()) {
       return;
     }
+    const fixtures = e2e.fixtures();
 
     const feedList = await callMcpTool(MCP_TOOL_NAMES.feedList, {
       profileName,
@@ -227,7 +215,7 @@ describe.sequential("MCP E2E", () => {
       confirmToken: expect.stringMatching(/^ct_/)
     });
 
-    const runtime = getRuntime();
+    const runtime = e2e.runtime();
     const preparedConfirm = prepareEchoAction(runtime, {
       profileName,
       summary: "MCP actions.confirm echo"
@@ -259,9 +247,10 @@ describe.sequential("MCP E2E", () => {
   }, 180_000);
 
   it("covers profile, search, and jobs tools", async () => {
-    if (!availability.canRun || !fixtures) {
+    if (!e2e.canRun()) {
       return;
     }
+    const fixtures = e2e.fixtures();
 
     const profile = await callMcpTool(MCP_TOOL_NAMES.profileView, {
       profileName,

--- a/packages/core/src/__tests__/e2e/notifications.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/notifications.e2e.test.ts
@@ -1,29 +1,12 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  getRuntime,
-  checkCdpAvailable,
-  checkAuthenticated,
-  cleanupRuntime
-} from "./setup.js";
+import { describe, expect, it } from "vitest";
+import { setupE2ESuite } from "./setup.js";
 
 describe("Notifications E2E", () => {
-  let cdpOk = false;
-  let authOk = false;
-
-  beforeAll(async () => {
-    cdpOk = await checkCdpAvailable();
-    if (cdpOk) {
-      authOk = await checkAuthenticated();
-    }
-  });
-
-  afterAll(() => {
-    cleanupRuntime();
-  });
+  const e2e = setupE2ESuite();
 
   it("list notifications does not error, returns array", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const notifications = await runtime.notifications.listNotifications({ limit: 5 });
 
     expect(Array.isArray(notifications)).toBe(true);

--- a/packages/core/src/__tests__/e2e/post-write.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/post-write.e2e.test.ts
@@ -1,12 +1,13 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
-  getRuntime,
-  checkCdpAvailable,
-  checkAuthenticated,
-  cleanupRuntime
-} from "./setup.js";
+  expectPreparedAction,
+  expectPreparedOutboundText,
+  expectRateLimitPreview,
+  isOptInEnabled
+} from "./helpers.js";
+import { setupE2ESuite } from "./setup.js";
 
-const writeTest = process.env.LINKEDIN_ENABLE_POST_WRITE_E2E === "1" ? it : it.skip;
+const writeTest = isOptInEnabled("LINKEDIN_ENABLE_POST_WRITE_E2E") ? it : it.skip;
 
 /**
  * Post Write E2E — two-phase commit create a LinkedIn post.
@@ -17,23 +18,11 @@ const writeTest = process.env.LINKEDIN_ENABLE_POST_WRITE_E2E === "1" ? it : it.s
  * Flow: posts.prepareCreate → twoPhaseCommit.confirmByToken
  */
 describe("Post Write E2E (2PC post.create)", () => {
-  let cdpOk = false;
-  let authOk = false;
-
-  beforeAll(async () => {
-    cdpOk = await checkCdpAvailable();
-    if (cdpOk) {
-      authOk = await checkAuthenticated();
-    }
-  });
-
-  afterAll(() => {
-    cleanupRuntime();
-  });
+  const e2e = setupE2ESuite();
 
   writeTest("creates a public post via prepare → confirm", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const timestamp = new Date().toISOString();
     const postText = `E2E post from linkedin-owa-agentools [${timestamp}]`;
 
@@ -43,13 +32,8 @@ describe("Post Write E2E (2PC post.create)", () => {
       operatorNote: "Automated E2E post write test"
     });
 
-    expect(prepared.preparedActionId).toBeTruthy();
-    expect(prepared.preparedActionId).toMatch(/^pa_/);
-    expect(prepared.confirmToken).toBeTruthy();
-    expect(prepared.confirmToken).toMatch(/^ct_/);
-    expect(prepared.preview).toHaveProperty("summary");
-    expect(prepared.preview).toHaveProperty("target");
-    expect(prepared.preview).toHaveProperty("outbound");
+    expectPreparedAction(prepared);
+    expectPreparedOutboundText(prepared, postText);
 
     const result = await runtime.twoPhaseCommit.confirmByToken({
       confirmToken: prepared.confirmToken
@@ -64,17 +48,13 @@ describe("Post Write E2E (2PC post.create)", () => {
   }, 180_000);
 
   it("prepare returns valid preview with rate limit info", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const prepared = await runtime.posts.prepareCreate({
       text: `E2E preview-only post [${new Date().toISOString()}]`,
       visibility: "public"
     });
 
-    expect(prepared.preview).toHaveProperty("rate_limit");
-    const rateLimit = prepared.preview.rate_limit as Record<string, unknown>;
-    expect(rateLimit).toHaveProperty("counter_key", "linkedin.post.create");
-    expect(typeof rateLimit.remaining).toBe("number");
-    expect(typeof rateLimit.allowed).toBe("boolean");
+    expectRateLimitPreview(prepared.preview, "linkedin.post.create");
   }, 60_000);
 });

--- a/packages/core/src/__tests__/e2e/profile.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/profile.e2e.test.ts
@@ -1,29 +1,12 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  getRuntime,
-  checkCdpAvailable,
-  checkAuthenticated,
-  cleanupRuntime
-} from "./setup.js";
+import { describe, expect, it } from "vitest";
+import { setupE2ESuite } from "./setup.js";
 
 describe("Profile E2E", () => {
-  let cdpOk = false;
-  let authOk = false;
-
-  beforeAll(async () => {
-    cdpOk = await checkCdpAvailable();
-    if (cdpOk) {
-      authOk = await checkAuthenticated();
-    }
-  });
-
-  afterAll(() => {
-    cleanupRuntime();
-  });
+  const e2e = setupE2ESuite();
 
   it("view own profile (me) returns full_name, headline, profile_url", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const profile = await runtime.profile.viewProfile({ target: "me" });
 
     expect(profile.full_name.length).toBeGreaterThan(0);
@@ -32,8 +15,8 @@ describe("Profile E2E", () => {
   });
 
   it("view target profile (realsimonmiller) returns structured data", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const profile = await runtime.profile.viewProfile({ target: "realsimonmiller" });
 
     expect(typeof profile.full_name).toBe("string");

--- a/packages/core/src/__tests__/e2e/search.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/search.e2e.test.ts
@@ -1,29 +1,12 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  getRuntime,
-  checkCdpAvailable,
-  checkAuthenticated,
-  cleanupRuntime
-} from "./setup.js";
+import { describe, expect, it } from "vitest";
+import { setupE2ESuite } from "./setup.js";
 
 describe("Search E2E", () => {
-  let cdpOk = false;
-  let authOk = false;
-
-  beforeAll(async () => {
-    cdpOk = await checkCdpAvailable();
-    if (cdpOk) {
-      authOk = await checkAuthenticated();
-    }
-  });
-
-  afterAll(() => {
-    cleanupRuntime();
-  });
+  const e2e = setupE2ESuite();
 
   it("search people Simon Miller returns results with name, headline", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const result = await runtime.search.search({
       query: "Simon Miller",
       category: "people",
@@ -44,8 +27,8 @@ describe("Search E2E", () => {
   });
 
   it("search companies Power International returns results", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const result = await runtime.search.search({
       query: "Power International",
       category: "companies",
@@ -65,8 +48,8 @@ describe("Search E2E", () => {
   });
 
   it("search jobs software engineer copenhagen returns results", async () => {
-    if (!cdpOk || !authOk) return;
-    const runtime = getRuntime();
+    if (!e2e.canRun()) return;
+    const runtime = e2e.runtime();
     const result = await runtime.search.search({
       query: "software engineer copenhagen",
       category: "jobs",

--- a/packages/core/src/__tests__/e2e/setup.ts
+++ b/packages/core/src/__tests__/e2e/setup.ts
@@ -1,3 +1,4 @@
+import { afterAll, beforeAll } from "vitest";
 import { createCoreRuntime, type CoreRuntime } from "../../runtime.js";
 
 const CDP_URL = process.env.LINKEDIN_CDP_URL ?? "http://localhost:18800";
@@ -11,6 +12,25 @@ export interface E2EAvailability {
   canRun: boolean;
   reason: string;
 }
+
+export interface E2ESuite<TFixtures = void> {
+  availability(): E2EAvailability;
+  canRun(): boolean;
+  runtime(): CoreRuntime;
+  fixtures(): TFixtures;
+}
+
+interface E2ESuiteOptions<TFixtures> {
+  fixtures?: (runtime: CoreRuntime) => Promise<TFixtures>;
+  timeoutMs?: number;
+}
+
+const UNINITIALIZED_AVAILABILITY: E2EAvailability = {
+  cdpAvailable: false,
+  authenticated: false,
+  canRun: false,
+  reason: "E2E availability has not been initialized."
+};
 
 export function getRuntime(): CoreRuntime {
   if (!sharedRuntime) {
@@ -69,6 +89,42 @@ export async function getE2EAvailability(): Promise<E2EAvailability> {
   };
 
   return sharedAvailability;
+}
+
+export function setupE2ESuite<TFixtures = void>(
+  options: E2ESuiteOptions<TFixtures> = {}
+): E2ESuite<TFixtures> {
+  let availability = UNINITIALIZED_AVAILABILITY;
+  let suiteFixtures: TFixtures | undefined;
+
+  beforeAll(async () => {
+    availability = await getE2EAvailability();
+    if (availability.canRun && options.fixtures) {
+      suiteFixtures = await options.fixtures(getRuntime());
+    }
+  }, options.timeoutMs);
+
+  afterAll(() => {
+    cleanupRuntime();
+    availability = UNINITIALIZED_AVAILABILITY;
+    suiteFixtures = undefined;
+  });
+
+  return {
+    availability: () => availability,
+    canRun: () => availability.canRun,
+    runtime: () => getRuntime(),
+    fixtures: () => {
+      if (!options.fixtures) {
+        throw new Error("This E2E suite does not define fixtures.");
+      }
+      if (suiteFixtures === undefined) {
+        throw new Error("E2E fixtures are not available for this suite.");
+      }
+
+      return suiteFixtures;
+    }
+  };
 }
 
 export function cleanupRuntime(): void {

--- a/packages/mcp/src/bin/linkedin-mcp.ts
+++ b/packages/mcp/src/bin/linkedin-mcp.ts
@@ -53,6 +53,7 @@ type ToolErrorResult = {
   isError: true;
   content: Array<{ type: "text"; text: string }>;
 };
+type ToolHandler = (args: ToolArgs) => Promise<ToolResult>;
 
 const mcpPrivacyConfig = resolvePrivacyConfig();
 const SELECTOR_AUDIT_DOC_PATH = "docs/selector-audit.md";
@@ -1586,101 +1587,40 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
   };
 });
 
+const TOOL_HANDLERS: Record<string, ToolHandler> = {
+  [LINKEDIN_SESSION_STATUS_TOOL]: handleSessionStatus,
+  [LINKEDIN_SESSION_OPEN_LOGIN_TOOL]: handleSessionOpenLogin,
+  [LINKEDIN_SESSION_HEALTH_TOOL]: handleSessionHealth,
+  [LINKEDIN_INBOX_LIST_THREADS_TOOL]: handleListThreads,
+  [LINKEDIN_INBOX_GET_THREAD_TOOL]: handleGetThread,
+  [LINKEDIN_INBOX_PREPARE_REPLY_TOOL]: handlePrepareReply,
+  [LINKEDIN_PROFILE_VIEW_TOOL]: handleProfileView,
+  [LINKEDIN_SEARCH_TOOL]: handleSearch,
+  [LINKEDIN_CONNECTIONS_LIST_TOOL]: handleConnectionsList,
+  [LINKEDIN_CONNECTIONS_PENDING_TOOL]: handleConnectionsPending,
+  [LINKEDIN_CONNECTIONS_INVITE_TOOL]: handleConnectionsInvite,
+  [LINKEDIN_CONNECTIONS_ACCEPT_TOOL]: handleConnectionsAccept,
+  [LINKEDIN_CONNECTIONS_WITHDRAW_TOOL]: handleConnectionsWithdraw,
+  [LINKEDIN_NETWORK_PREPARE_FOLLOWUP_AFTER_ACCEPT_TOOL]: handlePrepareFollowupAfterAccept,
+  [LINKEDIN_FEED_LIST_TOOL]: handleFeedList,
+  [LINKEDIN_FEED_VIEW_POST_TOOL]: handleFeedViewPost,
+  [LINKEDIN_FEED_LIKE_TOOL]: handleFeedLike,
+  [LINKEDIN_FEED_COMMENT_TOOL]: handleFeedComment,
+  [LINKEDIN_POST_PREPARE_CREATE_TOOL]: handlePostPrepareCreate,
+  [LINKEDIN_NOTIFICATIONS_LIST_TOOL]: handleNotificationsList,
+  [LINKEDIN_JOBS_SEARCH_TOOL]: handleJobsSearch,
+  [LINKEDIN_JOBS_VIEW_TOOL]: handleJobsView,
+  [LINKEDIN_ACTIONS_CONFIRM_TOOL]: handleConfirm
+};
+
 export async function handleToolCall(
   name: string,
   args: ToolArgs = {}
 ): Promise<ToolResult | ToolErrorResult> {
   try {
-    if (name === LINKEDIN_SESSION_STATUS_TOOL) {
-      return await handleSessionStatus(args);
-    }
-
-    if (name === LINKEDIN_SESSION_OPEN_LOGIN_TOOL) {
-      return await handleSessionOpenLogin(args);
-    }
-
-    if (name === LINKEDIN_SESSION_HEALTH_TOOL) {
-      return await handleSessionHealth(args);
-    }
-
-    if (name === LINKEDIN_INBOX_LIST_THREADS_TOOL) {
-      return await handleListThreads(args);
-    }
-
-    if (name === LINKEDIN_INBOX_GET_THREAD_TOOL) {
-      return await handleGetThread(args);
-    }
-
-    if (name === LINKEDIN_INBOX_PREPARE_REPLY_TOOL) {
-      return await handlePrepareReply(args);
-    }
-
-    if (name === LINKEDIN_PROFILE_VIEW_TOOL) {
-      return await handleProfileView(args);
-    }
-
-    if (name === LINKEDIN_SEARCH_TOOL) {
-      return await handleSearch(args);
-    }
-
-    if (name === LINKEDIN_CONNECTIONS_LIST_TOOL) {
-      return await handleConnectionsList(args);
-    }
-
-    if (name === LINKEDIN_CONNECTIONS_PENDING_TOOL) {
-      return await handleConnectionsPending(args);
-    }
-
-    if (name === LINKEDIN_CONNECTIONS_INVITE_TOOL) {
-      return await handleConnectionsInvite(args);
-    }
-
-    if (name === LINKEDIN_CONNECTIONS_ACCEPT_TOOL) {
-      return await handleConnectionsAccept(args);
-    }
-
-    if (name === LINKEDIN_CONNECTIONS_WITHDRAW_TOOL) {
-      return await handleConnectionsWithdraw(args);
-    }
-
-    if (name === LINKEDIN_NETWORK_PREPARE_FOLLOWUP_AFTER_ACCEPT_TOOL) {
-      return await handlePrepareFollowupAfterAccept(args);
-    }
-
-    if (name === LINKEDIN_FEED_LIST_TOOL) {
-      return await handleFeedList(args);
-    }
-
-    if (name === LINKEDIN_FEED_VIEW_POST_TOOL) {
-      return await handleFeedViewPost(args);
-    }
-
-    if (name === LINKEDIN_FEED_LIKE_TOOL) {
-      return await handleFeedLike(args);
-    }
-
-    if (name === LINKEDIN_FEED_COMMENT_TOOL) {
-      return await handleFeedComment(args);
-    }
-
-    if (name === LINKEDIN_POST_PREPARE_CREATE_TOOL) {
-      return await handlePostPrepareCreate(args);
-    }
-
-    if (name === LINKEDIN_NOTIFICATIONS_LIST_TOOL) {
-      return await handleNotificationsList(args);
-    }
-
-    if (name === LINKEDIN_JOBS_SEARCH_TOOL) {
-      return await handleJobsSearch(args);
-    }
-
-    if (name === LINKEDIN_JOBS_VIEW_TOOL) {
-      return await handleJobsView(args);
-    }
-
-    if (name === LINKEDIN_ACTIONS_CONFIRM_TOOL) {
-      return await handleConfirm(args);
+    const handler = TOOL_HANDLERS[name];
+    if (handler) {
+      return await handler(args);
     }
 
     return toErrorResult(`Unknown tool: ${name}`);
@@ -1689,16 +1629,13 @@ export async function handleToolCall(
   }
 }
 
-server.setRequestHandler(
-  CallToolRequestSchema,
-  async (request: CallToolRequest) => {
-    const name = request.params.name;
-    const args = (request.params.arguments ?? {}) as ToolArgs;
-    return handleToolCall(name, args);
-  }
-);
+server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
+  const name = request.params.name;
+  const args = (request.params.arguments ?? {}) as ToolArgs;
+  return handleToolCall(name, args);
+});
 
-export async function startLinkedInMcpServer(): Promise<void> {
+async function startLinkedInMcpServer(): Promise<void> {
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/scripts/run-e2e.js
+++ b/scripts/run-e2e.js
@@ -8,7 +8,6 @@ const DEFAULT_CDP_URL = "http://localhost:18800";
 const LINKEDIN_FEED_URL = "https://www.linkedin.com/feed/";
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const vitestEntrypoint = path.join(projectRoot, "node_modules", "vitest", "vitest.mjs");
-const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 
 function log(message) {
   process.stdout.write(`${message}\n`);
@@ -88,6 +87,18 @@ async function detectAuthenticatedSession(cdpUrl) {
   }
 }
 
+function waitForExit(child) {
+  return new Promise((resolve, reject) => {
+    child.on("exit", (exitCode, signal) => {
+      resolve({
+        exitCode: exitCode ?? 1,
+        signal: signal ?? null
+      });
+    });
+    child.on("error", reject);
+  });
+}
+
 async function main() {
   const cdpUrl = process.env.LINKEDIN_CDP_URL ?? DEFAULT_CDP_URL;
   const availability = await detectAuthenticatedSession(cdpUrl);
@@ -98,24 +109,6 @@ async function main() {
   }
 
   log(`[e2e] ${availability.reason}`);
-  log("[e2e] Building workspace before running E2E tests.");
-
-  const build = spawn(npmCommand, ["run", "build"], {
-    cwd: projectRoot,
-    stdio: "inherit",
-    env: process.env
-  });
-
-  const buildCode = await new Promise((resolve, reject) => {
-    build.on("exit", (code) => resolve(code ?? 1));
-    build.on("error", reject);
-  });
-
-  if (buildCode !== 0) {
-    log(`[e2e] Build failed with exit code ${buildCode}.`);
-    process.exit(Number(buildCode));
-  }
-
   log("[e2e] Running Vitest E2E suite.");
 
   const child = spawn(
@@ -132,18 +125,20 @@ async function main() {
     }
   );
 
-  child.on("exit", (code, signal) => {
-    if (signal) {
-      process.kill(process.pid, signal);
-      return;
-    }
-    process.exit(code ?? 1);
-  });
-
-  child.on("error", (error) => {
+  let result;
+  try {
+    result = await waitForExit(child);
+  } catch (error) {
     log(`[e2e] Failed to start Vitest: ${summarizeError(error)}`);
     process.exit(1);
-  });
+  }
+
+  if (result.signal) {
+    process.kill(process.pid, result.signal);
+    return;
+  }
+
+  process.exit(result.exitCode);
 }
 
 void main();


### PR DESCRIPTION
## Summary\n- consolidate shared E2E availability setup behind a reusable suite helper\n- extract shared 2PC test assertions and reuse them across write-focused E2E specs\n- simplify the E2E runner and trim the MCP bin testability surface to the necessary pieces\n\n## Validation\n- npm run typecheck\n- npm run lint\n- npm test\n- npm run build\n- npm run test:e2e *(skipped: CDP endpoint unavailable at http://localhost:18800)*\n\nCloses #52