### PR TITLE
refactor: simplify selector locale fallback plumbing

### DIFF
--- a/packages/core/src/__tests__/selectorLocale.test.ts
+++ b/packages/core/src/__tests__/selectorLocale.test.ts
@@ -27,6 +27,14 @@ describe("getLinkedInSelectorPhrases", () => {
     ]);
   });
 
+  it("uses english base phrases when a locale has no override", () => {
+    expect(
+      getLinkedInSelectorPhrases("send", "da", {
+        includeEnglishFallback: false
+      })
+    ).toEqual(["Send"]);
+  });
+
   it("deduplicates english fallback phrases when the locale already shares them", () => {
     expect(getLinkedInSelectorPhrases("send", "da")).toEqual(["Send"]);
   });

--- a/packages/core/src/auth/sessionInspection.ts
+++ b/packages/core/src/auth/sessionInspection.ts
@@ -15,13 +15,7 @@ export interface LinkedInSessionInspection {
 const LOGIN_FORM_SELECTOR = "input[name='session_key'], input#username";
 const CHECKPOINT_FORM_SELECTOR = "form[action*='checkpoint']";
 const AUTH_NAV_SELECTOR = "nav.global-nav";
-
-function createAuthProfileSelector(selectorLocale: LinkedInSelectorLocale): string {
-  return [
-    buildLinkedInAriaLabelContainsSelector("button", "me", selectorLocale),
-    "[data-control-name='nav.settings_view_profile']"
-  ].join(", ");
-}
+const AUTH_PROFILE_MENU_SELECTOR = "[data-control-name='nav.settings_view_profile']";
 
 async function isVisibleSafe(page: Page, selector: string): Promise<boolean> {
   try {
@@ -101,9 +95,13 @@ export async function inspectLinkedInSession(
   }
 
   const navVisible = await isVisibleSafe(page, AUTH_NAV_SELECTOR);
+  const profileMenuSelector = [
+    buildLinkedInAriaLabelContainsSelector("button", "me", selectorLocale),
+    AUTH_PROFILE_MENU_SELECTOR
+  ].join(", ");
   const profileMenuVisible = await isVisibleSafe(
     page,
-    createAuthProfileSelector(selectorLocale)
+    profileMenuSelector
   );
   const sessionCookiePresent = await hasSessionCookie(page);
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -2,7 +2,6 @@ import { mkdirSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
-  DEFAULT_LINKEDIN_SELECTOR_LOCALE,
   resolveLinkedInSelectorLocale,
   type LinkedInSelectorLocale
 } from "./selectorLocale.js";
@@ -78,7 +77,6 @@ export function resolveLinkedInSelectorLocaleConfig(
   selectorLocale?: string | LinkedInSelectorLocale
 ): LinkedInSelectorLocale {
   return resolveLinkedInSelectorLocale(
-    selectorLocale ?? process.env[LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV],
-    DEFAULT_LINKEDIN_SELECTOR_LOCALE
+    selectorLocale ?? process.env[LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV]
   );
 }

--- a/packages/core/src/selectorLocale.ts
+++ b/packages/core/src/selectorLocale.ts
@@ -98,6 +98,8 @@ type SelectorPhraseDictionary = Record<
   readonly string[]
 >;
 
+type SelectorPhraseOverrides = Partial<SelectorPhraseDictionary>;
+
 const ENGLISH_SELECTOR_PHRASES: SelectorPhraseDictionary = {
   accept: ["Accept"],
   add_comment: ["Add a comment"],
@@ -154,8 +156,7 @@ const ENGLISH_SELECTOR_PHRASES: SelectorPhraseDictionary = {
   write_message: ["Write a message"]
 };
 
-const DANISH_SELECTOR_PHRASES: SelectorPhraseDictionary = {
-  ...ENGLISH_SELECTOR_PHRASES,
+const DANISH_SELECTOR_PHRASE_OVERRIDES: SelectorPhraseOverrides = {
   accept: ["Accepter"],
   add_comment: ["Tilføj en kommentar", "Skriv en kommentar"],
   add_note: ["Tilføj en note", "Tilføj en bemærkning"],
@@ -199,7 +200,6 @@ const DANISH_SELECTOR_PHRASES: SelectorPhraseDictionary = {
   resources: ["Ressourcer"],
   respond: ["Svar"],
   save: ["Gem"],
-  send: ["Send"],
   send_without_note: ["Send uden note", "Send uden en note"],
   start_post: ["Start et opslag", "Start et indlæg"],
   support: ["Støt", "Støtter"],
@@ -214,13 +214,37 @@ const DANISH_SELECTOR_PHRASES: SelectorPhraseDictionary = {
   write_message: ["Skriv en besked", "Skriv en meddelelse"]
 };
 
-const LINKEDIN_SELECTOR_PHRASES: Record<
+const LINKEDIN_SELECTOR_PHRASE_OVERRIDES: Record<
   LinkedInSelectorLocale,
-  SelectorPhraseDictionary
+  SelectorPhraseOverrides
 > = {
-  en: ENGLISH_SELECTOR_PHRASES,
-  da: DANISH_SELECTOR_PHRASES
+  en: {},
+  da: DANISH_SELECTOR_PHRASE_OVERRIDES
 };
+
+const LINKEDIN_SELECTOR_LOCALE_SET = new Set<LinkedInSelectorLocale>(
+  LINKEDIN_SELECTOR_LOCALES
+);
+
+function isLinkedInSelectorLocale(
+  value: string
+): value is LinkedInSelectorLocale {
+  return LINKEDIN_SELECTOR_LOCALE_SET.has(value as LinkedInSelectorLocale);
+}
+
+function getPrimaryLinkedInSelectorPhrases(
+  key: LinkedInSelectorPhraseKey,
+  locale: LinkedInSelectorLocale
+): readonly string[] {
+  if (locale === "en") {
+    return ENGLISH_SELECTOR_PHRASES[key];
+  }
+
+  return (
+    LINKEDIN_SELECTOR_PHRASE_OVERRIDES[locale][key] ??
+    ENGLISH_SELECTOR_PHRASES[key]
+  );
+}
 
 export function resolveLinkedInSelectorLocale(
   value: string | LinkedInSelectorLocale | undefined,
@@ -235,12 +259,8 @@ export function resolveLinkedInSelectorLocale(
     return fallback;
   }
 
-  const baseLocale = normalized.split(/[-_]/u)[0];
-  return LINKEDIN_SELECTOR_LOCALES.includes(
-    baseLocale as LinkedInSelectorLocale
-  )
-    ? (baseLocale as LinkedInSelectorLocale)
-    : fallback;
+  const [baseLocale = ""] = normalized.split(/[-_]/u);
+  return isLinkedInSelectorLocale(baseLocale) ? baseLocale : fallback;
 }
 
 interface SelectorPhraseOptions {
@@ -251,12 +271,27 @@ interface SelectorRegexOptions extends SelectorPhraseOptions {
   exact?: boolean;
 }
 
+interface ResolvedSelectorPhrasePattern {
+  phrases: string[];
+  body: string;
+}
+
 function normalizePhraseKeys(
   keys: LinkedInSelectorPhraseKey | readonly LinkedInSelectorPhraseKey[]
 ): LinkedInSelectorPhraseKey[] {
-  return Array.isArray(keys)
-    ? [...keys]
-    : [keys as LinkedInSelectorPhraseKey];
+  return typeof keys === "string" ? [keys] : [...keys];
+}
+
+function resolveLinkedInSelectorPhrasePattern(
+  keys: LinkedInSelectorPhraseKey | readonly LinkedInSelectorPhraseKey[],
+  locale: LinkedInSelectorLocale,
+  options: SelectorPhraseOptions = {}
+): ResolvedSelectorPhrasePattern {
+  const phrases = getLinkedInSelectorPhrases(keys, locale, options);
+  return {
+    phrases,
+    body: phrases.map((phrase) => escapeRegExp(phrase)).join("|") || "^$"
+  };
 }
 
 export function getLinkedInSelectorPhrases(
@@ -266,20 +301,17 @@ export function getLinkedInSelectorPhrases(
 ): string[] {
   const includeEnglishFallback = options.includeEnglishFallback ?? true;
   const normalizedKeys = normalizePhraseKeys(keys);
-  const localeDictionary = LINKEDIN_SELECTOR_PHRASES[locale];
 
-  const localizedValues = normalizedKeys.flatMap(
-    (key) => localeDictionary[key] ?? []
+  const primaryValues = normalizedKeys.flatMap((key) =>
+    getPrimaryLinkedInSelectorPhrases(key, locale)
   );
 
   if (!includeEnglishFallback || locale === "en") {
-    return dedupePhrases(localizedValues);
+    return dedupePhrases(primaryValues);
   }
 
-  const englishValues = normalizedKeys.flatMap(
-    (key) => ENGLISH_SELECTOR_PHRASES[key] ?? []
-  );
-  return dedupePhrases([...localizedValues, ...englishValues]);
+  const englishValues = normalizedKeys.flatMap((key) => ENGLISH_SELECTOR_PHRASES[key]);
+  return dedupePhrases([...primaryValues, ...englishValues]);
 }
 
 export function buildLinkedInSelectorPhraseRegex(
@@ -287,8 +319,7 @@ export function buildLinkedInSelectorPhraseRegex(
   locale: LinkedInSelectorLocale,
   options: SelectorRegexOptions = {}
 ): RegExp {
-  const phrases = getLinkedInSelectorPhrases(keys, locale, options);
-  const body = phrases.map((phrase) => escapeRegExp(phrase)).join("|") || "^$";
+  const { body } = resolveLinkedInSelectorPhrasePattern(keys, locale, options);
   const pattern = options.exact ? `^(?:${body})$` : `(?:${body})`;
   return new RegExp(pattern, "i");
 }
@@ -298,8 +329,7 @@ export function formatLinkedInSelectorRegexHint(
   locale: LinkedInSelectorLocale,
   options: SelectorRegexOptions = {}
 ): string {
-  const phrases = getLinkedInSelectorPhrases(keys, locale, options);
-  const body = phrases.map((phrase) => escapeRegExp(phrase)).join("|") || "^$";
+  const { body } = resolveLinkedInSelectorPhrasePattern(keys, locale, options);
   return options.exact ? `/^(?:${body})$/i` : `/${body}/i`;
 }
 
@@ -311,7 +341,7 @@ export function buildLinkedInAriaLabelContainsSelector(
   options: SelectorPhraseOptions = {}
 ): string {
   const selectors = Array.isArray(roots) ? roots : [roots];
-  const phrases = getLinkedInSelectorPhrases(keys, locale, options);
+  const { phrases } = resolveLinkedInSelectorPhrasePattern(keys, locale, options);
 
   return selectors
     .flatMap((root) =>


### PR DESCRIPTION
## Summary\n- keep English selector phrases as the single source of truth and let locale dictionaries only define translated overrides\n- centralize phrase-to-pattern compilation inside the selector locale helper to remove duplicated regex/hint work\n- add a regression test for keys that intentionally fall back to the English base phrase\n\n## Validation\n- npm run typecheck\n- npm run lint\n- npm test\n- npm run build\n\nCloses #55