### PR TITLE
test: improve E2E developer workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,10 @@ which makes it safe to invoke in CI.
 See `docs/e2e-testing.md` for the full workflow, safe targets, and opt-in write
 flags.
 
+Pass `npm run test:e2e -- --require-session` when a missing session should fail
+instead of skip, and use `--fixtures <file>` to capture or replay the shared
+CLI/MCP coverage fixtures while iterating on E2E failures.
+
 ### Prerequisites
 
 - Node.js 22+
@@ -397,6 +401,9 @@ confirm entrypoints. Real outbound confirms remain opt-in.
 ```bash
 # Default run: safe coverage only
 npm run test:e2e
+
+# Focus a specific E2E file while keeping the runner checks
+npm run test:e2e -- packages/core/src/__tests__/e2e/cli.e2e.test.ts
 
 # Raw Vitest E2E run when you already know the session is available
 npm run test:e2e:raw

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -13,14 +13,32 @@ npm run test:e2e
 
 The runner:
 
-1. Checks that a CDP endpoint is reachable.
-2. Verifies that the attached browser is already authenticated with LinkedIn.
-3. Builds the workspace.
+1. Prints the effective E2E configuration.
+2. Checks that a CDP endpoint is reachable.
+3. Verifies that the attached browser is already authenticated with LinkedIn.
 4. Runs the Vitest E2E suite.
 
 If no authenticated session is available, the runner prints a skip reason and
 exits successfully. This makes it safe for CI environments that do not have a
 LinkedIn browser session.
+
+Pass `--require-session` when a missing CDP/authenticated session should fail
+instead of skip:
+
+```bash
+npm run test:e2e -- --require-session
+```
+
+The same strict behavior is available through
+`LINKEDIN_E2E_REQUIRE_SESSION=1`.
+
+The runner forwards any remaining arguments to Vitest, so focused reruns stay
+simple:
+
+```bash
+npm run test:e2e -- packages/core/src/__tests__/e2e/cli.e2e.test.ts
+npm run test:e2e -- --reporter=verbose packages/core/src/__tests__/e2e/error-paths.e2e.test.ts
+```
 
 To force the raw Vitest suite directly, use:
 
@@ -39,6 +57,38 @@ Environment variables:
 
 - `LINKEDIN_CDP_URL` — optional, defaults to `http://localhost:18800`
 - `LINKEDIN_E2E_PROFILE` — optional logical profile name, defaults to `default`
+- `LINKEDIN_E2E_REQUIRE_SESSION` — optional, set to `1` or `true` to fail instead of skip
+- `LINKEDIN_E2E_FIXTURE_FILE` — optional JSON file used to record or replay shared CLI/MCP fixtures
+- `LINKEDIN_E2E_REFRESH_FIXTURES` — optional, set to `1` or `true` to overwrite the fixture file
+- `LINKEDIN_E2E_JOB_QUERY` — optional job query override for live fixture discovery, defaults to `software engineer`
+- `LINKEDIN_E2E_JOB_LOCATION` — optional job location override for live fixture discovery, defaults to `Copenhagen`
+
+## Fixture replay workflow
+
+The CLI and MCP contract suites only need a few stable identifiers: a message
+thread id, a feed post URL, a job id, and a connection target. The runner can
+capture those into a small JSON file so you can replay the same targets while
+iterating on contract or output bugs.
+
+Capture or refresh the fixtures:
+
+```bash
+npm run test:e2e -- \
+  --fixtures .tmp/e2e-fixtures.json \
+  --refresh-fixtures \
+  packages/core/src/__tests__/e2e/cli.e2e.test.ts
+```
+
+Replay the saved fixtures on later runs:
+
+```bash
+npm run test:e2e -- \
+  --fixtures .tmp/e2e-fixtures.json \
+  packages/core/src/__tests__/e2e/mcp.e2e.test.ts
+```
+
+If the replay file becomes stale or malformed, rerun with `--refresh-fixtures`
+to overwrite it with fresh live-discovery output.
 
 ## Safe defaults
 
@@ -137,3 +187,5 @@ The E2E suite now covers:
   outbound actions.
 - The confirm E2Es are intentionally split between safe default coverage and
   explicit opt-in side effects.
+- The default runner does not build the workspace; it executes the Vitest E2E
+  config directly from source.

--- a/packages/core/src/__tests__/e2e/helpers.ts
+++ b/packages/core/src/__tests__/e2e/helpers.ts
@@ -1,3 +1,5 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
 import type { CoreRuntime } from "../../runtime.js";
 import { toLinkedInAssistantErrorPayload } from "../../errors.js";
 import { TEST_ECHO_ACTION_TYPE } from "../../twoPhaseCommit.js";
@@ -50,6 +52,13 @@ export interface PreparedActionResult {
   preview: Record<string, unknown>;
 }
 
