### PR TITLE
docs: document data delete command behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,17 +125,28 @@ npm exec -w @linkedin-assistant/cli -- linkedin keepalive stop --profile default
 Delete local tool state:
 
 ```bash
+# Preview the shared local runtime footprint (default dry-run)
 npm exec -w @linkedin-assistant/cli -- linkedin data delete
+
+# Delete shared local runtime data after interactive confirmation
 npm exec -w @linkedin-assistant/cli -- linkedin data delete --confirm
+
+# Preview the wider wipe that also includes tool-owned browser profiles
 npm exec -w @linkedin-assistant/cli -- linkedin data delete --include-profile
+
+# Delete shared data plus tool-owned browser profiles (second confirmation)
 npm exec -w @linkedin-assistant/cli -- linkedin data delete --include-profile --confirm
 ```
 
 - `linkedin data delete` is a dry-run preview by default.
-- Rerun with `--confirm` to perform the destructive deletion in an interactive terminal.
+- The default scope is the shared local runtime footprint: `state.sqlite` and its SQLite sidecars, `artifacts/`, `keepalive/`, and the auth cooldown file.
+- Rerun with `--confirm` in an interactive terminal to perform the destructive deletion.
+- Answering anything other than `yes` cancels the deletion and leaves all files untouched.
 - Stop any running keepalive daemons before deleting local state.
-- `config.json` is preserved by design.
-- `--include-profile` prompts a second time before removing local browser profile data.
+- `config.json` is preserved by design, and data from external browsers attached with `--cdp-url` is never deleted.
+- `--include-profile` prompts a second time before removing tool-owned browser profiles, saved sessions, and cookies.
+- If that second prompt is declined, the command still deletes the shared runtime data and preserves `profiles/`.
+- If some paths cannot be removed, the command exits non-zero after deleting the paths it can and reports `failed_paths` entries with `path`, `code`, `message`, and `recoveryHint`.
 
 ### Selector audit
 
@@ -351,6 +362,7 @@ The read-only MCP tool descriptions reference this diagnostic path.
 - Errors use structured taxonomy:
   - `AUTH_REQUIRED`, `CAPTCHA_OR_CHALLENGE`, `RATE_LIMITED`, `UI_CHANGED_SELECTOR_FAILED`, `NETWORK_ERROR`, `TIMEOUT`, `TARGET_NOT_FOUND`, `ACTION_PRECONDITION_FAILED`, `UNKNOWN`
 - CLI and MCP return structured JSON errors (`code`, `message`, `details`).
+- `linkedin data delete` intentionally uses a filesystem-first helper instead of booting `createCoreRuntime()` so the command does not recreate directories, logs, or `state.sqlite` while wiping local state.
 
 ## Quality Gates
 

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -92,6 +92,7 @@ function maybeWarnAboutSelectorLocaleConfig(selectorLocale?: string): void {
   writeCliNotice(warning.guidance);
 }
 
+/** Human-readable preview row for a single local-data target. */
 interface LocalDataPreviewItem {
   exists: boolean;
   label: string;
@@ -99,6 +100,10 @@ interface LocalDataPreviewItem {
   path: string;
 }
 
+/**
+ * Aggregated inventory reused by the dry-run output, confirmation prompts, and
+ * final JSON payloads for `linkedin data delete`.
+ */
 interface LocalDataDeletionPreview {
   baseDir: string;
   deleteItems: LocalDataPreviewItem[];
@@ -2449,19 +2454,20 @@ export function createCliProgram(): Command {
     .command("delete")
     .description(
       [
-        "Preview local runtime data deletion; rerun with --confirm to delete.",
-        "Default behavior is a dry-run preview of the local database, artifacts, keepalive state, and auth cooldown files.",
+        "Preview local runtime data deletion; rerun with --confirm in an interactive terminal to delete.",
+        "Default behavior is a dry-run preview of the shared local database, artifacts, keepalive state, and auth cooldown files. --include-profile expands the scope to all tool-owned browser profiles and adds a second confirmation before removing saved sessions and cookies.",
+        "Answering anything other than \"yes\" cancels safely. If some paths fail, the command reports failed_paths with recovery guidance after deleting what it can.",
         "config.json is preserved by design. Stop keepalive daemons first. Data from external browsers attached with --cdp-url is never deleted."
       ].join("\n\n")
     )
     .option(
       "--confirm",
-      "Permanently delete the listed tool-owned local data after interactive confirmation",
+      "Permanently delete the listed tool-owned local data after interactive confirmation prompts",
       false
     )
     .option(
       "--include-profile",
-      "Also delete tool-owned browser profile data after a second confirmation",
+      "Also preview/delete tool-owned browser profile data; destructive mode adds a second confirmation",
       false
     )
     .addHelpText(
@@ -2479,7 +2485,17 @@ export function createCliProgram(): Command {
         "  - default behavior is a dry-run preview",
         "  - config.json is preserved by design",
         "  - active keepalive daemons must be stopped first",
-        "  - data from external browsers attached with --cdp-url is never deleted"
+        "  - data from external browsers attached with --cdp-url is never deleted",
+        "",
+        "Interactive flow:",
+        "  - --confirm requires an interactive terminal",
+        "  - answering anything other than \"yes\" cancels without deleting files",
+        "  - --include-profile adds a second prompt for browser sessions and cookies",
+        "",
+        "Partial failures:",
+        "  - the command keeps deleting other targets when possible",
+        "  - failed_paths reports path, code, message, and recoveryHint",
+        "  - fix the reported issue and rerun the same command"
       ].join("\n")
     )
     .action(async (options: { confirm: boolean; includeProfile: boolean }) => {

--- a/packages/cli/test/dataDelete.test.ts
+++ b/packages/cli/test/dataDelete.test.ts
@@ -451,6 +451,9 @@ describe("linkedin data delete", () => {
     expect(help).toContain("--confirm");
     expect(help).toContain("Default behavior is a dry-run preview");
     expect(help).toContain("config.json is preserved by design");
+    expect(help).toContain("Answering anything other than \"yes\" cancels safely");
+    expect(help).toContain("failed_paths");
+    expect(help).toContain("recovery guidance");
     expect(help).toContain("--cdp-url");
   });
 });

--- a/packages/core/src/localData.ts
+++ b/packages/core/src/localData.ts
@@ -5,35 +5,82 @@ import { resolveRateLimitStateFilePaths } from "./auth/rateLimitState.js";
 import { resolveConfigPaths } from "./config.js";
 import { LinkedInAssistantError } from "./errors.js";
 
+/**
+ * Filesystem-first helpers for inventorying and deleting tool-owned local
+ * state.
+ *
+ * @remarks
+ * These helpers intentionally avoid booting the normal runtime.
+ * `createCoreRuntime()` eagerly creates directories, opens `state.sqlite`, and
+ * writes lifecycle logs, which would recreate state during a deletion flow.
+ */
 export interface LocalDataDeletionPlanOptions {
+  /**
+   * Optional assistant home override used to resolve the owned local-state
+   * footprint.
+   */
   baseDir?: string;
+  /**
+   * When true, the deletion plan also includes tool-owned browser profile
+   * directories.
+   */
   includeProfile?: boolean;
+  /**
+   * Optional override for the auth cooldown file, mainly for tests and custom
+   * installs.
+   */
   rateLimitStatePath?: string;
 }
 
+/**
+ * Canonical local-data inventory resolved before any destructive action runs.
+ */
 export interface LocalDataDeletionPlan {
+  /** Canonical assistant home used to scope in-base deletion targets. */
   baseDir: string;
+  /** Indicates whether browser profiles were explicitly opted into the plan. */
   includeProfile: boolean;
+  /** Absolute target paths that the deletion workflow may remove. */
   targets: string[];
 }
 
+/**
+ * Actionable information about a single filesystem target that could not be
+ * removed.
+ */
 export interface LocalDataDeletionFailure {
+  /** Absolute path that failed deletion. */
   path: string;
+  /** Best-effort filesystem error code, when one is available. */
   code: string | null;
+  /** Human-readable error message surfaced to the operator. */
   message: string;
+  /** Optional retry guidance derived from the filesystem error code. */
   recoveryHint?: string;
 }
 
+/**
+ * Summary returned after a deletion attempt finishes scanning every target.
+ */
 export interface LocalDataDeletionResult {
+  /** Timestamp captured immediately before deletion begins. */
   startedAt: string;
+  /** Timestamp captured after the last deletion attempt completes. */
   completedAt: string;
+  /** Paths that were removed successfully. */
   deletedPaths: string[];
+  /** Paths that were already absent when the command reached them. */
   missingPaths: string[];
+  /** Paths that still require operator attention or a retry. */
   failedPaths: LocalDataDeletionFailure[];
 }
 
 const SQLITE_SIDECAR_SUFFIXES = ["-journal", "-wal", "-shm"] as const;
 
+/**
+ * Resolves the directory that stores keepalive PID, state, and event-log
+ * files.
+ */
 export function resolveKeepAliveDir(baseDir?: string): string {
   return path.join(resolveConfigPaths(baseDir).baseDir, "keepalive");
 }
@@ -195,6 +242,15 @@ function toDeletionFailure(
   };
 }
 
+/**
+ * Resolves the canonical set of tool-owned paths eligible for local-data
+ * deletion.
+ *
+ * @remarks
+ * The plan only includes runtime-owned state. `config.json` remains outside
+ * the deletion plan so the command behaves like privacy cleanup instead of a
+ * full factory reset.
+ */
 export function createLocalDataDeletionPlan(
   options: LocalDataDeletionPlanOptions = {}
 ): LocalDataDeletionPlan {
@@ -252,6 +308,15 @@ export function createLocalDataDeletionPlan(
   };
 }
 
+/**
+ * Deletes the planned local-data targets from disk.
+ *
+ * @remarks
+ * Missing paths are reported in `missingPaths` and do not fail the command.
+ * Other filesystem errors are accumulated so the helper can continue deleting
+ * remaining targets before throwing a `LinkedInAssistantError` with
+ * `failed_paths` details.
+ */
 export async function deleteLocalData(
   options: LocalDataDeletionPlanOptions = {}
 ): Promise<LocalDataDeletionResult> {


### PR DESCRIPTION
## Summary
- expand README coverage for the data delete command's dry-run, confirmation, cancellation, profile opt-in, and partial-failure behavior
- add inline TSDoc for the filesystem-first local-data deletion helpers and CLI preview types
- tighten the CLI help-text test so the new guidance stays documented

Closes #91

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build