### PR TITLE
fix: harden E2E coverage infrastructure

### DIFF
--- a/packages/core/src/__tests__/e2e/helpers.ts
+++ b/packages/core/src/__tests__/e2e/helpers.ts
@@ -50,9 +50,18 @@ export interface PreparedActionResult {
   preview: Record<string, unknown>;
 }
 
-interface CommandExecutionOptions {
+export interface CommandExecutionOptions {
   assistantHome?: string;
+  timeoutMs?: number;
+  maxAttempts?: number;
+  retryDelayMs?: number;
 }
+
+export type CliRunner = (argv: string[]) => Promise<void>;
+export type McpToolCaller = (
+  name: string,
+  args: Record<string, unknown>
+) => Promise<unknown>;
 
 const DEFAULT_PROFILE_NAME = process.env.LINKEDIN_E2E_PROFILE ?? "default";
 const DEFAULT_MESSAGE_TARGET_PATTERN =
@@ -63,6 +72,10 @@ const DEFAULT_LIKE_POST_URL = process.env.LINKEDIN_E2E_LIKE_POST_URL;
 const DEFAULT_COMMENT_POST_URL = process.env.LINKEDIN_E2E_COMMENT_POST_URL;
 const DEFAULT_CONNECTION_CONFIRM_MODE =
   process.env.LINKEDIN_E2E_CONNECTION_CONFIRM_MODE ?? "";
+const DEFAULT_MAX_ATTEMPTS = 1;
+const DEFAULT_RETRY_DELAY_MS = 250;
+const TRANSIENT_E2E_ERROR_PATTERN =
+  /timed out|timeout|Target closed|Execution context was destroyed|page crashed|browser has been closed|context was closed|ECONNRESET|ECONNREFUSED|EPIPE/i;
 
 function readEnabledFlag(name: string): boolean {
   const value = process.env[name];
@@ -163,6 +176,193 @@ function parseJsonObjects(text: string): Record<string, unknown>[] {
   return objects;
 }
 
+function summarizeUnknownValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function resolveMaxAttempts(value: number | undefined): number {
+  if (value === undefined) {
+    return DEFAULT_MAX_ATTEMPTS;
+  }
+
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error("maxAttempts must be a positive integer.");
+  }
+
+  return value;
+}
+
+function resolveRetryDelayMs(value: number | undefined): number {
+  if (value === undefined) {
+    return DEFAULT_RETRY_DELAY_MS;
+  }
+
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error("retryDelayMs must be zero or greater.");
+  }
+
+  return value;
+}
+
+function getTimeoutMs(value: number | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error("timeoutMs must be a positive number.");
+  }
+
+  return value;
+}
+
+function shouldRetryTransientError(error: unknown): boolean {
+  const message =
+    error instanceof Error && error.message.trim().length > 0
+      ? error.message
+      : summarizeUnknownValue(error);
+
+  return TRANSIENT_E2E_ERROR_PATTERN.test(message);
+}
+
+async function sleep(delayMs: number): Promise<void> {
+  if (delayMs <= 0) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
+async function withOptionalTimeout<T>(
+  promise: Promise<T>,
+  label: string,
+  timeoutMs: number | undefined
+): Promise<T> {
+  if (timeoutMs === undefined) {
+    return promise;
+  }
+
+  return await new Promise<T>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${timeoutMs}ms.`));
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timeoutId);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timeoutId);
+        reject(error);
+      }
+    );
+  });
+}
+
+async function captureCommandExecution(
+  execute: () => Promise<void>
+): Promise<CapturedCommandResult> {
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+  const originalExitCode = process.exitCode;
+  let exitCode = 0;
+
+  process.stdout.write = createWriteInterceptor(stdoutChunks);
+  process.stderr.write = createWriteInterceptor(stderrChunks);
+  process.exitCode = 0;
+
+  let error: unknown;
+
+  try {
+    await execute();
+  } catch (caught) {
+    error = caught;
+    if ((process.exitCode ?? 0) === 0) {
+      process.exitCode = 1;
+    }
+
+    stderrChunks.push(
+      `${JSON.stringify(toLinkedInAssistantErrorPayload(caught), null, 2)}\n`
+    );
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    exitCode = process.exitCode ?? 0;
+    process.exitCode = originalExitCode;
+  }
+
+  return {
+    stdout: stdoutChunks.join(""),
+    stderr: stderrChunks.join(""),
+    exitCode,
+    ...(error === undefined ? {} : { error })
+  };
+}
+
+function assertObjectRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function parseJsonObjectText(text: string, label: string): Record<string, unknown> {
+  try {
+    return assertObjectRecord(JSON.parse(text) as unknown, label);
+  } catch {
+    const objects = parseJsonObjects(text);
+    const lastObject = objects.at(-1);
+    if (lastObject) {
+      return lastObject;
+    }
+
+    throw new Error(`${label} did not contain a JSON object: ${text}`);
+  }
+}
+
+export function mapMcpToolResult(name: string, rawResult: unknown): MappedMcpResult {
+  const record = assertObjectRecord(rawResult, `Tool ${name} result`);
+  const content = record.content;
+  if (!Array.isArray(content)) {
+    throw new Error(`Tool ${name} returned invalid content: ${summarizeUnknownValue(content)}`);
+  }
+
+  const textItems = content.filter((item) => {
+    if (typeof item !== "object" || item === null || Array.isArray(item)) {
+      return false;
+    }
+
+    const entry = item as Record<string, unknown>;
+    return entry.type === "text" && typeof entry.text === "string";
+  }) as Array<Record<string, unknown>>;
+
+  const lastText = textItems.at(-1)?.text;
+  if (typeof lastText !== "string" || lastText.trim().length === 0) {
+    throw new Error(`Tool ${name} returned no text content.`);
+  }
+
+  const payload = parseJsonObjectText(lastText, `Tool ${name} payload`);
+
+  return {
+    payload,
+    isError: record.isError === true
+  };
+}
+
 export function getDefaultProfileName(): string {
   return DEFAULT_PROFILE_NAME;
 }
@@ -191,54 +391,59 @@ export function getOptInCommentPostUrl(): string | undefined {
   return DEFAULT_COMMENT_POST_URL;
 }
 
+export async function runCliCommandWith(
+  runner: CliRunner,
+  args: string[],
+  options: CommandExecutionOptions = {}
+): Promise<CapturedCommandResult> {
+  const maxAttempts = resolveMaxAttempts(options.maxAttempts);
+  const retryDelayMs = resolveRetryDelayMs(options.retryDelayMs);
+  const timeoutMs = getTimeoutMs(options.timeoutMs);
+  let lastResult: CapturedCommandResult | undefined;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const execute = async (): Promise<void> => {
+      await runner(["node", "linkedin", "--cdp-url", getCdpUrl(), ...args]);
+    };
+
+    const wrappedExecution = async (): Promise<void> => {
+      if (options.assistantHome) {
+        await withAssistantHome(options.assistantHome, execute);
+        return;
+      }
+
+      await withE2EEnvironment(execute);
+    };
+
+    const result = await captureCommandExecution(() =>
+      withOptionalTimeout(
+        wrappedExecution(),
+        `CLI command ${args.join(" ")}`,
+        timeoutMs
+      )
+    );
+    lastResult = result;
+
+    if (!result.error || !shouldRetryTransientError(result.error) || attempt >= maxAttempts) {
+      return result;
+    }
+
+    await sleep(retryDelayMs);
+  }
+
+  return lastResult ?? {
+    stdout: "",
+    stderr: "",
+    exitCode: 1,
+    error: new Error("CLI command did not produce a result.")
+  };
+}
+
 export async function runCliCommand(
   args: string[],
   options: CommandExecutionOptions = {}
 ): Promise<CapturedCommandResult> {
-  const stdoutChunks: string[] = [];
-  const stderrChunks: string[] = [];
-  const originalStdoutWrite = process.stdout.write;
-  const originalStderrWrite = process.stderr.write;
-  const originalExitCode = process.exitCode;
-  let exitCode = 0;
-
-  process.stdout.write = createWriteInterceptor(stdoutChunks);
-  process.stderr.write = createWriteInterceptor(stderrChunks);
-  process.exitCode = 0;
-
-  let error: unknown;
-  const execute = async (): Promise<void> => {
-    await runCli(["node", "linkedin", "--cdp-url", getCdpUrl(), ...args]);
-  };
-
-  try {
-    if (options.assistantHome) {
-      await withAssistantHome(options.assistantHome, execute);
-    } else {
-      await withE2EEnvironment(execute);
-    }
-  } catch (caught) {
-    error = caught;
-    if ((process.exitCode ?? 0) === 0) {
-      process.exitCode = 1;
-    }
-
-    stderrChunks.push(
-      `${JSON.stringify(toLinkedInAssistantErrorPayload(caught), null, 2)}\n`
-    );
-  } finally {
-    process.stdout.write = originalStdoutWrite;
-    process.stderr.write = originalStderrWrite;
-    exitCode = process.exitCode ?? 0;
-    process.exitCode = originalExitCode;
-  }
-
-  return {
-    stdout: stdoutChunks.join(""),
-    stderr: stderrChunks.join(""),
-    exitCode,
-    ...(error === undefined ? {} : { error })
-  };
+  return runCliCommandWith(runCli, args, options);
 }
 
 export function getLastJsonObject(text: string): Record<string, unknown> {
@@ -250,33 +455,58 @@ export function getLastJsonObject(text: string): Record<string, unknown> {
   return lastObject;
 }
 
+export async function callMcpToolWith(
+  caller: McpToolCaller,
+  name: string,
+  args: Record<string, unknown> = {},
+  options: CommandExecutionOptions = {}
+): Promise<MappedMcpResult> {
+  const maxAttempts = resolveMaxAttempts(options.maxAttempts);
+  const retryDelayMs = resolveRetryDelayMs(options.retryDelayMs);
+  const timeoutMs = getTimeoutMs(options.timeoutMs);
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const execute = async (): Promise<unknown> =>
+      caller(name, {
+        cdpUrl: getCdpUrl(),
+        ...args
+      });
+
+    const wrappedExecution = async (): Promise<unknown> => {
+      if (options.assistantHome) {
+        return await withAssistantHome(options.assistantHome, execute);
+      }
+
+      return await withE2EEnvironment(execute);
+    };
+
+    try {
+      const rawResult = await withOptionalTimeout(
+        wrappedExecution(),
+        `MCP tool ${name}`,
+        timeoutMs
+      );
+      return mapMcpToolResult(name, rawResult);
+    } catch (error) {
+      lastError = error;
+      if (!shouldRetryTransientError(error) || attempt >= maxAttempts) {
+        throw error;
+      }
+
+      await sleep(retryDelayMs);
+    }
+  }
+
+  throw lastError;
+}
+
 export async function callMcpTool(
   name: string,
   args: Record<string, unknown> = {},
   options: CommandExecutionOptions = {}
 ): Promise<MappedMcpResult> {
-  const execute = async () =>
-    handleToolCall(name, {
-      cdpUrl: getCdpUrl(),
-      ...args
-    });
-  const rawResult = options.assistantHome
-    ? await withAssistantHome(options.assistantHome, execute)
-    : await withE2EEnvironment(execute);
-  const content = rawResult.content[0];
-  if (!content) {
-    throw new Error(`Tool ${name} returned no content.`);
-  }
-
-  const payload = JSON.parse(content.text) as unknown;
-  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
-    throw new Error(`Tool ${name} returned a non-object payload.`);
-  }
-
-  return {
-    payload: payload as Record<string, unknown>,
-    isError: "isError" in rawResult && rawResult.isError === true
-  };
+  return callMcpToolWith(handleToolCall, name, args, options);
 }
 
 function asRecord(value: unknown, label: string): Record<string, unknown> {

--- a/packages/core/src/__tests__/e2e/setup.ts
+++ b/packages/core/src/__tests__/e2e/setup.ts
@@ -1,15 +1,35 @@
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+  type Dirent
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, type TestContext } from "vitest";
 import { createCoreRuntime, type CoreRuntime } from "../../runtime.js";
 
-const CDP_URL = process.env.LINKEDIN_CDP_URL ?? "http://localhost:18800";
+export const DEFAULT_E2E_CDP_URL = "http://localhost:18800";
+export const E2E_BASE_DIR_PREFIX = "linkedin-e2e-shared-";
+export const E2E_OWNER_METADATA_FILE = ".owner.json";
 
 let sharedRuntime: CoreRuntime | undefined;
 let sharedAvailability: E2EAvailability | undefined;
 let sharedBaseDir: string | undefined;
-let activeSuiteCount = 0;
+const activeSuites = new Set<symbol>();
+let exitCleanupRegistered = false;
+
+interface E2EOwnerMetadata {
+  pid: number;
+  createdAtMs: number;
+}
+
+interface ErrnoLikeError extends Error {
+  code?: string;
+}
 
 export interface E2EAvailability {
   cdpAvailable: boolean;
@@ -37,23 +57,224 @@ const UNINITIALIZED_AVAILABILITY: E2EAvailability = {
   reason: "E2E availability has not been initialized."
 };
 
+function summarizeUnknownError(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+function readConfiguredCdpUrl(): string {
+  const value = process.env.LINKEDIN_CDP_URL;
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : DEFAULT_E2E_CDP_URL;
+}
+
+function getCdpUrlValidationError(cdpUrl: string): string | undefined {
+  try {
+    const url = new URL(cdpUrl);
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      return undefined;
+    }
+
+    return `LINKEDIN_CDP_URL must use http:// or https://. Received: ${cdpUrl}.`;
+  } catch {
+    return `LINKEDIN_CDP_URL must be an absolute http(s) URL. Received: ${cdpUrl}.`;
+  }
+}
+
+function getCdpVersionEndpoint(cdpUrl: string): string {
+  return new URL("/json/version", cdpUrl).toString();
+}
+
+function getOwnerMetadataPath(baseDir: string): string {
+  return path.join(baseDir, E2E_OWNER_METADATA_FILE);
+}
+
+function writeOwnerMetadata(baseDir: string): void {
+  const metadata: E2EOwnerMetadata = {
+    pid: process.pid,
+    createdAtMs: Date.now()
+  };
+
+  writeFileSync(getOwnerMetadataPath(baseDir), JSON.stringify(metadata), "utf8");
+}
+
+function readOwnerMetadata(baseDir: string): E2EOwnerMetadata | undefined {
+  const metadataPath = getOwnerMetadataPath(baseDir);
+  if (!existsSync(metadataPath)) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(metadataPath, "utf8")) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return undefined;
+    }
+
+    const record = parsed as Record<string, unknown>;
+    const pid = record.pid;
+    const createdAtMs = record.createdAtMs;
+    if (
+      typeof pid !== "number" ||
+      !Number.isInteger(pid) ||
+      pid <= 0 ||
+      typeof createdAtMs !== "number" ||
+      !Number.isFinite(createdAtMs)
+    ) {
+      return undefined;
+    }
+
+    return { pid, createdAtMs };
+  } catch {
+    return undefined;
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (pid === process.pid) {
+    return true;
+  }
+
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as ErrnoLikeError).code !== "ESRCH";
+  }
+}
+
+function cleanupStaleE2EBaseDirs(): void {
+  const tmpDir = os.tmpdir();
+  const entries = readdirSync(tmpDir, {
+    withFileTypes: true
+  });
+
+  for (const entry of entries) {
+    if (!isStaleE2EDirectoryEntry(entry)) {
+      continue;
+    }
+
+    const candidateDir = path.join(tmpDir, entry.name);
+    const owner = readOwnerMetadata(candidateDir);
+    if (!owner || isProcessAlive(owner.pid)) {
+      continue;
+    }
+
+    rmSync(candidateDir, { recursive: true, force: true });
+  }
+}
+
+function isStaleE2EDirectoryEntry(entry: Dirent): boolean {
+  return entry.isDirectory() && entry.name.startsWith(E2E_BASE_DIR_PREFIX);
+}
+
+function ensureExitCleanupRegistered(): void {
+  if (exitCleanupRegistered) {
+    return;
+  }
+
+  process.once("exit", cleanupRuntime);
+  exitCleanupRegistered = true;
+}
+
+async function probeCdpEndpoint(cdpUrl: string): Promise<{
+  available: boolean;
+  reason: string;
+}> {
+  const validationError = getCdpUrlValidationError(cdpUrl);
+  if (validationError) {
+    return {
+      available: false,
+      reason: validationError
+    };
+  }
+
+  try {
+    const resp = await fetch(getCdpVersionEndpoint(cdpUrl));
+    if (resp.ok) {
+      return {
+        available: true,
+        reason: `CDP endpoint is reachable at ${cdpUrl}.`
+      };
+    }
+
+    return {
+      available: false,
+      reason:
+        `CDP endpoint at ${cdpUrl} responded with HTTP ${resp.status}. ` +
+        "Start the local browser bridge or set LINKEDIN_CDP_URL to a reachable endpoint."
+    };
+  } catch (error) {
+    return {
+      available: false,
+      reason:
+        `No CDP endpoint is reachable at ${cdpUrl}. ` +
+        `Start the local browser bridge or set LINKEDIN_CDP_URL to a reachable endpoint. (${summarizeUnknownError(error)})`
+    };
+  }
+}
+
+async function probeAuthentication(): Promise<{
+  authenticated: boolean;
+  reason: string;
+}> {
+  const cdpUrl = getCdpUrl();
+
+  try {
+    const status = await getRuntime().auth.status();
+    if (status.authenticated) {
+      return {
+        authenticated: true,
+        reason: `Authenticated LinkedIn session detected via ${cdpUrl}.`
+      };
+    }
+
+    return {
+      authenticated: false,
+      reason:
+        `LinkedIn session is not authenticated via ${cdpUrl}. ` +
+        "Complete login in the attached browser session and retry."
+    };
+  } catch (error) {
+    return {
+      authenticated: false,
+      reason:
+        `Could not verify LinkedIn authentication via ${cdpUrl}. ` +
+        summarizeUnknownError(error)
+    };
+  }
+}
+
 export function getRuntime(): CoreRuntime {
   if (!sharedRuntime) {
+    const cdpUrl = getCdpUrl();
+    const validationError = getCdpUrlValidationError(cdpUrl);
+    if (validationError) {
+      throw new Error(validationError);
+    }
+
     sharedRuntime = createCoreRuntime({
       baseDir: getE2EBaseDir(),
-      cdpUrl: CDP_URL
+      cdpUrl
     });
   }
   return sharedRuntime;
 }
 
 export function getCdpUrl(): string {
-  return CDP_URL;
+  return readConfiguredCdpUrl();
 }
 
 export function getE2EBaseDir(): string {
   if (!sharedBaseDir) {
-    sharedBaseDir = mkdtempSync(path.join(os.tmpdir(), "linkedin-e2e-"));
+    cleanupStaleE2EBaseDirs();
+    ensureExitCleanupRegistered();
+
+    sharedBaseDir = mkdtempSync(path.join(os.tmpdir(), E2E_BASE_DIR_PREFIX));
+    writeOwnerMetadata(sharedBaseDir);
   }
 
   return sharedBaseDir;
@@ -82,22 +303,11 @@ export async function withE2EEnvironment<T>(callback: () => Promise<T>): Promise
 }
 
 export async function checkCdpAvailable(): Promise<boolean> {
-  try {
-    const resp = await fetch(`${CDP_URL}/json/version`);
-    return resp.ok;
-  } catch {
-    return false;
-  }
+  return (await probeCdpEndpoint(getCdpUrl())).available;
 }
 
 export async function checkAuthenticated(): Promise<boolean> {
-  try {
-    const runtime = getRuntime();
-    const status = await runtime.auth.status();
-    return status.authenticated;
-  } catch {
-    return false;
-  }
+  return (await probeAuthentication()).authenticated;
 }
 
 export async function getE2EAvailability(): Promise<E2EAvailability> {
@@ -105,25 +315,24 @@ export async function getE2EAvailability(): Promise<E2EAvailability> {
     return sharedAvailability;
   }
 
-  const cdpAvailable = await checkCdpAvailable();
-  if (!cdpAvailable) {
+  const cdpUrl = getCdpUrl();
+  const cdp = await probeCdpEndpoint(cdpUrl);
+  if (!cdp.available) {
     sharedAvailability = {
-      cdpAvailable,
+      cdpAvailable: false,
       authenticated: false,
       canRun: false,
-      reason: `No CDP endpoint is reachable at ${CDP_URL}.`
+      reason: cdp.reason
     };
     return sharedAvailability;
   }
 
-  const authenticated = await checkAuthenticated();
+  const auth = await probeAuthentication();
   sharedAvailability = {
-    cdpAvailable,
-    authenticated,
-    canRun: cdpAvailable && authenticated,
-    reason: authenticated
-      ? `Authenticated LinkedIn session detected via ${CDP_URL}.`
-      : `LinkedIn session is not authenticated via ${CDP_URL}.`
+    cdpAvailable: true,
+    authenticated: auth.authenticated,
+    canRun: auth.authenticated,
+    reason: auth.reason
   };
 
   return sharedAvailability;
@@ -132,11 +341,17 @@ export async function getE2EAvailability(): Promise<E2EAvailability> {
 export function setupE2ESuite<TFixtures = void>(
   options: E2ESuiteOptions<TFixtures> = {}
 ): E2ESuite<TFixtures> {
+  const suiteId = Symbol("e2e-suite");
   let availability = UNINITIALIZED_AVAILABILITY;
   let suiteFixtures: TFixtures | undefined;
+  let suiteRegistered = false;
 
   beforeAll(async () => {
-    activeSuiteCount += 1;
+    if (!suiteRegistered) {
+      activeSuites.add(suiteId);
+      suiteRegistered = true;
+    }
+
     availability = await getE2EAvailability();
     if (availability.canRun && options.fixtures) {
       suiteFixtures = await options.fixtures(getRuntime());
@@ -144,8 +359,9 @@ export function setupE2ESuite<TFixtures = void>(
   }, options.timeoutMs);
 
   afterAll(() => {
-    activeSuiteCount = Math.max(0, activeSuiteCount - 1);
-    if (activeSuiteCount === 0) {
+    const removed = suiteRegistered ? activeSuites.delete(suiteId) : false;
+    suiteRegistered = false;
+    if (removed && activeSuites.size === 0) {
       cleanupRuntime();
     }
 
@@ -172,24 +388,39 @@ export function setupE2ESuite<TFixtures = void>(
 
 export function skipIfE2EUnavailable<TFixtures>(
   suite: E2ESuite<TFixtures>,
-  context: TestContext
-): void {
+  context?: Pick<TestContext, "skip"> | null
+): boolean {
   if (!suite.canRun()) {
-    context.skip(`Skipping LinkedIn E2E: ${suite.availability().reason}`);
+    const availability = suite.availability();
+    const reason =
+      typeof availability?.reason === "string" && availability.reason.trim().length > 0
+        ? availability.reason
+        : "LinkedIn E2E prerequisites are unavailable.";
+
+    if (context && typeof context.skip === "function") {
+      context.skip(`Skipping LinkedIn E2E: ${reason}`);
+    }
+
+    return true;
   }
+
+  return false;
 }
 
 export function cleanupRuntime(): void {
-  if (sharedRuntime) {
-    sharedRuntime.close();
-    sharedRuntime = undefined;
-  }
+  const runtime = sharedRuntime;
+  const baseDir = sharedBaseDir;
 
-  if (sharedBaseDir && existsSync(sharedBaseDir)) {
-    rmSync(sharedBaseDir, { recursive: true, force: true });
-  }
-
+  sharedRuntime = undefined;
   sharedBaseDir = undefined;
   sharedAvailability = undefined;
-  activeSuiteCount = 0;
+  activeSuites.clear();
+
+  if (runtime) {
+    runtime.close();
+  }
+
+  if (baseDir && existsSync(baseDir)) {
+    rmSync(baseDir, { recursive: true, force: true });
+  }
 }

--- a/packages/core/src/__tests__/e2eHelpers.test.ts
+++ b/packages/core/src/__tests__/e2eHelpers.test.ts
@@ -1,0 +1,145 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  callMcpToolWith,
+  getLastJsonObject,
+  mapMcpToolResult,
+  runCliCommandWith
+} from "./e2e/helpers.js";
+
+const tempDirs: string[] = [];
+
+function createTempAssistantHome(): string {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "linkedin-e2e-helper-"));
+  tempDirs.push(tempDir);
+  return tempDir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const tempDir = tempDirs.pop();
+    if (!tempDir) {
+      continue;
+    }
+
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe("E2E helper command wrappers", () => {
+  it("retries transient CLI failures and returns the final attempt output", async () => {
+    const runner = vi.fn(async () => {
+      if (runner.mock.calls.length === 1) {
+        throw new Error("Target closed while attaching to the browser");
+      }
+
+      process.stdout.write('{"ok":true}\n');
+    });
+
+    const result = await runCliCommandWith(runner, ["status"], {
+      assistantHome: createTempAssistantHome(),
+      maxAttempts: 2,
+      retryDelayMs: 0
+    });
+
+    expect(runner).toHaveBeenCalledTimes(2);
+    expect(result.exitCode).toBe(0);
+    expect(result.error).toBeUndefined();
+    expect(getLastJsonObject(result.stdout)).toEqual({ ok: true });
+  });
+
+  it("surfaces CLI timeouts as structured error output", async () => {
+    const runner = vi.fn(async () => {
+      await new Promise<void>(() => undefined);
+    });
+
+    const result = await runCliCommandWith(runner, ["status"], {
+      assistantHome: createTempAssistantHome(),
+      timeoutMs: 1
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.error).toBeDefined();
+    expect(getLastJsonObject(result.stderr)).toMatchObject({
+      message: expect.stringContaining("timed out after 1ms")
+    });
+  });
+});
+
+describe("E2E helper MCP wrappers", () => {
+  it("uses the last text content item when mapping MCP tool results", () => {
+    const result = mapMcpToolResult("linkedin.test", {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "warmup log"
+        },
+        {
+          type: "resource",
+          uri: "memory://example"
+        },
+        {
+          type: "text",
+          text: 'log prefix\n{"ok":true}'
+        }
+      ]
+    });
+
+    expect(result).toEqual({
+      payload: { ok: true },
+      isError: true
+    });
+  });
+
+  it("retries transient MCP failures before returning a payload", async () => {
+    const caller = vi.fn(async () => {
+      if (caller.mock.calls.length === 1) {
+        throw new Error("Browser has been closed unexpectedly");
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: '{"ok":true}'
+          }
+        ]
+      };
+    });
+
+    const result = await callMcpToolWith(
+      caller,
+      "linkedin.test",
+      {
+        sample: true
+      },
+      {
+        assistantHome: createTempAssistantHome(),
+        maxAttempts: 2,
+        retryDelayMs: 0
+      }
+    );
+
+    expect(caller).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      payload: { ok: true },
+      isError: false
+    });
+  });
+
+  it("throws a clear error when MCP output contains no JSON object", () => {
+    expect(() =>
+      mapMcpToolResult("linkedin.test", {
+        content: [
+          {
+            type: "text",
+            text: "plain text only"
+          }
+        ]
+      })
+    ).toThrow("Tool linkedin.test payload did not contain a JSON object");
+  });
+});

--- a/packages/core/src/__tests__/e2eSetup.test.ts
+++ b/packages/core/src/__tests__/e2eSetup.test.ts
@@ -1,23 +1,40 @@
-import { existsSync } from "node:fs";
-import { afterEach, describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  DEFAULT_E2E_CDP_URL,
+  E2E_BASE_DIR_PREFIX,
+  E2E_OWNER_METADATA_FILE,
   cleanupRuntime,
+  getCdpUrl,
+  getE2EAvailability,
   getE2EBaseDir,
+  skipIfE2EUnavailable,
   withAssistantHome,
-  withE2EEnvironment
+  withE2EEnvironment,
+  type E2ESuite
 } from "./e2e/setup.js";
 
 const originalAssistantHome = process.env.LINKEDIN_ASSISTANT_HOME;
+const originalCdpUrl = process.env.LINKEDIN_CDP_URL;
 
 afterEach(() => {
   cleanupRuntime();
+  vi.restoreAllMocks();
 
   if (originalAssistantHome === undefined) {
     delete process.env.LINKEDIN_ASSISTANT_HOME;
+  } else {
+    process.env.LINKEDIN_ASSISTANT_HOME = originalAssistantHome;
+  }
+
+  if (originalCdpUrl === undefined) {
+    delete process.env.LINKEDIN_CDP_URL;
     return;
   }
 
-  process.env.LINKEDIN_ASSISTANT_HOME = originalAssistantHome;
+  process.env.LINKEDIN_CDP_URL = originalCdpUrl;
 });
 
 describe("E2E setup helpers", () => {
@@ -51,6 +68,7 @@ describe("E2E setup helpers", () => {
 
     cleanupRuntime();
     expect(existsSync(firstDir)).toBe(false);
+    expect(() => cleanupRuntime()).not.toThrow();
 
     const secondDir = getE2EBaseDir();
     expect(secondDir).not.toBe(firstDir);
@@ -58,5 +76,91 @@ describe("E2E setup helpers", () => {
     cleanupRuntime();
 
     expect(existsSync(secondDir)).toBe(false);
+  });
+
+  it("defaults the CDP URL when LINKEDIN_CDP_URL is unset", () => {
+    delete process.env.LINKEDIN_CDP_URL;
+
+    expect(getCdpUrl()).toBe(DEFAULT_E2E_CDP_URL);
+  });
+
+  it("reports malformed CDP URLs as unavailable", async () => {
+    process.env.LINKEDIN_CDP_URL = "not-a-url";
+
+    const availability = await getE2EAvailability();
+
+    expect(availability).toMatchObject({
+      cdpAvailable: false,
+      authenticated: false,
+      canRun: false
+    });
+    expect(availability.reason).toContain("absolute http(s) URL");
+  });
+
+  it("reports unreachable CDP endpoints with actionable guidance", async () => {
+    process.env.LINKEDIN_CDP_URL = "http://127.0.0.1:45555";
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("connect ECONNREFUSED"));
+
+    const availability = await getE2EAvailability();
+
+    expect(availability).toMatchObject({
+      cdpAvailable: false,
+      authenticated: false,
+      canRun: false
+    });
+    expect(availability.reason).toContain("http://127.0.0.1:45555");
+    expect(availability.reason).toContain("LINKEDIN_CDP_URL");
+  });
+
+  it("cleans stale shared E2E directories left by crashed processes", () => {
+    const staleDir = mkdtempSync(path.join(os.tmpdir(), E2E_BASE_DIR_PREFIX));
+    writeFileSync(
+      path.join(staleDir, E2E_OWNER_METADATA_FILE),
+      JSON.stringify({
+        pid: 999_999,
+        createdAtMs: Date.now() - 1_000
+      }),
+      "utf8"
+    );
+
+    const baseDir = getE2EBaseDir();
+
+    expect(baseDir).not.toBe(staleDir);
+    expect(existsSync(baseDir)).toBe(true);
+    expect(existsSync(staleDir)).toBe(false);
+  });
+});
+
+describe("skipIfE2EUnavailable", () => {
+  it("returns true when availability is missing and context is null", () => {
+    const suite = {
+      availability: () => undefined,
+      canRun: () => false,
+      runtime: () => {
+        throw new Error("runtime should not be used");
+      },
+      fixtures: () => undefined
+    } as unknown as E2ESuite;
+
+    expect(skipIfE2EUnavailable(suite, null)).toBe(true);
+  });
+
+  it("uses a fallback reason when the suite has no availability details", () => {
+    const context = {
+      skip: vi.fn()
+    };
+    const suite = {
+      availability: () => undefined,
+      canRun: () => false,
+      runtime: () => {
+        throw new Error("runtime should not be used");
+      },
+      fixtures: () => undefined
+    } as unknown as E2ESuite;
+
+    expect(skipIfE2EUnavailable(suite, context)).toBe(true);
+    expect(context.skip).toHaveBeenCalledWith(
+      "Skipping LinkedIn E2E: LinkedIn E2E prerequisites are unavailable."
+    );
   });
 });

--- a/packages/core/src/__tests__/runtimeClose.test.ts
+++ b/packages/core/src/__tests__/runtimeClose.test.ts
@@ -1,0 +1,37 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createCoreRuntime } from "../runtime.js";
+
+const tempDirs: string[] = [];
+
+function createTempBaseDir(): string {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "linkedin-runtime-close-"));
+  tempDirs.push(tempDir);
+  return tempDir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const tempDir = tempDirs.pop();
+    if (!tempDir) {
+      continue;
+    }
+
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe("core runtime close", () => {
+  it("allows close to be called repeatedly", () => {
+    const runtime = createCoreRuntime({
+      baseDir: createTempBaseDir()
+    });
+
+    expect(() => {
+      runtime.close();
+      runtime.close();
+    }).not.toThrow();
+  });
+});

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -124,6 +124,7 @@ export function createCoreRuntime(
   const artifacts = new ArtifactHelpers(paths, runId, db, privacy);
   const confirmFailureArtifacts = resolveConfirmFailureArtifactConfig();
   const profileManager = new ProfileManager(paths);
+  let closed = false;
   let runtime: CoreRuntime;
 
   const testAutoConfirm = createDefaultTestAutoConfirmConfig();
@@ -202,6 +203,11 @@ export function createCoreRuntime(
       );
     },
     close: () => {
+      if (closed) {
+        return;
+      }
+
+      closed = true;
       logger.log("info", "runtime.closed", { runId });
       db.close();
     }


### PR DESCRIPTION
## Summary
- harden shared E2E setup around malformed CDP URLs, clearer availability reasons, stale temp-dir cleanup, and repeated teardown
- make test-only CLI/MCP helpers more defensive with timeout/retry support and resilient MCP payload parsing
- add unit coverage for setup edge cases, helper wrapper contracts, and idempotent runtime shutdown

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #69