### PR TITLE
fix: harden local data deletion flow

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -33,7 +33,6 @@ import {
   parseDraftQualityDataset,
   resolveFollowupSinceWindow,
   redactStructuredValue,
-  resolveConfigPaths,
   resolveKeepAliveDir,
   resolvePrivacyConfig,
   toLinkedInAssistantErrorPayload,
@@ -468,7 +467,7 @@ async function runDataDelete(input: {
   const requestedPlan = createLocalDataDeletionPlan({
     includeProfile: input.includeProfile
   });
-  const { profilesDir } = resolveConfigPaths();
+  const profilesDir = path.join(requestedPlan.baseDir, "profiles");
 
   console.log("This permanently deletes local LinkedIn Assistant data:");
   printDeletionTargets(requestedPlan.targets);
@@ -503,8 +502,11 @@ async function runDataDelete(input: {
     deleted: true,
     include_profile_requested: input.includeProfile,
     include_profile_deleted: includeProfile,
+    started_at: deletionResult.startedAt,
+    completed_at: deletionResult.completedAt,
     deleted_paths: deletionResult.deletedPaths,
-    missing_paths: deletionResult.missingPaths
+    missing_paths: deletionResult.missingPaths,
+    failed_paths: deletionResult.failedPaths
   });
 }
 

--- a/packages/cli/test/dataDelete.test.ts
+++ b/packages/cli/test/dataDelete.test.ts
@@ -155,8 +155,15 @@ describe("linkedin data delete", () => {
     expect(JSON.parse(String(finalOutput))).toMatchObject({
       deleted: true,
       include_profile_requested: false,
-      include_profile_deleted: false
+      include_profile_deleted: false,
+      failed_paths: []
     });
+    expect(JSON.parse(String(finalOutput))).toEqual(
+      expect.objectContaining({
+        started_at: expect.any(String),
+        completed_at: expect.any(String)
+      })
+    );
   });
 
   it("deletes browser profiles only after the extra confirmation", async () => {

--- a/packages/core/src/localData.ts
+++ b/packages/core/src/localData.ts
@@ -1,4 +1,5 @@
-import { access, rm } from "node:fs/promises";
+import { realpathSync, statSync } from "node:fs";
+import * as fsPromises from "node:fs/promises";
 import path from "node:path";
 import { resolveRateLimitStateFilePaths } from "./auth/rateLimitState.js";
 import { resolveConfigPaths } from "./config.js";
@@ -16,9 +17,19 @@ export interface LocalDataDeletionPlan {
   targets: string[];
 }
 
+export interface LocalDataDeletionFailure {
+  path: string;
+  code: string | null;
+  message: string;
+  recoveryHint?: string;
+}
+
 export interface LocalDataDeletionResult {
+  startedAt: string;
+  completedAt: string;
   deletedPaths: string[];
   missingPaths: string[];
+  failedPaths: LocalDataDeletionFailure[];
 }
 
 const SQLITE_SIDECAR_SUFFIXES = ["-journal", "-wal", "-shm"] as const;
@@ -35,8 +46,32 @@ function normalizePath(targetPath: string): string {
   return path.resolve(targetPath);
 }
 
+function resolvePathInput(targetPath: string, label: string): string {
+  if (targetPath.trim().length === 0) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must not be empty.`,
+      {
+        target_path: targetPath
+      }
+    );
+  }
+
+  return normalizePath(targetPath);
+}
+
 function dedupePaths(targetPaths: string[]): string[] {
   return [...new Set(targetPaths.map((targetPath) => normalizePath(targetPath)))];
+}
+
+function isErrnoException(
+  error: unknown
+): error is Error & { code?: string } {
+  return error instanceof Error && "code" in error;
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return isErrnoException(error) && error.code === "ENOENT";
 }
 
 function assertSafeDeletePath(targetPath: string, label: string): void {
@@ -52,21 +87,112 @@ function assertSafeDeletePath(targetPath: string, label: string): void {
   }
 }
 
-async function pathExists(targetPath: string): Promise<boolean> {
+function resolveCanonicalDirectoryPath(targetPath: string): string {
+  const normalizedTargetPath = normalizePath(targetPath);
+
   try {
-    await access(targetPath);
-    return true;
-  } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
-      return false;
+    const existingTargetPath = realpathSync(normalizedTargetPath);
+    if (!statSync(existingTargetPath).isDirectory()) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        "Refusing to delete local data because its configured base directory is not a directory.",
+        {
+          base_dir: normalizedTargetPath,
+          resolved_path: existingTargetPath
+        }
+      );
     }
 
-    throw error;
+    return existingTargetPath;
+  } catch (error) {
+    if (!isMissingPathError(error)) {
+      throw error;
+    }
+
+    const parentPath = path.dirname(normalizedTargetPath);
+    if (parentPath === normalizedTargetPath) {
+      return normalizedTargetPath;
+    }
+
+    return path.resolve(
+      resolveCanonicalDirectoryPath(parentPath),
+      path.basename(normalizedTargetPath)
+    );
   }
+}
+
+function resolveDeletionTargetPath(targetPath: string): string {
+  const normalizedTargetPath = normalizePath(targetPath);
+
+  return path.resolve(
+    resolveCanonicalDirectoryPath(path.dirname(normalizedTargetPath)),
+    path.basename(normalizedTargetPath)
+  );
+}
+
+function isPathWithinParent(parentPath: string, targetPath: string): boolean {
+  const relativePath = path.relative(parentPath, targetPath);
+  return (
+    relativePath.length === 0 ||
+    (!relativePath.startsWith("..") && !path.isAbsolute(relativePath))
+  );
+}
+
+function assertTargetWithinBaseDir(targetPath: string, baseDir: string): void {
+  if (isPathWithinParent(baseDir, targetPath)) {
+    return;
+  }
+
+  throw new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    "Refusing to delete a local-data target that escapes the configured base directory.",
+    {
+      base_dir: baseDir,
+      target_path: targetPath
+    }
+  );
+}
+
+function resolveRecoveryHint(code: string | undefined): string | undefined {
+  switch (code) {
+    case "EACCES":
+    case "EPERM":
+      return "Check filesystem permissions for this path and retry.";
+    case "EBUSY":
+      return "Close any process still using this path, then retry the deletion.";
+    case "ENOSPC":
+      return "Free disk space and retry the deletion.";
+    case "ENOTEMPTY":
+      return "Another process changed this directory during deletion. Retry once local activity has stopped.";
+    case "EROFS":
+      return "This path is on a read-only filesystem. Remount it writable or choose a writable assistant home.";
+    default:
+      return undefined;
+  }
+}
+
+function toDeletionFailure(
+  targetPath: string,
+  error: unknown
+): LocalDataDeletionFailure {
+  if (error instanceof Error) {
+    const code = isErrnoException(error) && typeof error.code === "string"
+      ? error.code
+      : null;
+    const recoveryHint = resolveRecoveryHint(code ?? undefined);
+    return {
+      path: targetPath,
+      code,
+      message: error.message,
+      ...(recoveryHint ? { recoveryHint } : {})
+    };
+  }
+
+  return {
+    path: targetPath,
+    code: null,
+    message: String(error)
+  };
 }
 
 export function createLocalDataDeletionPlan(
@@ -74,24 +200,53 @@ export function createLocalDataDeletionPlan(
 ): LocalDataDeletionPlan {
   const paths = resolveConfigPaths(options.baseDir);
   const includeProfile = options.includeProfile ?? false;
-  const baseDir = normalizePath(paths.baseDir);
+  const normalizedBaseDir = resolvePathInput(
+    paths.baseDir,
+    "local data base directory"
+  );
+  const canonicalBaseDir = resolveCanonicalDirectoryPath(normalizedBaseDir);
 
-  assertSafeDeletePath(baseDir, "local data");
+  assertSafeDeletePath(canonicalBaseDir, "local data");
 
-  const targets = dedupePaths([
+  const rawTargets = [
     ...resolveDatabasePaths(paths.dbPath),
     paths.artifactsDir,
     resolveKeepAliveDir(paths.baseDir),
     ...resolveRateLimitStateFilePaths(options.rateLimitStatePath, options.baseDir),
     ...(includeProfile ? [paths.profilesDir] : [])
-  ]);
+  ];
+
+  const targets = dedupePaths(
+    rawTargets.map((targetPath) => {
+      const normalizedTargetPath = resolvePathInput(
+        targetPath,
+        "local-data target path"
+      );
+
+      if (isPathWithinParent(normalizedBaseDir, normalizedTargetPath)) {
+        const relativeTargetPath = path.relative(
+          normalizedBaseDir,
+          normalizedTargetPath
+        );
+        const canonicalTargetPath = path.resolve(
+          canonicalBaseDir,
+          relativeTargetPath
+        );
+
+        assertTargetWithinBaseDir(canonicalTargetPath, canonicalBaseDir);
+        return canonicalTargetPath;
+      }
+
+      return resolveDeletionTargetPath(normalizedTargetPath);
+    })
+  );
 
   for (const targetPath of targets) {
     assertSafeDeletePath(targetPath, "a local-data target");
   }
 
   return {
-    baseDir,
+    baseDir: canonicalBaseDir,
     includeProfile,
     targets
   };
@@ -101,26 +256,52 @@ export async function deleteLocalData(
   options: LocalDataDeletionPlanOptions = {}
 ): Promise<LocalDataDeletionResult> {
   const deletionPlan = createLocalDataDeletionPlan(options);
+  const startedAt = new Date().toISOString();
   const deletedPaths: string[] = [];
   const missingPaths: string[] = [];
+  const failedPaths: LocalDataDeletionFailure[] = [];
 
   for (const targetPath of deletionPlan.targets) {
-    if (!(await pathExists(targetPath))) {
-      missingPaths.push(targetPath);
-      continue;
-    }
+    try {
+      await fsPromises.rm(targetPath, {
+        force: false,
+        recursive: true,
+        maxRetries: 3,
+        retryDelay: 100
+      });
+      deletedPaths.push(targetPath);
+    } catch (error) {
+      if (isMissingPathError(error)) {
+        missingPaths.push(targetPath);
+        continue;
+      }
 
-    await rm(targetPath, {
-      force: false,
-      recursive: true,
-      maxRetries: 3,
-      retryDelay: 100
-    });
-    deletedPaths.push(targetPath);
+      failedPaths.push(toDeletionFailure(targetPath, error));
+    }
   }
 
-  return {
+  const completedAt = new Date().toISOString();
+  const result: LocalDataDeletionResult = {
+    startedAt,
+    completedAt,
     deletedPaths,
-    missingPaths
+    missingPaths,
+    failedPaths
   };
+
+  if (failedPaths.length > 0) {
+    throw new LinkedInAssistantError(
+      "UNKNOWN",
+      "Local data deletion completed with some failures. Review failed_paths and retry after following the recovery guidance.",
+      {
+        started_at: startedAt,
+        completed_at: completedAt,
+        deleted_paths: deletedPaths,
+        missing_paths: missingPaths,
+        failed_paths: failedPaths
+      }
+    );
+  }
+
+  return result;
 }

--- a/packages/core/test/localData.test.ts
+++ b/packages/core/test/localData.test.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from "node:fs";
 import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -9,16 +10,46 @@ import {
   resolveKeepAliveDir
 } from "../src/index.js";
 
+function isMissingPathError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function resolveCanonicalDirectoryPath(targetPath: string): string {
+  const normalizedTargetPath = path.resolve(targetPath);
+
+  try {
+    return realpathSync(normalizedTargetPath);
+  } catch (error) {
+    if (!isMissingPathError(error)) {
+      throw error;
+    }
+
+    const parentPath = path.dirname(normalizedTargetPath);
+    if (parentPath === normalizedTargetPath) {
+      return normalizedTargetPath;
+    }
+
+    return path.resolve(
+      resolveCanonicalDirectoryPath(parentPath),
+      path.basename(normalizedTargetPath)
+    );
+  }
+}
+
+function resolveExpectedDeletionPath(targetPath: string): string {
+  const normalizedTargetPath = path.resolve(targetPath);
+  return path.resolve(
+    resolveCanonicalDirectoryPath(path.dirname(normalizedTargetPath)),
+    path.basename(normalizedTargetPath)
+  );
+}
+
 async function pathExists(targetPath: string): Promise<boolean> {
   try {
     await access(targetPath);
     return true;
   } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
+    if (isMissingPathError(error)) {
       return false;
     }
 
@@ -97,16 +128,16 @@ describe("local data deletion", () => {
     expect(plan.includeProfile).toBe(false);
     expect(plan.targets).toEqual(
       expect.arrayContaining([
-        path.resolve(paths.dbPath),
-        path.resolve(`${paths.dbPath}-journal`),
-        path.resolve(`${paths.dbPath}-wal`),
-        path.resolve(`${paths.dbPath}-shm`),
-        path.resolve(paths.artifactsDir),
-        path.resolve(keepAliveDir),
-        path.resolve(rateLimitStatePath)
+        resolveExpectedDeletionPath(paths.dbPath),
+        resolveExpectedDeletionPath(`${paths.dbPath}-journal`),
+        resolveExpectedDeletionPath(`${paths.dbPath}-wal`),
+        resolveExpectedDeletionPath(`${paths.dbPath}-shm`),
+        resolveExpectedDeletionPath(paths.artifactsDir),
+        resolveExpectedDeletionPath(keepAliveDir),
+        resolveExpectedDeletionPath(rateLimitStatePath)
       ])
     );
-    expect(plan.targets).not.toContain(path.resolve(paths.profilesDir));
+    expect(plan.targets).not.toContain(resolveExpectedDeletionPath(paths.profilesDir));
   });
 
   it("uses an explicit rate-limit state path when provided", () => {
@@ -121,8 +152,10 @@ describe("local data deletion", () => {
       rateLimitStatePath: explicitRateLimitStatePath
     });
 
-    expect(plan.targets).toContain(path.resolve(explicitRateLimitStatePath));
-    expect(plan.targets).not.toContain(path.resolve(rateLimitStatePath));
+    expect(plan.targets).toContain(
+      resolveExpectedDeletionPath(explicitRateLimitStatePath)
+    );
+    expect(plan.targets).not.toContain(resolveExpectedDeletionPath(rateLimitStatePath));
   });
 
   it("resolves the keepalive directory from the shared config path", () => {
@@ -148,15 +181,17 @@ describe("local data deletion", () => {
 
     expect(result.deletedPaths).toEqual(
       expect.arrayContaining([
-        path.resolve(paths.dbPath),
-        path.resolve(`${paths.dbPath}-journal`),
-        path.resolve(`${paths.dbPath}-wal`),
-        path.resolve(`${paths.dbPath}-shm`),
-        path.resolve(paths.artifactsDir),
-        path.resolve(keepAliveDir),
-        path.resolve(rateLimitStatePath)
+        resolveExpectedDeletionPath(paths.dbPath),
+        resolveExpectedDeletionPath(`${paths.dbPath}-journal`),
+        resolveExpectedDeletionPath(`${paths.dbPath}-wal`),
+        resolveExpectedDeletionPath(`${paths.dbPath}-shm`),
+        resolveExpectedDeletionPath(paths.artifactsDir),
+        resolveExpectedDeletionPath(keepAliveDir),
+        resolveExpectedDeletionPath(rateLimitStatePath)
       ])
     );
+    expect(result.failedPaths).toEqual([]);
+    expect(result.startedAt <= result.completedAt).toBe(true);
     expect(await pathExists(paths.dbPath)).toBe(false);
     expect(await pathExists(`${paths.dbPath}-journal`)).toBe(false);
     expect(await pathExists(`${paths.dbPath}-wal`)).toBe(false);
@@ -183,19 +218,20 @@ describe("local data deletion", () => {
 
     expect(result.deletedPaths).toEqual(
       expect.arrayContaining([
-        path.resolve(paths.dbPath),
-        path.resolve(keepAliveDir)
+        resolveExpectedDeletionPath(paths.dbPath),
+        resolveExpectedDeletionPath(keepAliveDir)
       ])
     );
     expect(result.missingPaths).toEqual(
       expect.arrayContaining([
-        path.resolve(`${paths.dbPath}-journal`),
-        path.resolve(`${paths.dbPath}-wal`),
-        path.resolve(`${paths.dbPath}-shm`),
-        path.resolve(paths.artifactsDir),
-        path.resolve(rateLimitStatePath)
+        resolveExpectedDeletionPath(`${paths.dbPath}-journal`),
+        resolveExpectedDeletionPath(`${paths.dbPath}-wal`),
+        resolveExpectedDeletionPath(`${paths.dbPath}-shm`),
+        resolveExpectedDeletionPath(paths.artifactsDir),
+        resolveExpectedDeletionPath(rateLimitStatePath)
       ])
     );
+    expect(result.failedPaths).toEqual([]);
     expect(await pathExists(paths.dbPath)).toBe(false);
     expect(await pathExists(keepAliveDir)).toBe(false);
     expect(await pathExists(configFilePath)).toBe(true);
@@ -210,7 +246,10 @@ describe("local data deletion", () => {
       includeProfile: true
     });
 
-    expect(result.deletedPaths).toContain(path.resolve(paths.profilesDir));
+    expect(result.deletedPaths).toContain(
+      resolveExpectedDeletionPath(paths.profilesDir)
+    );
+    expect(result.failedPaths).toEqual([]);
     expect(await pathExists(paths.profilesDir)).toBe(false);
     expect(await pathExists(configFilePath)).toBe(true);
   });
@@ -225,15 +264,16 @@ describe("local data deletion", () => {
     expect(secondResult.deletedPaths).toEqual([]);
     expect(secondResult.missingPaths).toEqual(
       expect.arrayContaining([
-        path.resolve(paths.dbPath),
-        path.resolve(`${paths.dbPath}-journal`),
-        path.resolve(`${paths.dbPath}-wal`),
-        path.resolve(`${paths.dbPath}-shm`),
-        path.resolve(paths.artifactsDir),
-        path.resolve(keepAliveDir),
-        path.resolve(rateLimitStatePath)
+        resolveExpectedDeletionPath(paths.dbPath),
+        resolveExpectedDeletionPath(`${paths.dbPath}-journal`),
+        resolveExpectedDeletionPath(`${paths.dbPath}-wal`),
+        resolveExpectedDeletionPath(`${paths.dbPath}-shm`),
+        resolveExpectedDeletionPath(paths.artifactsDir),
+        resolveExpectedDeletionPath(keepAliveDir),
+        resolveExpectedDeletionPath(rateLimitStatePath)
       ])
     );
+    expect(secondResult.failedPaths).toEqual([]);
     expect(await pathExists(configFilePath)).toBe(true);
     expect(await pathExists(paths.profilesDir)).toBe(true);
   });

--- a/packages/core/test/localDataDefaultPaths.test.ts
+++ b/packages/core/test/localDataDefaultPaths.test.ts
@@ -1,18 +1,49 @@
+import { realpathSync } from "node:fs";
 import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+function isMissingPathError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function resolveCanonicalDirectoryPath(targetPath: string): string {
+  const normalizedTargetPath = path.resolve(targetPath);
+
+  try {
+    return realpathSync(normalizedTargetPath);
+  } catch (error) {
+    if (!isMissingPathError(error)) {
+      throw error;
+    }
+
+    const parentPath = path.dirname(normalizedTargetPath);
+    if (parentPath === normalizedTargetPath) {
+      return normalizedTargetPath;
+    }
+
+    return path.resolve(
+      resolveCanonicalDirectoryPath(parentPath),
+      path.basename(normalizedTargetPath)
+    );
+  }
+}
+
+function resolveExpectedDeletionPath(targetPath: string): string {
+  const normalizedTargetPath = path.resolve(targetPath);
+  return path.resolve(
+    resolveCanonicalDirectoryPath(path.dirname(normalizedTargetPath)),
+    path.basename(normalizedTargetPath)
+  );
+}
 
 async function pathExists(targetPath: string): Promise<boolean> {
   try {
     await access(targetPath);
     return true;
   } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
+    if (isMissingPathError(error)) {
       return false;
     }
 
@@ -94,8 +125,8 @@ describe("local data deletion default paths", () => {
     );
     expect(plan.targets).toEqual(
       expect.arrayContaining([
-        path.resolve(currentRateLimitStatePath),
-        path.resolve(legacyRateLimitStatePath)
+        resolveExpectedDeletionPath(currentRateLimitStatePath),
+        resolveExpectedDeletionPath(legacyRateLimitStatePath)
       ])
     );
     expect(currentRateLimitStatePath).not.toBe(legacyRateLimitStatePath);
@@ -122,10 +153,11 @@ describe("local data deletion default paths", () => {
 
     expect(result.deletedPaths).toEqual(
       expect.arrayContaining([
-        path.resolve(currentRateLimitStatePath),
-        path.resolve(legacyRateLimitStatePath)
+        resolveExpectedDeletionPath(currentRateLimitStatePath),
+        resolveExpectedDeletionPath(legacyRateLimitStatePath)
       ])
     );
+    expect(result.failedPaths).toEqual([]);
     expect(await pathExists(currentRateLimitStatePath)).toBe(false);
     expect(await pathExists(legacyRateLimitStatePath)).toBe(false);
     expect(await pathExists(configFilePath)).toBe(true);

--- a/packages/core/test/localDataHardening.test.ts
+++ b/packages/core/test/localDataHardening.test.ts
@@ -1,0 +1,274 @@
+import { realpathSync } from "node:fs";
+import { access, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createLocalDataDeletionPlan,
+  deleteLocalData,
+  resolveConfigPaths,
+  resolveKeepAliveDir
+} from "../src/index.js";
+
+type RemovePath = typeof import("node:fs/promises").rm;
+
+function isMissingPathError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function resolveCanonicalDirectoryPath(targetPath: string): string {
+  const normalizedTargetPath = path.resolve(targetPath);
+
+  try {
+    return realpathSync(normalizedTargetPath);
+  } catch (error) {
+    if (!isMissingPathError(error)) {
+      throw error;
+    }
+
+    const parentPath = path.dirname(normalizedTargetPath);
+    if (parentPath === normalizedTargetPath) {
+      return normalizedTargetPath;
+    }
+
+    return path.resolve(
+      resolveCanonicalDirectoryPath(parentPath),
+      path.basename(normalizedTargetPath)
+    );
+  }
+}
+
+function resolveExpectedDeletionPath(targetPath: string): string {
+  const normalizedTargetPath = path.resolve(targetPath);
+  return path.resolve(
+    resolveCanonicalDirectoryPath(path.dirname(normalizedTargetPath)),
+    path.basename(normalizedTargetPath)
+  );
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await access(targetPath);
+    return true;
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+async function importLocalDataWithMockedRm(
+  rmImplementation: RemovePath
+): Promise<typeof import("../src/localData.js")> {
+  vi.resetModules();
+  vi.doMock("node:fs/promises", async () => {
+    const actual = await vi.importActual<typeof import("node:fs/promises")>(
+      "node:fs/promises"
+    );
+
+    return {
+      ...actual,
+      rm: rmImplementation
+    };
+  });
+
+  return await import("../src/localData.js");
+}
+
+describe("local data deletion hardening", () => {
+  let tempDir = "";
+  let baseDir = "";
+  let configFilePath = "";
+  let rateLimitStatePath = "";
+  let previousAssistantHome: string | undefined;
+
+  beforeEach(async () => {
+    previousAssistantHome = process.env.LINKEDIN_ASSISTANT_HOME;
+    delete process.env.LINKEDIN_ASSISTANT_HOME;
+
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-local-data-hardening-"));
+    baseDir = path.join(tempDir, "assistant-home");
+    configFilePath = path.join(baseDir, "config.json");
+    rateLimitStatePath = path.join(baseDir, "rate-limit-state.json");
+  });
+
+  afterEach(async () => {
+    vi.unmock("node:fs/promises");
+    vi.resetModules();
+    vi.restoreAllMocks();
+
+    if (typeof previousAssistantHome === "string") {
+      process.env.LINKEDIN_ASSISTANT_HOME = previousAssistantHome;
+    } else {
+      delete process.env.LINKEDIN_ASSISTANT_HOME;
+    }
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function seedLocalDataFixture(): Promise<ReturnType<typeof resolveConfigPaths>> {
+    const paths = resolveConfigPaths(baseDir);
+    const keepAliveDir = resolveKeepAliveDir(baseDir);
+
+    await mkdir(path.dirname(paths.dbPath), { recursive: true });
+    await writeFile(paths.dbPath, "sqlite-data", "utf8");
+    await writeFile(`${paths.dbPath}-journal`, "sqlite-journal", "utf8");
+    await writeFile(`${paths.dbPath}-wal`, "sqlite-wal", "utf8");
+    await writeFile(`${paths.dbPath}-shm`, "sqlite-shm", "utf8");
+    await mkdir(path.join(paths.artifactsDir, "run-123"), { recursive: true });
+    await writeFile(
+      path.join(paths.artifactsDir, "run-123", "events.jsonl"),
+      "{\"event\":\"runtime.started\"}\n",
+      "utf8"
+    );
+    await mkdir(keepAliveDir, { recursive: true });
+    await writeFile(path.join(keepAliveDir, "default.pid"), "321\n", "utf8");
+    await writeFile(path.join(keepAliveDir, "default.state.json"), "{}\n", "utf8");
+    await writeFile(
+      path.join(keepAliveDir, "default.events.jsonl"),
+      "{\"event\":\"keepalive.tick\"}\n",
+      "utf8"
+    );
+    await mkdir(path.join(paths.profilesDir, "default"), { recursive: true });
+    await writeFile(
+      path.join(paths.profilesDir, "default", "Preferences"),
+      "profile-data",
+      "utf8"
+    );
+    await writeFile(rateLimitStatePath, "{\"cooldown\":true}\n", "utf8");
+    await writeFile(configFilePath, "{\"safe\":true}\n", "utf8");
+
+    return paths;
+  }
+
+  it("rejects blank base directories instead of resolving them from cwd", () => {
+    expect(() =>
+      createLocalDataDeletionPlan({ baseDir: "   " })
+    ).toThrowError("must not be empty");
+  });
+
+  it("canonicalizes targets through a symlinked assistant home", async () => {
+    const realBaseDir = path.join(tempDir, "real-home");
+    const symlinkBaseDir = path.join(tempDir, "assistant-home-link");
+
+    await mkdir(realBaseDir, { recursive: true });
+    await symlink(realBaseDir, symlinkBaseDir);
+
+    const plan = createLocalDataDeletionPlan({ baseDir: symlinkBaseDir });
+    const resolvedBaseDir = resolveCanonicalDirectoryPath(realBaseDir);
+
+    expect(plan.baseDir).toBe(resolvedBaseDir);
+    expect(plan.targets).toEqual(
+      expect.arrayContaining([
+        path.join(resolvedBaseDir, "state.sqlite"),
+        path.join(resolvedBaseDir, "state.sqlite-journal"),
+        path.join(resolvedBaseDir, "state.sqlite-wal"),
+        path.join(resolvedBaseDir, "state.sqlite-shm"),
+        path.join(resolvedBaseDir, "artifacts"),
+        path.join(resolvedBaseDir, "keepalive"),
+        path.join(resolvedBaseDir, "rate-limit-state.json")
+      ])
+    );
+    expect(plan.targets).not.toContain(path.resolve(symlinkBaseDir, "artifacts"));
+  });
+
+  it("deletes symlinked target entries without touching data outside the assistant home", async () => {
+    const paths = resolveConfigPaths(baseDir);
+    const externalArtifactsDir = path.join(tempDir, "external-artifacts");
+    const externalArtifactFile = path.join(externalArtifactsDir, "outside.jsonl");
+
+    await mkdir(baseDir, { recursive: true });
+    await mkdir(externalArtifactsDir, { recursive: true });
+    await writeFile(externalArtifactFile, "outside", "utf8");
+    await symlink(externalArtifactsDir, paths.artifactsDir);
+
+    const result = await deleteLocalData({ baseDir });
+
+    expect(result.deletedPaths).toContain(
+      resolveExpectedDeletionPath(paths.artifactsDir)
+    );
+    expect(result.failedPaths).toEqual([]);
+    expect(await pathExists(paths.artifactsDir)).toBe(false);
+    expect(await pathExists(externalArtifactsDir)).toBe(true);
+    expect(await pathExists(externalArtifactFile)).toBe(true);
+  });
+
+  it("continues deleting other targets after a permission-style failure and returns recovery guidance", async () => {
+    const paths = await seedLocalDataFixture();
+    const keepAliveDir = resolveKeepAliveDir(baseDir);
+    const actualFsPromises = await vi.importActual<typeof import("node:fs/promises")>(
+      "node:fs/promises"
+    );
+    const { deleteLocalData: deleteLocalDataWithMock } =
+      await importLocalDataWithMockedRm(async (targetPath, options) => {
+        if (String(targetPath) === resolveExpectedDeletionPath(paths.artifactsDir)) {
+          throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+        }
+
+        await actualFsPromises.rm(targetPath, options);
+      });
+
+    await expect(deleteLocalDataWithMock({ baseDir })).rejects.toMatchObject({
+      message:
+        "Local data deletion completed with some failures. Review failed_paths and retry after following the recovery guidance.",
+      details: {
+        deleted_paths: expect.arrayContaining([
+          resolveExpectedDeletionPath(paths.dbPath),
+          resolveExpectedDeletionPath(`${paths.dbPath}-journal`),
+          resolveExpectedDeletionPath(`${paths.dbPath}-wal`),
+          resolveExpectedDeletionPath(`${paths.dbPath}-shm`),
+          resolveExpectedDeletionPath(keepAliveDir),
+          resolveExpectedDeletionPath(rateLimitStatePath)
+        ]),
+        failed_paths: [
+          {
+            path: resolveExpectedDeletionPath(paths.artifactsDir),
+            code: "EACCES",
+            message: "permission denied",
+            recoveryHint: "Check filesystem permissions for this path and retry."
+          }
+        ]
+      }
+    });
+
+    expect(await pathExists(paths.dbPath)).toBe(false);
+    expect(await pathExists(`${paths.dbPath}-journal`)).toBe(false);
+    expect(await pathExists(`${paths.dbPath}-wal`)).toBe(false);
+    expect(await pathExists(`${paths.dbPath}-shm`)).toBe(false);
+    expect(await pathExists(keepAliveDir)).toBe(false);
+    expect(await pathExists(rateLimitStatePath)).toBe(false);
+    expect(await pathExists(paths.artifactsDir)).toBe(true);
+    expect(await pathExists(configFilePath)).toBe(true);
+    expect(await pathExists(paths.profilesDir)).toBe(true);
+  });
+
+  it("treats concurrently removed targets as missing instead of failing", async () => {
+    const paths = await seedLocalDataFixture();
+    const actualFsPromises = await vi.importActual<typeof import("node:fs/promises")>(
+      "node:fs/promises"
+    );
+    const { deleteLocalData: deleteLocalDataWithMock } =
+      await importLocalDataWithMockedRm(async (targetPath, options) => {
+        if (String(targetPath) === resolveExpectedDeletionPath(paths.artifactsDir)) {
+          await actualFsPromises.rm(targetPath, options);
+          throw Object.assign(new Error("no such file or directory"), {
+            code: "ENOENT"
+          });
+        }
+
+        await actualFsPromises.rm(targetPath, options);
+      });
+
+    const result = await deleteLocalDataWithMock({ baseDir });
+
+    expect(result.missingPaths).toContain(
+      resolveExpectedDeletionPath(paths.artifactsDir)
+    );
+    expect(result.failedPaths).toEqual([]);
+    expect(result.startedAt <= result.completedAt).toBe(true);
+    expect(await pathExists(paths.artifactsDir)).toBe(false);
+    expect(await pathExists(configFilePath)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary\n- harden local data deletion path handling with canonical path resolution, root/blank-path guards, and bounded target checks\n- continue deleting unaffected targets on filesystem errors and return actionable recovery guidance with structured audit timestamps\n- add focused coverage for canonical paths, symlink safety, concurrent deletions, partial failures, and CLI audit output\n\n## Testing\n- npm run typecheck\n- npm run lint\n- npm test\n- npm run build\n\nCloses #74