### PR TITLE
test: harden E2E coverage contracts

### DIFF
--- a/packages/core/src/__tests__/e2e/auth.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/auth.e2e.test.ts
@@ -1,26 +1,26 @@
 import { describe, expect, it } from "vitest";
-import { setupE2ESuite } from "./setup.js";
+import { setupE2ESuite, skipIfE2EUnavailable } from "./setup.js";
 
 describe("Auth E2E", () => {
   const e2e = setupE2ESuite();
 
-  it("status returns authenticated: true", async () => {
-    if (!e2e.canRun()) return;
+  it("status returns authenticated: true", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const status = await runtime.auth.status();
     expect(status.authenticated).toBe(true);
   });
 
-  it("ensureAuthenticated does not throw", async () => {
-    if (!e2e.canRun()) return;
+  it("ensureAuthenticated does not throw", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     await expect(runtime.auth.ensureAuthenticated()).resolves.toMatchObject({
       authenticated: true
     });
   });
 
-  it("current URL contains linkedin.com", async () => {
-    if (!e2e.canRun()) return;
+  it("current URL contains linkedin.com", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const status = await runtime.auth.status();
     expect(status.currentUrl).toContain("linkedin.com");

--- a/packages/core/src/__tests__/e2e/cli.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/cli.e2e.test.ts
@@ -7,7 +7,7 @@ import {
   prepareEchoAction,
   runCliCommand
 } from "./helpers.js";
-import { setupE2ESuite } from "./setup.js";
+import { setupE2ESuite, skipIfE2EUnavailable } from "./setup.js";
 
 describe.sequential("CLI E2E", () => {
   const e2e = setupE2ESuite({
@@ -16,10 +16,8 @@ describe.sequential("CLI E2E", () => {
   });
   const profileName = getDefaultProfileName();
 
-  it("covers session, health, rate-limit, login, and selector audit commands", async () => {
-    if (!e2e.canRun()) {
-      return;
-    }
+  it("covers session, health, rate-limit, login, and selector audit commands", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
 
     const status = await runCliCommand(["status", "--profile", profileName]);
     expect(status.error).toBeUndefined();
@@ -85,10 +83,8 @@ describe.sequential("CLI E2E", () => {
     }
   }, 240_000);
 
-  it("covers inbox commands and both confirm entrypoints", async () => {
-    if (!e2e.canRun()) {
-      return;
-    }
+  it("covers inbox commands and both confirm entrypoints", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const fixtures = e2e.fixtures();
 
     const inboxList = await runCliCommand([
@@ -188,10 +184,8 @@ describe.sequential("CLI E2E", () => {
     });
   }, 180_000);
 
-  it("covers connections, followups, and keepalive commands", async () => {
-    if (!e2e.canRun()) {
-      return;
-    }
+  it("covers connections, followups, and keepalive commands", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const fixtures = e2e.fixtures();
 
     const connectionsList = await runCliCommand([
@@ -314,10 +308,8 @@ describe.sequential("CLI E2E", () => {
     });
   }, 180_000);
 
-  it("covers feed, post, profile, search, jobs, and notifications commands", async () => {
-    if (!e2e.canRun()) {
-      return;
-    }
+  it("covers feed, post, profile, search, jobs, and notifications commands", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const fixtures = e2e.fixtures();
 
     const feedList = await runCliCommand([

--- a/packages/core/src/__tests__/e2e/connections-write.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/connections-write.e2e.test.ts
@@ -5,7 +5,7 @@ import {
   getDefaultConnectionTarget,
   isOptInEnabled
 } from "./helpers.js";
-import { setupE2ESuite } from "./setup.js";
+import { setupE2ESuite, skipIfE2EUnavailable } from "./setup.js";
 
 const connectionConfirmMode = getConnectionConfirmMode();
 const connectionConfirmEnabled =
@@ -16,8 +16,8 @@ const connectionConfirmTest = connectionConfirmEnabled ? it : it.skip;
 describe("Connections Write E2E (2PC invitation flows)", () => {
   const e2e = setupE2ESuite();
 
-  it("prepare returns valid previews for invite, accept, and withdraw", async () => {
-    if (!e2e.canRun()) return;
+  it("prepare returns valid previews for invite, accept, and withdraw", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const targetProfile = getDefaultConnectionTarget();
 
@@ -37,8 +37,8 @@ describe("Connections Write E2E (2PC invitation flows)", () => {
     }
   });
 
-  connectionConfirmTest("confirms the configured connection flow via prepare → confirm", async () => {
-    if (!e2e.canRun()) return;
+  connectionConfirmTest("confirms the configured connection flow via prepare → confirm", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const targetProfile = getDefaultConnectionTarget();
 

--- a/packages/core/src/__tests__/e2e/connections.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/connections.e2e.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { setupE2ESuite } from "./setup.js";
+import { setupE2ESuite, skipIfE2EUnavailable } from "./setup.js";
 
 describe("Connections E2E", () => {
   const e2e = setupE2ESuite();
 
-  it("list connections returns array with name, profile_url", async () => {
-    if (!e2e.canRun()) return;
+  it("list connections returns array with name, profile_url", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const connections = await runtime.connections.listConnections();
 
@@ -17,8 +17,8 @@ describe("Connections E2E", () => {
     }
   });
 
-  it("list with limit 5 returns <= 5 results", async () => {
-    if (!e2e.canRun()) return;
+  it("list with limit 5 returns <= 5 results", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const connections = await runtime.connections.listConnections({ limit: 5 });
 

--- a/packages/core/src/__tests__/e2e/error-paths.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/error-paths.e2e.test.ts
@@ -9,7 +9,7 @@ import {
   type SelectorAuditPageDefinition
 } from "../../selectorAudit.js";
 import { getFeedPost } from "./helpers.js";
-import { getCdpUrl, setupE2ESuite } from "./setup.js";
+import { getCdpUrl, setupE2ESuite, skipIfE2EUnavailable } from "./setup.js";
 
 const LIKE_RATE_LIMIT_CONFIG = {
   counterKey: "linkedin.feed.like_post",
@@ -54,8 +54,8 @@ async function expectAssistantError(
 describe("E2E error paths", () => {
   const e2e = setupE2ESuite();
 
-  it("rejects expired confirmation tokens before execution", async () => {
-    if (!e2e.canRun()) return;
+  it("rejects expired confirmation tokens before execution", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
 
     const isolated = await createIsolatedRuntime();
     try {
@@ -81,8 +81,8 @@ describe("E2E error paths", () => {
     }
   }, 120_000);
 
-  it("surfaces rate limit failures without performing the action", async () => {
-    if (!e2e.canRun()) return;
+  it("surfaces rate limit failures without performing the action", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
 
     const isolated = await createIsolatedRuntime();
     try {
@@ -117,8 +117,8 @@ describe("E2E error paths", () => {
     }
   }, 120_000);
 
-  it("detects UI drift through selector audit failure artifacts", async () => {
-    if (!e2e.canRun()) return;
+  it("detects UI drift through selector audit failure artifacts", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
 
     const isolated = await createIsolatedRuntime();
     try {

--- a/packages/core/src/__tests__/e2e/feed-like.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/feed-like.e2e.test.ts
@@ -6,7 +6,7 @@ import {
   getOptInLikePostUrl,
   isOptInEnabled
 } from "./helpers.js";
-import { setupE2ESuite } from "./setup.js";
+import { setupE2ESuite, skipIfE2EUnavailable } from "./setup.js";
 
 const likeConfirmPostUrl = getOptInLikePostUrl();
 const likeConfirmTest =
@@ -19,8 +19,8 @@ const likeConfirmTest =
 describe("Feed Like E2E (2PC like_post)", () => {
   const e2e = setupE2ESuite();
 
-  it("prepare returns valid preview with rate limit info", async () => {
-    if (!e2e.canRun()) return;
+  it("prepare returns valid preview with rate limit info", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const post = await getFeedPost(runtime);
 
@@ -32,8 +32,8 @@ describe("Feed Like E2E (2PC like_post)", () => {
     expectRateLimitPreview(prepared.preview, "linkedin.feed.like_post");
   }, 60_000);
 
-  likeConfirmTest("likes a feed post via prepare → confirm", async () => {
-    if (!e2e.canRun()) return;
+  likeConfirmTest("likes a feed post via prepare → confirm", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const postUrl = likeConfirmPostUrl!;
     const prepared = runtime.feed.prepareLikePost({

--- a/packages/core/src/__tests__/e2e/feed-write.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/feed-write.e2e.test.ts
@@ -7,7 +7,7 @@ import {
   getOptInCommentPostUrl,
   isOptInEnabled
 } from "./helpers.js";
-import { setupE2ESuite } from "./setup.js";
+import { setupE2ESuite, skipIfE2EUnavailable } from "./setup.js";
 
 const commentConfirmPostUrl = getOptInCommentPostUrl();
 const commentConfirmTest =
@@ -30,8 +30,8 @@ const commentConfirmTest =
 describe("Feed Write E2E (2PC comment_on_post)", () => {
   const e2e = setupE2ESuite();
 
-  commentConfirmTest("comments on a feed post via prepare → confirm", async () => {
-    if (!e2e.canRun()) return;
+  commentConfirmTest("comments on a feed post via prepare → confirm", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
 
     const targetPostUrl = commentConfirmPostUrl!;
@@ -61,8 +61,8 @@ describe("Feed Write E2E (2PC comment_on_post)", () => {
     expect(result.result).toHaveProperty("text", commentText);
   }, 120_000);
 
-  it("prepare returns valid preview with rate limit info", async () => {
-    if (!e2e.canRun()) return;
+  it("prepare returns valid preview with rate limit info", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const targetPost = await getFeedPost(runtime);
     const prepared = runtime.feed.prepareCommentOnPost({

--- a/packages/core/src/__tests__/e2e/feed.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/feed.e2e.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { setupE2ESuite } from "./setup.js";
+import { setupE2ESuite, skipIfE2EUnavailable } from "./setup.js";
 
 describe("Feed E2E", () => {
   const e2e = setupE2ESuite();
 
-  it("view feed returns posts array with author, text", async () => {
-    if (!e2e.canRun()) return;
+  it("view feed returns posts array with author, text", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const posts = await runtime.feed.viewFeed({ limit: 5 });
 
@@ -17,8 +17,8 @@ describe("Feed E2E", () => {
     }
   });
 
-  it("view feed with limit respects parameter", async () => {
-    if (!e2e.canRun()) return;
+  it("view feed with limit respects parameter", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const posts = await runtime.feed.viewFeed({ limit: 3 });
 

--- a/packages/core/src/__tests__/e2e/health.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/health.e2e.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getCdpUrl, setupE2ESuite } from "./setup.js";
+import { getCdpUrl, setupE2ESuite, skipIfE2EUnavailable } from "./setup.js";
 import { CDPConnectionPool } from "../../connectionPool.js";
 import {
   SessionKeepAliveService,
@@ -9,8 +9,8 @@ import {
 describe("Health E2E", () => {
   const e2e = setupE2ESuite();
 
-  it("browser health returns healthy: true", async () => {
-    if (!e2e.canRun()) return;
+  it("browser health returns healthy: true", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const health = await runtime.healthCheck();
 
@@ -19,8 +19,8 @@ describe("Health E2E", () => {
     expect(health.browser.pageResponsive).toBe(true);
   });
 
-  it("session health returns authenticated: true", async () => {
-    if (!e2e.canRun()) return;
+  it("session health returns authenticated: true", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const health = await runtime.healthCheck();
 
@@ -32,8 +32,8 @@ describe("Health E2E", () => {
 describe("KeepAlive E2E", () => {
   const e2e = setupE2ESuite();
 
-  it("starts, emits health-event, and stops cleanly", async () => {
-    if (!e2e.canRun()) return;
+  it("starts, emits health-event, and stops cleanly", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
 
     const pool = new CDPConnectionPool({ idleTimeoutMs: 60_000 });
     const service = new SessionKeepAliveService(pool, {

--- a/packages/core/src/__tests__/e2e/helpers.ts
+++ b/packages/core/src/__tests__/e2e/helpers.ts
@@ -1,4 +1,5 @@
 import type { CoreRuntime } from "../../runtime.js";
+import { toLinkedInAssistantErrorPayload } from "../../errors.js";
 import { TEST_ECHO_ACTION_TYPE } from "../../twoPhaseCommit.js";
 import { runCli } from "../../../../cli/src/bin/linkedin.js";
 import { handleToolCall } from "../../../../mcp/src/bin/linkedin-mcp.js";
@@ -28,7 +29,7 @@ import {
   LINKEDIN_SESSION_OPEN_LOGIN_TOOL,
   LINKEDIN_SESSION_STATUS_TOOL
 } from "../../../../mcp/src/index.js";
-import { getCdpUrl } from "./setup.js";
+import { getCdpUrl, withAssistantHome, withE2EEnvironment } from "./setup.js";
 
 export interface CapturedCommandResult {
   stdout: string;
@@ -47,6 +48,10 @@ export interface PreparedActionResult {
   confirmToken: string;
   expiresAtMs?: number;
   preview: Record<string, unknown>;
+}
+
+interface CommandExecutionOptions {
+  assistantHome?: string;
 }
 
 const DEFAULT_PROFILE_NAME = process.env.LINKEDIN_E2E_PROFILE ?? "default";
@@ -186,7 +191,10 @@ export function getOptInCommentPostUrl(): string | undefined {
   return DEFAULT_COMMENT_POST_URL;
 }
 
-export async function runCliCommand(args: string[]): Promise<CapturedCommandResult> {
+export async function runCliCommand(
+  args: string[],
+  options: CommandExecutionOptions = {}
+): Promise<CapturedCommandResult> {
   const stdoutChunks: string[] = [];
   const stderrChunks: string[] = [];
   const originalStdoutWrite = process.stdout.write;
@@ -199,11 +207,25 @@ export async function runCliCommand(args: string[]): Promise<CapturedCommandResu
   process.exitCode = 0;
 
   let error: unknown;
+  const execute = async (): Promise<void> => {
+    await runCli(["node", "linkedin", "--cdp-url", getCdpUrl(), ...args]);
+  };
 
   try {
-    await runCli(["node", "linkedin", "--cdp-url", getCdpUrl(), ...args]);
+    if (options.assistantHome) {
+      await withAssistantHome(options.assistantHome, execute);
+    } else {
+      await withE2EEnvironment(execute);
+    }
   } catch (caught) {
     error = caught;
+    if ((process.exitCode ?? 0) === 0) {
+      process.exitCode = 1;
+    }
+
+    stderrChunks.push(
+      `${JSON.stringify(toLinkedInAssistantErrorPayload(caught), null, 2)}\n`
+    );
   } finally {
     process.stdout.write = originalStdoutWrite;
     process.stderr.write = originalStderrWrite;
@@ -230,12 +252,17 @@ export function getLastJsonObject(text: string): Record<string, unknown> {
 
 export async function callMcpTool(
   name: string,
-  args: Record<string, unknown> = {}
+  args: Record<string, unknown> = {},
+  options: CommandExecutionOptions = {}
 ): Promise<MappedMcpResult> {
-  const rawResult = await handleToolCall(name, {
-    cdpUrl: getCdpUrl(),
-    ...args
-  });
+  const execute = async () =>
+    handleToolCall(name, {
+      cdpUrl: getCdpUrl(),
+      ...args
+    });
+  const rawResult = options.assistantHome
+    ? await withAssistantHome(options.assistantHome, execute)
+    : await withE2EEnvironment(execute);
   const content = rawResult.content[0];
   if (!content) {
     throw new Error(`Tool ${name} returned no content.`);

--- a/packages/core/src/__tests__/e2e/inbox-write.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/inbox-write.e2e.test.ts
@@ -6,7 +6,7 @@ import {
   getMessageThread,
   isOptInEnabled
 } from "./helpers.js";
-import { setupE2ESuite } from "./setup.js";
+import { setupE2ESuite, skipIfE2EUnavailable } from "./setup.js";
 
 const messageConfirmTest = isOptInEnabled("LINKEDIN_E2E_ENABLE_MESSAGE_CONFIRM")
   ? it
@@ -25,8 +25,8 @@ const messageConfirmTest = isOptInEnabled("LINKEDIN_E2E_ENABLE_MESSAGE_CONFIRM")
 describe("Inbox Write E2E (2PC send_message)", () => {
   const e2e = setupE2ESuite();
 
-  messageConfirmTest("sends a message to Simon Miller via prepare → confirm", async () => {
-    if (!e2e.canRun()) return;
+  messageConfirmTest("sends a message to Simon Miller via prepare → confirm", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
 
     const simonThread = await getMessageThread(runtime);
@@ -53,8 +53,8 @@ describe("Inbox Write E2E (2PC send_message)", () => {
     expect(result.result).toHaveProperty("sent", true);
   }, 120_000);
 
-  it("prepare returns valid preview with rate limit info", async () => {
-    if (!e2e.canRun()) return;
+  it("prepare returns valid preview with rate limit info", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const simonThread = await getMessageThread(runtime);
 

--- a/packages/core/src/__tests__/e2e/inbox.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/inbox.e2e.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { setupE2ESuite } from "./setup.js";
+import { setupE2ESuite, skipIfE2EUnavailable } from "./setup.js";
 
 describe("Inbox E2E", () => {
   const e2e = setupE2ESuite();
 
-  it("list threads returns array with thread_id, title", async () => {
-    if (!e2e.canRun()) return;
+  it("list threads returns array with thread_id, title", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const threads = await runtime.inbox.listThreads({ limit: 20 });
 
@@ -17,8 +17,8 @@ describe("Inbox E2E", () => {
     }
   });
 
-  it("list with limit respects parameter", async () => {
-    if (!e2e.canRun()) return;
+  it("list with limit respects parameter", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const threads = await runtime.inbox.listThreads({ limit: 5 });
 

--- a/packages/core/src/__tests__/e2e/jobs.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/jobs.e2e.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { setupE2ESuite } from "./setup.js";
+import { setupE2ESuite, skipIfE2EUnavailable } from "./setup.js";
 
 describe("Jobs E2E", () => {
   const e2e = setupE2ESuite();
 
-  it("search jobs returns structured results with count", async () => {
-    if (!e2e.canRun()) return;
+  it("search jobs returns structured results with count", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const result = await runtime.jobs.searchJobs({
       query: "software engineer",

--- a/packages/core/src/__tests__/e2e/mcp.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/mcp.e2e.test.ts
@@ -7,7 +7,7 @@ import {
   MCP_TOOL_NAMES,
   prepareEchoAction
 } from "./helpers.js";
-import { setupE2ESuite } from "./setup.js";
+import { setupE2ESuite, skipIfE2EUnavailable } from "./setup.js";
 
 describe.sequential("MCP E2E", () => {
   const e2e = setupE2ESuite({
@@ -16,10 +16,8 @@ describe.sequential("MCP E2E", () => {
   });
   const profileName = getDefaultProfileName();
 
-  it("covers session tools", async () => {
-    if (!e2e.canRun()) {
-      return;
-    }
+  it("covers session tools", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
 
     const status = await callMcpTool(MCP_TOOL_NAMES.sessionStatus, {
       profileName
@@ -60,10 +58,8 @@ describe.sequential("MCP E2E", () => {
     });
   }, 120_000);
 
-  it("covers inbox, connections, and followup tools", async () => {
-    if (!e2e.canRun()) {
-      return;
-    }
+  it("covers inbox, connections, and followup tools", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const fixtures = e2e.fixtures();
 
     const inboxList = await callMcpTool(MCP_TOOL_NAMES.inboxListThreads, {
@@ -151,10 +147,8 @@ describe.sequential("MCP E2E", () => {
     });
   }, 180_000);
 
-  it("covers feed, post, actions confirm, and notifications tools", async () => {
-    if (!e2e.canRun()) {
-      return;
-    }
+  it("covers feed, post, actions confirm, and notifications tools", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const fixtures = e2e.fixtures();
 
     const feedList = await callMcpTool(MCP_TOOL_NAMES.feedList, {
@@ -246,10 +240,8 @@ describe.sequential("MCP E2E", () => {
     });
   }, 180_000);
 
-  it("covers profile, search, and jobs tools", async () => {
-    if (!e2e.canRun()) {
-      return;
-    }
+  it("covers profile, search, and jobs tools", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const fixtures = e2e.fixtures();
 
     const profile = await callMcpTool(MCP_TOOL_NAMES.profileView, {

--- a/packages/core/src/__tests__/e2e/notifications.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/notifications.e2e.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { setupE2ESuite } from "./setup.js";
+import { setupE2ESuite, skipIfE2EUnavailable } from "./setup.js";
 
 describe("Notifications E2E", () => {
   const e2e = setupE2ESuite();
 
-  it("list notifications does not error, returns array", async () => {
-    if (!e2e.canRun()) return;
+  it("list notifications does not error, returns array", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const notifications = await runtime.notifications.listNotifications({ limit: 5 });
 

--- a/packages/core/src/__tests__/e2e/post-write.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/post-write.e2e.test.ts
@@ -5,7 +5,7 @@ import {
   expectRateLimitPreview,
   isOptInEnabled
 } from "./helpers.js";
-import { setupE2ESuite } from "./setup.js";
+import { setupE2ESuite, skipIfE2EUnavailable } from "./setup.js";
 
 const writeTest = isOptInEnabled("LINKEDIN_ENABLE_POST_WRITE_E2E") ? it : it.skip;
 
@@ -20,8 +20,8 @@ const writeTest = isOptInEnabled("LINKEDIN_ENABLE_POST_WRITE_E2E") ? it : it.ski
 describe("Post Write E2E (2PC post.create)", () => {
   const e2e = setupE2ESuite();
 
-  writeTest("creates a public post via prepare → confirm", async () => {
-    if (!e2e.canRun()) return;
+  writeTest("creates a public post via prepare → confirm", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const timestamp = new Date().toISOString();
     const postText = `E2E post from linkedin-owa-agentools [${timestamp}]`;
@@ -47,8 +47,8 @@ describe("Post Write E2E (2PC post.create)", () => {
     expect(result.result).toHaveProperty("verification_snippet");
   }, 180_000);
 
-  it("prepare returns valid preview with rate limit info", async () => {
-    if (!e2e.canRun()) return;
+  it("prepare returns valid preview with rate limit info", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const prepared = await runtime.posts.prepareCreate({
       text: `E2E preview-only post [${new Date().toISOString()}]`,

--- a/packages/core/src/__tests__/e2e/profile.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/profile.e2e.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { setupE2ESuite } from "./setup.js";
+import { setupE2ESuite, skipIfE2EUnavailable } from "./setup.js";
 
 describe("Profile E2E", () => {
   const e2e = setupE2ESuite();
 
-  it("view own profile (me) returns full_name, headline, profile_url", async () => {
-    if (!e2e.canRun()) return;
+  it("view own profile (me) returns full_name, headline, profile_url", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const profile = await runtime.profile.viewProfile({ target: "me" });
 
@@ -14,8 +14,8 @@ describe("Profile E2E", () => {
     expect(profile.profile_url).toContain("linkedin.com/in/");
   });
 
-  it("view target profile (realsimonmiller) returns structured data", async () => {
-    if (!e2e.canRun()) return;
+  it("view target profile (realsimonmiller) returns structured data", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const profile = await runtime.profile.viewProfile({ target: "realsimonmiller" });
 

--- a/packages/core/src/__tests__/e2e/search.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/search.e2e.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { setupE2ESuite } from "./setup.js";
+import { setupE2ESuite, skipIfE2EUnavailable } from "./setup.js";
 
 describe("Search E2E", () => {
   const e2e = setupE2ESuite();
 
-  it("search people Simon Miller returns results with name, headline", async () => {
-    if (!e2e.canRun()) return;
+  it("search people Simon Miller returns results with name, headline", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const result = await runtime.search.search({
       query: "Simon Miller",
@@ -26,8 +26,8 @@ describe("Search E2E", () => {
     }
   });
 
-  it("search companies Power International returns results", async () => {
-    if (!e2e.canRun()) return;
+  it("search companies Power International returns results", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const result = await runtime.search.search({
       query: "Power International",
@@ -47,8 +47,8 @@ describe("Search E2E", () => {
     }
   });
 
-  it("search jobs software engineer copenhagen returns results", async () => {
-    if (!e2e.canRun()) return;
+  it("search jobs software engineer copenhagen returns results", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const result = await runtime.search.search({
       query: "software engineer copenhagen",

--- a/packages/core/src/__tests__/e2e/setup.ts
+++ b/packages/core/src/__tests__/e2e/setup.ts
@@ -1,10 +1,15 @@
-import { afterAll, beforeAll } from "vitest";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, type TestContext } from "vitest";
 import { createCoreRuntime, type CoreRuntime } from "../../runtime.js";
 
 const CDP_URL = process.env.LINKEDIN_CDP_URL ?? "http://localhost:18800";
 
 let sharedRuntime: CoreRuntime | undefined;
 let sharedAvailability: E2EAvailability | undefined;
+let sharedBaseDir: string | undefined;
+let activeSuiteCount = 0;
 
 export interface E2EAvailability {
   cdpAvailable: boolean;
@@ -34,13 +39,46 @@ const UNINITIALIZED_AVAILABILITY: E2EAvailability = {
 
 export function getRuntime(): CoreRuntime {
   if (!sharedRuntime) {
-    sharedRuntime = createCoreRuntime({ cdpUrl: CDP_URL });
+    sharedRuntime = createCoreRuntime({
+      baseDir: getE2EBaseDir(),
+      cdpUrl: CDP_URL
+    });
   }
   return sharedRuntime;
 }
 
 export function getCdpUrl(): string {
   return CDP_URL;
+}
+
+export function getE2EBaseDir(): string {
+  if (!sharedBaseDir) {
+    sharedBaseDir = mkdtempSync(path.join(os.tmpdir(), "linkedin-e2e-"));
+  }
+
+  return sharedBaseDir;
+}
+
+export async function withAssistantHome<T>(
+  assistantHome: string,
+  callback: () => Promise<T>
+): Promise<T> {
+  const previousHome = process.env.LINKEDIN_ASSISTANT_HOME;
+  process.env.LINKEDIN_ASSISTANT_HOME = assistantHome;
+
+  try {
+    return await callback();
+  } finally {
+    if (previousHome === undefined) {
+      delete process.env.LINKEDIN_ASSISTANT_HOME;
+    } else {
+      process.env.LINKEDIN_ASSISTANT_HOME = previousHome;
+    }
+  }
+}
+
+export async function withE2EEnvironment<T>(callback: () => Promise<T>): Promise<T> {
+  return withAssistantHome(getE2EBaseDir(), callback);
 }
 
 export async function checkCdpAvailable(): Promise<boolean> {
@@ -98,6 +136,7 @@ export function setupE2ESuite<TFixtures = void>(
   let suiteFixtures: TFixtures | undefined;
 
   beforeAll(async () => {
+    activeSuiteCount += 1;
     availability = await getE2EAvailability();
     if (availability.canRun && options.fixtures) {
       suiteFixtures = await options.fixtures(getRuntime());
@@ -105,7 +144,11 @@ export function setupE2ESuite<TFixtures = void>(
   }, options.timeoutMs);
 
   afterAll(() => {
-    cleanupRuntime();
+    activeSuiteCount = Math.max(0, activeSuiteCount - 1);
+    if (activeSuiteCount === 0) {
+      cleanupRuntime();
+    }
+
     availability = UNINITIALIZED_AVAILABILITY;
     suiteFixtures = undefined;
   });
@@ -127,10 +170,26 @@ export function setupE2ESuite<TFixtures = void>(
   };
 }
 
+export function skipIfE2EUnavailable<TFixtures>(
+  suite: E2ESuite<TFixtures>,
+  context: TestContext
+): void {
+  if (!suite.canRun()) {
+    context.skip(`Skipping LinkedIn E2E: ${suite.availability().reason}`);
+  }
+}
+
 export function cleanupRuntime(): void {
   if (sharedRuntime) {
     sharedRuntime.close();
     sharedRuntime = undefined;
   }
+
+  if (sharedBaseDir && existsSync(sharedBaseDir)) {
+    rmSync(sharedBaseDir, { recursive: true, force: true });
+  }
+
+  sharedBaseDir = undefined;
   sharedAvailability = undefined;
+  activeSuiteCount = 0;
 }

--- a/packages/core/src/__tests__/e2eConfirmContracts.test.ts
+++ b/packages/core/src/__tests__/e2eConfirmContracts.test.ts
@@ -1,0 +1,214 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createCoreRuntime } from "../runtime.js";
+import { TEST_ECHO_ACTION_TYPE } from "../twoPhaseCommit.js";
+import {
+  callMcpTool,
+  getLastJsonObject,
+  MCP_TOOL_NAMES,
+  runCliCommand,
+  type PreparedActionResult
+} from "./e2e/helpers.js";
+
+const originalAssistantHome = process.env.LINKEDIN_ASSISTANT_HOME;
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const tempDir = tempDirs.pop();
+    if (!tempDir) {
+      continue;
+    }
+
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+
+  if (originalAssistantHome === undefined) {
+    delete process.env.LINKEDIN_ASSISTANT_HOME;
+    return;
+  }
+
+  process.env.LINKEDIN_ASSISTANT_HOME = originalAssistantHome;
+});
+
+function createTempAssistantHome(): string {
+  const baseDir = mkdtempSync(path.join(tmpdir(), "linkedin-e2e-contracts-"));
+  tempDirs.push(baseDir);
+  return baseDir;
+}
+
+function prepareEchoAction(
+  assistantHome: string,
+  profileName: string = "default"
+): PreparedActionResult {
+  const runtime = createCoreRuntime({ baseDir: assistantHome });
+  const text = `echo-${Date.now()}`;
+  const target = {
+    profile_name: profileName
+  } satisfies Record<string, unknown>;
+
+  try {
+    return runtime.twoPhaseCommit.prepare({
+      actionType: TEST_ECHO_ACTION_TYPE,
+      target,
+      payload: {
+        text
+      },
+      preview: {
+        summary: `Echo action for ${profileName}`,
+        target,
+        outbound: {
+          text
+        }
+      }
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+function readPreparedActionStatus(
+  assistantHome: string,
+  preparedActionId: string
+): string | null | undefined {
+  const runtime = createCoreRuntime({ baseDir: assistantHome });
+
+  try {
+    return runtime.db.getPreparedActionById(preparedActionId)?.status;
+  } finally {
+    runtime.close();
+  }
+}
+
+describe("E2E helper contract hardening", () => {
+  it("extracts the last JSON object from mixed CLI output", () => {
+    const payload = getLastJsonObject(`
+[linkedin] warning about attached browser session
+{"preview":true}
+Preview summary: not-json {still not json}
+{"result":{"text":"value with } brace"}}
+`);
+
+    expect(payload).toEqual({
+      result: {
+        text: "value with } brace"
+      }
+    });
+  });
+});
+
+describe("CLI confirm contract hardening", () => {
+  it("reports profile mismatches without consuming the prepared action", async () => {
+    const assistantHome = createTempAssistantHome();
+    const prepared = prepareEchoAction(assistantHome, "primary");
+
+    const result = await runCliCommand(
+      [
+        "actions",
+        "confirm",
+        "--profile",
+        "secondary",
+        "--token",
+        prepared.confirmToken,
+        "--yes"
+      ],
+      { assistantHome }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.error).toBeDefined();
+    expect(getLastJsonObject(result.stderr)).toMatchObject({
+      code: "ACTION_PRECONDITION_FAILED",
+      details: {
+        expected_profile_name: "primary",
+        provided_profile_name: "secondary"
+      }
+    });
+    expect(readPreparedActionStatus(assistantHome, prepared.preparedActionId)).toBe(
+      "prepared"
+    );
+  });
+
+  it("rejects non-interactive confirmations without mutating the prepared action", async () => {
+    const assistantHome = createTempAssistantHome();
+    const prepared = prepareEchoAction(assistantHome);
+
+    const result = await runCliCommand(
+      ["actions", "confirm", "--profile", "default", "--token", prepared.confirmToken],
+      { assistantHome }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.error).toBeDefined();
+    expect(getLastJsonObject(result.stderr)).toMatchObject({
+      code: "ACTION_PRECONDITION_FAILED",
+      message: expect.stringContaining("without --yes")
+    });
+    expect(readPreparedActionStatus(assistantHome, prepared.preparedActionId)).toBe(
+      "prepared"
+    );
+  });
+
+  it("returns TARGET_NOT_FOUND for unknown confirmation tokens", async () => {
+    const assistantHome = createTempAssistantHome();
+
+    const result = await runCliCommand(
+      ["actions", "confirm", "--profile", "default", "--token", "ct_missing", "--yes"],
+      { assistantHome }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.error).toBeDefined();
+    expect(getLastJsonObject(result.stderr)).toMatchObject({
+      code: "TARGET_NOT_FOUND"
+    });
+  });
+});
+
+describe("MCP confirm contract hardening", () => {
+  it("reports profile mismatches without consuming the prepared action", async () => {
+    const assistantHome = createTempAssistantHome();
+    const prepared = prepareEchoAction(assistantHome, "primary");
+
+    const result = await callMcpTool(
+      MCP_TOOL_NAMES.actionsConfirm,
+      {
+        profileName: "secondary",
+        token: prepared.confirmToken
+      },
+      { assistantHome }
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.payload).toMatchObject({
+      code: "ACTION_PRECONDITION_FAILED",
+      details: {
+        expected_profile_name: "primary",
+        provided_profile_name: "secondary"
+      }
+    });
+    expect(readPreparedActionStatus(assistantHome, prepared.preparedActionId)).toBe(
+      "prepared"
+    );
+  });
+
+  it("returns TARGET_NOT_FOUND for unknown confirmation tokens", async () => {
+    const assistantHome = createTempAssistantHome();
+
+    const result = await callMcpTool(
+      MCP_TOOL_NAMES.actionsConfirm,
+      {
+        profileName: "default",
+        token: "ct_missing"
+      },
+      { assistantHome }
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.payload).toMatchObject({
+      code: "TARGET_NOT_FOUND"
+    });
+  });
+});

--- a/packages/core/src/__tests__/e2eSetup.test.ts
+++ b/packages/core/src/__tests__/e2eSetup.test.ts
@@ -1,0 +1,62 @@
+import { existsSync } from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  cleanupRuntime,
+  getE2EBaseDir,
+  withAssistantHome,
+  withE2EEnvironment
+} from "./e2e/setup.js";
+
+const originalAssistantHome = process.env.LINKEDIN_ASSISTANT_HOME;
+
+afterEach(() => {
+  cleanupRuntime();
+
+  if (originalAssistantHome === undefined) {
+    delete process.env.LINKEDIN_ASSISTANT_HOME;
+    return;
+  }
+
+  process.env.LINKEDIN_ASSISTANT_HOME = originalAssistantHome;
+});
+
+describe("E2E setup helpers", () => {
+  it("uses a stable assistant home inside E2E environment callbacks", async () => {
+    process.env.LINKEDIN_ASSISTANT_HOME = "/tmp/original-linkedin-home";
+
+    const baseDir = getE2EBaseDir();
+    expect(existsSync(baseDir)).toBe(true);
+
+    await withE2EEnvironment(async () => {
+      expect(process.env.LINKEDIN_ASSISTANT_HOME).toBe(baseDir);
+      expect(getE2EBaseDir()).toBe(baseDir);
+    });
+
+    expect(process.env.LINKEDIN_ASSISTANT_HOME).toBe("/tmp/original-linkedin-home");
+  });
+
+  it("restores the previous assistant home after explicit overrides", async () => {
+    process.env.LINKEDIN_ASSISTANT_HOME = "/tmp/original-linkedin-home";
+
+    await withAssistantHome("/tmp/isolated-linkedin-home", async () => {
+      expect(process.env.LINKEDIN_ASSISTANT_HOME).toBe("/tmp/isolated-linkedin-home");
+    });
+
+    expect(process.env.LINKEDIN_ASSISTANT_HOME).toBe("/tmp/original-linkedin-home");
+  });
+
+  it("cleans up the shared E2E assistant home between runs", () => {
+    const firstDir = getE2EBaseDir();
+    expect(existsSync(firstDir)).toBe(true);
+
+    cleanupRuntime();
+    expect(existsSync(firstDir)).toBe(false);
+
+    const secondDir = getE2EBaseDir();
+    expect(secondDir).not.toBe(firstDir);
+    expect(existsSync(secondDir)).toBe(true);
+    cleanupRuntime();
+
+    expect(existsSync(secondDir)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- replace silent E2E early-returns with explicit skipped tests in the live suites
- isolate shared E2E assistant-home state for runtime, CLI, and MCP helpers
- add non-live contract tests for CLI/MCP confirm failure paths and E2E setup helpers

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #61