### PR TITLE
refactor: simplify local data deletion flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ npm exec -w @linkedin-assistant/cli -- linkedin data delete --include-profile
 ```
 
 - `linkedin data delete` always requires an interactive terminal confirmation.
+- Stop any running keepalive daemons before deleting local state.
 - `--include-profile` prompts a second time before removing local browser profile data.
 
 ### Selector audit

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -34,6 +34,7 @@ import {
   resolveFollowupSinceWindow,
   redactStructuredValue,
   resolveConfigPaths,
+  resolveKeepAliveDir,
   resolvePrivacyConfig,
   toLinkedInAssistantErrorPayload,
   type DraftQualityReport,
@@ -163,9 +164,8 @@ function profileSlug(profileName: string): string {
 }
 
 function getKeepAliveFiles(profileName: string): KeepAliveFiles {
-  const baseDir = resolveConfigPaths().baseDir;
   const slug = profileSlug(profileName);
-  const dir = path.join(baseDir, "keepalive");
+  const dir = resolveKeepAliveDir();
   return {
     dir,
     pidPath: path.join(dir, `${slug}.pid`),
@@ -381,56 +381,8 @@ function printDeletionTargets(targetPaths: string[]): void {
   }
 }
 
-async function stopKeepAliveDaemonByPid(pid: number): Promise<void> {
-  if (!isProcessRunning(pid)) {
-    return;
-  }
-
-  try {
-    process.kill(pid, "SIGTERM");
-  } catch (error) {
-    throw new LinkedInAssistantError(
-      "UNKNOWN",
-      "Failed to stop a running keepalive daemon before deleting local data.",
-      {
-        pid,
-        cause: error instanceof Error ? error.message : String(error)
-      }
-    );
-  }
-
-  const deadline = Date.now() + 5_000;
-  while (Date.now() < deadline) {
-    await sleep(200);
-    if (!isProcessRunning(pid)) {
-      return;
-    }
-  }
-
-  try {
-    process.kill(pid, "SIGKILL");
-  } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      error.code === "ESRCH"
-    ) {
-      return;
-    }
-
-    throw new LinkedInAssistantError(
-      "UNKNOWN",
-      "Failed to force-stop a running keepalive daemon before deleting local data.",
-      {
-        pid,
-        cause: error instanceof Error ? error.message : String(error)
-      }
-    );
-  }
-}
-
-async function stopAllKeepAliveDaemons(): Promise<number[]> {
-  const keepAliveDir = path.join(resolveConfigPaths().baseDir, "keepalive");
+async function findRunningKeepAlivePids(): Promise<number[]> {
+  const keepAliveDir = resolveKeepAliveDir();
   let entries: Dirent[];
 
   try {
@@ -454,24 +406,64 @@ async function stopAllKeepAliveDaemons(): Promise<number[]> {
     }
 
     const pidFilePath = path.join(keepAliveDir, entry.name);
-    const rawPid = await readFile(pidFilePath, "utf8");
+    let rawPid: string;
+
+    try {
+      rawPid = await readFile(pidFilePath, "utf8");
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        continue;
+      }
+
+      throw error;
+    }
+
     const pid = Number.parseInt(rawPid.trim(), 10);
     if (Number.isInteger(pid) && pid > 0 && isProcessRunning(pid)) {
       runningPids.add(pid);
     }
   }
 
-  const stoppedPids: number[] = [];
-  for (const pid of runningPids) {
-    await stopKeepAliveDaemonByPid(pid);
-    stoppedPids.push(pid);
-  }
-
-  return stoppedPids;
+  return [...runningPids];
 }
 
-async function runDataDelete(input: { includeProfile: boolean }): Promise<void> {
+function assertCdpUrlUnsupportedForDataDelete(cdpUrl?: string): void {
+  if (!cdpUrl) {
+    return;
+  }
+
+  throw new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    "The data delete command only deletes tool-owned local filesystem state and does not support --cdp-url."
+  );
+}
+
+async function assertNoRunningKeepAliveDaemons(): Promise<void> {
+  const runningKeepAlivePids = await findRunningKeepAlivePids();
+  if (runningKeepAlivePids.length === 0) {
+    return;
+  }
+
+  throw new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    "Stop running keepalive daemons before deleting local data.",
+    {
+      running_keepalive_pids: runningKeepAlivePids
+    }
+  );
+}
+
+async function runDataDelete(input: {
+  includeProfile: boolean;
+  cdpUrl: string | undefined;
+}): Promise<void> {
   assertInteractiveTerminal("delete local data");
+  assertCdpUrlUnsupportedForDataDelete(input.cdpUrl);
+  await assertNoRunningKeepAliveDaemons();
 
   const requestedPlan = createLocalDataDeletionPlan({
     includeProfile: input.includeProfile
@@ -505,30 +497,14 @@ async function runDataDelete(input: { includeProfile: boolean }): Promise<void> 
     }
   }
 
-  const finalPlan = createLocalDataDeletionPlan({ includeProfile });
-  const runtime = createCoreRuntime({ privacy: cliPrivacyConfig });
-
-  try {
-    runtime.logger.log("warn", "cli.data.delete.start", {
-      includeProfileRequested: input.includeProfile,
-      includeProfileDeleted: includeProfile,
-      targets: finalPlan.targets
-    });
-  } finally {
-    runtime.close();
-  }
-
-  const stoppedKeepAlivePids = await stopAllKeepAliveDaemons();
   const deletionResult = await deleteLocalData({ includeProfile });
 
   printJson({
     deleted: true,
-    run_id: runtime.runId,
     include_profile_requested: input.includeProfile,
     include_profile_deleted: includeProfile,
     deleted_paths: deletionResult.deletedPaths,
-    missing_paths: deletionResult.missingPaths,
-    stopped_keepalive_pids: stoppedKeepAlivePids
+    missing_paths: deletionResult.missingPaths
   });
 }
 
@@ -2042,7 +2018,8 @@ export async function runCli(argv: string[] = process.argv): Promise<void> {
     )
     .action(async (options: { includeProfile: boolean }) => {
       await runDataDelete({
-        includeProfile: options.includeProfile
+        includeProfile: options.includeProfile,
+        cdpUrl: readCdpUrl()
       });
     });
 

--- a/packages/cli/test/dataDelete.test.ts
+++ b/packages/cli/test/dataDelete.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { stdin, stdout } from "node:process";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveConfigPaths } from "../../core/src/index.js";
+import { resolveConfigPaths, resolveKeepAliveDir } from "../../core/src/index.js";
 
 const readlineMocks = vi.hoisted(() => ({
   close: vi.fn(),
@@ -72,15 +72,22 @@ describe("linkedin data delete", () => {
 
   async function seedLocalDataFixture(): Promise<{
     artifactsDir: string;
+    configFilePath: string;
     dbPath: string;
     keepAliveDir: string;
     profilesDir: string;
     rateLimitStatePath: string;
   }> {
     const paths = resolveConfigPaths();
-    const keepAliveDir = path.join(paths.baseDir, "keepalive");
+    const keepAliveDir = resolveKeepAliveDir();
     const rateLimitStatePath = path.join(paths.baseDir, "rate-limit-state.json");
+    const configFilePath = path.join(paths.baseDir, "config.json");
 
+    await mkdir(path.dirname(paths.dbPath), { recursive: true });
+    await writeFile(paths.dbPath, "sqlite-data", "utf8");
+    await writeFile(`${paths.dbPath}-journal`, "sqlite-journal", "utf8");
+    await writeFile(`${paths.dbPath}-wal`, "sqlite-wal", "utf8");
+    await writeFile(`${paths.dbPath}-shm`, "sqlite-shm", "utf8");
     await mkdir(path.join(paths.artifactsDir, "run-1"), { recursive: true });
     await writeFile(
       path.join(paths.artifactsDir, "run-1", "events.jsonl"),
@@ -102,9 +109,11 @@ describe("linkedin data delete", () => {
       "utf8"
     );
     await writeFile(rateLimitStatePath, "{\"cooldown\":true}\n", "utf8");
+    await writeFile(configFilePath, "{\"safe\":true}\n", "utf8");
 
     return {
       artifactsDir: paths.artifactsDir,
+      configFilePath,
       dbPath: paths.dbPath,
       keepAliveDir,
       profilesDir: paths.profilesDir,
@@ -133,10 +142,14 @@ describe("linkedin data delete", () => {
 
     expect(readlineMocks.question).toHaveBeenCalledTimes(1);
     expect(await pathExists(fixture.dbPath)).toBe(false);
+    expect(await pathExists(`${fixture.dbPath}-journal`)).toBe(false);
+    expect(await pathExists(`${fixture.dbPath}-wal`)).toBe(false);
+    expect(await pathExists(`${fixture.dbPath}-shm`)).toBe(false);
     expect(await pathExists(fixture.artifactsDir)).toBe(false);
     expect(await pathExists(fixture.keepAliveDir)).toBe(false);
     expect(await pathExists(fixture.rateLimitStatePath)).toBe(false);
     expect(await pathExists(fixture.profilesDir)).toBe(true);
+    expect(await pathExists(fixture.configFilePath)).toBe(true);
 
     const finalOutput = consoleLogSpy.mock.calls.at(-1)?.[0];
     expect(JSON.parse(String(finalOutput))).toMatchObject({
@@ -156,10 +169,14 @@ describe("linkedin data delete", () => {
 
     expect(readlineMocks.question).toHaveBeenCalledTimes(2);
     expect(await pathExists(fixture.dbPath)).toBe(false);
+    expect(await pathExists(`${fixture.dbPath}-journal`)).toBe(false);
+    expect(await pathExists(`${fixture.dbPath}-wal`)).toBe(false);
+    expect(await pathExists(`${fixture.dbPath}-shm`)).toBe(false);
     expect(await pathExists(fixture.artifactsDir)).toBe(false);
     expect(await pathExists(fixture.keepAliveDir)).toBe(false);
     expect(await pathExists(fixture.rateLimitStatePath)).toBe(false);
     expect(await pathExists(fixture.profilesDir)).toBe(false);
+    expect(await pathExists(fixture.configFilePath)).toBe(true);
 
     const finalOutput = consoleLogSpy.mock.calls.at(-1)?.[0];
     expect(JSON.parse(String(finalOutput))).toMatchObject({
@@ -167,5 +184,44 @@ describe("linkedin data delete", () => {
       include_profile_requested: true,
       include_profile_deleted: true
     });
+  });
+
+  it("refuses to run with --cdp-url", async () => {
+    await expect(
+      runCli([
+        "node",
+        "linkedin",
+        "--cdp-url",
+        "ws://127.0.0.1:9222/devtools/browser/test",
+        "data",
+        "delete"
+      ])
+    ).rejects.toMatchObject({
+      message:
+        "The data delete command only deletes tool-owned local filesystem state and does not support --cdp-url."
+    });
+
+    expect(readlineMocks.createInterface).not.toHaveBeenCalled();
+    expect(await pathExists(assistantHome)).toBe(false);
+  });
+
+  it("refuses to run while a keepalive daemon is active", async () => {
+    const fixture = await seedLocalDataFixture();
+    await writeFile(
+      path.join(fixture.keepAliveDir, "default.pid"),
+      `${process.pid}\n`,
+      "utf8"
+    );
+
+    await expect(
+      runCli(["node", "linkedin", "data", "delete"])
+    ).rejects.toMatchObject({
+      message: "Stop running keepalive daemons before deleting local data."
+    });
+
+    expect(readlineMocks.createInterface).not.toHaveBeenCalled();
+    expect(await pathExists(fixture.dbPath)).toBe(true);
+    expect(await pathExists(fixture.keepAliveDir)).toBe(true);
+    expect(await pathExists(fixture.rateLimitStatePath)).toBe(true);
   });
 });

--- a/packages/core/src/auth/rateLimitState.ts
+++ b/packages/core/src/auth/rateLimitState.ts
@@ -15,28 +15,41 @@ const LEGACY_STATE_FILE_PATH = path.join(
   "rate-limit-state.json"
 );
 
-export function resolveRateLimitStateFilePath(stateFilePath?: string): string {
+export function resolveRateLimitStateFilePath(
+  stateFilePath?: string,
+  baseDir?: string
+): string {
   if (stateFilePath) {
     return stateFilePath;
   }
 
-  return path.join(resolveConfigPaths().baseDir, "rate-limit-state.json");
+  return path.join(resolveConfigPaths(baseDir).baseDir, "rate-limit-state.json");
 }
 
 export function resolveLegacyRateLimitStateFilePath(): string {
   return LEGACY_STATE_FILE_PATH;
 }
 
-function shouldIncludeLegacyStateFilePath(stateFilePath?: string): boolean {
+function shouldIncludeLegacyStateFilePath(
+  stateFilePath?: string,
+  baseDir?: string
+): boolean {
   return (
     !stateFilePath &&
+    typeof baseDir !== "string" &&
     typeof process.env.LINKEDIN_ASSISTANT_HOME !== "string"
   );
 }
 
-function resolveStateFilePaths(stateFilePath?: string): string[] {
-  const primaryStateFilePath = resolveRateLimitStateFilePath(stateFilePath);
-  if (!shouldIncludeLegacyStateFilePath(stateFilePath)) {
+export function resolveRateLimitStateFilePaths(
+  stateFilePath?: string,
+  baseDir?: string
+): string[] {
+  const primaryStateFilePath = resolveRateLimitStateFilePath(
+    stateFilePath,
+    baseDir
+  );
+  if (!shouldIncludeLegacyStateFilePath(stateFilePath, baseDir)) {
     return [primaryStateFilePath];
   }
 
@@ -70,7 +83,9 @@ function isValidRateLimitState(value: unknown): value is RateLimitState {
 export async function readRateLimitState(
   stateFilePath?: string
 ): Promise<RateLimitState | null> {
-  for (const resolvedStateFilePath of resolveStateFilePaths(stateFilePath)) {
+  for (const resolvedStateFilePath of resolveRateLimitStateFilePaths(
+    stateFilePath
+  )) {
     try {
       const rawState = await readFile(resolvedStateFilePath, "utf8");
       const parsed = JSON.parse(rawState) as unknown;
@@ -111,7 +126,9 @@ export async function writeRateLimitState(
 }
 
 export async function clearRateLimitState(stateFilePath?: string): Promise<void> {
-  for (const resolvedStateFilePath of resolveStateFilePaths(stateFilePath)) {
+  for (const resolvedStateFilePath of resolveRateLimitStateFilePaths(
+    stateFilePath
+  )) {
     try {
       await unlink(resolvedStateFilePath);
     } catch (error) {

--- a/packages/core/src/localData.ts
+++ b/packages/core/src/localData.ts
@@ -1,9 +1,6 @@
 import { access, rm } from "node:fs/promises";
 import path from "node:path";
-import {
-  resolveLegacyRateLimitStateFilePath,
-  resolveRateLimitStateFilePath
-} from "./auth/rateLimitState.js";
+import { resolveRateLimitStateFilePaths } from "./auth/rateLimitState.js";
 import { resolveConfigPaths } from "./config.js";
 import { LinkedInAssistantError } from "./errors.js";
 
@@ -24,112 +21,32 @@ export interface LocalDataDeletionResult {
   missingPaths: string[];
 }
 
-function resolveKeepAliveDir(baseDir: string): string {
-  return path.join(baseDir, "keepalive");
+const SQLITE_SIDECAR_SUFFIXES = ["-journal", "-wal", "-shm"] as const;
+
+export function resolveKeepAliveDir(baseDir?: string): string {
+  return path.join(resolveConfigPaths(baseDir).baseDir, "keepalive");
 }
 
-function shouldIncludeLegacyRateLimitStatePath(
-  options: LocalDataDeletionPlanOptions
-): boolean {
-  return (
-    !options.rateLimitStatePath &&
-    typeof process.env.LINKEDIN_ASSISTANT_HOME !== "string"
-  );
+function resolveDatabasePaths(dbPath: string): string[] {
+  return [dbPath, ...SQLITE_SIDECAR_SUFFIXES.map((suffix) => `${dbPath}${suffix}`)];
 }
 
 function normalizePath(targetPath: string): string {
   return path.resolve(targetPath);
 }
 
-function isSameOrChildPath(parentPath: string, candidatePath: string): boolean {
-  return (
-    candidatePath === parentPath ||
-    candidatePath.startsWith(`${parentPath}${path.sep}`)
-  );
-}
-
 function dedupePaths(targetPaths: string[]): string[] {
   return [...new Set(targetPaths.map((targetPath) => normalizePath(targetPath)))];
 }
 
-function assertSafeBaseDir(baseDir: string): void {
-  const resolvedBaseDir = normalizePath(baseDir);
-  if (resolvedBaseDir === path.parse(resolvedBaseDir).root) {
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
-      "Refusing to delete local data when the configured base directory is the filesystem root.",
-      {
-        base_dir: resolvedBaseDir
-      }
-    );
-  }
-}
-
-function createAllowedTargetSet(options: LocalDataDeletionPlanOptions): Set<string> {
-  const paths = resolveConfigPaths(options.baseDir);
-  return new Set(
-    dedupePaths([
-      paths.dbPath,
-      paths.artifactsDir,
-      resolveKeepAliveDir(paths.baseDir),
-      paths.profilesDir,
-      resolveRateLimitStateFilePath(options.rateLimitStatePath),
-      ...(shouldIncludeLegacyRateLimitStatePath(options)
-        ? [resolveLegacyRateLimitStateFilePath()]
-        : [])
-    ])
-  );
-}
-
-function assertSafeDeletionTarget(
-  targetPath: string,
-  options: LocalDataDeletionPlanOptions
-): void {
-  const paths = resolveConfigPaths(options.baseDir);
-  assertSafeBaseDir(paths.baseDir);
-
+function assertSafeDeletePath(targetPath: string, label: string): void {
   const resolvedTargetPath = normalizePath(targetPath);
-  const allowedTargets = createAllowedTargetSet(options);
-  const resolvedBaseDir = normalizePath(paths.baseDir);
-
-  if (!allowedTargets.has(resolvedTargetPath)) {
+  if (resolvedTargetPath === path.parse(resolvedTargetPath).root) {
     throw new LinkedInAssistantError(
       "ACTION_PRECONDITION_FAILED",
-      "Refusing to delete an unexpected local-data path.",
+      `Refusing to delete ${label} because it resolves to the filesystem root.`,
       {
         target_path: resolvedTargetPath
-      }
-    );
-  }
-
-  const isLegacyRateLimitStatePath =
-    resolvedTargetPath === normalizePath(resolveLegacyRateLimitStateFilePath());
-  const isExplicitRateLimitStatePath =
-    typeof options.rateLimitStatePath === "string" &&
-    resolvedTargetPath ===
-      normalizePath(resolveRateLimitStateFilePath(options.rateLimitStatePath));
-
-  if (
-    !isLegacyRateLimitStatePath &&
-    !isExplicitRateLimitStatePath &&
-    !isSameOrChildPath(resolvedBaseDir, resolvedTargetPath)
-  ) {
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
-      "Refusing to delete a path outside the configured local-data directory.",
-      {
-        base_dir: resolvedBaseDir,
-        target_path: resolvedTargetPath
-      }
-    );
-  }
-
-  if (resolvedTargetPath === resolvedBaseDir) {
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
-      "Refusing to delete the configured local-data base directory directly.",
-      {
-        base_dir: resolvedBaseDir
       }
     );
   }
@@ -157,25 +74,24 @@ export function createLocalDataDeletionPlan(
 ): LocalDataDeletionPlan {
   const paths = resolveConfigPaths(options.baseDir);
   const includeProfile = options.includeProfile ?? false;
-  const rateLimitTargets = options.rateLimitStatePath
-    ? [resolveRateLimitStateFilePath(options.rateLimitStatePath)]
-    : shouldIncludeLegacyRateLimitStatePath(options)
-      ? [
-          resolveRateLimitStateFilePath(),
-          resolveLegacyRateLimitStateFilePath()
-        ]
-      : [resolveRateLimitStateFilePath()];
+  const baseDir = normalizePath(paths.baseDir);
+
+  assertSafeDeletePath(baseDir, "local data");
 
   const targets = dedupePaths([
-    paths.dbPath,
+    ...resolveDatabasePaths(paths.dbPath),
     paths.artifactsDir,
     resolveKeepAliveDir(paths.baseDir),
-    ...rateLimitTargets,
+    ...resolveRateLimitStateFilePaths(options.rateLimitStatePath, options.baseDir),
     ...(includeProfile ? [paths.profilesDir] : [])
   ]);
 
+  for (const targetPath of targets) {
+    assertSafeDeletePath(targetPath, "a local-data target");
+  }
+
   return {
-    baseDir: normalizePath(paths.baseDir),
+    baseDir,
     includeProfile,
     targets
   };
@@ -189,8 +105,6 @@ export async function deleteLocalData(
   const missingPaths: string[] = [];
 
   for (const targetPath of deletionPlan.targets) {
-    assertSafeDeletionTarget(targetPath, options);
-
     if (!(await pathExists(targetPath))) {
       missingPaths.push(targetPath);
       continue;

--- a/packages/core/test/localData.test.ts
+++ b/packages/core/test/localData.test.ts
@@ -5,7 +5,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createLocalDataDeletionPlan,
   deleteLocalData,
-  resolveConfigPaths
+  resolveConfigPaths,
+  resolveKeepAliveDir
 } from "../src/index.js";
 
 async function pathExists(targetPath: string): Promise<boolean> {
@@ -28,24 +29,39 @@ async function pathExists(targetPath: string): Promise<boolean> {
 describe("local data deletion", () => {
   let tempDir = "";
   let baseDir = "";
+  let configFilePath = "";
   let rateLimitStatePath = "";
+  let previousAssistantHome: string | undefined;
 
   beforeEach(async () => {
+    previousAssistantHome = process.env.LINKEDIN_ASSISTANT_HOME;
+    delete process.env.LINKEDIN_ASSISTANT_HOME;
+
     tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-local-data-"));
     baseDir = path.join(tempDir, "assistant-home");
-    rateLimitStatePath = path.join(tempDir, "rate-limit-state.json");
+    configFilePath = path.join(baseDir, "config.json");
+    rateLimitStatePath = path.join(baseDir, "rate-limit-state.json");
   });
 
   afterEach(async () => {
+    if (typeof previousAssistantHome === "string") {
+      process.env.LINKEDIN_ASSISTANT_HOME = previousAssistantHome;
+    } else {
+      delete process.env.LINKEDIN_ASSISTANT_HOME;
+    }
+
     await rm(tempDir, { recursive: true, force: true });
   });
 
   async function seedLocalDataFixture(): Promise<ReturnType<typeof resolveConfigPaths>> {
     const paths = resolveConfigPaths(baseDir);
-    const keepAliveDir = path.join(baseDir, "keepalive");
+    const keepAliveDir = resolveKeepAliveDir(baseDir);
 
     await mkdir(path.dirname(paths.dbPath), { recursive: true });
     await writeFile(paths.dbPath, "sqlite-data", "utf8");
+    await writeFile(`${paths.dbPath}-journal`, "sqlite-journal", "utf8");
+    await writeFile(`${paths.dbPath}-wal`, "sqlite-wal", "utf8");
+    await writeFile(`${paths.dbPath}-shm`, "sqlite-shm", "utf8");
     await mkdir(path.join(paths.artifactsDir, "run-123"), { recursive: true });
     await writeFile(
       path.join(paths.artifactsDir, "run-123", "events.jsonl"),
@@ -67,23 +83,24 @@ describe("local data deletion", () => {
       "utf8"
     );
     await writeFile(rateLimitStatePath, "{\"cooldown\":true}\n", "utf8");
+    await writeFile(configFilePath, "{\"safe\":true}\n", "utf8");
 
     return paths;
   }
 
-  it("builds a deletion plan without browser profiles by default", () => {
+  it("builds a deletion plan under the configured base directory by default", () => {
     const paths = resolveConfigPaths(baseDir);
-    const keepAliveDir = path.join(baseDir, "keepalive");
+    const keepAliveDir = resolveKeepAliveDir(baseDir);
 
-    const plan = createLocalDataDeletionPlan({
-      baseDir,
-      rateLimitStatePath
-    });
+    const plan = createLocalDataDeletionPlan({ baseDir });
 
     expect(plan.includeProfile).toBe(false);
     expect(plan.targets).toEqual(
       expect.arrayContaining([
         path.resolve(paths.dbPath),
+        path.resolve(`${paths.dbPath}-journal`),
+        path.resolve(`${paths.dbPath}-wal`),
+        path.resolve(`${paths.dbPath}-shm`),
         path.resolve(paths.artifactsDir),
         path.resolve(keepAliveDir),
         path.resolve(rateLimitStatePath)
@@ -92,27 +109,47 @@ describe("local data deletion", () => {
     expect(plan.targets).not.toContain(path.resolve(paths.profilesDir));
   });
 
-  it("deletes database, artifacts, keepalive files, and rate-limit state", async () => {
-    const paths = await seedLocalDataFixture();
-    const keepAliveDir = path.join(baseDir, "keepalive");
+  it("uses an explicit rate-limit state path when provided", () => {
+    const explicitRateLimitStatePath = path.join(
+      tempDir,
+      "external",
+      "rate-limit-state.json"
+    );
 
-    const result = await deleteLocalData({
+    const plan = createLocalDataDeletionPlan({
       baseDir,
-      rateLimitStatePath
+      rateLimitStatePath: explicitRateLimitStatePath
     });
+
+    expect(plan.targets).toContain(path.resolve(explicitRateLimitStatePath));
+    expect(plan.targets).not.toContain(path.resolve(rateLimitStatePath));
+  });
+
+  it("deletes database sidecars and preserves config.json by default", async () => {
+    const paths = await seedLocalDataFixture();
+    const keepAliveDir = resolveKeepAliveDir(baseDir);
+
+    const result = await deleteLocalData({ baseDir });
 
     expect(result.deletedPaths).toEqual(
       expect.arrayContaining([
         path.resolve(paths.dbPath),
+        path.resolve(`${paths.dbPath}-journal`),
+        path.resolve(`${paths.dbPath}-wal`),
+        path.resolve(`${paths.dbPath}-shm`),
         path.resolve(paths.artifactsDir),
         path.resolve(keepAliveDir),
         path.resolve(rateLimitStatePath)
       ])
     );
     expect(await pathExists(paths.dbPath)).toBe(false);
+    expect(await pathExists(`${paths.dbPath}-journal`)).toBe(false);
+    expect(await pathExists(`${paths.dbPath}-wal`)).toBe(false);
+    expect(await pathExists(`${paths.dbPath}-shm`)).toBe(false);
     expect(await pathExists(paths.artifactsDir)).toBe(false);
     expect(await pathExists(keepAliveDir)).toBe(false);
     expect(await pathExists(rateLimitStatePath)).toBe(false);
+    expect(await pathExists(configFilePath)).toBe(true);
     expect(await pathExists(paths.profilesDir)).toBe(true);
   });
 
@@ -121,11 +158,11 @@ describe("local data deletion", () => {
 
     const result = await deleteLocalData({
       baseDir,
-      includeProfile: true,
-      rateLimitStatePath
+      includeProfile: true
     });
 
     expect(result.deletedPaths).toContain(path.resolve(paths.profilesDir));
     expect(await pathExists(paths.profilesDir)).toBe(false);
+    expect(await pathExists(configFilePath)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- keep `linkedin data delete` filesystem-first by removing the runtime boot/logging path
- reuse shared keepalive and rate-limit path resolution instead of duplicating delete-only logic
- delete SQLite sidecar files alongside `state.sqlite` and preserve `config.json` by default
- refuse `--cdp-url` and active keepalive daemons rather than trying to stop daemons implicitly
- harden the core and CLI deletion tests around sidecars, config preservation, and the new guard rails

## Why
The merged build from PR #50 still recreated local state during deletion and had duplicated ownership rules for rate-limit and keepalive paths. This refactor keeps the command smaller, safer, and easier to extend without painting future state cleanup into a corner.

## Notes
- I checked the current open issues before refactoring; there were no direct conflicts.
- Issue #5 still depends on the shared SQLite state model, so this keeps deletion scoped to the full local state footprint rather than introducing partial profile cleanup semantics.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

Closes #58