+export interface CliCoverageFixtures {
+  threadId: string;
+  postUrl: string;
+  jobId: string;
+  connectionTarget: string;
+}
+
 export interface CommandExecutionOptions {
   assistantHome?: string;
   timeoutMs?: number;
@@ -63,23 +72,40 @@ export type McpToolCaller = (
   args: Record<string, unknown>
 ) => Promise<unknown>;
 
-const DEFAULT_PROFILE_NAME = process.env.LINKEDIN_E2E_PROFILE ?? "default";
-const DEFAULT_MESSAGE_TARGET_PATTERN =
-  process.env.LINKEDIN_E2E_MESSAGE_TARGET_PATTERN ?? "Simon Miller";
-const DEFAULT_CONNECTION_TARGET =
-  process.env.LINKEDIN_E2E_CONNECTION_TARGET ?? "realsimonmiller";
-const DEFAULT_LIKE_POST_URL = process.env.LINKEDIN_E2E_LIKE_POST_URL;
-const DEFAULT_COMMENT_POST_URL = process.env.LINKEDIN_E2E_COMMENT_POST_URL;
-const DEFAULT_CONNECTION_CONFIRM_MODE =
-  process.env.LINKEDIN_E2E_CONNECTION_CONFIRM_MODE ?? "";
 const DEFAULT_MAX_ATTEMPTS = 1;
 const DEFAULT_RETRY_DELAY_MS = 250;
+const DEFAULT_JOB_QUERY = "software engineer";
+const DEFAULT_JOB_LOCATION = "Copenhagen";
+const E2E_FIXTURE_FORMAT_VERSION = 1;
 const TRANSIENT_E2E_ERROR_PATTERN =
   /timed out|timeout|Target closed|Execution context was destroyed|page crashed|browser has been closed|context was closed|ECONNRESET|ECONNREFUSED|EPIPE/i;
 
-function readEnabledFlag(name: string): boolean {
+function readTrimmedEnv(name: string): string | undefined {
   const value = process.env[name];
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readEnabledFlag(name: string): boolean {
+  const value = readTrimmedEnv(name);
   return value === "1" || value === "true";
+}
+
+function getDefaultJobQuery(): string {
+  return readTrimmedEnv("LINKEDIN_E2E_JOB_QUERY") ?? DEFAULT_JOB_QUERY;
+}
+
+function getDefaultJobLocation(): string {
+  return readTrimmedEnv("LINKEDIN_E2E_JOB_LOCATION") ?? DEFAULT_JOB_LOCATION;
+}
+
+function getFixtureFilePath(): string | undefined {
+  const configuredPath = readTrimmedEnv("LINKEDIN_E2E_FIXTURE_FILE");
+  return configuredPath ? path.resolve(configuredPath) : undefined;
 }
 
 function coerceChunk(
@@ -111,6 +137,9 @@ function createWriteInterceptor(
   }) as typeof process.stdout.write;
 }
 
+// CLI and MCP E2Es often print progress lines before their final JSON payload.
+// Extract every top-level JSON object so tests can reliably assert on the last
+// machine-readable result without forcing the command surface to stay silent.
 function parseJsonObjects(text: string): Record<string, unknown>[] {
   const objects: Record<string, unknown>[] = [];
   let depth = 0;
@@ -174,6 +203,89 @@ function parseJsonObjects(text: string): Record<string, unknown>[] {
   }
 
   return objects;
+}
+
+function assertNonEmptyString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+
+  return value.trim();
+}
+
+function parseCliCoverageFixtures(
+  value: unknown,
+  sourceLabel: string
+): CliCoverageFixtures {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${sourceLabel} must contain a JSON object.`);
+  }
+
+  const record = value as Record<string, unknown>;
+  const fixtureFormat = record.format;
+  if (fixtureFormat !== undefined && fixtureFormat !== E2E_FIXTURE_FORMAT_VERSION) {
+    throw new Error(
+      `${sourceLabel} uses unsupported format ${String(fixtureFormat)}. ` +
+        "Refresh the fixtures to rewrite the file with the current format."
+    );
+  }
+
+  const capturedProfileName = record.profileName;
+  const expectedProfileName = getDefaultProfileName();
+  if (
+    typeof capturedProfileName === "string" &&
+    capturedProfileName.trim().length > 0 &&
+    capturedProfileName.trim() !== expectedProfileName
+  ) {
+    throw new Error(
+      `${sourceLabel} was captured for profile ${capturedProfileName.trim()} but the current ` +
+        `E2E profile is ${expectedProfileName}. Refresh the fixtures or set LINKEDIN_E2E_PROFILE to match.`
+    );
+  }
+
+  return {
+    threadId: assertNonEmptyString(record.threadId, `${sourceLabel}.threadId`),
+    postUrl: assertNonEmptyString(record.postUrl, `${sourceLabel}.postUrl`),
+    jobId: assertNonEmptyString(record.jobId, `${sourceLabel}.jobId`),
+    connectionTarget: assertNonEmptyString(
+      record.connectionTarget,
+      `${sourceLabel}.connectionTarget`
+    )
+  };
+}
+
+function readCliCoverageFixturesFromFile(filePath: string): CliCoverageFixtures {
+  try {
+    const raw = readFileSync(filePath, "utf8");
+    return parseCliCoverageFixtures(JSON.parse(raw) as unknown, `Fixture file ${filePath}`);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Could not load coverage fixtures from ${filePath}. ${reason} ` +
+        "Delete the file or rerun with --refresh-fixtures (LINKEDIN_E2E_REFRESH_FIXTURES=1)."
+    );
+  }
+}
+
+function writeCliCoverageFixturesToFile(
+  filePath: string,
+  fixtures: CliCoverageFixtures
+): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(
+    filePath,
+    `${JSON.stringify(
+      {
+        format: E2E_FIXTURE_FORMAT_VERSION,
+        capturedAt: new Date().toISOString(),
+        profileName: getDefaultProfileName(),
+        ...fixtures
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
 }
 
 function summarizeUnknownValue(value: unknown): string {
@@ -364,15 +476,18 @@ export function mapMcpToolResult(name: string, rawResult: unknown): MappedMcpRes
 }
 
 export function getDefaultProfileName(): string {
-  return DEFAULT_PROFILE_NAME;
+  return readTrimmedEnv("LINKEDIN_E2E_PROFILE") ?? "default";
 }
 
 export function getDefaultConnectionTarget(): string {
-  return DEFAULT_CONNECTION_TARGET;
+  return readTrimmedEnv("LINKEDIN_E2E_CONNECTION_TARGET") ?? "realsimonmiller";
 }
 
 export function getDefaultMessageTargetPattern(): RegExp {
-  return new RegExp(DEFAULT_MESSAGE_TARGET_PATTERN, "i");
+  return new RegExp(
+    readTrimmedEnv("LINKEDIN_E2E_MESSAGE_TARGET_PATTERN") ?? "Simon Miller",
+    "i"
+  );
 }
 
 export function isOptInEnabled(name: string): boolean {
@@ -380,15 +495,15 @@ export function isOptInEnabled(name: string): boolean {
 }
 
 export function getConnectionConfirmMode(): string {
-  return DEFAULT_CONNECTION_CONFIRM_MODE;
+  return readTrimmedEnv("LINKEDIN_E2E_CONNECTION_CONFIRM_MODE") ?? "";
 }
 
 export function getOptInLikePostUrl(): string | undefined {
-  return DEFAULT_LIKE_POST_URL;
+  return readTrimmedEnv("LINKEDIN_E2E_LIKE_POST_URL");
 }
 
 export function getOptInCommentPostUrl(): string | undefined {
-  return DEFAULT_COMMENT_POST_URL;
+  return readTrimmedEnv("LINKEDIN_E2E_COMMENT_POST_URL");
 }
 
 export async function runCliCommandWith(
@@ -446,6 +561,9 @@ export async function runCliCommand(
   return runCliCommandWith(runCli, args, options);
 }
 
+// The CLI emits human guidance plus JSON. Tests assert against the last JSON
+// object so command output can stay useful for operators without breaking
+// programmatic E2E checks.
 export function getLastJsonObject(text: string): Record<string, unknown> {
   const objects = parseJsonObjects(text);
   const lastObject = objects.at(-1);
@@ -561,7 +679,7 @@ export function prepareEchoAction(
   expiresAtMs: number;
   preview: Record<string, unknown>;
 } {
-  const profileName = input.profileName ?? DEFAULT_PROFILE_NAME;
+  const profileName = input.profileName ?? getDefaultProfileName();
   const text = input.text ?? `echo-${Date.now()}`;
   const target = {
     profile_name: profileName
@@ -588,15 +706,17 @@ export async function getMessageThread(runtime: CoreRuntime): Promise<{
   title: string;
   thread_url: string;
 }> {
+  const profileName = getDefaultProfileName();
   const threads = await runtime.inbox.listThreads({
     limit: 40,
-    profileName: DEFAULT_PROFILE_NAME
+    profileName
   });
 
   const match = threads.find((thread) => getDefaultMessageTargetPattern().test(thread.title));
   if (!match) {
     throw new Error(
-      `Could not find inbox thread matching ${DEFAULT_MESSAGE_TARGET_PATTERN}.`
+      `Could not find an inbox thread matching ${getDefaultMessageTargetPattern()} for profile ${profileName}. ` +
+        "Adjust LINKEDIN_E2E_MESSAGE_TARGET_PATTERN or reuse a saved fixture file with --fixtures <file>."
     );
   }
 
@@ -613,13 +733,15 @@ export async function getFeedPost(runtime: CoreRuntime): Promise<{
   author_name: string;
 }> {
   const posts = await runtime.feed.viewFeed({
-    profileName: DEFAULT_PROFILE_NAME,
+    profileName: getDefaultProfileName(),
     limit: 10
   });
 
   const post = posts[0];
   if (!post) {
-    throw new Error("No feed post was available for E2E coverage.");
+    throw new Error(
+      "No feed post was available for E2E coverage. Scroll the dedicated browser session to load the feed or refresh the saved fixtures with --refresh-fixtures."
+    );
   }
 
   return {
@@ -633,16 +755,22 @@ export async function getJob(runtime: CoreRuntime): Promise<{
   job_id: string;
   title: string;
 }> {
+  const profileName = getDefaultProfileName();
+  const jobQuery = getDefaultJobQuery();
+  const jobLocation = getDefaultJobLocation();
   const search = await runtime.jobs.searchJobs({
-    profileName: DEFAULT_PROFILE_NAME,
-    query: "software engineer",
-    location: "Copenhagen",
+    profileName,
+    query: jobQuery,
+    location: jobLocation,
     limit: 5
   });
 
   const job = search.results[0];
   if (!job) {
-    throw new Error("No LinkedIn job result was available for E2E coverage.");
+    throw new Error(
+      `No LinkedIn job result was available for E2E coverage with query ${jobQuery} in ${jobLocation}. ` +
+        "Adjust LINKEDIN_E2E_JOB_QUERY / LINKEDIN_E2E_JOB_LOCATION or refresh the saved fixtures."
+    );
   }
 
   return {
@@ -651,12 +779,7 @@ export async function getJob(runtime: CoreRuntime): Promise<{
   };
 }
 
-export async function getCliCoverageFixtures(runtime: CoreRuntime): Promise<{
-  threadId: string;
-  postUrl: string;
-  jobId: string;
-  connectionTarget: string;
-}> {
+async function discoverCliCoverageFixtures(runtime: CoreRuntime): Promise<CliCoverageFixtures> {
   const thread = await getMessageThread(runtime);
   const post = await getFeedPost(runtime);
   const job = await getJob(runtime);
@@ -665,8 +788,27 @@ export async function getCliCoverageFixtures(runtime: CoreRuntime): Promise<{
     threadId: thread.thread_id,
     postUrl: post.post_url,
     jobId: job.job_id,
-    connectionTarget: DEFAULT_CONNECTION_TARGET
+    connectionTarget: getDefaultConnectionTarget()
   };
+}
+
+// CLI and MCP surface tests only need a few stable identifiers. Keeping that
+// contract in one small fixture object makes it easy to capture once and replay
+// when iterating on contract bugs without rediscovering every LinkedIn target.
+export async function getCliCoverageFixtures(runtime: CoreRuntime): Promise<CliCoverageFixtures> {
+  const fixtureFilePath = getFixtureFilePath();
+
+  if (!fixtureFilePath) {
+    return discoverCliCoverageFixtures(runtime);
+  }
+
+  if (!readEnabledFlag("LINKEDIN_E2E_REFRESH_FIXTURES") && existsSync(fixtureFilePath)) {
+    return readCliCoverageFixturesFromFile(fixtureFilePath);
+  }
+
+  const fixtures = await discoverCliCoverageFixtures(runtime);
+  writeCliCoverageFixturesToFile(fixtureFilePath, fixtures);
+  return fixtures;
 }
 
 export const MCP_TOOL_NAMES = {

--- a/packages/core/src/__tests__/e2e/setup.ts
+++ b/packages/core/src/__tests__/e2e/setup.ts
@@ -347,6 +347,9 @@ export function setupE2ESuite<TFixtures = void>(
   let suiteRegistered = false;
 
   beforeAll(async () => {
+    // Real-session E2Es share one runtime so the suite only pays the CDP/auth
+    // probe cost once. Optional fixtures are resolved after the availability
+    // check so callers can safely reuse the same runtime-backed discovery.
     if (!suiteRegistered) {
       activeSuites.add(suiteId);
       suiteRegistered = true;
@@ -374,6 +377,9 @@ export function setupE2ESuite<TFixtures = void>(
     canRun: () => availability.canRun,
     runtime: () => getRuntime(),
     fixtures: () => {
+      // Fixtures are populated in beforeAll after the suite confirms that a
+      // live LinkedIn session is actually runnable. Accessing them earlier is a
+      // test bug, so fail loudly with a specific message.
       if (!options.fixtures) {
         throw new Error("This E2E suite does not define fixtures.");
       }

--- a/packages/core/src/__tests__/e2eHelpers.test.ts
+++ b/packages/core/src/__tests__/e2eHelpers.test.ts
@@ -1,20 +1,62 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   callMcpToolWith,
+  getCliCoverageFixtures,
+  getDefaultConnectionTarget,
+  getDefaultProfileName,
   getLastJsonObject,
   mapMcpToolResult,
   runCliCommandWith
 } from "./e2e/helpers.js";
 
 const tempDirs: string[] = [];
+const originalEnv = {
+  profile: process.env.LINKEDIN_E2E_PROFILE,
+  connectionTarget: process.env.LINKEDIN_E2E_CONNECTION_TARGET,
+  fixtureFile: process.env.LINKEDIN_E2E_FIXTURE_FILE,
+  refreshFixtures: process.env.LINKEDIN_E2E_REFRESH_FIXTURES
+};
 
 function createTempAssistantHome(): string {
   const tempDir = mkdtempSync(path.join(tmpdir(), "linkedin-e2e-helper-"));
   tempDirs.push(tempDir);
   return tempDir;
+}
+
+function createFixtureRuntime() {
+  return {
+    inbox: {
+      listThreads: vi.fn(async () => [
+        {
+          thread_id: "thread-123",
+          title: "Simon Miller",
+          thread_url: "https://www.linkedin.com/messaging/thread-123"
+        }
+      ])
+    },
+    feed: {
+      viewFeed: vi.fn(async () => [
+        {
+          post_id: "post-123",
+          post_url: "https://www.linkedin.com/feed/update/post-123",
+          author_name: "Fixture Author"
+        }
+      ])
+    },
+    jobs: {
+      searchJobs: vi.fn(async () => ({
+        results: [
+          {
+            job_id: "job-123",
+            title: "Fixture Job"
+          }
+        ]
+      }))
+    }
+  } as unknown as Parameters<typeof getCliCoverageFixtures>[0];
 }
 
 afterEach(() => {
@@ -25,6 +67,30 @@ afterEach(() => {
     }
 
     rmSync(tempDir, { recursive: true, force: true });
+  }
+
+  if (originalEnv.profile === undefined) {
+    delete process.env.LINKEDIN_E2E_PROFILE;
+  } else {
+    process.env.LINKEDIN_E2E_PROFILE = originalEnv.profile;
+  }
+
+  if (originalEnv.connectionTarget === undefined) {
+    delete process.env.LINKEDIN_E2E_CONNECTION_TARGET;
+  } else {
+    process.env.LINKEDIN_E2E_CONNECTION_TARGET = originalEnv.connectionTarget;
+  }
+
+  if (originalEnv.fixtureFile === undefined) {
+    delete process.env.LINKEDIN_E2E_FIXTURE_FILE;
+  } else {
+    process.env.LINKEDIN_E2E_FIXTURE_FILE = originalEnv.fixtureFile;
+  }
+
+  if (originalEnv.refreshFixtures === undefined) {
+    delete process.env.LINKEDIN_E2E_REFRESH_FIXTURES;
+  } else {
+    process.env.LINKEDIN_E2E_REFRESH_FIXTURES = originalEnv.refreshFixtures;
   }
 });
 
@@ -141,5 +207,111 @@ describe("E2E helper MCP wrappers", () => {
         ]
       })
     ).toThrow("Tool linkedin.test payload did not contain a JSON object");
+  });
+});
+
+describe("E2E fixture helpers", () => {
+  it("reads env overrides dynamically instead of freezing them at import time", () => {
+    process.env.LINKEDIN_E2E_PROFILE = "primary";
+    process.env.LINKEDIN_E2E_CONNECTION_TARGET = "target-a";
+
+    expect(getDefaultProfileName()).toBe("primary");
+    expect(getDefaultConnectionTarget()).toBe("target-a");
+
+    process.env.LINKEDIN_E2E_PROFILE = "secondary";
+    process.env.LINKEDIN_E2E_CONNECTION_TARGET = "target-b";
+
+    expect(getDefaultProfileName()).toBe("secondary");
+    expect(getDefaultConnectionTarget()).toBe("target-b");
+  });
+
+  it("replays saved CLI coverage fixtures without rediscovering live targets", async () => {
+    const tempDir = createTempAssistantHome();
+    const fixturePath = path.join(tempDir, "fixtures.json");
+    process.env.LINKEDIN_E2E_PROFILE = "fixture-profile";
+    process.env.LINKEDIN_E2E_FIXTURE_FILE = fixturePath;
+
+    writeFileSync(
+      fixturePath,
+      `${JSON.stringify(
+        {
+          format: 1,
+          profileName: "fixture-profile",
+          threadId: "thread-from-file",
+          postUrl: "https://www.linkedin.com/feed/update/from-file",
+          jobId: "job-from-file",
+          connectionTarget: "fixture-target"
+        },
+        null,
+        2
+      )}\n`,
+      "utf8"
+    );
+
+    const runtime = createFixtureRuntime();
+    const fixtures = await getCliCoverageFixtures(runtime);
+
+    expect(fixtures).toEqual({
+      threadId: "thread-from-file",
+      postUrl: "https://www.linkedin.com/feed/update/from-file",
+      jobId: "job-from-file",
+      connectionTarget: "fixture-target"
+    });
+    expect(runtime.inbox.listThreads).not.toHaveBeenCalled();
+    expect(runtime.feed.viewFeed).not.toHaveBeenCalled();
+    expect(runtime.jobs.searchJobs).not.toHaveBeenCalled();
+  });
+
+  it("refreshes and rewrites the coverage fixture file when requested", async () => {
+    const tempDir = createTempAssistantHome();
+    const fixturePath = path.join(tempDir, "fixtures.json");
+    process.env.LINKEDIN_E2E_PROFILE = "refresh-profile";
+    process.env.LINKEDIN_E2E_CONNECTION_TARGET = "refresh-target";
+    process.env.LINKEDIN_E2E_FIXTURE_FILE = fixturePath;
+    process.env.LINKEDIN_E2E_REFRESH_FIXTURES = "1";
+
+    const runtime = createFixtureRuntime();
+    const fixtures = await getCliCoverageFixtures(runtime);
+
+    expect(fixtures).toEqual({
+      threadId: "thread-123",
+      postUrl: "https://www.linkedin.com/feed/update/post-123",
+      jobId: "job-123",
+      connectionTarget: "refresh-target"
+    });
+
+    const savedFixtures = JSON.parse(readFileSync(fixturePath, "utf8")) as Record<string, unknown>;
+    expect(savedFixtures).toMatchObject({
+      format: 1,
+      profileName: "refresh-profile",
+      threadId: "thread-123",
+      postUrl: "https://www.linkedin.com/feed/update/post-123",
+      jobId: "job-123",
+      connectionTarget: "refresh-target"
+    });
+    expect(typeof savedFixtures.capturedAt).toBe("string");
+  });
+
+  it("fails with actionable guidance when the saved fixture file is invalid", async () => {
+    const tempDir = createTempAssistantHome();
+    const fixturePath = path.join(tempDir, "fixtures.json");
+    process.env.LINKEDIN_E2E_FIXTURE_FILE = fixturePath;
+
+    writeFileSync(
+      fixturePath,
+      `${JSON.stringify(
+        {
+          format: 1,
+          threadId: "thread-only"
+        },
+        null,
+        2
+      )}\n`,
+      "utf8"
+    );
+
+    await expect(getCliCoverageFixtures(createFixtureRuntime())).rejects.toThrow(
+      "--refresh-fixtures"
+    );
   });
 });

--- a/packages/core/src/__tests__/e2eRunner.test.ts
+++ b/packages/core/src/__tests__/e2eRunner.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatRunnerConfiguration,
+  formatUnavailableGuidance,
+  getRunnerHelpText,
+  parseRunnerOptions
+} from "../../../../scripts/run-e2e.js";
+
+describe("run-e2e runner options", () => {
+  it("parses runner flags and preserves remaining vitest args", () => {
+    const options = parseRunnerOptions([
+      "--require-session",
+      "--fixtures",
+      ".tmp/e2e-fixtures.json",
+      "--refresh-fixtures",
+      "--reporter=verbose",
+      "packages/core/src/__tests__/e2e/cli.e2e.test.ts"
+    ]);
+
+    expect(options).toEqual({
+      showHelp: false,
+      requireSession: true,
+      refreshFixtures: true,
+      fixtureFile: ".tmp/e2e-fixtures.json",
+      vitestArgs: [
+        "--reporter=verbose",
+        "packages/core/src/__tests__/e2e/cli.e2e.test.ts"
+      ]
+    });
+  });
+
+  it("starts from environment defaults before applying CLI overrides", () => {
+    const options = parseRunnerOptions(["packages/core/src/__tests__/e2e/mcp.e2e.test.ts"], {
+      LINKEDIN_E2E_REQUIRE_SESSION: "true",
+      LINKEDIN_E2E_FIXTURE_FILE: ".tmp/from-env.json",
+      LINKEDIN_E2E_REFRESH_FIXTURES: "1"
+    });
+
+    expect(options).toEqual({
+      showHelp: false,
+      requireSession: true,
+      refreshFixtures: true,
+      fixtureFile: ".tmp/from-env.json",
+      vitestArgs: ["packages/core/src/__tests__/e2e/mcp.e2e.test.ts"]
+    });
+  });
+
+  it("rejects empty fixture flag values", () => {
+    expect(() => parseRunnerOptions(["--fixtures", ""]))
+      .toThrow("--fixtures requires a file path argument");
+    expect(() => parseRunnerOptions(["--fixtures="]))
+      .toThrow("--fixtures requires a non-empty file path");
+  });
+});
+
+describe("run-e2e runner messaging", () => {
+  it("formats a readable configuration summary", () => {
+    const lines = formatRunnerConfiguration(
+      {
+        showHelp: false,
+        requireSession: true,
+        refreshFixtures: true,
+        fixtureFile: ".tmp/e2e-fixtures.json",
+        vitestArgs: ["packages/core/src/__tests__/e2e/error-paths.e2e.test.ts"]
+      },
+      {
+        LINKEDIN_CDP_URL: "http://127.0.0.1:18800",
+        LINKEDIN_E2E_PROFILE: "review-profile",
+        LINKEDIN_E2E_ENABLE_MESSAGE_CONFIRM: "1"
+      }
+    );
+
+    expect(lines).toEqual(
+      expect.arrayContaining([
+        "CDP endpoint: http://127.0.0.1:18800",
+        "Profile: review-profile",
+        "Session policy: required",
+        expect.stringContaining("Coverage fixtures:"),
+        "Opt-in confirms: message",
+        "Vitest args: packages/core/src/__tests__/e2e/error-paths.e2e.test.ts"
+      ])
+    );
+  });
+
+  it("distinguishes skip guidance from required-session failures", () => {
+    expect(
+      formatUnavailableGuidance("session missing", {
+        showHelp: false,
+        requireSession: false,
+        refreshFixtures: false,
+        fixtureFile: undefined,
+        vitestArgs: []
+      })
+    ).toEqual(
+      expect.arrayContaining([
+        "Skipping LinkedIn E2E suite: session missing",
+        expect.stringContaining("--require-session")
+      ])
+    );
+
+    expect(
+      formatUnavailableGuidance("session missing", {
+        showHelp: false,
+        requireSession: true,
+        refreshFixtures: false,
+        fixtureFile: undefined,
+        vitestArgs: []
+      })
+    ).toEqual(
+      expect.arrayContaining([
+        "LinkedIn E2E prerequisites are required but unavailable: session missing",
+        "Fix the session prerequisites above and rerun the same command."
+      ])
+    );
+  });
+
+  it("documents fixture replay and strict mode in the help text", () => {
+    const helpText = getRunnerHelpText();
+
+    expect(helpText).toContain("--require-session");
+    expect(helpText).toContain("--fixtures <file>");
+    expect(helpText).toContain("--refresh-fixtures");
+    expect(helpText).toContain("LINKEDIN_E2E_REQUIRE_SESSION");
+    expect(helpText).toContain("docs/e2e-testing.md");
+  });
+});

--- a/scripts/run-e2e.js
+++ b/scripts/run-e2e.js
@@ -4,21 +4,205 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "playwright-core";
 
-const DEFAULT_CDP_URL = "http://localhost:18800";
+export const DEFAULT_CDP_URL = "http://localhost:18800";
 const LINKEDIN_FEED_URL = "https://www.linkedin.com/feed/";
+const RUNNER_PREFIX = "[linkedin:e2e]";
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const vitestEntrypoint = path.join(projectRoot, "node_modules", "vitest", "vitest.mjs");
 
 function log(message) {
-  process.stdout.write(`${message}\n`);
+  process.stdout.write(`${RUNNER_PREFIX} ${message}\n`);
 }
 
-function summarizeError(error) {
+function logError(message) {
+  process.stderr.write(`${RUNNER_PREFIX} ${message}\n`);
+}
+
+export function summarizeError(error) {
   if (error instanceof Error) {
     return error.message;
   }
 
   return String(error);
+}
+
+function readTrimmedEnv(name, env = process.env) {
+  const value = env[name];
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readEnabledFlag(name, env = process.env) {
+  const value = readTrimmedEnv(name, env);
+  return value === "1" || value === "true";
+}
+
+function parseFixtureFlag(argument) {
+  const prefix = "--fixtures=";
+  if (!argument.startsWith(prefix)) {
+    return undefined;
+  }
+
+  const value = argument.slice(prefix.length).trim();
+  if (value.length === 0) {
+    throw new Error("--fixtures requires a non-empty file path.");
+  }
+
+  return value;
+}
+
+export function parseRunnerOptions(argv, env = process.env) {
+  let showHelp = false;
+  let requireSession = readEnabledFlag("LINKEDIN_E2E_REQUIRE_SESSION", env);
+  let refreshFixtures = readEnabledFlag("LINKEDIN_E2E_REFRESH_FIXTURES", env);
+  let fixtureFile = readTrimmedEnv("LINKEDIN_E2E_FIXTURE_FILE", env);
+  const vitestArgs = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
+    if (argument === "--help" || argument === "-h") {
+      showHelp = true;
+      continue;
+    }
+
+    if (argument === "--require-session") {
+      requireSession = true;
+      continue;
+    }
+
+    if (argument === "--refresh-fixtures") {
+      refreshFixtures = true;
+      continue;
+    }
+
+    const inlineFixtureFile = parseFixtureFlag(argument);
+    if (inlineFixtureFile) {
+      fixtureFile = inlineFixtureFile;
+      continue;
+    }
+
+    if (argument === "--fixtures") {
+      const nextArgument = argv[index + 1];
+      const resolvedPath =
+        typeof nextArgument === "string" ? nextArgument.trim() : "";
+      if (resolvedPath.length === 0) {
+        throw new Error("--fixtures requires a file path argument.");
+      }
+
+      fixtureFile = resolvedPath;
+      index += 1;
+      continue;
+    }
+
+    vitestArgs.push(argument);
+  }
+
+  return {
+    showHelp,
+    requireSession,
+    refreshFixtures,
+    fixtureFile,
+    vitestArgs
+  };
+}
+
+function getEnabledOptInLabels(env = process.env) {
+  const labels = [];
+
+  if (readEnabledFlag("LINKEDIN_E2E_ENABLE_MESSAGE_CONFIRM", env)) {
+    labels.push("message");
+  }
+  if (readEnabledFlag("LINKEDIN_E2E_ENABLE_CONNECTION_CONFIRM", env)) {
+    labels.push("connections");
+  }
+  if (readEnabledFlag("LINKEDIN_E2E_ENABLE_LIKE_CONFIRM", env)) {
+    labels.push("like");
+  }
+  if (readEnabledFlag("LINKEDIN_E2E_ENABLE_COMMENT_CONFIRM", env)) {
+    labels.push("comment");
+  }
+  if (readEnabledFlag("LINKEDIN_ENABLE_POST_WRITE_E2E", env)) {
+    labels.push("post");
+  }
+
+  return labels;
+}
+
+export function formatRunnerConfiguration(options, env = process.env) {
+  const profileName = readTrimmedEnv("LINKEDIN_E2E_PROFILE", env) ?? "default";
+  const cdpUrl = readTrimmedEnv("LINKEDIN_CDP_URL", env) ?? DEFAULT_CDP_URL;
+  const fixtureFile =
+    options.fixtureFile === undefined
+      ? "live discovery"
+      : path.resolve(projectRoot, options.fixtureFile);
+  const enabledWrites = getEnabledOptInLabels(env);
+
+  return [
+    `CDP endpoint: ${cdpUrl}`,
+    `Profile: ${profileName}`,
+    `Session policy: ${options.requireSession ? "required" : "skip when unavailable"}`,
+    options.fixtureFile === undefined
+      ? `Coverage fixtures: ${fixtureFile}`
+      : `Coverage fixtures: ${fixtureFile}${
+          options.refreshFixtures ? " (refresh enabled)" : ""
+        }`,
+    `Opt-in confirms: ${enabledWrites.length > 0 ? enabledWrites.join(", ") : "none"}`,
+    ...(options.vitestArgs.length > 0
+      ? [`Vitest args: ${options.vitestArgs.join(" ")}`]
+      : [])
+  ];
+}
+
+export function getRunnerHelpText() {
+  return [
+    "LinkedIn real-session E2E runner",
+    "",
+    "Usage:",
+    "  npm run test:e2e -- [runner options] [vitest args]",
+    "",
+    "Runner options:",
+    "  --help                 Show this help text.",
+    "  --require-session      Fail instead of skipping when CDP/auth is unavailable.",
+    "  --fixtures <file>      Read or record CLI/MCP coverage fixtures at <file>.",
+    "  --refresh-fixtures     Re-discover fixtures and overwrite the fixture file.",
+    "",
+    "Vitest examples:",
+    "  npm run test:e2e -- packages/core/src/__tests__/e2e/cli.e2e.test.ts",
+    "  npm run test:e2e -- --reporter=verbose packages/core/src/__tests__/e2e/error-paths.e2e.test.ts",
+    "",
+    "Fixture replay examples:",
+    "  npm run test:e2e -- --fixtures .tmp/e2e-fixtures.json packages/core/src/__tests__/e2e/cli.e2e.test.ts",
+    "  npm run test:e2e -- --fixtures .tmp/e2e-fixtures.json --refresh-fixtures packages/core/src/__tests__/e2e/mcp.e2e.test.ts",
+    "",
+    "Environment overrides:",
+    "  LINKEDIN_CDP_URL              CDP endpoint to probe (default: http://localhost:18800)",
+    "  LINKEDIN_E2E_PROFILE          Logical profile name used by the E2E helpers",
+    "  LINKEDIN_E2E_REQUIRE_SESSION  Same as --require-session when set to 1/true",
+    "  LINKEDIN_E2E_FIXTURE_FILE     Same as --fixtures <file>",
+    "  LINKEDIN_E2E_REFRESH_FIXTURES Same as --refresh-fixtures when set to 1/true",
+    "",
+    "Docs:",
+    "  docs/e2e-testing.md"
+  ].join("\n");
+}
+
+export function formatUnavailableGuidance(reason, options) {
+  return [
+    `${options.requireSession ? "LinkedIn E2E prerequisites are required but unavailable" : "Skipping LinkedIn E2E suite"}: ${reason}`,
+    options.requireSession
+      ? "Fix the session prerequisites above and rerun the same command."
+      : "Pass --require-session (or set LINKEDIN_E2E_REQUIRE_SESSION=1) to fail instead of skip.",
+    "See docs/e2e-testing.md for setup, safe targets, and fixture replay guidance."
+  ];
+}
+
+function formatVitestFailure(exitCode) {
+  return `E2E suite failed with exit code ${exitCode}. Re-run with npm run test:e2e:raw -- <args> if you want direct Vitest output without the availability checks.`;
 }
 
 async function detectAuthenticatedSession(cdpUrl) {
@@ -99,28 +283,59 @@ function waitForExit(child) {
   });
 }
 
-async function main() {
-  const cdpUrl = process.env.LINKEDIN_CDP_URL ?? DEFAULT_CDP_URL;
+export async function main(argv = process.argv.slice(2), env = process.env) {
+  const options = parseRunnerOptions(argv, env);
+
+  if (options.showHelp) {
+    process.stdout.write(`${getRunnerHelpText()}\n`);
+    return 0;
+  }
+
+  const cdpUrl = readTrimmedEnv("LINKEDIN_CDP_URL", env) ?? DEFAULT_CDP_URL;
+  log("Checking LinkedIn session prerequisites.");
+  for (const line of formatRunnerConfiguration(options, {
+    ...env,
+    LINKEDIN_CDP_URL: cdpUrl
+  })) {
+    log(line);
+  }
+
   const availability = await detectAuthenticatedSession(cdpUrl);
 
   if (!availability.ok) {
-    log(`[e2e] Skipping LinkedIn E2E suite: ${availability.reason}`);
-    process.exit(0);
+    for (const line of formatUnavailableGuidance(availability.reason, options)) {
+      if (options.requireSession) {
+        logError(line);
+      } else {
+        log(line);
+      }
+    }
+    return options.requireSession ? 1 : 0;
   }
 
-  log(`[e2e] ${availability.reason}`);
-  log("[e2e] Running Vitest E2E suite.");
+  log(availability.reason);
+  log("Running Vitest E2E suite.");
 
   const child = spawn(
     process.execPath,
-    [vitestEntrypoint, "run", "-c", "vitest.config.e2e.ts"],
+    [vitestEntrypoint, "run", "-c", "vitest.config.e2e.ts", ...options.vitestArgs],
     {
       cwd: projectRoot,
       stdio: "inherit",
       env: {
-        ...process.env,
-        LINKEDIN_E2E: process.env.LINKEDIN_E2E ?? "1",
-        LINKEDIN_CDP_URL: cdpUrl
+        ...env,
+        LINKEDIN_E2E: env.LINKEDIN_E2E ?? "1",
+        LINKEDIN_CDP_URL: cdpUrl,
+        ...(options.fixtureFile
+          ? {
+              LINKEDIN_E2E_FIXTURE_FILE: options.fixtureFile
+            }
+          : {}),
+        ...(options.refreshFixtures
+          ? {
+              LINKEDIN_E2E_REFRESH_FIXTURES: "1"
+            }
+          : {})
       }
     }
   );
@@ -129,16 +344,36 @@ async function main() {
   try {
     result = await waitForExit(child);
   } catch (error) {
-    log(`[e2e] Failed to start Vitest: ${summarizeError(error)}`);
-    process.exit(1);
+    logError(`Failed to start Vitest: ${summarizeError(error)}`);
+    return 1;
   }
 
   if (result.signal) {
     process.kill(process.pid, result.signal);
-    return;
+    return 1;
   }
 
-  process.exit(result.exitCode);
+  if (result.exitCode === 0) {
+    log("E2E suite passed.");
+    return 0;
+  }
+
+  logError(formatVitestFailure(result.exitCode));
+  return result.exitCode;
 }
 
-void main();
+const isDirectExecution =
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isDirectExecution) {
+  void main().then(
+    (exitCode) => {
+      process.exit(exitCode);
+    },
+    (error) => {
+      logError(summarizeError(error));
+      process.exit(1);
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- improve the real-session E2E runner UX with clearer help, skip/fail guidance, and forwarded Vitest args
- add CLI/MCP coverage fixture capture/replay support plus dynamic env overrides for live discovery
- document the updated workflow and add unit coverage for the runner and fixture helpers

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #94