### PR TITLE
feat: polish data delete command UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,15 @@ Delete local tool state:
 
 ```bash
 npm exec -w @linkedin-assistant/cli -- linkedin data delete
+npm exec -w @linkedin-assistant/cli -- linkedin data delete --confirm
 npm exec -w @linkedin-assistant/cli -- linkedin data delete --include-profile
+npm exec -w @linkedin-assistant/cli -- linkedin data delete --include-profile --confirm
 ```
 
-- `linkedin data delete` always requires an interactive terminal confirmation.
+- `linkedin data delete` is a dry-run preview by default.
+- Rerun with `--confirm` to perform the destructive deletion in an interactive terminal.
 - Stop any running keepalive daemons before deleting local state.
+- `config.json` is preserved by design.
 - `--include-profile` prompts a second time before removing local browser profile data.
 
 ### Selector audit

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -3,6 +3,7 @@ import type { Dirent } from "node:fs";
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import {
+  access,
   appendFile,
   mkdir,
   readFile,
@@ -19,6 +20,7 @@ import { Command } from "commander";
 import {
   DEFAULT_FOLLOWUP_SINCE,
   LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV,
+  asLinkedInAssistantError,
   clearRateLimitState,
   createLocalDataDeletionPlan,
   evaluateDraftQuality,
@@ -34,13 +36,16 @@ import {
   normalizeLinkedInPostVisibility,
   parseDraftQualityCandidateSet,
   parseDraftQualityDataset,
+  resolveConfigPaths,
   resolveFollowupSinceWindow,
   resolveLinkedInSelectorLocaleConfigResolution,
   redactStructuredValue,
   resolveKeepAliveDir,
+  resolveLegacyRateLimitStateFilePath,
   resolvePrivacyConfig,
   toLinkedInAssistantErrorPayload,
   type DraftQualityReport,
+  type LocalDataDeletionFailure,
   type SearchCategory,
   type SelectorAuditReport
 } from "@linkedin-assistant/core";
@@ -85,6 +90,22 @@ function maybeWarnAboutSelectorLocaleConfig(selectorLocale?: string): void {
   writeCliWarning(warning.message);
   writeCliNotice(warning.actionTaken);
   writeCliNotice(warning.guidance);
+}
+
+interface LocalDataPreviewItem {
+  exists: boolean;
+  label: string;
+  note?: string;
+  path: string;
+}
+
+interface LocalDataDeletionPreview {
+  baseDir: string;
+  deleteItems: LocalDataPreviewItem[];
+  existingDeletePaths: string[];
+  includeProfileRequested: boolean;
+  missingDeletePaths: string[];
+  preserveItems: LocalDataPreviewItem[];
 }
 
 function coercePositiveInt(value: string, label: string): number {
@@ -448,10 +469,295 @@ function assertInteractiveTerminal(operation: string): void {
   }
 }
 
-function printDeletionTargets(targetPaths: string[]): void {
-  for (const targetPath of targetPaths) {
-    console.log(`- ${targetPath}`);
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await access(targetPath);
+    return true;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return false;
+    }
+
+    throw error;
   }
+}
+
+function pluralize(
+  count: number,
+  singular: string,
+  plural: string = `${singular}s`
+): string {
+  return count === 1 ? singular : plural;
+}
+
+function resolveLocalDataDeleteLabel(
+  targetPath: string,
+  paths: ReturnType<typeof resolveConfigPaths>,
+  keepAliveDir: string,
+  legacyRateLimitStatePath: string
+): string {
+  if (targetPath === path.resolve(paths.dbPath)) {
+    return "SQLite database";
+  }
+
+  if (targetPath === path.resolve(`${paths.dbPath}-journal`)) {
+    return "SQLite rollback journal";
+  }
+
+  if (targetPath === path.resolve(`${paths.dbPath}-wal`)) {
+    return "SQLite write-ahead log";
+  }
+
+  if (targetPath === path.resolve(`${paths.dbPath}-shm`)) {
+    return "SQLite shared-memory file";
+  }
+
+  if (targetPath === path.resolve(paths.artifactsDir)) {
+    return "Run artifacts";
+  }
+
+  if (targetPath === path.resolve(keepAliveDir)) {
+    return "Keepalive daemon state";
+  }
+
+  if (targetPath === path.resolve(paths.profilesDir)) {
+    return "Browser profiles";
+  }
+
+  if (targetPath === legacyRateLimitStatePath) {
+    return "Legacy auth cooldown state";
+  }
+
+  if (targetPath.endsWith(`${path.sep}rate-limit-state.json`)) {
+    return "Auth cooldown state";
+  }
+
+  return "Local data target";
+}
+
+async function createLocalDataDeletionPreview(
+  includeProfile: boolean
+): Promise<LocalDataDeletionPreview> {
+  const deletionPlan = createLocalDataDeletionPlan({ includeProfile });
+  const resolvedPaths = resolveConfigPaths(deletionPlan.baseDir);
+  const keepAliveDir = resolveKeepAliveDir(deletionPlan.baseDir);
+  const legacyRateLimitStatePath = path.resolve(
+    resolveLegacyRateLimitStateFilePath()
+  );
+
+  const deleteItems = await Promise.all(
+    deletionPlan.targets.map(async (targetPath) => ({
+      exists: await pathExists(targetPath),
+      label: resolveLocalDataDeleteLabel(
+        targetPath,
+        resolvedPaths,
+        keepAliveDir,
+        legacyRateLimitStatePath
+      ),
+      ...(targetPath === path.resolve(resolvedPaths.profilesDir)
+        ? {
+            note: "Deletes tool-owned cookies, local storage, and saved browser sessions."
+          }
+        : {}),
+      path: targetPath
+    }))
+  );
+
+  const preserveItems = await Promise.all(
+    [
+      ...(!includeProfile
+        ? [
+            {
+              label: "Browser profiles",
+              note: "Preserved unless you rerun with --include-profile.",
+              path: path.resolve(resolvedPaths.profilesDir)
+            }
+          ]
+        : []),
+      {
+        label: "Config file",
+        note: "Preserved by design. Delete manually only if you want a full local reset.",
+        path: path.resolve(path.join(deletionPlan.baseDir, "config.json"))
+      }
+    ].map(async (item) => ({
+      ...item,
+      exists: await pathExists(item.path)
+    }))
+  );
+
+  return {
+    baseDir: deletionPlan.baseDir,
+    deleteItems,
+    existingDeletePaths: deleteItems
+      .filter((item) => item.exists)
+      .map((item) => item.path),
+    includeProfileRequested: includeProfile,
+    missingDeletePaths: deleteItems
+      .filter((item) => !item.exists)
+      .map((item) => item.path),
+    preserveItems
+  };
+}
+
+function printLocalDataPreviewSection(
+  title: string,
+  items: LocalDataPreviewItem[]
+): void {
+  if (items.length === 0) {
+    return;
+  }
+
+  console.log(title);
+  for (const item of items) {
+    const note = item.note ? ` — ${item.note}` : "";
+    console.log(
+      `- ${item.label}: ${item.path} (${item.exists ? "present" : "already absent"})${note}`
+    );
+  }
+}
+
+function printLocalDataDeletionPreview(
+  preview: LocalDataDeletionPreview,
+  destructiveMode: boolean
+): void {
+  if (destructiveMode) {
+    console.log("Local data deletion requested.");
+  } else {
+    console.log("Local data deletion preview (dry-run). No files were removed.");
+  }
+
+  console.log(`Assistant home: ${preview.baseDir}`);
+  printLocalDataPreviewSection("Delete targets:", preview.deleteItems);
+  printLocalDataPreviewSection("Preserved paths:", preview.preserveItems);
+
+  if (preview.existingDeletePaths.length === 0) {
+    console.log("Nothing to delete. Tool-owned runtime state is already absent.");
+    return;
+  }
+
+  if (!destructiveMode) {
+    console.log(
+      `Rerun with --confirm to permanently delete ${preview.existingDeletePaths.length} existing ${pluralize(preview.existingDeletePaths.length, "path")}.`
+    );
+    if (preview.includeProfileRequested) {
+      console.log(
+        "Browser profiles are included in this preview and still require a second confirmation during deletion."
+      );
+    }
+    return;
+  }
+
+  console.log(
+    `Ready to delete ${preview.existingDeletePaths.length} existing ${pluralize(preview.existingDeletePaths.length, "path")} after confirmation.`
+  );
+  if (preview.includeProfileRequested) {
+    console.log(
+      "Deleting browser profiles requires a second confirmation because signed-in browser state will be lost."
+    );
+  }
+}
+
+function isLocalDataDeletionFailure(
+  value: unknown
+): value is LocalDataDeletionFailure {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<LocalDataDeletionFailure>;
+  return (
+    typeof candidate.path === "string" &&
+    (typeof candidate.code === "string" || candidate.code === null) &&
+    typeof candidate.message === "string" &&
+    (typeof candidate.recoveryHint === "string" ||
+      typeof candidate.recoveryHint === "undefined")
+  );
+}
+
+function extractLocalDataDeletionFailures(
+  value: unknown
+): LocalDataDeletionFailure[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter(isLocalDataDeletionFailure);
+}
+
+function formatLocalDataDeletionError(error: unknown): LinkedInAssistantError {
+  const assistantError = asLinkedInAssistantError(
+    error,
+    "UNKNOWN",
+    "Local data deletion failed."
+  );
+  const failedPaths = extractLocalDataDeletionFailures(
+    assistantError.details.failed_paths
+  );
+  if (failedPaths.length === 0) {
+    return assistantError;
+  }
+
+  const deletedCount = Array.isArray(assistantError.details.deleted_paths)
+    ? assistantError.details.deleted_paths.length
+    : 0;
+  const firstFailure = failedPaths[0]!;
+  const deletedSummary =
+    deletedCount > 0
+      ? `${deletedCount} ${pluralize(deletedCount, "path")} ${deletedCount === 1 ? "was" : "were"} removed before the failure.`
+      : "No paths were removed before the failure.";
+
+  return new LinkedInAssistantError(
+    assistantError.code,
+    `Local data deletion completed with ${failedPaths.length} ${pluralize(failedPaths.length, "failure")}. ${deletedSummary} First blocked path: ${firstFailure.path}. ${firstFailure.recoveryHint ?? "Review failed_paths for recovery guidance and retry."}`,
+    assistantError.details,
+    { cause: assistantError }
+  );
+}
+
+function printLocalDataDeletionFailure(error: LinkedInAssistantError): void {
+  const failedPaths = extractLocalDataDeletionFailures(error.details.failed_paths);
+  if (failedPaths.length === 0) {
+    return;
+  }
+
+  console.error("Local data deletion could not finish cleanly.");
+  for (const failure of failedPaths.slice(0, 3)) {
+    console.error(
+      `- ${failure.path}: ${failure.message}${failure.recoveryHint ? ` ${failure.recoveryHint}` : ""}`
+    );
+  }
+
+  if (failedPaths.length > 3) {
+    const remainingFailures = failedPaths.length - 3;
+    console.error(
+      `- ${remainingFailures} more ${pluralize(remainingFailures, "failure")} not shown. Inspect failed_paths in the JSON error output for the full list.`
+    );
+  }
+}
+
+function printLocalDataDeletionSummary(input: {
+  deletedCount: number;
+  includeProfileDeleted: boolean;
+  includeProfileRequested: boolean;
+  missingCount: number;
+}): void {
+  console.log("Local data deletion completed.");
+  console.log(
+    `- Removed ${input.deletedCount} ${pluralize(input.deletedCount, "path")}.`
+  );
+  if (input.missingCount > 0) {
+    console.log(
+      `- Skipped ${input.missingCount} already-absent ${pluralize(input.missingCount, "path")}.`
+    );
+  }
+  if (input.includeProfileRequested && !input.includeProfileDeleted) {
+    console.log("- Browser profiles were preserved.");
+  }
+  console.log("- config.json remains untouched.");
 }
 
 async function findRunningKeepAlivePids(): Promise<number[]> {
@@ -523,7 +829,7 @@ async function assertNoRunningKeepAliveDaemons(): Promise<void> {
 
   throw new LinkedInAssistantError(
     "ACTION_PRECONDITION_FAILED",
-    "Stop running keepalive daemons before deleting local data.",
+    `Stop running keepalive daemons before deleting local data. Active PID${runningKeepAlivePids.length === 1 ? "" : "s"}: ${runningKeepAlivePids.join(", ")}.`,
     {
       running_keepalive_pids: runningKeepAlivePids
     }
@@ -531,57 +837,104 @@ async function assertNoRunningKeepAliveDaemons(): Promise<void> {
 }
 
 async function runDataDelete(input: {
+  confirm: boolean;
   includeProfile: boolean;
   cdpUrl: string | undefined;
 }): Promise<void> {
-  assertInteractiveTerminal("delete local data");
   assertCdpUrlUnsupportedForDataDelete(input.cdpUrl);
+  const preview = await createLocalDataDeletionPreview(input.includeProfile);
+
+  if (!input.confirm) {
+    printLocalDataDeletionPreview(preview, false);
+    printJson({
+      base_dir: preview.baseDir,
+      confirm_required: true,
+      dry_run: true,
+      existing_paths: preview.existingDeletePaths,
+      include_profile_requested: input.includeProfile,
+      missing_paths: preview.missingDeletePaths,
+      nothing_to_delete: preview.existingDeletePaths.length === 0,
+      preserved_paths: preview.preserveItems.map((item) => item.path),
+      would_delete_paths: preview.deleteItems.map((item) => item.path)
+    });
+    return;
+  }
+
+  if (preview.existingDeletePaths.length === 0) {
+    printLocalDataDeletionPreview(preview, true);
+    printJson({
+      deleted: false,
+      dry_run: false,
+      include_profile_deleted: false,
+      include_profile_requested: input.includeProfile,
+      missing_paths: preview.missingDeletePaths,
+      nothing_to_delete: true,
+      preserved_paths: preview.preserveItems.map((item) => item.path)
+    });
+    return;
+  }
+
+  assertInteractiveTerminal("delete local data with --confirm");
   await assertNoRunningKeepAliveDaemons();
+  printLocalDataDeletionPreview(preview, true);
 
-  const requestedPlan = createLocalDataDeletionPlan({
-    includeProfile: input.includeProfile
-  });
-  const profilesDir = path.join(requestedPlan.baseDir, "profiles");
-
-  console.log("This permanently deletes local LinkedIn Assistant data:");
-  printDeletionTargets(requestedPlan.targets);
-  if (!input.includeProfile) {
-    console.log(`- preserving browser profiles at ${profilesDir}`);
-  }
-
-  const deleteAllConfirmed = await promptYesNo(
-    "Delete the listed local data?"
-  );
+  const deleteAllConfirmed = await promptYesNo("Delete the listed local data?");
   if (!deleteAllConfirmed) {
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
-      "Operator declined local data deletion."
-    );
+    console.log("Deletion cancelled. No files were removed.");
+    printJson({
+      cancelled: true,
+      deleted: false,
+      dry_run: false,
+      include_profile_deleted: false,
+      include_profile_requested: input.includeProfile,
+      preserved_paths: preview.preserveItems.map((item) => item.path),
+      would_delete_paths: preview.existingDeletePaths
+    });
+    return;
   }
 
+  const profileItem = preview.deleteItems.find(
+    (item) => item.label === "Browser profiles"
+  );
   let includeProfile = false;
-  if (input.includeProfile) {
+  if (input.includeProfile && profileItem?.exists) {
     includeProfile = await promptYesNo(
-      `Delete browser profile data at ${profilesDir}?`
+      `Delete browser profile data at ${profileItem.path}? This removes saved sessions and cookies.`
     );
 
     if (!includeProfile) {
       console.log("Browser profile deletion declined. Profiles will be preserved.");
     }
+  } else if (input.includeProfile) {
+    console.log("Browser profiles are already absent. Skipping the extra profile confirmation.");
   }
 
-  const deletionResult = await deleteLocalData({ includeProfile });
+  try {
+    const deletionResult = await deleteLocalData({ includeProfile });
+    printLocalDataDeletionSummary({
+      deletedCount: deletionResult.deletedPaths.length,
+      includeProfileDeleted: includeProfile,
+      includeProfileRequested: input.includeProfile,
+      missingCount: deletionResult.missingPaths.length
+    });
 
-  printJson({
-    deleted: true,
-    include_profile_requested: input.includeProfile,
-    include_profile_deleted: includeProfile,
-    started_at: deletionResult.startedAt,
-    completed_at: deletionResult.completedAt,
-    deleted_paths: deletionResult.deletedPaths,
-    missing_paths: deletionResult.missingPaths,
-    failed_paths: deletionResult.failedPaths
-  });
+    printJson({
+      deleted: true,
+      dry_run: false,
+      include_profile_requested: input.includeProfile,
+      include_profile_deleted: includeProfile,
+      missing_paths: deletionResult.missingPaths,
+      preserved_paths: preview.preserveItems.map((item) => item.path),
+      started_at: deletionResult.startedAt,
+      completed_at: deletionResult.completedAt,
+      deleted_paths: deletionResult.deletedPaths,
+      failed_paths: deletionResult.failedPaths
+    });
+  } catch (error) {
+    const formattedError = formatLocalDataDeletionError(error);
+    printLocalDataDeletionFailure(formattedError);
+    throw formattedError;
+  }
 }
 
 async function runStatus(profileName: string, cdpUrl?: string): Promise<void> {
@@ -2020,10 +2373,7 @@ async function runConfirmAction(input: {
   }
 }
 
-export async function runCli(argv: string[] = process.argv): Promise<void> {
-  const originalArgv = process.argv;
-  process.argv = argv;
-
+export function createCliProgram(): Command {
   const program = new Command();
 
   program
@@ -2093,18 +2443,48 @@ export async function runCli(argv: string[] = process.argv): Promise<void> {
 
   const dataCommand = program
     .command("data")
-    .description("Inspect and delete local LinkedIn Assistant data");
+    .description("Preview and delete tool-owned local LinkedIn Assistant data");
 
   dataCommand
     .command("delete")
-    .description("Delete local database, artifacts, logs, and optional browser profiles")
+    .description(
+      [
+        "Preview local runtime data deletion; rerun with --confirm to delete.",
+        "Default behavior is a dry-run preview of the local database, artifacts, keepalive state, and auth cooldown files.",
+        "config.json is preserved by design. Stop keepalive daemons first. Data from external browsers attached with --cdp-url is never deleted."
+      ].join("\n\n")
+    )
     .option(
-      "--include-profile",
-      "Also delete local browser profile data after extra confirmation",
+      "--confirm",
+      "Permanently delete the listed tool-owned local data after interactive confirmation",
       false
     )
-    .action(async (options: { includeProfile: boolean }) => {
+    .option(
+      "--include-profile",
+      "Also delete tool-owned browser profile data after a second confirmation",
+      false
+    )
+    .addHelpText(
+      "after",
+      [
+        "",
+        "Deletes when confirmed:",
+        "  - state.sqlite and SQLite sidecars",
+        "  - run artifacts and logs",
+        "  - keepalive daemon state",
+        "  - auth cooldown state",
+        "  - all tool-owned browser profiles when --include-profile is set",
+        "",
+        "Safety:",
+        "  - default behavior is a dry-run preview",
+        "  - config.json is preserved by design",
+        "  - active keepalive daemons must be stopped first",
+        "  - data from external browsers attached with --cdp-url is never deleted"
+      ].join("\n")
+    )
+    .action(async (options: { confirm: boolean; includeProfile: boolean }) => {
       await runDataDelete({
+        confirm: options.confirm,
         includeProfile: options.includeProfile,
         cdpUrl: readCdpUrl()
       });
@@ -2821,6 +3201,15 @@ export async function runCli(argv: string[] = process.argv): Promise<void> {
         runtime.close();
       }
     });
+
+  return program;
+}
+
+export async function runCli(argv: string[] = process.argv): Promise<void> {
+  const originalArgv = process.argv;
+  process.argv = argv;
+
+  const program = createCliProgram();
 
   try {
     await program.parseAsync(argv);

--- a/packages/cli/test/dataDelete.test.ts
+++ b/packages/cli/test/dataDelete.test.ts
@@ -3,7 +3,6 @@ import os from "node:os";
 import path from "node:path";
 import { stdin, stdout } from "node:process";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveConfigPaths, resolveKeepAliveDir } from "../../core/src/index.js";
 
 const readlineMocks = vi.hoisted(() => ({
   close: vi.fn(),
@@ -11,7 +10,9 @@ const readlineMocks = vi.hoisted(() => ({
   question: vi.fn()
 }));
 
-vi.mock("@linkedin-assistant/core", async () => await import("../../core/src/index.js"));
+vi.mock("@linkedin-assistant/core", async () =>
+  await import("../../core/src/index.js")
+);
 
 vi.mock("node:readline/promises", () => ({
   createInterface: readlineMocks.createInterface.mockImplementation(() => ({
@@ -20,7 +21,8 @@ vi.mock("node:readline/promises", () => ({
   }))
 }));
 
-import { runCli } from "../src/bin/linkedin.js";
+import * as core from "@linkedin-assistant/core";
+import { createCliProgram, runCli } from "../src/bin/linkedin.js";
 
 async function pathExists(targetPath: string): Promise<boolean> {
   try {
@@ -53,6 +55,7 @@ function setInteractiveMode(inputIsTty: boolean, outputIsTty: boolean): void {
 describe("linkedin data delete", () => {
   let tempDir = "";
   let assistantHome = "";
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(async () => {
@@ -61,14 +64,25 @@ describe("linkedin data delete", () => {
     process.env.LINKEDIN_ASSISTANT_HOME = assistantHome;
     setInteractiveMode(true, true);
     vi.clearAllMocks();
+    readlineMocks.createInterface.mockImplementation(() => ({
+      close: readlineMocks.close,
+      question: readlineMocks.question
+    }));
     consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
   });
 
   afterEach(async () => {
+    consoleErrorSpy.mockRestore();
     consoleLogSpy.mockRestore();
     delete process.env.LINKEDIN_ASSISTANT_HOME;
     await rm(tempDir, { recursive: true, force: true });
   });
+
+  function getLastJsonOutput(): Record<string, unknown> {
+    const finalOutput = consoleLogSpy.mock.calls.at(-1)?.[0];
+    return JSON.parse(String(finalOutput)) as Record<string, unknown>;
+  }
 
   async function seedLocalDataFixture(): Promise<{
     artifactsDir: string;
@@ -78,8 +92,8 @@ describe("linkedin data delete", () => {
     profilesDir: string;
     rateLimitStatePath: string;
   }> {
-    const paths = resolveConfigPaths();
-    const keepAliveDir = resolveKeepAliveDir();
+    const paths = core.resolveConfigPaths();
+    const keepAliveDir = core.resolveKeepAliveDir();
     const rateLimitStatePath = path.join(paths.baseDir, "rate-limit-state.json");
     const configFilePath = path.join(paths.baseDir, "config.json");
 
@@ -121,24 +135,72 @@ describe("linkedin data delete", () => {
     };
   }
 
-  it("refuses to run in non-interactive mode", async () => {
+  it("shows a dry-run preview by default without deleting anything", async () => {
+    const fixture = await seedLocalDataFixture();
+    setInteractiveMode(false, false);
+
+    await runCli(["node", "linkedin", "data", "delete"]);
+
+    expect(readlineMocks.createInterface).not.toHaveBeenCalled();
+    expect(await pathExists(fixture.dbPath)).toBe(true);
+    expect(await pathExists(`${fixture.dbPath}-journal`)).toBe(true);
+    expect(await pathExists(`${fixture.dbPath}-wal`)).toBe(true);
+    expect(await pathExists(`${fixture.dbPath}-shm`)).toBe(true);
+    expect(await pathExists(fixture.artifactsDir)).toBe(true);
+    expect(await pathExists(fixture.keepAliveDir)).toBe(true);
+    expect(await pathExists(fixture.rateLimitStatePath)).toBe(true);
+    expect(await pathExists(fixture.profilesDir)).toBe(true);
+    expect(await pathExists(fixture.configFilePath)).toBe(true);
+
+    const finalOutput = getLastJsonOutput();
+    expect(finalOutput).toMatchObject({
+      confirm_required: true,
+      dry_run: true,
+      include_profile_requested: false,
+      nothing_to_delete: false
+    });
+    expect(finalOutput.existing_paths).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(path.join("assistant-home", "state.sqlite")),
+        expect.stringContaining(path.join("assistant-home", "state.sqlite-journal")),
+        expect.stringContaining(path.join("assistant-home", "state.sqlite-wal")),
+        expect.stringContaining(path.join("assistant-home", "state.sqlite-shm")),
+        expect.stringContaining(path.join("assistant-home", "artifacts")),
+        expect.stringContaining(path.join("assistant-home", "keepalive")),
+        expect.stringContaining(path.join("assistant-home", "rate-limit-state.json"))
+      ])
+    );
+    expect(finalOutput.preserved_paths).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(path.join("assistant-home", "profiles")),
+        expect.stringContaining(path.join("assistant-home", "config.json"))
+      ])
+    );
+    expect(
+      consoleLogSpy.mock.calls.some(([message]) =>
+        String(message).includes("Rerun with --confirm")
+      )
+    ).toBe(true);
+  });
+
+  it("refuses destructive deletion in non-interactive mode", async () => {
+    await seedLocalDataFixture();
     setInteractiveMode(false, false);
 
     await expect(
-      runCli(["node", "linkedin", "data", "delete"])
+      runCli(["node", "linkedin", "data", "delete", "--confirm"])
     ).rejects.toMatchObject({
-      message: "Refusing to delete local data in non-interactive mode."
+      message: "Refusing to delete local data with --confirm in non-interactive mode."
     });
 
     expect(readlineMocks.createInterface).not.toHaveBeenCalled();
-    expect(await pathExists(assistantHome)).toBe(false);
   });
 
   it("deletes local state while preserving browser profiles by default", async () => {
     const fixture = await seedLocalDataFixture();
     readlineMocks.question.mockResolvedValueOnce("yes");
 
-    await runCli(["node", "linkedin", "data", "delete"]);
+    await runCli(["node", "linkedin", "data", "delete", "--confirm"]);
 
     expect(readlineMocks.question).toHaveBeenCalledTimes(1);
     expect(await pathExists(fixture.dbPath)).toBe(false);
@@ -151,19 +213,15 @@ describe("linkedin data delete", () => {
     expect(await pathExists(fixture.profilesDir)).toBe(true);
     expect(await pathExists(fixture.configFilePath)).toBe(true);
 
-    const finalOutput = consoleLogSpy.mock.calls.at(-1)?.[0];
-    expect(JSON.parse(String(finalOutput))).toMatchObject({
+    expect(getLastJsonOutput()).toMatchObject({
       deleted: true,
-      include_profile_requested: false,
+      dry_run: false,
+      failed_paths: [],
       include_profile_deleted: false,
-      failed_paths: []
+      include_profile_requested: false,
+      started_at: expect.any(String),
+      completed_at: expect.any(String)
     });
-    expect(JSON.parse(String(finalOutput))).toEqual(
-      expect.objectContaining({
-        started_at: expect.any(String),
-        completed_at: expect.any(String)
-      })
-    );
   });
 
   it("deletes browser profiles only after the extra confirmation", async () => {
@@ -172,7 +230,14 @@ describe("linkedin data delete", () => {
       .mockResolvedValueOnce("yes")
       .mockResolvedValueOnce("yes");
 
-    await runCli(["node", "linkedin", "data", "delete", "--include-profile"]);
+    await runCli([
+      "node",
+      "linkedin",
+      "data",
+      "delete",
+      "--include-profile",
+      "--confirm"
+    ]);
 
     expect(readlineMocks.question).toHaveBeenCalledTimes(2);
     expect(await pathExists(fixture.dbPath)).toBe(false);
@@ -185,23 +250,18 @@ describe("linkedin data delete", () => {
     expect(await pathExists(fixture.profilesDir)).toBe(false);
     expect(await pathExists(fixture.configFilePath)).toBe(true);
 
-    const finalOutput = consoleLogSpy.mock.calls.at(-1)?.[0];
-    expect(JSON.parse(String(finalOutput))).toMatchObject({
+    expect(getLastJsonOutput()).toMatchObject({
       deleted: true,
       include_profile_requested: true,
       include_profile_deleted: true
     });
   });
 
-  it("aborts without deleting anything when the operator declines deletion", async () => {
+  it("cancels without deleting anything when the operator declines confirmation", async () => {
     const fixture = await seedLocalDataFixture();
     readlineMocks.question.mockResolvedValueOnce("no");
 
-    await expect(
-      runCli(["node", "linkedin", "data", "delete"])
-    ).rejects.toMatchObject({
-      message: "Operator declined local data deletion."
-    });
+    await runCli(["node", "linkedin", "data", "delete", "--confirm"]);
 
     expect(readlineMocks.question).toHaveBeenCalledTimes(1);
     expect(await pathExists(fixture.dbPath)).toBe(true);
@@ -213,6 +273,14 @@ describe("linkedin data delete", () => {
     expect(await pathExists(fixture.rateLimitStatePath)).toBe(true);
     expect(await pathExists(fixture.profilesDir)).toBe(true);
     expect(await pathExists(fixture.configFilePath)).toBe(true);
+
+    expect(getLastJsonOutput()).toMatchObject({
+      cancelled: true,
+      deleted: false,
+      dry_run: false,
+      include_profile_deleted: false,
+      include_profile_requested: false
+    });
   });
 
   it("preserves profiles when the extra profile confirmation is declined", async () => {
@@ -221,7 +289,14 @@ describe("linkedin data delete", () => {
       .mockResolvedValueOnce("yes")
       .mockResolvedValueOnce("no");
 
-    await runCli(["node", "linkedin", "data", "delete", "--include-profile"]);
+    await runCli([
+      "node",
+      "linkedin",
+      "data",
+      "delete",
+      "--include-profile",
+      "--confirm"
+    ]);
 
     expect(readlineMocks.question).toHaveBeenCalledTimes(2);
     expect(await pathExists(fixture.dbPath)).toBe(false);
@@ -238,12 +313,29 @@ describe("linkedin data delete", () => {
         String(message).includes("Browser profile deletion declined")
       )
     ).toBe(true);
-
-    const finalOutput = consoleLogSpy.mock.calls.at(-1)?.[0];
-    expect(JSON.parse(String(finalOutput))).toMatchObject({
+    expect(getLastJsonOutput()).toMatchObject({
       deleted: true,
       include_profile_requested: true,
       include_profile_deleted: false
+    });
+  });
+
+  it("shows a friendly nothing-to-delete preview when local state is absent", async () => {
+    setInteractiveMode(false, false);
+
+    await runCli(["node", "linkedin", "data", "delete"]);
+
+    expect(readlineMocks.createInterface).not.toHaveBeenCalled();
+    expect(await pathExists(assistantHome)).toBe(false);
+    expect(
+      consoleLogSpy.mock.calls.some(([message]) =>
+        String(message).includes("Nothing to delete")
+      )
+    ).toBe(true);
+    expect(getLastJsonOutput()).toMatchObject({
+      confirm_required: true,
+      dry_run: true,
+      nothing_to_delete: true
     });
   });
 
@@ -266,7 +358,7 @@ describe("linkedin data delete", () => {
     expect(await pathExists(assistantHome)).toBe(false);
   });
 
-  it("allows deletion to proceed when keepalive pid files are stale", async () => {
+  it("allows destructive deletion to proceed when keepalive pid files are stale", async () => {
     const fixture = await seedLocalDataFixture();
     await writeFile(
       path.join(fixture.keepAliveDir, "default.pid"),
@@ -275,7 +367,7 @@ describe("linkedin data delete", () => {
     );
     readlineMocks.question.mockResolvedValueOnce("yes");
 
-    await runCli(["node", "linkedin", "data", "delete"]);
+    await runCli(["node", "linkedin", "data", "delete", "--confirm"]);
 
     expect(readlineMocks.question).toHaveBeenCalledTimes(1);
     expect(await pathExists(fixture.dbPath)).toBe(false);
@@ -285,7 +377,7 @@ describe("linkedin data delete", () => {
     expect(await pathExists(fixture.configFilePath)).toBe(true);
   });
 
-  it("refuses to run while a keepalive daemon is active", async () => {
+  it("refuses destructive deletion while a keepalive daemon is active", async () => {
     const fixture = await seedLocalDataFixture();
     await writeFile(
       path.join(fixture.keepAliveDir, "default.pid"),
@@ -294,14 +386,71 @@ describe("linkedin data delete", () => {
     );
 
     await expect(
-      runCli(["node", "linkedin", "data", "delete"])
+      runCli(["node", "linkedin", "data", "delete", "--confirm"])
     ).rejects.toMatchObject({
-      message: "Stop running keepalive daemons before deleting local data."
+      message: expect.stringContaining(
+        "Stop running keepalive daemons before deleting local data. Active PID"
+      )
     });
 
     expect(readlineMocks.createInterface).not.toHaveBeenCalled();
     expect(await pathExists(fixture.dbPath)).toBe(true);
     expect(await pathExists(fixture.keepAliveDir)).toBe(true);
     expect(await pathExists(fixture.rateLimitStatePath)).toBe(true);
+  });
+
+  it("formats actionable partial-failure guidance when deletion fails", async () => {
+    const fixture = await seedLocalDataFixture();
+    readlineMocks.question.mockResolvedValueOnce("yes");
+    const deleteSpy = vi.spyOn(core, "deleteLocalData").mockRejectedValueOnce(
+      new core.LinkedInAssistantError(
+        "UNKNOWN",
+        "Local data deletion completed with some failures.",
+        {
+          deleted_paths: [fixture.artifactsDir],
+          failed_paths: [
+            {
+              code: "EACCES",
+              message: "permission denied",
+              path: fixture.dbPath,
+              recoveryHint: "Check filesystem permissions for this path and retry."
+            }
+          ],
+          missing_paths: []
+        }
+      )
+    );
+
+    await expect(
+      runCli(["node", "linkedin", "data", "delete", "--confirm"])
+    ).rejects.toMatchObject({
+      message: expect.stringContaining(
+        "Check filesystem permissions for this path and retry."
+      )
+    });
+
+    expect(
+      consoleErrorSpy.mock.calls.some(([message]) =>
+        String(message).includes("Local data deletion could not finish cleanly")
+      )
+    ).toBe(true);
+
+    deleteSpy.mockRestore();
+  });
+
+  it("documents dry-run safety and recovery details in --help", () => {
+    const program = createCliProgram();
+    const dataCommand = program.commands.find((command) => command.name() === "data");
+    const deleteCommand = dataCommand?.commands.find(
+      (command) => command.name() === "delete"
+    );
+
+    expect(deleteCommand).toBeDefined();
+
+    const help = deleteCommand?.helpInformation() ?? "";
+    expect(help).toContain("--confirm");
+    expect(help).toContain("Default behavior is a dry-run preview");
+    expect(help).toContain("config.json is preserved by design");
+    expect(help).toContain("--cdp-url");
   });
 });


### PR DESCRIPTION
## Summary
- default `linkedin data delete` to a dry-run preview and require `--confirm` for destructive execution
- improve human-readable progress, cancellation, and partial-failure messaging for local data deletion
- expand help text and CLI coverage for dry-run, keepalive, nothing-to-delete, and profile-confirmation flows

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

Closes #80