### PR TITLE
feat: polish draft-quality CLI UX

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -43,6 +43,7 @@ import {
   type SelectorAuditReport
 } from "@linkedin-assistant/core";
 import {
+  DraftQualityProgressReporter,
   formatDraftQualityError,
   formatDraftQualityReport,
   resolveDraftQualityOutputMode
@@ -284,6 +285,22 @@ async function writeOutputJsonFile(filePath: string, value: unknown): Promise<st
   await mkdir(path.dirname(resolvedPath), { recursive: true });
   await writeJsonFile(resolvedPath, value);
   return resolvedPath;
+}
+
+function createDraftQualityProgressLogger(
+  onLog: (entry: { event: string; payload: Record<string, unknown> }) => void
+): {
+  log(
+    level: "debug" | "info" | "warn" | "error",
+    event: string,
+    payload?: Record<string, unknown>
+  ): void;
+} {
+  return {
+    log(_level, event, payload = {}) {
+      onLog({ event, payload });
+    }
+  };
 }
 
 async function readKeepAlivePid(profileName: string): Promise<number | null> {
@@ -1815,6 +1832,7 @@ async function runDraftQualityAudit(input: {
   datasetPath: string;
   candidatesPath?: string;
   json: boolean;
+  progress: boolean;
   verbose: boolean;
   outputPath?: string;
 }): Promise<void> {
@@ -1822,6 +1840,16 @@ async function runDraftQualityAudit(input: {
     { json: input.json },
     Boolean(stdout.isTTY)
   );
+  const progressEnabled =
+    outputMode === "human" && input.progress && Boolean(process.stderr.isTTY);
+  const progressReporter = new DraftQualityProgressReporter({
+    enabled: progressEnabled
+  });
+  const logger = progressEnabled
+    ? createDraftQualityProgressLogger((entry) => {
+        progressReporter.handleLog(entry);
+      })
+    : undefined;
 
   try {
     const datasetPath = path.resolve(input.datasetPath);
@@ -1839,6 +1867,7 @@ async function runDraftQualityAudit(input: {
     const report = await evaluateDraftQuality({
       dataset,
       ...(candidates ? { candidates } : {}),
+      ...(logger ? { logger } : {}),
       dataset_path: datasetPath,
       ...(candidatesPath ? { candidates_path: candidatesPath } : {})
     });
@@ -1855,12 +1884,11 @@ async function runDraftQualityAudit(input: {
         "cli"
       ) as DraftQualityReport;
       const output = formatDraftQualityReport(redactedReport, {
-        verbose: input.verbose
+        verbose: input.verbose,
+        ...(writtenReportPath ? { reportPath: writtenReportPath } : {})
       });
 
-      console.log(
-        writtenReportPath ? `${output}\nJSON report written to ${writtenReportPath}` : output
-      );
+      console.log(output);
     }
 
     if (report.outcome === "fail") {
@@ -2678,38 +2706,49 @@ export async function runCli(argv: string[] = process.argv): Promise<void> {
 
   auditCommand
     .command("draft-quality")
-    .description("Evaluate draft replies against thread-specific quality expectations")
-    .requiredOption("--dataset <path>", "Path to the draft-quality dataset JSON file")
+    .description("Evaluate draft replies against case-specific quality expectations")
+    .requiredOption(
+      "--dataset <path>",
+      "Path to the draft-quality dataset JSON file (cases + expectations)"
+    )
     .option(
       "--candidates <path>",
-      "Optional JSON file with external candidate drafts keyed by case_id"
+      "Optional JSON file with candidate drafts keyed by case_id/draft_id"
     )
     .option("--json", "Print the full JSON report (recommended for automation)", false)
     .option(
       "--verbose",
-      "Show draft-by-draft detail in human-readable output",
+      "Show per-draft metric details in human-readable output",
       false
     )
+    .option("--no-progress", "Hide per-case progress updates in human-readable output")
     .option("--output <path>", "Write the JSON report to a file")
     .addHelpText(
       "after",
       [
         "",
-        "The dataset can embed candidate_drafts or you can provide --candidates.",
-        "Interactive terminals default to a human-readable summary.",
-        "Use --json for automation and --output to persist the JSON report."
+        "The dataset can embed candidate_drafts/candidateDrafts or you can provide --candidates.",
+        "Interactive terminals default to a human-readable summary with per-case progress.",
+        "Use --json for automation and --output to persist the JSON report.",
+        "",
+        "Examples:",
+        "  linkedin audit draft-quality --dataset dataset.json",
+        "  linkedin audit draft-quality --dataset dataset.json --candidates candidates.json --verbose",
+        "  linkedin audit draft-quality --dataset dataset.json --json --output reports/draft-quality.json"
       ].join("\n")
     )
     .action(async (options: {
       dataset: string;
       candidates?: string;
       json: boolean;
+      progress: boolean;
       verbose: boolean;
       output?: string;
     }) => {
       await runDraftQualityAudit({
         datasetPath: options.dataset,
         json: options.json,
+        progress: options.progress,
         verbose: options.verbose,
         ...(options.candidates ? { candidatesPath: options.candidates } : {}),
         ...(options.output ? { outputPath: options.output } : {})

--- a/packages/cli/src/draftQualityOutput.ts
+++ b/packages/cli/src/draftQualityOutput.ts
@@ -2,6 +2,7 @@ import type {
   DraftQualityCaseResult,
   DraftQualityHardFailure,
   DraftQualityReport,
+  JsonLogEntry,
   LinkedInAssistantErrorPayload
 } from "@linkedin-assistant/core";
 
@@ -9,7 +10,15 @@ export type DraftQualityOutputMode = "human" | "json";
 
 export interface FormatDraftQualityReportOptions {
   verbose?: boolean;
+  reportPath?: string;
 }
+
+export interface DraftQualityProgressReporterOptions {
+  enabled?: boolean;
+  writeLine?: (line: string) => void;
+}
+
+type DraftQualityProgressLogEntry = Pick<JsonLogEntry, "event" | "payload">;
 
 const CONTROL_CHARACTER_PATTERN = new RegExp(
   `[${String.fromCharCode(0)}-${String.fromCharCode(31)}${String.fromCharCode(127)}-${String.fromCharCode(159)}]+`,
@@ -30,6 +39,14 @@ function sanitizeConsoleText(value: string): string {
   return sanitized.length > 0 ? sanitized : "[sanitized]";
 }
 
+function formatCountLabel(
+  count: number,
+  singular: string,
+  plural: string = `${singular}s`
+): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
 function formatPercent(value: number): string {
   return `${(value * 100).toFixed(1)}%`;
 }
@@ -48,6 +65,30 @@ function appendSection(lines: string[], title: string, entries: string[]): void 
   lines.push(...entries);
 }
 
+function truncateForDisplay(value: string, maxLength: number = 180): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
+}
+
+function formatValueForDisplay(value: unknown): string {
+  if (typeof value === "string") {
+    return truncateForDisplay(value);
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  if (value === null || value === undefined) {
+    return String(value);
+  }
+
+  try {
+    return truncateForDisplay(JSON.stringify(value));
+  } catch {
+    return truncateForDisplay(String(value));
+  }
+}
+
 function formatSourceCounts(report: DraftQualityReport): string | null {
   const entries = Object.entries(report.summary.source_counts)
     .filter(([, count]) => count > 0)
@@ -56,15 +97,77 @@ function formatSourceCounts(report: DraftQualityReport): string | null {
   return entries.length > 0 ? entries.join(" | ") : null;
 }
 
-function formatFailureCounts(report: DraftQualityReport): string {
+function formatMetricSummaryLine(
+  label: string,
+  average: number,
+  failedDraftCount: number
+): string {
+  return `- ${label}: ${formatPercent(average)} average | ${formatCountLabel(failedDraftCount, "failing draft")}`;
+}
+
+function formatCheckSummaryLine(report: DraftQualityReport): string {
+  return `- Checks: ${formatCountLabel(report.summary.hard_failure_count, "hard-check hit")} | ${formatCountLabel(report.summary.judge_failure_count, "judge fallback")} | ${formatCountLabel(report.summary.warning_count, "warning")}`;
+}
+
+function formatSummary(report: DraftQualityReport): string {
+  return `Summary: ${report.summary.passed_drafts} of ${report.summary.total_drafts} drafts passed (${formatPercent(report.summary.pass_rate)}) across ${report.summary.evaluated_case_count}/${report.summary.total_cases} cases.`;
+}
+
+function formatOverviewEntries(report: DraftQualityReport): string[] {
+  const entries = [
+    `- Cases: ${report.summary.total_cases} total | ${report.summary.evaluated_case_count} evaluated | ${report.summary.skipped_case_count} skipped`,
+    `- Drafts: ${report.summary.passed_drafts} passed | ${report.summary.failed_drafts} failed`,
+    formatCheckSummaryLine(report)
+  ];
+
+  const sources = formatSourceCounts(report);
+  if (sources) {
+    entries.push(`- Sources: ${sources}`);
+  }
+
+  return entries;
+}
+
+function formatMetricEntries(report: DraftQualityReport): string[] {
   return [
-    `relevance ${report.summary.failed_metric_counts.relevance}`,
-    `tone ${report.summary.failed_metric_counts.tone}`,
-    `length ${report.summary.failed_metric_counts.length}`,
-    `hard checks ${report.summary.hard_failure_count}`,
-    `judge fallbacks ${report.summary.judge_failure_count}`,
-    `warnings ${report.summary.warning_count}`
-  ].join(" | ");
+    formatMetricSummaryLine(
+      "Relevance",
+      report.summary.metric_averages.relevance,
+      report.summary.failed_metric_counts.relevance
+    ),
+    formatMetricSummaryLine(
+      "Tone",
+      report.summary.metric_averages.tone,
+      report.summary.failed_metric_counts.tone
+    ),
+    formatMetricSummaryLine(
+      "Length",
+      report.summary.metric_averages.length,
+      report.summary.failed_metric_counts.length
+    )
+  ];
+}
+
+function formatNextSteps(
+  report: DraftQualityReport,
+  options: FormatDraftQualityReportOptions
+): string[] {
+  const steps: string[] = [];
+
+  if (!options.verbose) {
+    steps.push("Rerun with --verbose to inspect every evaluated draft.");
+  }
+
+  if (report.summary.skipped_case_count > 0) {
+    steps.push("Review skipped cases with no candidate drafts before comparing pass rates.");
+  }
+
+  if (!options.reportPath) {
+    steps.push("Use --output <path> to save the JSON report to a file.");
+  }
+
+  steps.push("Use --json for automation or to capture the structured report.");
+  return steps;
 }
 
 function formatLengthExpectation(result: DraftQualityCaseResult): string {
@@ -97,10 +200,16 @@ function formatFailureBlock(result: DraftQualityCaseResult): string[] {
     lines.push(`  Scenario: ${sanitizeConsoleText(result.case_scenario)}`);
   }
 
+  if (result.case_channel) {
+    lines.push(`  Channel: ${sanitizeConsoleText(result.case_channel)}`);
+  }
+
   if (result.overall.failed_metrics.length > 0) {
     lines.push(
-      `  Overall: failed ${result.overall.failed_metrics.map(sanitizeConsoleText).join(", ")}`
+      `  Overall: failed ${result.overall.failed_metrics.map(sanitizeConsoleText).join(", ")} (score ${formatPercent(result.overall.score)})`
     );
+  } else {
+    lines.push(`  Overall: failed (score ${formatPercent(result.overall.score)})`);
   }
 
   if (!result.metrics.relevance.passed) {
@@ -156,15 +265,49 @@ function formatDraftDetail(result: DraftQualityCaseResult): string[] {
     toneDetails.optional_matched.length > 0
       ? `; optional ${toneDetails.optional_matched.map(sanitizeConsoleText).join(", ")}`
       : "";
+  const toneNotes: string[] = [];
   const hardFailures = formatHardFailures(result.overall.hard_failures);
+
+  if (toneDetails.missing.length > 0) {
+    toneNotes.push(`missing ${toneDetails.missing.map(sanitizeConsoleText).join(", ")}`);
+  }
+
+  if (toneDetails.forbidden_triggered.length > 0) {
+    toneNotes.push(
+      `forbidden ${toneDetails.forbidden_triggered.map(sanitizeConsoleText).join(", ")}`
+    );
+  }
+
+  if (result.case_scenario) {
+    lines.push(`  Scenario: ${sanitizeConsoleText(result.case_scenario)}`);
+  }
+
+  if (result.case_channel) {
+    lines.push(`  Channel: ${sanitizeConsoleText(result.case_channel)}`);
+  }
+
+  lines.push(`  Overall: ${formatStatus(result.overall.passed)} score ${formatPercent(result.overall.score)}`);
 
   lines.push(
     `  Relevance: ${formatStatus(result.metrics.relevance.passed)} ${
       result.metrics.relevance.details.covered_point_ids.length
     }/${result.metrics.relevance.details.total_required_points} required points covered`
   );
+
+  if (result.metrics.relevance.details.missing_point_ids.length > 0) {
+    lines.push(
+      `  Missing points: ${result.metrics.relevance.details.missing_point_ids.map(sanitizeConsoleText).join(", ")}`
+    );
+  }
+
+  if (result.metrics.relevance.details.off_topic_signals.length > 0) {
+    lines.push(
+      `  Relevance notes: ${result.metrics.relevance.details.off_topic_signals.map(sanitizeConsoleText).join(" | ")}`
+    );
+  }
+
   lines.push(
-    `  Tone: ${formatStatus(result.metrics.tone.passed)} matched ${matchedTones}${optionalTones}`
+    `  Tone: ${formatStatus(result.metrics.tone.passed)} matched ${matchedTones}${optionalTones}${toneNotes.length > 0 ? `; ${toneNotes.join("; ")}` : ""}`
   );
   lines.push(`  Length: ${formatStatus(result.metrics.length.passed)} ${formatLengthExpectation(result)}`);
 
@@ -197,6 +340,7 @@ export function formatDraftQualityReport(
   const lines = [`Draft Quality Evaluation: ${report.outcome.toUpperCase()}`];
 
   lines.push(`Run: ${sanitizeConsoleText(report.run_id)}`);
+  lines.push(`Generated At: ${sanitizeConsoleText(report.generated_at)}`);
   if (report.dataset_path) {
     lines.push(`Dataset: ${sanitizeConsoleText(report.dataset_path)}`);
   }
@@ -204,18 +348,14 @@ export function formatDraftQualityReport(
     lines.push(`Candidates: ${sanitizeConsoleText(report.candidates_path)}`);
   }
 
-  lines.push(
-    `Summary: Evaluated ${report.summary.total_drafts} drafts across ${report.summary.evaluated_case_count}/${report.summary.total_cases} cases. ${report.summary.passed_drafts} passed. ${report.summary.failed_drafts} failed. Pass rate ${formatPercent(report.summary.pass_rate)}.`
-  );
-  lines.push(
-    `Metric Averages: relevance ${formatPercent(report.summary.metric_averages.relevance)} | tone ${formatPercent(report.summary.metric_averages.tone)} | length ${formatPercent(report.summary.metric_averages.length)}`
-  );
-  lines.push(`Failure Counts: ${formatFailureCounts(report)}`);
-
-  const sources = formatSourceCounts(report);
-  if (sources) {
-    lines.push(`Sources: ${sources}`);
+  if (options.reportPath) {
+    lines.push(`Report JSON: ${sanitizeConsoleText(options.reportPath)}`);
   }
+
+  lines.push(formatSummary(report));
+
+  appendSection(lines, "Overview", formatOverviewEntries(report));
+  appendSection(lines, "Metrics", formatMetricEntries(report));
 
   appendSection(
     lines,
@@ -239,6 +379,12 @@ export function formatDraftQualityReport(
     );
   }
 
+  appendSection(
+    lines,
+    "Next Steps",
+    formatNextSteps(report, options).map((step) => `- ${step}`)
+  );
+
   return lines.join("\n");
 }
 
@@ -247,9 +393,15 @@ function readString(payload: Record<string, unknown>, key: string): string | nul
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+function readNumber(payload: Record<string, unknown>, key: string): number | null {
+  const value = payload[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
 export function formatDraftQualityError(error: LinkedInAssistantErrorPayload): string {
-  const lines = [`Draft quality evaluation failed: ${sanitizeConsoleText(error.message)}`];
-  const location = readString(error.details, "location") ?? readString(error.details, "path");
+  const lines = [`Draft quality evaluation failed [${sanitizeConsoleText(error.code)}]`, sanitizeConsoleText(error.message)];
+  const location = readString(error.details, "location");
+  const filePath = readString(error.details, "path");
   const field = readString(error.details, "field");
   const caseId = readString(error.details, "case_id");
   const draftId = readString(error.details, "draft_id");
@@ -257,6 +409,11 @@ export function formatDraftQualityError(error: LinkedInAssistantErrorPayload): s
   if (location) {
     lines.push(`Location: ${sanitizeConsoleText(location)}`);
   }
+
+  if (filePath) {
+    lines.push(`Path: ${sanitizeConsoleText(filePath)}`);
+  }
+
   if (field) {
     lines.push(`Field: ${sanitizeConsoleText(field)}`);
   }
@@ -267,5 +424,130 @@ export function formatDraftQualityError(error: LinkedInAssistantErrorPayload): s
     lines.push(`Draft: ${sanitizeConsoleText(draftId)}`);
   }
 
+  const knownDetailKeys = new Set(["location", "path", "field", "case_id", "draft_id"]);
+  const extraDetails = Object.entries(error.details).filter(([key]) => !knownDetailKeys.has(key));
+
+  if (extraDetails.length > 0) {
+    lines.push(
+      `Details: ${extraDetails.map(([key, value]) => `${key}=${formatValueForDisplay(value)}`).join(", ")}`
+    );
+  }
+
+  lines.push(
+    "Tip: run linkedin audit draft-quality --help for usage examples, or rerun with --json for the structured error payload."
+  );
+
   return lines.join("\n");
+}
+
+export class DraftQualityProgressReporter {
+  private readonly enabled: boolean;
+  private readonly writeLine: (line: string) => void;
+  private totalCases: number | null = null;
+  private nextCaseIndex = 1;
+  private readonly caseIndexes = new Map<string, number>();
+
+  constructor(options: DraftQualityProgressReporterOptions = {}) {
+    this.enabled = options.enabled ?? true;
+    this.writeLine = options.writeLine ?? ((line: string) => process.stderr.write(`${line}\n`));
+  }
+
+  handleLog(entry: DraftQualityProgressLogEntry): void {
+    if (!this.enabled) {
+      return;
+    }
+
+    if (entry.event === "draft_quality.evaluate.start") {
+      this.totalCases = readNumber(entry.payload, "total_cases");
+      const totalDrafts = readNumber(entry.payload, "candidate_draft_count");
+      const summaryParts: string[] = [];
+
+      if (this.totalCases !== null) {
+        summaryParts.push(formatCountLabel(this.totalCases, "case"));
+      }
+
+      if (totalDrafts !== null) {
+        summaryParts.push(formatCountLabel(totalDrafts, "draft"));
+      }
+
+      const summarySuffix =
+        summaryParts.length > 0 ? ` (${summaryParts.join(", ")})` : "";
+
+      this.writeLine(`Starting draft quality evaluation${summarySuffix}.`);
+      return;
+    }
+
+    if (entry.event === "draft_quality.case.start") {
+      const caseId = readString(entry.payload, "case_id") ?? "unknown";
+      const caseIndex = this.getCaseIndex(caseId, readNumber(entry.payload, "case_index"));
+      const totalCases = readNumber(entry.payload, "total_cases") ?? this.totalCases;
+      const draftCount = readNumber(entry.payload, "draft_count");
+      const draftSuffix =
+        draftCount === null ? "" : ` (${formatCountLabel(draftCount, "draft")})`;
+
+      this.writeLine(
+        `Evaluating ${formatProgressCaseIndex(caseIndex, totalCases)}: ${sanitizeConsoleText(caseId)}${draftSuffix}...`
+      );
+      return;
+    }
+
+    if (entry.event === "draft_quality.case.skipped") {
+      const caseId = readString(entry.payload, "case_id") ?? "unknown";
+      const caseIndex = this.getCaseIndex(caseId, readNumber(entry.payload, "case_index"));
+      const totalCases = readNumber(entry.payload, "total_cases") ?? this.totalCases;
+      this.writeLine(
+        `Skipping ${formatProgressCaseIndex(caseIndex, totalCases)}: ${sanitizeConsoleText(caseId)} — no candidate drafts.`
+      );
+      return;
+    }
+
+    if (entry.event === "draft_quality.case.done") {
+      const caseId = readString(entry.payload, "case_id") ?? "unknown";
+      const caseIndex = this.getCaseIndex(caseId, readNumber(entry.payload, "case_index"));
+      const totalCases = readNumber(entry.payload, "total_cases") ?? this.totalCases;
+      const passedDrafts = readNumber(entry.payload, "passed_drafts") ?? 0;
+      const failedDrafts = readNumber(entry.payload, "failed_drafts") ?? 0;
+
+      this.writeLine(
+        `Finished ${formatProgressCaseIndex(caseIndex, totalCases)}: ${sanitizeConsoleText(caseId)} — ${passedDrafts} passed, ${failedDrafts} failed.`
+      );
+      return;
+    }
+
+    if (entry.event === "draft_quality.evaluate.complete") {
+      const passedDrafts = readNumber(entry.payload, "total_drafts");
+      const failedDrafts = readNumber(entry.payload, "failed_drafts");
+
+      if (passedDrafts !== null && failedDrafts !== null) {
+        const passingCount = Math.max(passedDrafts - failedDrafts, 0);
+        this.writeLine(
+          `Draft quality evaluation finished. ${passingCount} passed, ${failedDrafts} failed.`
+        );
+        return;
+      }
+
+      this.writeLine("Draft quality evaluation finished.");
+    }
+  }
+
+  private getCaseIndex(caseId: string, explicitIndex: number | null): number {
+    if (explicitIndex !== null) {
+      this.caseIndexes.set(caseId, explicitIndex);
+      return explicitIndex;
+    }
+
+    const existing = this.caseIndexes.get(caseId);
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const caseIndex = this.nextCaseIndex;
+    this.caseIndexes.set(caseId, caseIndex);
+    this.nextCaseIndex += 1;
+    return caseIndex;
+  }
+}
+
+function formatProgressCaseIndex(caseIndex: number, totalCases: number | null): string {
+  return totalCases === null ? `case ${caseIndex}` : `case ${caseIndex}/${totalCases}`;
 }

--- a/packages/cli/test/draftQualityCommand.test.ts
+++ b/packages/cli/test/draftQualityCommand.test.ts
@@ -17,6 +17,10 @@ function setInteractiveMode(inputIsTty: boolean, outputIsTty: boolean): void {
     configurable: true,
     value: outputIsTty
   });
+  Object.defineProperty(process.stderr, "isTTY", {
+    configurable: true,
+    value: outputIsTty
+  });
 }
 
 async function writeJsonFixture(filePath: string, value: unknown): Promise<void> {
@@ -227,10 +231,31 @@ describe("linkedin audit draft-quality", () => {
 
     expect(process.exitCode).toBe(1);
     expect(output).toContain("Draft Quality Evaluation: FAIL");
-    expect(output).toContain("Summary: Evaluated 1 drafts across 1/1 cases. 0 passed. 1 failed.");
+    expect(output).toContain("Summary: 0 of 1 drafts passed (0.0%) across 1/1 cases.");
     expect(output).toContain(
       "Hard checks: Draft used forbidden phrases: just circling back"
     );
+    expect(stderrChunks.join("")).toContain(
+      "Starting draft quality evaluation (1 case, 1 draft)."
+    );
+  });
+
+  it("can hide per-case progress lines in human mode", async () => {
+    const datasetPath = path.join(tempDir, "passing-dataset.json");
+
+    await writeJsonFixture(datasetPath, createPassingDataset());
+
+    await runCli([
+      "node",
+      "linkedin",
+      "audit",
+      "draft-quality",
+      "--dataset",
+      datasetPath,
+      "--no-progress"
+    ]);
+
+    expect(process.exitCode ?? 0).toBe(0);
     expect(stderrChunks).toEqual([]);
   });
 
@@ -255,10 +280,10 @@ describe("linkedin audit draft-quality", () => {
 
     expect(process.exitCode).toBe(1);
     expect(consoleLogSpy).not.toHaveBeenCalled();
-    expect(stderrOutput).toContain(
-      "Draft quality evaluation failed: Draft-quality dataset must contain at least one case."
-    );
+    expect(stderrOutput).toContain("Draft quality evaluation failed [ACTION_PRECONDITION_FAILED]");
+    expect(stderrOutput).toContain("Draft-quality dataset must contain at least one case.");
     expect(stderrOutput).toContain("Location: dataset.cases");
+    expect(stderrOutput).toContain("Tip: run linkedin audit draft-quality --help");
   });
 
   it("rejects non-file dataset paths before reading", async () => {
@@ -278,9 +303,51 @@ describe("linkedin audit draft-quality", () => {
 
     expect(process.exitCode).toBe(1);
     expect(consoleLogSpy).not.toHaveBeenCalled();
+    expect(stderrOutput).toContain("Draft quality evaluation failed [ACTION_PRECONDITION_FAILED]");
     expect(stderrOutput).toContain(
-      "Draft quality evaluation failed: Expected draft-quality dataset path to point to a file."
+      "Expected draft-quality dataset path to point to a file."
     );
-    expect(stderrOutput).toContain(`Location: ${path.resolve(datasetDir)}`);
+    expect(stderrOutput).toContain(`Path: ${path.resolve(datasetDir)}`);
+  });
+
+  it("shows complete help output for the draft-quality command", async () => {
+    const stdoutChunks: string[] = [];
+    const stdoutWriteSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((...args: Parameters<typeof process.stdout.write>) => {
+        const [chunk] = args;
+        stdoutChunks.push(String(chunk));
+        return true;
+      });
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((((code?: Parameters<typeof process.exit>[0]) => {
+        throw new Error(`process.exit:${String(code ?? 0)}`);
+      }) as typeof process.exit));
+
+    try {
+      await expect(
+        runCli(["node", "linkedin", "audit", "draft-quality", "--help"])
+      ).rejects.toThrow("process.exit:0");
+    } finally {
+      stdoutWriteSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+
+    const helpOutput = stdoutChunks.join("");
+
+    expect(helpOutput).toContain(
+      "Evaluate draft replies against case-specific quality expectations"
+    );
+    expect(helpOutput).toContain("--dataset <path>");
+    expect(helpOutput).toContain("--candidates <path>");
+    expect(helpOutput).toContain("--json");
+    expect(helpOutput).toContain("--verbose");
+    expect(helpOutput).toContain("--no-progress");
+    expect(helpOutput).toContain("--output <path>");
+    expect(helpOutput).toContain("Examples:");
+    expect(helpOutput).toContain(
+      "linkedin audit draft-quality --dataset dataset.json --candidates candidates.json --verbose"
+    );
   });
 });

--- a/packages/cli/test/draftQualityOutput.test.ts
+++ b/packages/cli/test/draftQualityOutput.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { DraftQualityReport, LinkedInAssistantErrorPayload } from "@linkedin-assistant/core";
 import {
+  DraftQualityProgressReporter,
   formatDraftQualityError,
   formatDraftQualityReport,
   resolveDraftQualityOutputMode
@@ -207,20 +208,22 @@ describe("draft quality output helpers", () => {
   });
 
   it("renders a scannable human-readable report", () => {
-    const output = formatDraftQualityReport(createDraftQualityReportFixture());
+    const output = formatDraftQualityReport(createDraftQualityReportFixture(), {
+      reportPath: "reports/draft-quality.json"
+    });
 
     expect(output).toContain("Draft Quality Evaluation: FAIL");
-    expect(output).toContain(
-      "Summary: Evaluated 2 drafts across 2/2 cases. 1 passed. 1 failed. Pass rate 50.0%."
-    );
-    expect(output).toContain(
-      "Metric Averages: relevance 75.0% | tone 83.3% | length 100.0%"
-    );
-    expect(output).toContain(
-      "Failure Counts: relevance 1 | tone 1 | length 0 | hard checks 1 | judge fallbacks 0 | warnings 1"
-    );
+    expect(output).toContain("Generated At: 2026-03-08T12:00:00.000Z");
+    expect(output).toContain("Report JSON: reports/draft-quality.json");
+    expect(output).toContain("Summary: 1 of 2 drafts passed (50.0%) across 2/2 cases.");
+    expect(output).toContain("Overview");
+    expect(output).toContain("- Cases: 2 total | 2 evaluated | 0 skipped");
+    expect(output).toContain("- Checks: 1 hard-check hit | 0 judge fallbacks | 1 warning");
+    expect(output).toContain("Metrics");
+    expect(output).toContain("- Relevance: 75.0% average | 1 failing draft");
     expect(output).toContain("Warnings");
     expect(output).toContain("Failures");
+    expect(output).toContain("Next Steps");
     expect(output).toContain("Hard checks: Draft used forbidden phrases: just circling back");
   });
 
@@ -236,7 +239,10 @@ describe("draft quality output helpers", () => {
     expect(output).toContain(
       "FAIL followup_meeting_request_001/too_pushy (model)"
     );
-    expect(output).toContain("Tone: FAIL matched concise");
+    expect(output).toContain("Overall: FAIL score 56.1%");
+    expect(output).toContain(
+      "Tone: FAIL matched concise; missing warm, professional; forbidden pushy"
+    );
   });
 
   it("formats friendly human-readable errors", () => {
@@ -250,10 +256,10 @@ describe("draft quality output helpers", () => {
 
     const output = formatDraftQualityError(error);
 
-    expect(output).toContain(
-      "Draft quality evaluation failed: Draft-quality dataset must contain at least one case."
-    );
+    expect(output).toContain("Draft quality evaluation failed [ACTION_PRECONDITION_FAILED]");
+    expect(output).toContain("Draft-quality dataset must contain at least one case.");
     expect(output).toContain("Location: dataset.cases");
+    expect(output).toContain("Tip: run linkedin audit draft-quality --help");
   });
 
   it("sanitizes terminal control characters in human-readable output", () => {
@@ -269,5 +275,65 @@ describe("draft quality output helpers", () => {
     expect(output).toContain("Run: run danger");
     expect(output).toContain("- Beware next line");
     expect(output).toContain("Notes: Line one line two");
+  });
+
+  it("emits clear per-case progress lines", () => {
+    const lines: string[] = [];
+    const reporter = new DraftQualityProgressReporter({
+      writeLine: (line) => {
+        lines.push(line);
+      }
+    });
+
+    reporter.handleLog({
+      event: "draft_quality.evaluate.start",
+      payload: {
+        total_cases: 2,
+        candidate_draft_count: 3
+      }
+    });
+    reporter.handleLog({
+      event: "draft_quality.case.start",
+      payload: {
+        case_id: "case_a",
+        case_index: 1,
+        total_cases: 2,
+        draft_count: 2
+      }
+    });
+    reporter.handleLog({
+      event: "draft_quality.case.done",
+      payload: {
+        case_id: "case_a",
+        case_index: 1,
+        total_cases: 2,
+        passed_drafts: 1,
+        failed_drafts: 1
+      }
+    });
+    reporter.handleLog({
+      event: "draft_quality.case.skipped",
+      payload: {
+        case_id: "case_b",
+        case_index: 2,
+        total_cases: 2,
+        reason: "no_candidate_drafts"
+      }
+    });
+    reporter.handleLog({
+      event: "draft_quality.evaluate.complete",
+      payload: {
+        total_drafts: 2,
+        failed_drafts: 1
+      }
+    });
+
+    expect(lines).toEqual([
+      "Starting draft quality evaluation (2 cases, 3 drafts).",
+      "Evaluating case 1/2: case_a (2 drafts)...",
+      "Finished case 1/2: case_a — 1 passed, 1 failed.",
+      "Skipping case 2/2: case_b — no candidate drafts.",
+      "Draft quality evaluation finished. 1 passed, 1 failed."
+    ]);
   });
 });

--- a/packages/core/src/draftQualityEval.ts
+++ b/packages/core/src/draftQualityEval.ts
@@ -2166,9 +2166,16 @@ export async function evaluateDraftQuality(
     const limits = resolveEvaluationLimits(input.limits);
     validateResourceLimits(dataset, candidates, limits);
 
+    const draftsByCaseId = buildCandidateLookup(dataset, candidates);
+    const totalDraftCount = Array.from(draftsByCaseId.values()).reduce(
+      (total, drafts) => total + drafts.length,
+      0
+    );
+
     logEvaluationEvent(input.logger, "info", "draft_quality.evaluate.start", {
       run_id: runId,
       total_cases: dataset.cases.length,
+      candidate_draft_count: totalDraftCount,
       embedded_draft_count: dataset.cases.reduce(
         (total, draftCase) => total + draftCase.candidate_drafts.length,
         0
@@ -2177,15 +2184,15 @@ export async function evaluateDraftQuality(
       judge_enabled: Boolean(input.judge)
     });
 
-    const draftsByCaseId = buildCandidateLookup(dataset, candidates);
     const sourceCounts = createSourceCounts();
     const warnings: string[] = [];
     const caseResults: DraftQualityCaseResult[] = [];
     let skippedCaseCount = 0;
     let judgeFailureCount = 0;
 
-    for (const draftCase of dataset.cases) {
+    for (const [caseOffset, draftCase] of dataset.cases.entries()) {
       const drafts = draftsByCaseId.get(draftCase.id) ?? [];
+      const caseIndex = caseOffset + 1;
 
       if (drafts.length === 0) {
         skippedCaseCount += 1;
@@ -2194,10 +2201,23 @@ export async function evaluateDraftQuality(
         logEvaluationEvent(input.logger, "warn", "draft_quality.case.skipped", {
           run_id: runId,
           case_id: draftCase.id,
+          case_index: caseIndex,
+          total_cases: dataset.cases.length,
           reason: "no_candidate_drafts"
         });
         continue;
       }
+
+      logEvaluationEvent(input.logger, "info", "draft_quality.case.start", {
+        run_id: runId,
+        case_id: draftCase.id,
+        case_index: caseIndex,
+        total_cases: dataset.cases.length,
+        draft_count: drafts.length
+      });
+
+      let casePassedDrafts = 0;
+      let caseFailedDrafts = 0;
 
       for (const draft of drafts) {
         sourceCounts[draft.source] += 1;
@@ -2211,6 +2231,12 @@ export async function evaluateDraftQuality(
         });
         caseResults.push(evaluation.result);
 
+        if (evaluation.result.overall.passed) {
+          casePassedDrafts += 1;
+        } else {
+          caseFailedDrafts += 1;
+        }
+
         if (evaluation.warning) {
           warnings.push(evaluation.warning);
         }
@@ -2219,6 +2245,16 @@ export async function evaluateDraftQuality(
           judgeFailureCount += 1;
         }
       }
+
+      logEvaluationEvent(input.logger, "info", "draft_quality.case.done", {
+        run_id: runId,
+        case_id: draftCase.id,
+        case_index: caseIndex,
+        total_cases: dataset.cases.length,
+        draft_count: drafts.length,
+        passed_drafts: casePassedDrafts,
+        failed_drafts: caseFailedDrafts
+      });
     }
 
     if (caseResults.length === 0) {


### PR DESCRIPTION
## Summary
- improve `linkedin audit draft-quality` help text, examples, and human-mode flag descriptions
- add per-case progress reporting plus a more actionable draft-quality summary and error formatter
- expand CLI coverage for help output, progress behavior, and the updated human-readable report

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #78