### PR TITLE
test: add i18n selector coverage for #62

### DIFF
--- a/packages/core/src/__tests__/selectorAudit.test.ts
+++ b/packages/core/src/__tests__/selectorAudit.test.ts
@@ -1,5 +1,5 @@
 import { stat } from "node:fs/promises";
-import { errors as playwrightErrors } from "playwright-core";
+import { errors as playwrightErrors, type Page } from "playwright-core";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   LINKEDIN_SELECTOR_AUDIT_PAGES,
@@ -20,6 +20,52 @@ import {
 afterEach(async () => {
   await cleanupSelectorAuditTestHarnesses();
 });
+
+function summarizeRegistryShape(
+  registry: ReturnType<typeof createLinkedInSelectorAuditRegistry>
+): Array<{
+  page: string;
+  selectors: Array<{
+    key: string;
+    candidates: Array<{ key: string; strategy: string }>;
+  }>;
+}> {
+  return registry.map((pageDefinition) => ({
+    page: pageDefinition.page,
+    selectors: pageDefinition.selectors.map((selectorDefinition) => ({
+      key: selectorDefinition.key,
+      candidates: selectorDefinition.candidates.map((candidate) => ({
+        key: candidate.key,
+        strategy: candidate.strategy
+      }))
+    }))
+  }));
+}
+
+function createRoleMatchingPage(
+  accessibleNamesByRole: Readonly<Record<string, readonly string[]>>
+): Page {
+  return {
+    getByRole: (role: string, options?: { name?: unknown }) =>
+      ({
+        waitFor: async () => {
+          const nameMatcher = options?.name;
+          if (!(nameMatcher instanceof RegExp)) {
+            throw new Error(
+              "Expected selector audit role candidates to compile regex name matchers."
+            );
+          }
+
+          const accessibleNames = accessibleNamesByRole[role] ?? [];
+          if (!accessibleNames.some((accessibleName) => nameMatcher.test(accessibleName))) {
+            throw new Error(
+              `No ${role} accessible name matched /${nameMatcher.source}/i.`
+            );
+          }
+        }
+      })
+  } as unknown as Page;
+}
 
 describe("createLinkedInSelectorAuditRegistry", () => {
   it("covers the audit-scope pages with normalized strategies", () => {
@@ -53,6 +99,43 @@ describe("createLinkedInSelectorAuditRegistry", () => {
 
     expect(primaryCandidate?.selectorHint).toContain("Start et opslag");
     expect(primaryCandidate?.selectorHint).toContain("Start a post");
+  });
+
+  it("preserves selector keys and candidate ordering across locales", () => {
+    const englishRegistry = createLinkedInSelectorAuditRegistry("en");
+    const danishRegistry = createLinkedInSelectorAuditRegistry("da");
+
+    expect(summarizeRegistryShape(danishRegistry)).toEqual(
+      summarizeRegistryShape(englishRegistry)
+    );
+  });
+
+  it("resolves localized and english fallback accessible names in the same candidate", async () => {
+    const registry = createLinkedInSelectorAuditRegistry("da");
+    const feedDefinition = registry.find((pageDefinition) => pageDefinition.page === "feed");
+    const primaryCandidate = feedDefinition?.selectors
+      .find((selectorDefinition) => selectorDefinition.key === "post_composer_trigger")
+      ?.candidates.find((candidate) => candidate.strategy === "primary");
+
+    expect(primaryCandidate).toBeDefined();
+
+    const localizedPage = createRoleMatchingPage({
+      button: ["Start et opslag"]
+    });
+    const englishFallbackPage = createRoleMatchingPage({
+      button: ["Start a post"]
+    });
+    const unsupportedLocalePage = createRoleMatchingPage({
+      button: ["Partager une publication"]
+    });
+
+    await expect(primaryCandidate!.locatorFactory(localizedPage).waitFor()).resolves.toBeUndefined();
+    await expect(
+      primaryCandidate!.locatorFactory(englishFallbackPage).waitFor()
+    ).resolves.toBeUndefined();
+    await expect(
+      primaryCandidate!.locatorFactory(unsupportedLocalePage).waitFor()
+    ).rejects.toThrow("No button accessible name matched");
   });
 });
 

--- a/packages/core/src/__tests__/selectorLocale.test.ts
+++ b/packages/core/src/__tests__/selectorLocale.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   buildLinkedInAriaLabelContainsSelector,
   buildLinkedInSelectorPhraseRegex,
+  formatLinkedInSelectorRegexHint,
   getLinkedInSelectorPhrases,
-  resolveLinkedInSelectorLocale
+  resolveLinkedInSelectorLocale,
+  valueContainsLinkedInSelectorPhrase
 } from "../selectorLocale.js";
 
 describe("resolveLinkedInSelectorLocale", () => {
@@ -15,6 +17,12 @@ describe("resolveLinkedInSelectorLocale", () => {
   it("falls back to english for unsupported locales", () => {
     expect(resolveLinkedInSelectorLocale("fr")).toBe("en");
     expect(resolveLinkedInSelectorLocale(undefined)).toBe("en");
+  });
+
+  it("uses the provided fallback for blank and invalid locale values", () => {
+    expect(resolveLinkedInSelectorLocale("   ", "da")).toBe("da");
+    expect(resolveLinkedInSelectorLocale("fr-CA", "da")).toBe("da");
+    expect(resolveLinkedInSelectorLocale(undefined, "da")).toBe("da");
   });
 });
 
@@ -38,6 +46,21 @@ describe("getLinkedInSelectorPhrases", () => {
   it("deduplicates english fallback phrases when the locale already shares them", () => {
     expect(getLinkedInSelectorPhrases("send", "da")).toEqual(["Send"]);
   });
+
+  it("keeps locale-first ordering across multiple phrase keys", () => {
+    expect(getLinkedInSelectorPhrases(["messaging", "write_message"], "da")).toEqual([
+      "Beskeder",
+      "Skriv en besked",
+      "Skriv en meddelelse",
+      "Messaging",
+      "Messages",
+      "Write a message"
+    ]);
+  });
+
+  it("handles empty phrase sets without producing fallback matches", () => {
+    expect(getLinkedInSelectorPhrases([] as const, "da")).toEqual([]);
+  });
 });
 
 describe("buildLinkedInSelectorPhraseRegex", () => {
@@ -49,6 +72,39 @@ describe("buildLinkedInSelectorPhraseRegex", () => {
     expect(regex.test("Opret forbindelse")).toBe(true);
     expect(regex.test("Connect")).toBe(true);
     expect(regex.test("Invite to connect")).toBe(false);
+  });
+
+  it("escapes punctuation-heavy phrases in regex hints and exact matches", () => {
+    const hint = formatLinkedInSelectorRegexHint(
+      "what_do_you_want_to_talk_about",
+      "da",
+      { exact: true }
+    );
+    const regex = buildLinkedInSelectorPhraseRegex(
+      "what_do_you_want_to_talk_about",
+      "da",
+      { exact: true }
+    );
+
+    expect(hint).toContain("Hvad vil du tale om\\?");
+    expect(regex.test("Hvad vil du tale om?")).toBe(true);
+    expect(regex.test("Hvad vil du tale om")).toBe(false);
+  });
+
+  it("does not overmatch short labels when exact matching is required", () => {
+    const regex = buildLinkedInSelectorPhraseRegex("send", "da", {
+      exact: true
+    });
+
+    expect(regex.test("Send")).toBe(true);
+    expect(regex.test("Send uden note")).toBe(false);
+  });
+
+  it("treats empty phrase sets as non-matching selectors", () => {
+    const regex = buildLinkedInSelectorPhraseRegex([] as const, "da");
+
+    expect(regex.test("Opret forbindelse")).toBe(false);
+    expect(regex.test("")).toBe(true);
   });
 });
 
@@ -62,5 +118,37 @@ describe("buildLinkedInAriaLabelContainsSelector", () => {
 
     expect(selector).toContain('button[aria-label*="Kommenter" i]');
     expect(selector).toContain('button[aria-label*="Comment" i]');
+  });
+
+  it("supports multiple roots and custom attributes", () => {
+    const selector = buildLinkedInAriaLabelContainsSelector(
+      ["button", "div[role='button']"],
+      "connect",
+      "da",
+      "title"
+    );
+
+    expect(selector).toContain('button[title*="Opret forbindelse" i]');
+    expect(selector).toContain('div[role=\'button\'][title*="Connect" i]');
+  });
+
+  it("returns an empty selector when there are no phrase keys", () => {
+    expect(buildLinkedInAriaLabelContainsSelector("button", [] as const, "da")).toBe("");
+  });
+});
+
+describe("valueContainsLinkedInSelectorPhrase", () => {
+  it("matches localized phrases and english fallbacks", () => {
+    expect(valueContainsLinkedInSelectorPhrase("Skriv en besked", "write_message", "da")).toBe(
+      true
+    );
+    expect(valueContainsLinkedInSelectorPhrase("Write a message", "write_message", "da")).toBe(
+      true
+    );
+  });
+
+  it("returns false for empty values and empty phrase sets", () => {
+    expect(valueContainsLinkedInSelectorPhrase(undefined, "write_message", "da")).toBe(false);
+    expect(valueContainsLinkedInSelectorPhrase("", [] as const, "da")).toBe(false);
   });
 });

--- a/packages/core/src/__tests__/sessionInspection.test.ts
+++ b/packages/core/src/__tests__/sessionInspection.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BrowserContext, Locator, Page } from "playwright-core";
+import { inspectLinkedInSession } from "../auth/sessionInspection.js";
+
+function createMockPage(options: {
+  url: string;
+  cookies?: readonly { name: string; value: string }[];
+  isVisible?: (selector: string) => boolean;
+}): Page {
+  return {
+    url: vi.fn(() => options.url),
+    locator: vi.fn((selector: string) => {
+      const visible = options.isVisible?.(selector) ?? false;
+      const isVisible = vi.fn(async () => visible);
+      const first = vi.fn();
+      const mockLocator = {
+        first,
+        isVisible
+      } as unknown as Locator;
+      first.mockReturnValue(mockLocator);
+      return mockLocator;
+    }),
+    context: vi.fn(
+      () =>
+        ({
+          cookies: vi.fn(async () => options.cookies ?? [])
+        }) as unknown as BrowserContext
+    )
+  } as unknown as Page;
+}
+
+describe("inspectLinkedInSession", () => {
+  it("authenticates when the localized profile-menu aria label is visible", async () => {
+    const page = createMockPage({
+      url: "https://www.linkedin.com/feed/",
+      isVisible: (selector) => selector.includes('button[aria-label*="Mig" i]')
+    });
+
+    const status = await inspectLinkedInSession(page, {
+      selectorLocale: "da"
+    });
+
+    expect(status.authenticated).toBe(true);
+    expect(status.reason).toContain("authenticated");
+  });
+
+  it("keeps the english profile-menu fallback active for non-english locales", async () => {
+    const page = createMockPage({
+      url: "https://www.linkedin.com/feed/",
+      isVisible: (selector) => selector.includes('button[aria-label*="Me" i]')
+    });
+
+    const status = await inspectLinkedInSession(page, {
+      selectorLocale: "da"
+    });
+
+    expect(status.authenticated).toBe(true);
+    expect(status.reason).toContain("authenticated");
+  });
+
+  it("keeps the stable profile-menu attribute fallback locale-independent", async () => {
+    const page = createMockPage({
+      url: "https://www.linkedin.com/feed/",
+      isVisible: (selector) =>
+        selector.includes("[data-control-name='nav.settings_view_profile']")
+    });
+
+    const status = await inspectLinkedInSession(page, {
+      selectorLocale: "da"
+    });
+
+    expect(status.authenticated).toBe(true);
+    expect(status.reason).toContain("authenticated");
+  });
+});


### PR DESCRIPTION
## Summary
- expand `selectorLocale` coverage for locale fallback, empty phrase sets, exact matching, and selector builders
- add selector-audit regression tests for locale-invariant candidate ordering and locale-aware accessible-name resolution
- add session-inspection tests to cover localized and English fallback auth selectors

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #62