### PR TITLE
test: cover data deletion edge cases

### DIFF
--- a/packages/cli/test/dataDelete.test.ts
+++ b/packages/cli/test/dataDelete.test.ts
@@ -186,6 +186,60 @@ describe("linkedin data delete", () => {
     });
   });
 
+  it("aborts without deleting anything when the operator declines deletion", async () => {
+    const fixture = await seedLocalDataFixture();
+    readlineMocks.question.mockResolvedValueOnce("no");
+
+    await expect(
+      runCli(["node", "linkedin", "data", "delete"])
+    ).rejects.toMatchObject({
+      message: "Operator declined local data deletion."
+    });
+
+    expect(readlineMocks.question).toHaveBeenCalledTimes(1);
+    expect(await pathExists(fixture.dbPath)).toBe(true);
+    expect(await pathExists(`${fixture.dbPath}-journal`)).toBe(true);
+    expect(await pathExists(`${fixture.dbPath}-wal`)).toBe(true);
+    expect(await pathExists(`${fixture.dbPath}-shm`)).toBe(true);
+    expect(await pathExists(fixture.artifactsDir)).toBe(true);
+    expect(await pathExists(fixture.keepAliveDir)).toBe(true);
+    expect(await pathExists(fixture.rateLimitStatePath)).toBe(true);
+    expect(await pathExists(fixture.profilesDir)).toBe(true);
+    expect(await pathExists(fixture.configFilePath)).toBe(true);
+  });
+
+  it("preserves profiles when the extra profile confirmation is declined", async () => {
+    const fixture = await seedLocalDataFixture();
+    readlineMocks.question
+      .mockResolvedValueOnce("yes")
+      .mockResolvedValueOnce("no");
+
+    await runCli(["node", "linkedin", "data", "delete", "--include-profile"]);
+
+    expect(readlineMocks.question).toHaveBeenCalledTimes(2);
+    expect(await pathExists(fixture.dbPath)).toBe(false);
+    expect(await pathExists(`${fixture.dbPath}-journal`)).toBe(false);
+    expect(await pathExists(`${fixture.dbPath}-wal`)).toBe(false);
+    expect(await pathExists(`${fixture.dbPath}-shm`)).toBe(false);
+    expect(await pathExists(fixture.artifactsDir)).toBe(false);
+    expect(await pathExists(fixture.keepAliveDir)).toBe(false);
+    expect(await pathExists(fixture.rateLimitStatePath)).toBe(false);
+    expect(await pathExists(fixture.profilesDir)).toBe(true);
+    expect(await pathExists(fixture.configFilePath)).toBe(true);
+    expect(
+      consoleLogSpy.mock.calls.some(([message]) =>
+        String(message).includes("Browser profile deletion declined")
+      )
+    ).toBe(true);
+
+    const finalOutput = consoleLogSpy.mock.calls.at(-1)?.[0];
+    expect(JSON.parse(String(finalOutput))).toMatchObject({
+      deleted: true,
+      include_profile_requested: true,
+      include_profile_deleted: false
+    });
+  });
+
   it("refuses to run with --cdp-url", async () => {
     await expect(
       runCli([
@@ -203,6 +257,25 @@ describe("linkedin data delete", () => {
 
     expect(readlineMocks.createInterface).not.toHaveBeenCalled();
     expect(await pathExists(assistantHome)).toBe(false);
+  });
+
+  it("allows deletion to proceed when keepalive pid files are stale", async () => {
+    const fixture = await seedLocalDataFixture();
+    await writeFile(
+      path.join(fixture.keepAliveDir, "default.pid"),
+      "999999\n",
+      "utf8"
+    );
+    readlineMocks.question.mockResolvedValueOnce("yes");
+
+    await runCli(["node", "linkedin", "data", "delete"]);
+
+    expect(readlineMocks.question).toHaveBeenCalledTimes(1);
+    expect(await pathExists(fixture.dbPath)).toBe(false);
+    expect(await pathExists(fixture.keepAliveDir)).toBe(false);
+    expect(await pathExists(fixture.rateLimitStatePath)).toBe(false);
+    expect(await pathExists(fixture.profilesDir)).toBe(true);
+    expect(await pathExists(fixture.configFilePath)).toBe(true);
   });
 
   it("refuses to run while a keepalive daemon is active", async () => {

--- a/packages/core/test/localData.test.ts
+++ b/packages/core/test/localData.test.ts
@@ -125,6 +125,21 @@ describe("local data deletion", () => {
     expect(plan.targets).not.toContain(path.resolve(rateLimitStatePath));
   });
 
+  it("resolves the keepalive directory from the shared config path", () => {
+    expect(resolveKeepAliveDir(baseDir)).toBe(path.join(baseDir, "keepalive"));
+
+    process.env.LINKEDIN_ASSISTANT_HOME = baseDir;
+    expect(resolveKeepAliveDir()).toBe(path.join(baseDir, "keepalive"));
+  });
+
+  it("refuses to build a deletion plan for the filesystem root", () => {
+    const filesystemRoot = path.parse(baseDir).root;
+
+    expect(() =>
+      createLocalDataDeletionPlan({ baseDir: filesystemRoot })
+    ).toThrowError("filesystem root");
+  });
+
   it("deletes database sidecars and preserves config.json by default", async () => {
     const paths = await seedLocalDataFixture();
     const keepAliveDir = resolveKeepAliveDir(baseDir);
@@ -153,6 +168,40 @@ describe("local data deletion", () => {
     expect(await pathExists(paths.profilesDir)).toBe(true);
   });
 
+  it("reports missing paths cleanly when only part of the local state exists", async () => {
+    const paths = resolveConfigPaths(baseDir);
+    const keepAliveDir = resolveKeepAliveDir(baseDir);
+
+    await mkdir(path.dirname(paths.dbPath), { recursive: true });
+    await writeFile(paths.dbPath, "sqlite-data", "utf8");
+    await mkdir(keepAliveDir, { recursive: true });
+    await writeFile(path.join(keepAliveDir, "default.pid"), "321\n", "utf8");
+    await writeFile(configFilePath, "{\"safe\":true}\n", "utf8");
+    await mkdir(path.join(paths.profilesDir, "default"), { recursive: true });
+
+    const result = await deleteLocalData({ baseDir });
+
+    expect(result.deletedPaths).toEqual(
+      expect.arrayContaining([
+        path.resolve(paths.dbPath),
+        path.resolve(keepAliveDir)
+      ])
+    );
+    expect(result.missingPaths).toEqual(
+      expect.arrayContaining([
+        path.resolve(`${paths.dbPath}-journal`),
+        path.resolve(`${paths.dbPath}-wal`),
+        path.resolve(`${paths.dbPath}-shm`),
+        path.resolve(paths.artifactsDir),
+        path.resolve(rateLimitStatePath)
+      ])
+    );
+    expect(await pathExists(paths.dbPath)).toBe(false);
+    expect(await pathExists(keepAliveDir)).toBe(false);
+    expect(await pathExists(configFilePath)).toBe(true);
+    expect(await pathExists(paths.profilesDir)).toBe(true);
+  });
+
   it("deletes browser profiles only when includeProfile is enabled", async () => {
     const paths = await seedLocalDataFixture();
 
@@ -164,5 +213,28 @@ describe("local data deletion", () => {
     expect(result.deletedPaths).toContain(path.resolve(paths.profilesDir));
     expect(await pathExists(paths.profilesDir)).toBe(false);
     expect(await pathExists(configFilePath)).toBe(true);
+  });
+
+  it("is idempotent when deleteLocalData runs repeatedly", async () => {
+    const paths = await seedLocalDataFixture();
+    const keepAliveDir = resolveKeepAliveDir(baseDir);
+
+    await deleteLocalData({ baseDir });
+    const secondResult = await deleteLocalData({ baseDir });
+
+    expect(secondResult.deletedPaths).toEqual([]);
+    expect(secondResult.missingPaths).toEqual(
+      expect.arrayContaining([
+        path.resolve(paths.dbPath),
+        path.resolve(`${paths.dbPath}-journal`),
+        path.resolve(`${paths.dbPath}-wal`),
+        path.resolve(`${paths.dbPath}-shm`),
+        path.resolve(paths.artifactsDir),
+        path.resolve(keepAliveDir),
+        path.resolve(rateLimitStatePath)
+      ])
+    );
+    expect(await pathExists(configFilePath)).toBe(true);
+    expect(await pathExists(paths.profilesDir)).toBe(true);
   });
 });

--- a/packages/core/test/localDataDefaultPaths.test.ts
+++ b/packages/core/test/localDataDefaultPaths.test.ts
@@ -1,0 +1,133 @@
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await access(targetPath);
+    return true;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+async function importLocalDataModules(mockHomeDir: string): Promise<{
+  config: typeof import("../src/config.js");
+  localData: typeof import("../src/localData.js");
+  rateLimitState: typeof import("../src/auth/rateLimitState.js");
+}> {
+  vi.resetModules();
+  vi.doMock("node:os", async () => {
+    const actual = await vi.importActual<typeof import("node:os")>("node:os");
+
+    return {
+      ...actual,
+      default: {
+        ...actual,
+        homedir: () => mockHomeDir
+      },
+      homedir: () => mockHomeDir
+    };
+  });
+
+  const [config, localData, rateLimitState] = await Promise.all([
+    import("../src/config.js"),
+    import("../src/localData.js"),
+    import("../src/auth/rateLimitState.js")
+  ]);
+
+  return {
+    config,
+    localData,
+    rateLimitState
+  };
+}
+
+describe("local data deletion default paths", () => {
+  let previousAssistantHome: string | undefined;
+  let tempDir = "";
+  let mockHomeDir = "";
+
+  beforeEach(async () => {
+    previousAssistantHome = process.env.LINKEDIN_ASSISTANT_HOME;
+    delete process.env.LINKEDIN_ASSISTANT_HOME;
+
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-local-defaults-"));
+    mockHomeDir = path.join(tempDir, "mock-home");
+    await mkdir(mockHomeDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    vi.unmock("node:os");
+    vi.resetModules();
+
+    if (typeof previousAssistantHome === "string") {
+      process.env.LINKEDIN_ASSISTANT_HOME = previousAssistantHome;
+    } else {
+      delete process.env.LINKEDIN_ASSISTANT_HOME;
+    }
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("includes both current and legacy rate-limit files on the default paths", async () => {
+    const { config, localData, rateLimitState } = await importLocalDataModules(
+      mockHomeDir
+    );
+
+    const plan = localData.createLocalDataDeletionPlan();
+    const currentRateLimitStatePath = rateLimitState.resolveRateLimitStateFilePath();
+    const legacyRateLimitStatePath =
+      rateLimitState.resolveLegacyRateLimitStateFilePath();
+
+    expect(config.resolveConfigPaths().baseDir).toBe(
+      path.join(mockHomeDir, ".linkedin-assistant", "linkedin-owa-agentools")
+    );
+    expect(plan.targets).toEqual(
+      expect.arrayContaining([
+        path.resolve(currentRateLimitStatePath),
+        path.resolve(legacyRateLimitStatePath)
+      ])
+    );
+    expect(currentRateLimitStatePath).not.toBe(legacyRateLimitStatePath);
+  });
+
+  it("removes both current and legacy rate-limit files while preserving config.json", async () => {
+    const { config, localData, rateLimitState } = await importLocalDataModules(
+      mockHomeDir
+    );
+
+    const paths = config.resolveConfigPaths();
+    const currentRateLimitStatePath = rateLimitState.resolveRateLimitStateFilePath();
+    const legacyRateLimitStatePath =
+      rateLimitState.resolveLegacyRateLimitStateFilePath();
+    const configFilePath = path.join(paths.baseDir, "config.json");
+
+    await mkdir(path.dirname(currentRateLimitStatePath), { recursive: true });
+    await writeFile(currentRateLimitStatePath, "{\"cooldown\":true}\n", "utf8");
+    await mkdir(path.dirname(legacyRateLimitStatePath), { recursive: true });
+    await writeFile(legacyRateLimitStatePath, "{\"legacy\":true}\n", "utf8");
+    await writeFile(configFilePath, "{\"safe\":true}\n", "utf8");
+
+    const result = await localData.deleteLocalData();
+
+    expect(result.deletedPaths).toEqual(
+      expect.arrayContaining([
+        path.resolve(currentRateLimitStatePath),
+        path.resolve(legacyRateLimitStatePath)
+      ])
+    );
+    expect(await pathExists(currentRateLimitStatePath)).toBe(false);
+    expect(await pathExists(legacyRateLimitStatePath)).toBe(false);
+    expect(await pathExists(configFilePath)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- expand core deletion tests for shared keepalive path resolution, root safety, partial state, and idempotent deletes
- add default-path coverage for removing both current and legacy rate-limit state files while preserving config.json
- cover CLI confirmation declines and stale keepalive PID handling without duplicating the existing happy path cases

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #67