### PR TITLE
fix: polish selector locale UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Default tool-owned state home (profiles, DB, artifacts):
 - `~/.linkedin-assistant/linkedin-owa-agentools`
 - Override with `LINKEDIN_ASSISTANT_HOME=/custom/path`
 - Confirm-failure trace size cap: `LINKEDIN_ASSISTANT_CONFIRM_TRACE_MAX_BYTES` (defaults to `26214400`)
-- Selector locale for UI-text fallbacks: `LINKEDIN_ASSISTANT_SELECTOR_LOCALE` (defaults to `en`; supports `en`, `da`)
+- Selector locale for UI-text fallbacks: `LINKEDIN_ASSISTANT_SELECTOR_LOCALE` (defaults to `en`; supports `en`, `da`; region tags like `da-DK` normalize to `da`; unsupported values fall back to `en` with a warning)
 
 Privacy / redaction controls:
 
@@ -174,8 +174,10 @@ Failures
   `selector-audit/report.json`; screenshots, DOM snapshots, and accessibility
   snapshots are captured only for failures.
 - Selector audit also supports `--selector-locale <locale>` for localized UI
-  text fallbacks, and the default can be set with
-  `LINKEDIN_ASSISTANT_SELECTOR_LOCALE`.
+  text fallbacks. Region tags such as `da-DK` normalize to `da`, and
+  unsupported values fall back to `en` with a warning.
+- Set `LINKEDIN_ASSISTANT_SELECTOR_LOCALE` to change the default selector
+  locale for the current shell.
 
 Inbox MVP commands:
 

--- a/docs/selector-audit.md
+++ b/docs/selector-audit.md
@@ -123,10 +123,11 @@ Available switches:
 - `--verbose`: add selector-by-selector detail to human output
 - `--no-progress`: suppress live progress lines in human output
 - `--cdp-url <url>`: attach to an existing authenticated browser session
-- `--selector-locale <locale>`: use locale-aware UI text fallbacks (`en`, `da`)
+- `--selector-locale <locale>`: prefer locale-aware UI text fallbacks (`en`, `da`); region tags like `da-DK` normalize to `da`
 
 You can also set `LINKEDIN_ASSISTANT_SELECTOR_LOCALE` to change the default
-selector locale. General tool state and artifacts still follow
+selector locale. Unsupported values fall back to `en` with a warning. General
+tool state and artifacts still follow
 `LINKEDIN_ASSISTANT_HOME`.
 
 ### Core API

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -17,9 +17,11 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { Command } from "commander";
 import {
   DEFAULT_FOLLOWUP_SINCE,
+  LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV,
   clearRateLimitState,
   createLocalDataDeletionPlan,
   evaluateDraftQuality,
+  getLinkedInSelectorLocaleConfigWarning,
   isInRateLimitCooldown,
   LINKEDIN_FEED_REACTION_TYPES,
   LINKEDIN_POST_VISIBILITY_TYPES,
@@ -32,6 +34,7 @@ import {
   parseDraftQualityCandidateSet,
   parseDraftQualityDataset,
   resolveFollowupSinceWindow,
+  resolveLinkedInSelectorLocaleConfigResolution,
   redactStructuredValue,
   resolveConfigPaths,
   resolveKeepAliveDir,
@@ -58,6 +61,29 @@ const SELECTOR_AUDIT_DOC_PATH = "docs/selector-audit.md";
 const SELECTOR_AUDIT_DOC_REFERENCE =
   `See ${SELECTOR_AUDIT_DOC_PATH} for sample output, configuration, and troubleshooting.`;
 let cliSelectorLocale: string | undefined;
+
+function writeCliWarning(message: string): void {
+  process.stderr.write(`[linkedin] Warning: ${message}\n`);
+}
+
+function writeCliNotice(message: string): void {
+  process.stderr.write(`[linkedin] ${message}\n`);
+}
+
+function maybeWarnAboutSelectorLocaleConfig(selectorLocale?: string): void {
+  const warning = getLinkedInSelectorLocaleConfigWarning(
+    resolveLinkedInSelectorLocaleConfigResolution(selectorLocale),
+    "cli"
+  );
+
+  if (!warning) {
+    return;
+  }
+
+  writeCliWarning(warning.message);
+  writeCliNotice(warning.actionTaken);
+  writeCliNotice(warning.guidance);
+}
 
 function coercePositiveInt(value: string, label: string): number {
   const parsed = Number.parseInt(value, 10);
@@ -107,6 +133,8 @@ function printJson(value: unknown): void {
 }
 
 function createRuntime(cdpUrl?: string) {
+  maybeWarnAboutSelectorLocaleConfig(cliSelectorLocale);
+
   if (cdpUrl) {
     process.stderr.write(
       [
@@ -560,6 +588,8 @@ async function runKeepAliveStart(input: {
     await removeKeepAlivePid(input.profileName);
   }
 
+  maybeWarnAboutSelectorLocaleConfig(cliSelectorLocale);
+
   const cliEntrypoint = resolveKeepAliveCliEntrypoint();
   if (!cliEntrypoint) {
     throw new LinkedInAssistantError(
@@ -748,16 +778,7 @@ async function runKeepAliveDaemon(input: {
   jitterSeconds: number;
   maxConsecutiveFailures: number;
 }, cdpUrl?: string): Promise<void> {
-  const runtime = createCoreRuntime(
-    cdpUrl
-      ? {
-          cdpUrl,
-          ...(cliSelectorLocale ? { selectorLocale: cliSelectorLocale } : {})
-        }
-      : {
-          ...(cliSelectorLocale ? { selectorLocale: cliSelectorLocale } : {})
-        }
-  );
+  const runtime = createRuntime(cdpUrl);
   const profileName = input.profileName;
   let stopRequested = false;
   let consecutiveFailures = 0;
@@ -1956,11 +1977,18 @@ export async function runCli(argv: string[] = process.argv): Promise<void> {
     )
     .option(
       "--selector-locale <locale>",
-      `Selector locale for LinkedIn UI text fallbacks (${LINKEDIN_SELECTOR_LOCALES.join(", ")})`
+      `Prefer localized LinkedIn UI text first (${LINKEDIN_SELECTOR_LOCALES.join(
+        ", "
+      )}; region tags like da-DK normalize to da)`
     )
     .addHelpText(
       "after",
       [
+        "",
+        "Selector locale:",
+        `  --selector-locale <locale> overrides ${LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV} for one command.`,
+        `  ${LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV}=da sets the default for the current shell.`,
+        "  Unsupported locale values fall back to English with a warning on stderr.",
         "",
         "Diagnostics:",
         "  linkedin audit selectors --help",

--- a/packages/cli/test/selectorLocaleCli.test.ts
+++ b/packages/cli/test/selectorLocaleCli.test.ts
@@ -1,0 +1,130 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const cliSelectorLocaleMocks = vi.hoisted(() => ({
+  loggerLog: vi.fn(),
+  authStatus: vi.fn(async () => ({ authenticated: true })),
+  close: vi.fn(),
+  createCoreRuntime: vi.fn(() => ({
+    runId: "run-selector-locale-cli",
+    logger: { log: cliSelectorLocaleMocks.loggerLog },
+    auth: { status: cliSelectorLocaleMocks.authStatus },
+    close: cliSelectorLocaleMocks.close
+  })),
+  spawn: vi.fn(() => ({
+    pid: 12_345,
+    unref: vi.fn()
+  }))
+}));
+
+vi.mock("@linkedin-assistant/core", async () => {
+  const actual = await import("../../core/src/index.js");
+  return {
+    ...actual,
+    createCoreRuntime: cliSelectorLocaleMocks.createCoreRuntime
+  };
+});
+
+vi.mock("node:child_process", () => ({
+  spawn: cliSelectorLocaleMocks.spawn
+}));
+
+import {
+  LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV
+} from "../../core/src/index.js";
+import { runCli } from "../src/bin/linkedin.js";
+
+describe("CLI selector locale messaging", () => {
+  let tempDir = "";
+  let previousSelectorLocaleEnv: string | undefined;
+  let stderrChunks: string[] = [];
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let stderrWriteSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-cli-selector-locale-"));
+    previousSelectorLocaleEnv = process.env[LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV];
+    delete process.env[LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV];
+    process.env.LINKEDIN_ASSISTANT_HOME = path.join(tempDir, "assistant-home");
+    process.exitCode = undefined;
+    stderrChunks = [];
+    vi.clearAllMocks();
+    cliSelectorLocaleMocks.authStatus.mockResolvedValue({ authenticated: true });
+    cliSelectorLocaleMocks.createCoreRuntime.mockImplementation(() => ({
+      runId: "run-selector-locale-cli",
+      logger: { log: cliSelectorLocaleMocks.loggerLog },
+      auth: { status: cliSelectorLocaleMocks.authStatus },
+      close: cliSelectorLocaleMocks.close
+    }));
+    cliSelectorLocaleMocks.spawn.mockImplementation(() => ({
+      pid: 12_345,
+      unref: vi.fn()
+    }));
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    stderrWriteSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((...args: Parameters<typeof process.stderr.write>) => {
+        const [chunk] = args;
+        stderrChunks.push(String(chunk));
+        return true;
+      });
+  });
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore();
+    stderrWriteSpy.mockRestore();
+    process.exitCode = undefined;
+    delete process.env.LINKEDIN_ASSISTANT_HOME;
+    if (typeof previousSelectorLocaleEnv === "string") {
+      process.env[LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV] = previousSelectorLocaleEnv;
+    } else {
+      delete process.env[LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV];
+    }
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("warns when --selector-locale falls back to English for runtime commands", async () => {
+    await runCli(["node", "linkedin", "--selector-locale", "fr-CA", "status"]);
+
+    const stderrOutput = stderrChunks.join("");
+
+    expect(stderrOutput).toContain(
+      '[linkedin] Warning: Unsupported selector locale "fr-ca" from --selector-locale.'
+    );
+    expect(stderrOutput).toContain(
+      '[linkedin] Using English ("en") selector phrases for this run.'
+    );
+    expect(stderrOutput).toContain("Supported locales: en, da.");
+    expect(cliSelectorLocaleMocks.createCoreRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        privacy: expect.any(Object),
+        selectorLocale: "fr-CA"
+      })
+    );
+  });
+
+  it("warns before starting keepalive when env locale falls back to English", async () => {
+    process.env[LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV] = "fr-CA";
+
+    await runCli(["node", "linkedin", "keepalive", "start"]);
+
+    const stderrOutput = stderrChunks.join("");
+
+    expect(stderrOutput).toContain(
+      `[linkedin] Warning: Unsupported selector locale "fr-ca" from ${LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV}.`
+    );
+    expect(stderrOutput).toContain(
+      "override it for one command with --selector-locale <locale>."
+    );
+    expect(cliSelectorLocaleMocks.spawn).toHaveBeenCalledTimes(1);
+    expect(cliSelectorLocaleMocks.createCoreRuntime).not.toHaveBeenCalled();
+  });
+
+  it("stays quiet for supported locales", async () => {
+    await runCli(["node", "linkedin", "--selector-locale", "da-DK", "status"]);
+
+    expect(stderrChunks.join("")).toBe("");
+  });
+});

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -2,17 +2,26 @@ import { mkdirSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
+  DEFAULT_LINKEDIN_SELECTOR_LOCALE,
+  LINKEDIN_SELECTOR_LOCALES,
   resolveLinkedInSelectorLocaleResolution,
+  type LinkedInSelectorLocaleFallbackReason,
   type LinkedInSelectorLocaleResolution,
   type LinkedInSelectorLocale
 } from "./selectorLocale.js";
 
+/**
+ * Default directory used for tool-owned state when no custom home is configured.
+ */
 export const DEFAULT_LINKEDIN_ASSISTANT_HOME = path.join(
   os.homedir(),
   ".linkedin-assistant",
   "linkedin-owa-agentools"
 );
 
+/**
+ * Resolved on-disk locations for profiles, database state, and run artifacts.
+ */
 export interface ConfigPaths {
   baseDir: string;
   artifactsDir: string;
@@ -20,20 +29,53 @@ export interface ConfigPaths {
   dbPath: string;
 }
 
+/**
+ * Default maximum trace size captured for confirm-failure artifacts.
+ */
 export const DEFAULT_CONFIRM_TRACE_MAX_BYTES = 25 * 1024 * 1024;
 
+/**
+ * Configures confirm-failure artifact capture limits.
+ */
 export interface ConfirmFailureArtifactConfig {
   traceMaxBytes: number;
 }
 
+/**
+ * Environment variable that sets the default selector locale for the current
+ * shell or process tree.
+ */
 export const LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV =
   "LINKEDIN_ASSISTANT_SELECTOR_LOCALE";
 
+/**
+ * Indicates where the effective selector-locale value came from.
+ */
 export type LinkedInSelectorLocaleConfigSource = "default" | "env" | "option";
 
+/**
+ * Detailed selector-locale resolution, including precedence source and any
+ * fallback diagnostics.
+ */
 export interface LinkedInSelectorLocaleConfigResolution
   extends LinkedInSelectorLocaleResolution {
   source: LinkedInSelectorLocaleConfigSource;
+}
+
+/**
+ * Controls whether selector-locale guidance is formatted for runtime logs or
+ * end-user CLI output.
+ */
+export type LinkedInSelectorLocaleConfigWarningContext = "runtime" | "cli";
+
+/**
+ * Human-readable guidance for a selector-locale fallback.
+ */
+export interface LinkedInSelectorLocaleConfigWarning {
+  message: string;
+  actionTaken: string;
+  guidance: string;
+  supportedLocales: LinkedInSelectorLocale[];
 }
 
 function parsePositiveInteger(
@@ -52,6 +94,9 @@ function parsePositiveInteger(
   return parsed;
 }
 
+/**
+ * Resolves the base configuration directories for the current process.
+ */
 export function resolveConfigPaths(baseDir?: string): ConfigPaths {
   const resolvedBaseDir =
     baseDir ??
@@ -66,12 +111,19 @@ export function resolveConfigPaths(baseDir?: string): ConfigPaths {
   };
 }
 
+/**
+ * Ensures the configured state directories exist before the runtime writes to
+ * them.
+ */
 export function ensureConfigPaths(paths: ConfigPaths): void {
   mkdirSync(paths.baseDir, { recursive: true });
   mkdirSync(paths.artifactsDir, { recursive: true });
   mkdirSync(paths.profilesDir, { recursive: true });
 }
 
+/**
+ * Resolves artifact capture limits from the environment.
+ */
 export function resolveConfirmFailureArtifactConfig(): ConfirmFailureArtifactConfig {
   return {
     traceMaxBytes: parsePositiveInteger(
@@ -81,12 +133,24 @@ export function resolveConfirmFailureArtifactConfig(): ConfirmFailureArtifactCon
   };
 }
 
+/**
+ * Resolves the effective selector locale after applying option → env → default
+ * precedence.
+ */
 export function resolveLinkedInSelectorLocaleConfig(
   selectorLocale?: string | LinkedInSelectorLocale
 ): LinkedInSelectorLocale {
   return resolveLinkedInSelectorLocaleConfigResolution(selectorLocale).locale;
 }
 
+/**
+ * Resolves selector-locale config with source and fallback diagnostics.
+ *
+ * @remarks
+ * Explicit `selectorLocale` values win over
+ * `LINKEDIN_ASSISTANT_SELECTOR_LOCALE`, which in turn wins over the default
+ * English locale.
+ */
 export function resolveLinkedInSelectorLocaleConfigResolution(
   selectorLocale?: string | LinkedInSelectorLocale
 ): LinkedInSelectorLocaleConfigResolution {
@@ -104,5 +168,127 @@ export function resolveLinkedInSelectorLocaleConfigResolution(
   return {
     ...resolution,
     source
+  };
+}
+
+function formatSelectorLocaleSourceLabel(
+  source: LinkedInSelectorLocaleConfigSource,
+  context: LinkedInSelectorLocaleConfigWarningContext
+): string {
+  if (source === "env") {
+    return LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV;
+  }
+
+  if (source === "option") {
+    return context === "cli" ? "--selector-locale" : "selectorLocale option";
+  }
+
+  return "default selector locale";
+}
+
+function formatSelectorLocalePreview(
+  normalizedInput: string | undefined
+): string | null {
+  return typeof normalizedInput === "string" && normalizedInput.length > 0
+    ? `"${normalizedInput}"`
+    : null;
+}
+
+function formatSelectorLocaleFallbackMessage(
+  resolution: LinkedInSelectorLocaleConfigResolution,
+  context: LinkedInSelectorLocaleConfigWarningContext
+): string {
+  const sourceLabel = formatSelectorLocaleSourceLabel(resolution.source, context);
+  const localePreview = formatSelectorLocalePreview(resolution.normalizedInput);
+
+  switch (resolution.fallbackReason) {
+    case "blank":
+      return resolution.source === "env"
+        ? `${sourceLabel} was set but blank.`
+        : `${sourceLabel} was blank.`;
+    case "invalid_format":
+      return localePreview
+        ? `Invalid selector locale ${localePreview} from ${sourceLabel}.`
+        : `Invalid selector locale from ${sourceLabel}.`;
+    case "too_long":
+      return typeof resolution.inputLength === "number"
+        ? `Selector locale from ${sourceLabel} is too long (${resolution.inputLength} characters).`
+        : `Selector locale from ${sourceLabel} is too long.`;
+    case "unsupported_locale":
+    default:
+      return localePreview
+        ? `Unsupported selector locale ${localePreview} from ${sourceLabel}.`
+        : `Unsupported selector locale from ${sourceLabel}.`;
+  }
+}
+
+function formatSelectorLocaleExamples(
+  reason: LinkedInSelectorLocaleFallbackReason | undefined
+): string {
+  return reason === "unsupported_locale"
+    ? `Supported locales: ${LINKEDIN_SELECTOR_LOCALES.join(", ")}.`
+    : `Supported locales: ${LINKEDIN_SELECTOR_LOCALES.join(", ")}. Use a locale tag like en, da, or da-DK.`;
+}
+
+function formatSelectorLocaleGuidance(
+  resolution: LinkedInSelectorLocaleConfigResolution,
+  context: LinkedInSelectorLocaleConfigWarningContext
+): string {
+  const supportedLocalesMessage = formatSelectorLocaleExamples(
+    resolution.fallbackReason
+  );
+  const normalizedTagMessage = "Region tags like da-DK normalize to da.";
+
+  if (context === "cli") {
+    if (resolution.source === "env") {
+      return [
+        supportedLocalesMessage,
+        normalizedTagMessage,
+        `Update ${LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV} or override it for one command with --selector-locale <locale>.`
+      ].join(" ");
+    }
+
+    return [
+      supportedLocalesMessage,
+      normalizedTagMessage,
+      "Pass --selector-locale <locale> or omit the flag to use the default English selectors."
+    ].join(" ");
+  }
+
+  return [
+    supportedLocalesMessage,
+    normalizedTagMessage,
+    `Pass a supported selectorLocale value or update ${LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV}.`
+  ].join(" ");
+}
+
+function formatSelectorLocaleActionTaken(
+  locale: LinkedInSelectorLocale
+): string {
+  const localeLabel =
+    locale === DEFAULT_LINKEDIN_SELECTOR_LOCALE
+      ? 'English ("en")'
+      : `selector locale "${locale}"`;
+
+  return `Using ${localeLabel} selector phrases for this run.`;
+}
+
+/**
+ * Builds a human-readable warning when selector-locale config falls back away
+ * from the requested input.
+ */
+export function getLinkedInSelectorLocaleConfigWarning(
+  resolution: LinkedInSelectorLocaleConfigResolution,
+  context: LinkedInSelectorLocaleConfigWarningContext = "runtime"
+): LinkedInSelectorLocaleConfigWarning | null {
+  if (!resolution.fallbackUsed || resolution.source === "default") {
+    return null;
+  }
+
+  return {
+    message: formatSelectorLocaleFallbackMessage(resolution, context),
+    actionTaken: formatSelectorLocaleActionTaken(resolution.locale),
+    guidance: formatSelectorLocaleGuidance(resolution, context),
+    supportedLocales: [...LINKEDIN_SELECTOR_LOCALES]
   };
 }

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1,6 +1,7 @@
 import { ArtifactHelpers } from "./artifacts.js";
 import {
   ensureConfigPaths,
+  getLinkedInSelectorLocaleConfigWarning,
   resolveConfigPaths,
   resolveConfirmFailureArtifactConfig,
   resolveLinkedInSelectorLocaleConfigResolution,
@@ -151,10 +152,23 @@ export function createCoreRuntime(
     selectorLocale === DEFAULT_LINKEDIN_SELECTOR_LOCALE &&
     selectorLocaleResolution.source !== "default"
   ) {
+    const selectorLocaleWarning = getLinkedInSelectorLocaleConfigWarning(
+      selectorLocaleResolution,
+      "runtime"
+    );
+
     logger.log("warn", "runtime.selector_locale.fallback_to_english", {
       selector_locale_source: selectorLocaleResolution.source,
       resolved_selector_locale: selectorLocale,
       reason: selectorLocaleResolution.fallbackReason,
+      ...(selectorLocaleWarning
+        ? {
+            message: selectorLocaleWarning.message,
+            action_taken: selectorLocaleWarning.actionTaken,
+            guidance: selectorLocaleWarning.guidance,
+            supported_selector_locales: selectorLocaleWarning.supportedLocales
+          }
+        : {}),
       ...summarizeSelectorLocaleInput(
         selectorLocaleResolution.normalizedInput,
         selectorLocaleResolution.inputLength

--- a/packages/core/src/selectorLocale.ts
+++ b/packages/core/src/selectorLocale.ts
@@ -103,10 +103,16 @@ function sanitizeSelectorPhrases(values: readonly unknown[] | undefined): string
   return dedupePhrases(Array.isArray(values) ? values : EMPTY_SELECTOR_PHRASES);
 }
 
+/**
+ * Selector locales with first-class phrase coverage.
+ */
 export const LINKEDIN_SELECTOR_LOCALES = ["en", "da"] as const;
 export type LinkedInSelectorLocale =
   (typeof LINKEDIN_SELECTOR_LOCALES)[number];
 
+/**
+ * Default selector locale used when no explicit locale resolves successfully.
+ */
 export const DEFAULT_LINKEDIN_SELECTOR_LOCALE: LinkedInSelectorLocale = "en";
 
 export type LinkedInSelectorPhraseKey =
@@ -307,6 +313,10 @@ export type LinkedInSelectorLocaleFallbackReason =
   | "unsupported_locale"
   | "too_long";
 
+/**
+ * Diagnostics for resolving arbitrary locale input onto a supported selector
+ * locale.
+ */
 export interface LinkedInSelectorLocaleResolution {
   locale: LinkedInSelectorLocale;
   inputProvided: boolean;
@@ -370,6 +380,14 @@ function buildLinkedInSelectorLocaleResolution(
   };
 }
 
+/**
+ * Resolves arbitrary locale input to the nearest supported selector locale.
+ *
+ * @remarks
+ * Region tags such as `da-DK` normalize to their supported base locale.
+ * Unsupported, malformed, blank, or overly long values fall back to the
+ * provided fallback locale.
+ */
 export function resolveLinkedInSelectorLocaleResolution(
   value: string | LinkedInSelectorLocale | undefined,
   fallback: LinkedInSelectorLocale = DEFAULT_LINKEDIN_SELECTOR_LOCALE
@@ -444,6 +462,9 @@ export function resolveLinkedInSelectorLocaleResolution(
   });
 }
 
+/**
+ * Convenience wrapper that returns only the resolved selector locale.
+ */
 export function resolveLinkedInSelectorLocale(
   value: string | LinkedInSelectorLocale | undefined,
   fallback: LinkedInSelectorLocale = DEFAULT_LINKEDIN_SELECTOR_LOCALE
@@ -578,6 +599,10 @@ function resolveLinkedInSelectorPhrasePattern(
   return pattern;
 }
 
+/**
+ * Returns localized selector phrases in locale-first order with optional
+ * English fallback phrases appended afterward.
+ */
 export function getLinkedInSelectorPhrases(
   keys: LinkedInSelectorPhraseKey | readonly LinkedInSelectorPhraseKey[],
   locale: LinkedInSelectorLocale,
@@ -587,6 +612,10 @@ export function getLinkedInSelectorPhrases(
   return [...getLinkedInSelectorPhrasesFromNormalizedKeys(normalizedKeys, locale, options)];
 }
 
+/**
+ * Builds a Unicode-aware regular expression that matches the localized selector
+ * phrases for the requested semantic key or keys.
+ */
 export function buildLinkedInSelectorPhraseRegex(
   keys: LinkedInSelectorPhraseKey | readonly LinkedInSelectorPhraseKey[],
   locale: LinkedInSelectorLocale,
@@ -615,6 +644,10 @@ export function buildLinkedInSelectorPhraseRegex(
   return regex;
 }
 
+/**
+ * Formats the phrase regex that would be used for a selector key in diagnostic
+ * output such as selector audit hints.
+ */
 export function formatLinkedInSelectorRegexHint(
   keys: LinkedInSelectorPhraseKey | readonly LinkedInSelectorPhraseKey[],
   locale: LinkedInSelectorLocale,
@@ -624,6 +657,10 @@ export function formatLinkedInSelectorRegexHint(
   return options.exact ? `/^(?:${body})$/iu` : `/${body}/iu`;
 }
 
+/**
+ * Builds a comma-joined CSS selector that matches localized attribute values on
+ * one or more selector roots.
+ */
 export function buildLinkedInAriaLabelContainsSelector(
   roots: string | readonly string[],
   keys: LinkedInSelectorPhraseKey | readonly LinkedInSelectorPhraseKey[],
@@ -654,6 +691,10 @@ export function buildLinkedInAriaLabelContainsSelector(
     .join(", ");
 }
 
+/**
+ * Checks whether a text value contains any localized selector phrase for the
+ * requested semantic key or keys.
+ */
 export function valueContainsLinkedInSelectorPhrase(
   value: string | null | undefined,
   keys: LinkedInSelectorPhraseKey | readonly LinkedInSelectorPhraseKey[],

--- a/packages/core/test/runtimeSelectorLocale.test.ts
+++ b/packages/core/test/runtimeSelectorLocale.test.ts
@@ -68,6 +68,11 @@ describe("runtime selector locale logging", () => {
               selector_locale_source: "option",
               resolved_selector_locale: "en",
               reason: "unsupported_locale",
+              message:
+                'Unsupported selector locale "fr-ca" from selectorLocale option.',
+              action_taken: 'Using English ("en") selector phrases for this run.',
+              guidance: expect.stringContaining("Supported locales: en, da."),
+              supported_selector_locales: ["en", "da"],
               normalized_selector_locale: "fr-ca",
               requested_selector_locale_length: 5
             })
@@ -131,6 +136,11 @@ describe("runtime selector locale logging", () => {
               selector_locale_source: "env",
               resolved_selector_locale: "en",
               reason: "unsupported_locale",
+              message:
+                'Unsupported selector locale "fr-ca" from LINKEDIN_ASSISTANT_SELECTOR_LOCALE.',
+              action_taken: 'Using English ("en") selector phrases for this run.',
+              guidance: expect.stringContaining("Supported locales: en, da."),
+              supported_selector_locales: ["en", "da"],
               normalized_selector_locale: "fr-ca",
               requested_selector_locale_length: 5
             })

--- a/packages/core/test/selectorLocaleConfig.test.ts
+++ b/packages/core/test/selectorLocaleConfig.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV,
+  getLinkedInSelectorLocaleConfigWarning,
+  resolveLinkedInSelectorLocaleConfigResolution
+} from "../src/index.js";
+
+describe("selector locale config warnings", () => {
+  let previousSelectorLocaleEnv: string | undefined;
+
+  beforeEach(() => {
+    previousSelectorLocaleEnv = process.env[LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV];
+    delete process.env[LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV];
+  });
+
+  afterEach(() => {
+    if (typeof previousSelectorLocaleEnv === "string") {
+      process.env[LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV] = previousSelectorLocaleEnv;
+      return;
+    }
+
+    delete process.env[LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV];
+  });
+
+  it("formats CLI guidance for unsupported explicit locales", () => {
+    const warning = getLinkedInSelectorLocaleConfigWarning(
+      resolveLinkedInSelectorLocaleConfigResolution("fr-CA"),
+      "cli"
+    );
+
+    expect(warning).toMatchObject({
+      message: 'Unsupported selector locale "fr-ca" from --selector-locale.',
+      actionTaken: 'Using English ("en") selector phrases for this run.',
+      supportedLocales: ["en", "da"]
+    });
+    expect(warning?.guidance).toContain("Supported locales: en, da.");
+    expect(warning?.guidance).toContain("Region tags like da-DK normalize to da.");
+    expect(warning?.guidance).toContain("--selector-locale <locale>");
+  });
+
+  it("formats runtime guidance for env-based blank values", () => {
+    process.env[LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV] = "   ";
+
+    const warning = getLinkedInSelectorLocaleConfigWarning(
+      resolveLinkedInSelectorLocaleConfigResolution(),
+      "runtime"
+    );
+
+    expect(warning).toMatchObject({
+      message: `${LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV} was set but blank.`,
+      actionTaken: 'Using English ("en") selector phrases for this run.',
+      supportedLocales: ["en", "da"]
+    });
+    expect(warning?.guidance).toContain("Use a locale tag like en, da, or da-DK.");
+    expect(warning?.guidance).toContain(LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV);
+    expect(warning?.guidance).toContain("selectorLocale");
+  });
+
+  it("returns no warning for supported locales", () => {
+    const warning = getLinkedInSelectorLocaleConfigWarning(
+      resolveLinkedInSelectorLocaleConfigResolution("da-DK"),
+      "cli"
+    );
+
+    expect(warning).toBeNull();
+  });
+});

--- a/packages/mcp/src/bin/linkedin-mcp.ts
+++ b/packages/mcp/src/bin/linkedin-mcp.ts
@@ -176,9 +176,9 @@ const cdpUrlInputSchemaProperty = {
 
 const selectorLocaleInputSchemaProperty = {
   type: "string",
-  description: `Selector locale for LinkedIn UI text fallbacks (${LINKEDIN_SELECTOR_LOCALES.join(
+  description: `Prefer localized LinkedIn UI text first (${LINKEDIN_SELECTOR_LOCALES.join(
     ", "
-  )}). Defaults to en.`
+  )}; region tags like da-DK normalize to da). Unsupported values fall back to en.`
 } as const;
 
 function withCdpSchemaProperties(


### PR DESCRIPTION
## Summary
- add clearer selector-locale fallback guidance to CLI stderr and runtime warning logs
- document the supported locale inputs on the public config/selector helpers and sync CLI/MCP/docs wording
- add focused core and CLI coverage for locale fallback messaging

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #75