### PR TITLE
fix: harden selector locale fallbacks

### DIFF
--- a/packages/core/src/__tests__/selectorLocale.test.ts
+++ b/packages/core/src/__tests__/selectorLocale.test.ts
@@ -5,6 +5,7 @@ import {
   formatLinkedInSelectorRegexHint,
   getLinkedInSelectorPhrases,
   resolveLinkedInSelectorLocale,
+  resolveLinkedInSelectorLocaleResolution,
   valueContainsLinkedInSelectorPhrase
 } from "../selectorLocale.js";
 
@@ -12,6 +13,7 @@ describe("resolveLinkedInSelectorLocale", () => {
   it("normalizes region-specific locales to the supported base locale", () => {
     expect(resolveLinkedInSelectorLocale("da-DK")).toBe("da");
     expect(resolveLinkedInSelectorLocale("EN_us")).toBe("en");
+    expect(resolveLinkedInSelectorLocale("ＤＡ_ＤＫ")).toBe("da");
   });
 
   it("falls back to english for unsupported locales", () => {
@@ -23,6 +25,32 @@ describe("resolveLinkedInSelectorLocale", () => {
     expect(resolveLinkedInSelectorLocale("   ", "da")).toBe("da");
     expect(resolveLinkedInSelectorLocale("fr-CA", "da")).toBe("da");
     expect(resolveLinkedInSelectorLocale(undefined, "da")).toBe("da");
+  });
+
+  it("rejects malformed unicode and overly long locale values", () => {
+    expect(resolveLinkedInSelectorLocale("d\u200ba")).toBe("en");
+    expect(resolveLinkedInSelectorLocale("da".repeat(40))).toBe("en");
+  });
+});
+
+describe("resolveLinkedInSelectorLocaleResolution", () => {
+  it("returns diagnostics when falling back to english", () => {
+    expect(resolveLinkedInSelectorLocaleResolution("fr-CA")).toEqual({
+      locale: "en",
+      inputProvided: true,
+      normalizedInput: "fr-ca",
+      inputLength: 5,
+      fallbackUsed: true,
+      fallbackReason: "unsupported_locale"
+    });
+  });
+
+  it("marks missing inputs without reporting a fallback", () => {
+    expect(resolveLinkedInSelectorLocaleResolution(undefined)).toEqual({
+      locale: "en",
+      inputProvided: false,
+      fallbackUsed: false
+    });
   });
 });
 
@@ -60,6 +88,15 @@ describe("getLinkedInSelectorPhrases", () => {
 
   it("handles empty phrase sets without producing fallback matches", () => {
     expect(getLinkedInSelectorPhrases([] as const, "da")).toEqual([]);
+  });
+
+  it("ignores invalid phrase keys without throwing", () => {
+    expect(
+      getLinkedInSelectorPhrases(
+        ["connect", "not_a_phrase_key" as unknown as "connect"],
+        "da"
+      )
+    ).toEqual(["Opret forbindelse", "Forbind", "Connect"]);
   });
 });
 
@@ -150,5 +187,11 @@ describe("valueContainsLinkedInSelectorPhrase", () => {
   it("returns false for empty values and empty phrase sets", () => {
     expect(valueContainsLinkedInSelectorPhrase(undefined, "write_message", "da")).toBe(false);
     expect(valueContainsLinkedInSelectorPhrase("", [] as const, "da")).toBe(false);
+  });
+
+  it("matches Unicode-normalized phrase variants", () => {
+    expect(valueContainsLinkedInSelectorPhrase("A\u030Aben for", "open_to", "da")).toBe(
+      true
+    );
   });
 });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -2,7 +2,8 @@ import { mkdirSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
-  resolveLinkedInSelectorLocale,
+  resolveLinkedInSelectorLocaleResolution,
+  type LinkedInSelectorLocaleResolution,
   type LinkedInSelectorLocale
 } from "./selectorLocale.js";
 
@@ -27,6 +28,13 @@ export interface ConfirmFailureArtifactConfig {
 
 export const LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV =
   "LINKEDIN_ASSISTANT_SELECTOR_LOCALE";
+
+export type LinkedInSelectorLocaleConfigSource = "default" | "env" | "option";
+
+export interface LinkedInSelectorLocaleConfigResolution
+  extends LinkedInSelectorLocaleResolution {
+  source: LinkedInSelectorLocaleConfigSource;
+}
 
 function parsePositiveInteger(
   value: string | undefined,
@@ -76,7 +84,25 @@ export function resolveConfirmFailureArtifactConfig(): ConfirmFailureArtifactCon
 export function resolveLinkedInSelectorLocaleConfig(
   selectorLocale?: string | LinkedInSelectorLocale
 ): LinkedInSelectorLocale {
-  return resolveLinkedInSelectorLocale(
-    selectorLocale ?? process.env[LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV]
+  return resolveLinkedInSelectorLocaleConfigResolution(selectorLocale).locale;
+}
+
+export function resolveLinkedInSelectorLocaleConfigResolution(
+  selectorLocale?: string | LinkedInSelectorLocale
+): LinkedInSelectorLocaleConfigResolution {
+  const envSelectorLocale = process.env[LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV];
+  const source: LinkedInSelectorLocaleConfigSource =
+    selectorLocale === undefined
+      ? envSelectorLocale === undefined
+        ? "default"
+        : "env"
+      : "option";
+  const resolution = resolveLinkedInSelectorLocaleResolution(
+    source === "option" ? selectorLocale : envSelectorLocale
   );
+
+  return {
+    ...resolution,
+    source
+  };
 }

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -3,7 +3,7 @@ import {
   ensureConfigPaths,
   resolveConfigPaths,
   resolveConfirmFailureArtifactConfig,
-  resolveLinkedInSelectorLocaleConfig,
+  resolveLinkedInSelectorLocaleConfigResolution,
   type ConfigPaths,
   type ConfirmFailureArtifactConfig
 } from "./config.js";
@@ -66,7 +66,26 @@ import {
 } from "./twoPhaseCommit.js";
 import { resolvePrivacyConfig, type PrivacyConfig } from "./privacy.js";
 import { LinkedInSelectorAuditService } from "./selectorAudit.js";
-import type { LinkedInSelectorLocale } from "./selectorLocale.js";
+import {
+  DEFAULT_LINKEDIN_SELECTOR_LOCALE,
+  type LinkedInSelectorLocale
+} from "./selectorLocale.js";
+
+function summarizeSelectorLocaleInput(
+  normalizedInput: string | undefined,
+  inputLength: number | undefined
+): Record<string, string | number> {
+  if (typeof normalizedInput !== "string") {
+    return {};
+  }
+
+  return {
+    normalized_selector_locale: normalizedInput,
+    ...(typeof inputLength === "number"
+      ? { requested_selector_locale_length: inputLength }
+      : {})
+  };
+}
 
 export interface CreateCoreRuntimeOptions {
   baseDir?: string;
@@ -114,9 +133,10 @@ export function createCoreRuntime(
   ensureConfigPaths(paths);
   const privacy = resolvePrivacyConfig(options.privacy);
   const postSafetyLint = resolveLinkedInPostSafetyLintConfig(paths.baseDir);
-  const selectorLocale = resolveLinkedInSelectorLocaleConfig(
+  const selectorLocaleResolution = resolveLinkedInSelectorLocaleConfigResolution(
     options.selectorLocale
   );
+  const selectorLocale = selectorLocaleResolution.locale;
 
   const db = new AssistantDatabase(options.dbPath ?? paths.dbPath);
   const runId = options.runId ?? createRunId();
@@ -125,6 +145,22 @@ export function createCoreRuntime(
   const confirmFailureArtifacts = resolveConfirmFailureArtifactConfig();
   const profileManager = new ProfileManager(paths);
   let runtime: CoreRuntime;
+
+  if (
+    selectorLocaleResolution.fallbackUsed &&
+    selectorLocale === DEFAULT_LINKEDIN_SELECTOR_LOCALE &&
+    selectorLocaleResolution.source !== "default"
+  ) {
+    logger.log("warn", "runtime.selector_locale.fallback_to_english", {
+      selector_locale_source: selectorLocaleResolution.source,
+      resolved_selector_locale: selectorLocale,
+      reason: selectorLocaleResolution.fallbackReason,
+      ...summarizeSelectorLocaleInput(
+        selectorLocaleResolution.normalizedInput,
+        selectorLocaleResolution.inputLength
+      )
+    });
+  }
 
   const testAutoConfirm = createDefaultTestAutoConfirmConfig();
   const linkedInExecutors = createLinkedInActionExecutors();

--- a/packages/core/src/selectorLocale.ts
+++ b/packages/core/src/selectorLocale.ts
@@ -1,3 +1,37 @@
+const DEFAULT_SELECTOR_ATTRIBUTE_NAME = "aria-label";
+const MAX_SELECTOR_LOCALE_INPUT_LENGTH = 64;
+const SELECTOR_CACHE_KEY_SEPARATOR = "\u001f";
+const VALID_SELECTOR_ATTRIBUTE_NAME_PATTERN = /^[a-z_][-a-z0-9_:.]*$/iu;
+const VALID_SELECTOR_LOCALE_INPUT_PATTERN = /^[a-z0-9_-]+$/u;
+const EMPTY_SELECTOR_PHRASES: readonly string[] = Object.freeze([] as string[]);
+
+const selectorPhraseCache = new Map<string, readonly string[]>();
+const selectorPhrasePatternCache = new Map<string, ResolvedSelectorPhrasePattern>();
+const selectorPhraseRegexCache = new Map<string, RegExp>();
+
+function normalizeUnicode(
+  value: string,
+  form: "NFC" | "NFD" | "NFKC" | "NFKD"
+): string {
+  return value.normalize(form);
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/gu, " ").trim();
+}
+
+function normalizePhrase(value: string): string {
+  return normalizeWhitespace(normalizeUnicode(value, "NFC"));
+}
+
+function normalizePhraseForComparison(value: string): string {
+  return normalizeWhitespace(normalizeUnicode(value, "NFKC")).toLowerCase();
+}
+
+function normalizeLocaleInput(value: string): string {
+  return normalizeUnicode(value, "NFKC").trim().toLowerCase();
+}
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -6,21 +40,21 @@ function escapeCssAttributeValue(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
-function normalizePhrase(value: string): string {
-  return value.replace(/\s+/g, " ").trim();
-}
-
-function dedupePhrases(values: readonly string[]): string[] {
+function dedupePhrases(values: readonly unknown[]): string[] {
   const normalizedValues: string[] = [];
   const seen = new Set<string>();
 
   for (const value of values) {
+    if (typeof value !== "string") {
+      continue;
+    }
+
     const normalized = normalizePhrase(value);
     if (!normalized) {
       continue;
     }
 
-    const dedupeKey = normalized.toLowerCase();
+    const dedupeKey = normalizePhraseForComparison(normalized);
     if (seen.has(dedupeKey)) {
       continue;
     }
@@ -30,6 +64,43 @@ function dedupePhrases(values: readonly string[]): string[] {
   }
 
   return normalizedValues;
+}
+
+function createSelectorPhraseCacheKey(parts: readonly string[]): string {
+  return parts.join(SELECTOR_CACHE_KEY_SEPARATOR);
+}
+
+function normalizeSelectorRoots(roots: string | readonly string[]): string[] {
+  const rawRoots = Array.isArray(roots) ? roots : [roots];
+  const normalizedRoots: string[] = [];
+  const seen = new Set<string>();
+
+  for (const root of rawRoots) {
+    if (typeof root !== "string") {
+      continue;
+    }
+
+    const normalizedRoot = root.trim();
+    if (!normalizedRoot || seen.has(normalizedRoot)) {
+      continue;
+    }
+
+    seen.add(normalizedRoot);
+    normalizedRoots.push(normalizedRoot);
+  }
+
+  return normalizedRoots;
+}
+
+function normalizeSelectorAttributeName(attributeName: string): string {
+  const normalizedAttributeName = attributeName.trim();
+  return VALID_SELECTOR_ATTRIBUTE_NAME_PATTERN.test(normalizedAttributeName)
+    ? normalizedAttributeName
+    : DEFAULT_SELECTOR_ATTRIBUTE_NAME;
+}
+
+function sanitizeSelectorPhrases(values: readonly unknown[] | undefined): string[] {
+  return dedupePhrases(Array.isArray(values) ? values : EMPTY_SELECTOR_PHRASES);
 }
 
 export const LINKEDIN_SELECTOR_LOCALES = ["en", "da"] as const;
@@ -95,7 +166,7 @@ export type LinkedInSelectorPhraseKey =
 
 type SelectorPhraseDictionary = Record<
   LinkedInSelectorPhraseKey,
-  readonly string[]
+  readonly unknown[]
 >;
 
 type SelectorPhraseOverrides = Partial<SelectorPhraseDictionary>;
@@ -226,10 +297,55 @@ const LINKEDIN_SELECTOR_LOCALE_SET = new Set<LinkedInSelectorLocale>(
   LINKEDIN_SELECTOR_LOCALES
 );
 
+const LINKEDIN_SELECTOR_PHRASE_KEY_SET = new Set<LinkedInSelectorPhraseKey>(
+  Object.keys(ENGLISH_SELECTOR_PHRASES) as LinkedInSelectorPhraseKey[]
+);
+
+export type LinkedInSelectorLocaleFallbackReason =
+  | "blank"
+  | "invalid_format"
+  | "unsupported_locale"
+  | "too_long";
+
+export interface LinkedInSelectorLocaleResolution {
+  locale: LinkedInSelectorLocale;
+  inputProvided: boolean;
+  normalizedInput?: string;
+  inputLength?: number;
+  fallbackUsed: boolean;
+  fallbackReason?: LinkedInSelectorLocaleFallbackReason;
+}
+
 function isLinkedInSelectorLocale(
   value: string
 ): value is LinkedInSelectorLocale {
   return LINKEDIN_SELECTOR_LOCALE_SET.has(value as LinkedInSelectorLocale);
+}
+
+function isLinkedInSelectorPhraseKey(
+  value: unknown
+): value is LinkedInSelectorPhraseKey {
+  return (
+    typeof value === "string" &&
+    LINKEDIN_SELECTOR_PHRASE_KEY_SET.has(value as LinkedInSelectorPhraseKey)
+  );
+}
+
+function getEnglishSelectorPhrases(
+  key: LinkedInSelectorPhraseKey
+): readonly string[] {
+  return sanitizeSelectorPhrases(ENGLISH_SELECTOR_PHRASES[key]);
+}
+
+function getLocaleOverrideSelectorPhrases(
+  key: LinkedInSelectorPhraseKey,
+  locale: LinkedInSelectorLocale
+): readonly string[] {
+  return sanitizeSelectorPhrases(
+    locale === "en"
+      ? undefined
+      : LINKEDIN_SELECTOR_PHRASE_OVERRIDES[locale]?.[key]
+  );
 }
 
 function getPrimaryLinkedInSelectorPhrases(
@@ -237,30 +353,102 @@ function getPrimaryLinkedInSelectorPhrases(
   locale: LinkedInSelectorLocale
 ): readonly string[] {
   if (locale === "en") {
-    return ENGLISH_SELECTOR_PHRASES[key];
+    return getEnglishSelectorPhrases(key);
   }
 
-  return (
-    LINKEDIN_SELECTOR_PHRASE_OVERRIDES[locale][key] ??
-    ENGLISH_SELECTOR_PHRASES[key]
-  );
+  const localePhrases = getLocaleOverrideSelectorPhrases(key, locale);
+  return localePhrases.length > 0 ? localePhrases : getEnglishSelectorPhrases(key);
+}
+
+function buildLinkedInSelectorLocaleResolution(
+  locale: LinkedInSelectorLocale,
+  options: Omit<LinkedInSelectorLocaleResolution, "locale">
+): LinkedInSelectorLocaleResolution {
+  return {
+    locale,
+    ...options
+  };
+}
+
+export function resolveLinkedInSelectorLocaleResolution(
+  value: string | LinkedInSelectorLocale | undefined,
+  fallback: LinkedInSelectorLocale = DEFAULT_LINKEDIN_SELECTOR_LOCALE
+): LinkedInSelectorLocaleResolution {
+  if (typeof value !== "string") {
+    return buildLinkedInSelectorLocaleResolution(fallback, {
+      inputProvided: false,
+      fallbackUsed: false
+    });
+  }
+
+  const normalized = normalizeLocaleInput(value);
+  const normalizedInput = normalized.slice(0, MAX_SELECTOR_LOCALE_INPUT_LENGTH);
+  const inputLength = normalized.length;
+
+  if (!normalized) {
+    return buildLinkedInSelectorLocaleResolution(fallback, {
+      inputProvided: true,
+      normalizedInput,
+      inputLength,
+      fallbackUsed: true,
+      fallbackReason: "blank"
+    });
+  }
+
+  if (inputLength > MAX_SELECTOR_LOCALE_INPUT_LENGTH) {
+    return buildLinkedInSelectorLocaleResolution(fallback, {
+      inputProvided: true,
+      normalizedInput,
+      inputLength,
+      fallbackUsed: true,
+      fallbackReason: "too_long"
+    });
+  }
+
+  if (!VALID_SELECTOR_LOCALE_INPUT_PATTERN.test(normalized)) {
+    return buildLinkedInSelectorLocaleResolution(fallback, {
+      inputProvided: true,
+      normalizedInput,
+      inputLength,
+      fallbackUsed: true,
+      fallbackReason: "invalid_format"
+    });
+  }
+
+  const [baseLocale = ""] = normalized.split(/[-_]/u);
+  if (!/^[a-z]{2,3}$/u.test(baseLocale)) {
+    return buildLinkedInSelectorLocaleResolution(fallback, {
+      inputProvided: true,
+      normalizedInput,
+      inputLength,
+      fallbackUsed: true,
+      fallbackReason: "invalid_format"
+    });
+  }
+
+  if (!isLinkedInSelectorLocale(baseLocale)) {
+    return buildLinkedInSelectorLocaleResolution(fallback, {
+      inputProvided: true,
+      normalizedInput,
+      inputLength,
+      fallbackUsed: true,
+      fallbackReason: "unsupported_locale"
+    });
+  }
+
+  return buildLinkedInSelectorLocaleResolution(baseLocale, {
+    inputProvided: true,
+    normalizedInput,
+    inputLength,
+    fallbackUsed: false
+  });
 }
 
 export function resolveLinkedInSelectorLocale(
   value: string | LinkedInSelectorLocale | undefined,
   fallback: LinkedInSelectorLocale = DEFAULT_LINKEDIN_SELECTOR_LOCALE
 ): LinkedInSelectorLocale {
-  if (!value) {
-    return fallback;
-  }
-
-  const normalized = value.trim().toLowerCase();
-  if (!normalized) {
-    return fallback;
-  }
-
-  const [baseLocale = ""] = normalized.split(/[-_]/u);
-  return isLinkedInSelectorLocale(baseLocale) ? baseLocale : fallback;
+  return resolveLinkedInSelectorLocaleResolution(value, fallback).locale;
 }
 
 interface SelectorPhraseOptions {
@@ -272,14 +460,92 @@ interface SelectorRegexOptions extends SelectorPhraseOptions {
 }
 
 interface ResolvedSelectorPhrasePattern {
-  phrases: string[];
+  phrases: readonly string[];
   body: string;
+}
+
+function createSelectorPhraseOptionsKey(
+  options: SelectorPhraseOptions | SelectorRegexOptions
+): readonly string[] {
+  const includeEnglishFallback = options.includeEnglishFallback ?? true;
+  const optionParts = [includeEnglishFallback ? "with-en" : "no-en"];
+
+  if ("exact" in options) {
+    optionParts.push(options.exact ? "exact" : "contains");
+  }
+
+  return optionParts;
+}
+
+function createSelectorPhraseCombinationCacheKey(
+  cachePrefix: string,
+  locale: LinkedInSelectorLocale,
+  normalizedKeys: readonly LinkedInSelectorPhraseKey[],
+  options: SelectorPhraseOptions | SelectorRegexOptions = {}
+): string {
+  return createSelectorPhraseCacheKey([
+    cachePrefix,
+    locale,
+    ...createSelectorPhraseOptionsKey(options),
+    ...normalizedKeys
+  ]);
 }
 
 function normalizePhraseKeys(
   keys: LinkedInSelectorPhraseKey | readonly LinkedInSelectorPhraseKey[]
 ): LinkedInSelectorPhraseKey[] {
-  return typeof keys === "string" ? [keys] : [...keys];
+  const rawKeys = typeof keys === "string" ? [keys] : Array.isArray(keys) ? keys : [];
+  const normalizedKeys: LinkedInSelectorPhraseKey[] = [];
+  const seen = new Set<LinkedInSelectorPhraseKey>();
+
+  for (const key of rawKeys) {
+    if (!isLinkedInSelectorPhraseKey(key) || seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    normalizedKeys.push(key);
+  }
+
+  return normalizedKeys;
+}
+
+function getLinkedInSelectorPhrasesFromNormalizedKeys(
+  normalizedKeys: readonly LinkedInSelectorPhraseKey[],
+  locale: LinkedInSelectorLocale,
+  options: SelectorPhraseOptions = {}
+): readonly string[] {
+  if (normalizedKeys.length === 0) {
+    return EMPTY_SELECTOR_PHRASES;
+  }
+
+  const cacheKey = createSelectorPhraseCombinationCacheKey(
+    "phrases",
+    locale,
+    normalizedKeys,
+    options
+  );
+  const cachedPhrases = selectorPhraseCache.get(cacheKey);
+  if (cachedPhrases) {
+    return cachedPhrases;
+  }
+
+  const includeEnglishFallback = options.includeEnglishFallback ?? true;
+  const primaryValues = normalizedKeys.flatMap((key) =>
+    getPrimaryLinkedInSelectorPhrases(key, locale)
+  );
+
+  const phrases =
+    !includeEnglishFallback || locale === "en"
+      ? dedupePhrases(primaryValues)
+      : dedupePhrases([
+          ...primaryValues,
+          ...normalizedKeys.flatMap((key) => getEnglishSelectorPhrases(key))
+        ]);
+
+  const frozenPhrases = Object.freeze(phrases);
+  selectorPhraseCache.set(cacheKey, frozenPhrases);
+  return frozenPhrases;
 }
 
 function resolveLinkedInSelectorPhrasePattern(
@@ -287,11 +553,29 @@ function resolveLinkedInSelectorPhrasePattern(
   locale: LinkedInSelectorLocale,
   options: SelectorPhraseOptions = {}
 ): ResolvedSelectorPhrasePattern {
-  const phrases = getLinkedInSelectorPhrases(keys, locale, options);
-  return {
+  const normalizedKeys = normalizePhraseKeys(keys);
+  const cacheKey = createSelectorPhraseCombinationCacheKey(
+    "pattern",
+    locale,
+    normalizedKeys,
+    options
+  );
+  const cachedPattern = selectorPhrasePatternCache.get(cacheKey);
+  if (cachedPattern) {
+    return cachedPattern;
+  }
+
+  const phrases = getLinkedInSelectorPhrasesFromNormalizedKeys(
+    normalizedKeys,
+    locale,
+    options
+  );
+  const pattern = {
     phrases,
     body: phrases.map((phrase) => escapeRegExp(phrase)).join("|") || "^$"
   };
+  selectorPhrasePatternCache.set(cacheKey, pattern);
+  return pattern;
 }
 
 export function getLinkedInSelectorPhrases(
@@ -299,19 +583,8 @@ export function getLinkedInSelectorPhrases(
   locale: LinkedInSelectorLocale,
   options: SelectorPhraseOptions = {}
 ): string[] {
-  const includeEnglishFallback = options.includeEnglishFallback ?? true;
   const normalizedKeys = normalizePhraseKeys(keys);
-
-  const primaryValues = normalizedKeys.flatMap((key) =>
-    getPrimaryLinkedInSelectorPhrases(key, locale)
-  );
-
-  if (!includeEnglishFallback || locale === "en") {
-    return dedupePhrases(primaryValues);
-  }
-
-  const englishValues = normalizedKeys.flatMap((key) => ENGLISH_SELECTOR_PHRASES[key]);
-  return dedupePhrases([...primaryValues, ...englishValues]);
+  return [...getLinkedInSelectorPhrasesFromNormalizedKeys(normalizedKeys, locale, options)];
 }
 
 export function buildLinkedInSelectorPhraseRegex(
@@ -319,9 +592,27 @@ export function buildLinkedInSelectorPhraseRegex(
   locale: LinkedInSelectorLocale,
   options: SelectorRegexOptions = {}
 ): RegExp {
-  const { body } = resolveLinkedInSelectorPhrasePattern(keys, locale, options);
+  const normalizedKeys = normalizePhraseKeys(keys);
+  const cacheKey = createSelectorPhraseCombinationCacheKey(
+    "regex",
+    locale,
+    normalizedKeys,
+    options
+  );
+  const cachedRegex = selectorPhraseRegexCache.get(cacheKey);
+  if (cachedRegex) {
+    return cachedRegex;
+  }
+
+  const { body } = resolveLinkedInSelectorPhrasePattern(
+    normalizedKeys,
+    locale,
+    options
+  );
   const pattern = options.exact ? `^(?:${body})$` : `(?:${body})`;
-  return new RegExp(pattern, "i");
+  const regex = new RegExp(pattern, "iu");
+  selectorPhraseRegexCache.set(cacheKey, regex);
+  return regex;
 }
 
 export function formatLinkedInSelectorRegexHint(
@@ -330,23 +621,34 @@ export function formatLinkedInSelectorRegexHint(
   options: SelectorRegexOptions = {}
 ): string {
   const { body } = resolveLinkedInSelectorPhrasePattern(keys, locale, options);
-  return options.exact ? `/^(?:${body})$/i` : `/${body}/i`;
+  return options.exact ? `/^(?:${body})$/iu` : `/${body}/iu`;
 }
 
 export function buildLinkedInAriaLabelContainsSelector(
   roots: string | readonly string[],
   keys: LinkedInSelectorPhraseKey | readonly LinkedInSelectorPhraseKey[],
   locale: LinkedInSelectorLocale,
-  attributeName: string = "aria-label",
+  attributeName: string = DEFAULT_SELECTOR_ATTRIBUTE_NAME,
   options: SelectorPhraseOptions = {}
 ): string {
-  const selectors = Array.isArray(roots) ? roots : [roots];
-  const { phrases } = resolveLinkedInSelectorPhrasePattern(keys, locale, options);
+  const selectors = normalizeSelectorRoots(roots);
+  const normalizedAttributeName = normalizeSelectorAttributeName(attributeName);
+  const normalizedKeys = normalizePhraseKeys(keys);
+  if (selectors.length === 0 || normalizedKeys.length === 0) {
+    return "";
+  }
+
+  const phrases = getLinkedInSelectorPhrasesFromNormalizedKeys(
+    normalizedKeys,
+    locale,
+    options
+  );
 
   return selectors
     .flatMap((root) =>
       phrases.map(
-        (phrase) => `${root}[${attributeName}*="${escapeCssAttributeValue(phrase)}" i]`
+        (phrase) =>
+          `${root}[${normalizedAttributeName}*="${escapeCssAttributeValue(phrase)}" i]`
       )
     )
     .join(", ");
@@ -358,12 +660,19 @@ export function valueContainsLinkedInSelectorPhrase(
   locale: LinkedInSelectorLocale,
   options: SelectorPhraseOptions = {}
 ): boolean {
-  const normalizedValue = normalizePhrase(value ?? "").toLowerCase();
+  const normalizedValue = normalizePhraseForComparison(value ?? "");
   if (!normalizedValue) {
     return false;
   }
 
-  return getLinkedInSelectorPhrases(keys, locale, options).some((phrase) =>
-    normalizedValue.includes(phrase.toLowerCase())
-  );
+  const normalizedKeys = normalizePhraseKeys(keys);
+  if (normalizedKeys.length === 0) {
+    return false;
+  }
+
+  return getLinkedInSelectorPhrasesFromNormalizedKeys(
+    normalizedKeys,
+    locale,
+    options
+  ).some((phrase) => normalizedValue.includes(normalizePhraseForComparison(phrase)));
 }

--- a/packages/core/test/runtimeSelectorLocale.test.ts
+++ b/packages/core/test/runtimeSelectorLocale.test.ts
@@ -1,0 +1,146 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV,
+  createCoreRuntime,
+  resolveConfigPaths
+} from "../src/index.js";
+
+interface LoggedEvent {
+  level: string;
+  event: string;
+  payload: Record<string, unknown>;
+}
+
+async function readRunEvents(baseDir: string, runId: string): Promise<LoggedEvent[]> {
+  const eventsPath = path.join(resolveConfigPaths(baseDir).artifactsDir, runId, "events.jsonl");
+  const contents = await readFile(eventsPath, "utf8");
+
+  return contents
+    .trim()
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as LoggedEvent);
+}
+
+describe("runtime selector locale logging", () => {
+  let baseDir = "";
+  let previousSelectorLocaleEnv: string | undefined;
+
+  beforeEach(async () => {
+    previousSelectorLocaleEnv = process.env[LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV];
+    delete process.env[LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV];
+    baseDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-runtime-selector-locale-"));
+  });
+
+  afterEach(async () => {
+    if (typeof previousSelectorLocaleEnv === "string") {
+      process.env[LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV] = previousSelectorLocaleEnv;
+    } else {
+      delete process.env[LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV];
+    }
+
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  it("logs a warning when an explicit selector locale falls back to english", async () => {
+    const runtime = createCoreRuntime({
+      baseDir,
+      dbPath: ":memory:",
+      runId: "run-selector-locale-warning",
+      selectorLocale: "fr-CA"
+    });
+    let closed = false;
+
+    try {
+      runtime.close();
+      closed = true;
+
+      const events = await readRunEvents(baseDir, "run-selector-locale-warning");
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            level: "warn",
+            event: "runtime.selector_locale.fallback_to_english",
+            payload: expect.objectContaining({
+              selector_locale_source: "option",
+              resolved_selector_locale: "en",
+              reason: "unsupported_locale",
+              normalized_selector_locale: "fr-ca",
+              requested_selector_locale_length: 5
+            })
+          })
+        ])
+      );
+    } finally {
+      if (!closed) {
+        runtime.close();
+      }
+    }
+  });
+
+  it("does not log a warning for supported selector locales", async () => {
+    const runtime = createCoreRuntime({
+      baseDir,
+      dbPath: ":memory:",
+      runId: "run-selector-locale-supported",
+      selectorLocale: "da-DK"
+    });
+    let closed = false;
+
+    try {
+      runtime.close();
+      closed = true;
+
+      const events = await readRunEvents(baseDir, "run-selector-locale-supported");
+      expect(
+        events.some(
+          (event) => event.event === "runtime.selector_locale.fallback_to_english"
+        )
+      ).toBe(false);
+    } finally {
+      if (!closed) {
+        runtime.close();
+      }
+    }
+  });
+
+  it("logs env-based fallback warnings when the configured locale is invalid", async () => {
+    process.env[LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV] = "fr-CA";
+
+    const runtime = createCoreRuntime({
+      baseDir,
+      dbPath: ":memory:",
+      runId: "run-selector-locale-env-warning"
+    });
+    let closed = false;
+
+    try {
+      runtime.close();
+      closed = true;
+
+      const events = await readRunEvents(baseDir, "run-selector-locale-env-warning");
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            level: "warn",
+            event: "runtime.selector_locale.fallback_to_english",
+            payload: expect.objectContaining({
+              selector_locale_source: "env",
+              resolved_selector_locale: "en",
+              reason: "unsupported_locale",
+              normalized_selector_locale: "fr-ca",
+              requested_selector_locale_length: 5
+            })
+          })
+        ])
+      );
+    } finally {
+      if (!closed) {
+        runtime.close();
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add defensive selector-locale validation and diagnostics for malformed, unsupported, blank, Unicode-normalized, and overly long locale inputs
- harden selector phrase resolution with Unicode-safe deduplication, safe fallback handling for missing/corrupt phrase data, and cached regex compilation
- log runtime warnings when invalid selector-locale config falls back to English, and cover both option and env paths with tests

Closes #68

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build
