### PR TITLE
docs: document E2E coverage hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,9 @@ All notable changes to this project will be documented in this file.
 - Selector audit documentation covering CLI usage, sample output, core API
   configuration, README discoverability, CLI `--help` references, and MCP
   tool-description breadcrumbs.
+
+### Changed
+
+- Expanded the E2E testing documentation and runner help to cover coverage
+  lanes, profile-aware fixture replay, opt-in write flags, and contributor
+  workflow guidance for the real-session harness.

--- a/README.md
+++ b/README.md
@@ -390,11 +390,24 @@ The runner now skips cleanly when no authenticated CDP session is available,
 which makes it safe to invoke in CI.
 
 See `docs/e2e-testing.md` for the full workflow, safe targets, and opt-in write
-flags.
+flags. Run `npm run test:e2e -- --help` for the runner's built-in flag and
+environment reference.
 
 Pass `npm run test:e2e -- --require-session` when a missing session should fail
 instead of skip, and use `--fixtures <file>` to capture or replay the shared
-CLI/MCP coverage fixtures while iterating on E2E failures.
+CLI/MCP coverage fixtures while iterating on E2E failures. Saved fixtures are
+profile-specific, so refresh them when `LINKEDIN_E2E_PROFILE` changes.
+
+### Coverage lanes
+
+- Default lane: read-only runtime coverage, prepare-only mutation previews, and
+  safe `test.echo` confirms for the generic confirm entrypoints
+- Contract lanes: thin CLI and MCP suites that reuse the same live fixtures
+  instead of rediscovering targets on every run
+- Opt-in write lanes: real message, connection, like, comment, and post
+  confirms guarded behind explicit environment flags
+- Non-live guard rails: helper and runner unit tests that cover option parsing,
+  fixture replay, skip semantics, and confirm contract hardening
 
 ### Prerequisites
 
@@ -414,8 +427,15 @@ confirm entrypoints. Real outbound confirms remain opt-in.
 # Default run: safe coverage only
 npm run test:e2e
 
+# Show the runner help, flags, and env overrides
+npm run test:e2e -- --help
+
 # Focus a specific E2E file while keeping the runner checks
 npm run test:e2e -- packages/core/src/__tests__/e2e/cli.e2e.test.ts
+
+# Capture or refresh the shared CLI/MCP fixtures while debugging contract bugs
+npm run test:e2e -- --fixtures .tmp/e2e-fixtures.json --refresh-fixtures \
+  packages/core/src/__tests__/e2e/cli.e2e.test.ts
 
 # Raw Vitest E2E run when you already know the session is available
 npm run test:e2e:raw

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -46,6 +46,36 @@ To force the raw Vitest suite directly, use:
 npm run test:e2e:raw
 ```
 
+The runner itself also has built-in help:
+
+```bash
+npm run test:e2e -- --help
+```
+
+## Coverage lanes
+
+The E2E matrix now has four layers:
+
+- Live runtime suites in `packages/core/src/__tests__/e2e/*.e2e.test.ts`
+  validate the LinkedIn interaction logic directly.
+- Thin CLI contract coverage in
+  `packages/core/src/__tests__/e2e/cli.e2e.test.ts` validates parsing, JSON
+  output, exit codes, keepalive behavior, selector audit, and confirm
+  entrypoints.
+- Thin MCP contract coverage in
+  `packages/core/src/__tests__/e2e/mcp.e2e.test.ts` validates tool payload
+  shape, structured errors, and registration gaps.
+- Non-live unit tests in `packages/core/src/__tests__/e2eRunner.test.ts`,
+  `packages/core/src/__tests__/e2eSetup.test.ts`,
+  `packages/core/src/__tests__/e2eHelpers.test.ts`, and
+  `packages/core/src/__tests__/e2eConfirmContracts.test.ts` harden runner
+  parsing, skip semantics, fixture replay, retry behavior, and confirm
+  contracts without needing LinkedIn access.
+
+The default `npm run test:e2e` path only executes tests that are read-only,
+preview-only, or use the `test.echo` executor for the generic confirm
+entrypoints. Real outbound confirms remain opt-in.
+
 ## Prerequisites
 
 - Node.js 22+
@@ -62,6 +92,16 @@ Environment variables:
 - `LINKEDIN_E2E_REFRESH_FIXTURES` — optional, set to `1` or `true` to overwrite the fixture file
 - `LINKEDIN_E2E_JOB_QUERY` — optional job query override for live fixture discovery, defaults to `software engineer`
 - `LINKEDIN_E2E_JOB_LOCATION` — optional job location override for live fixture discovery, defaults to `Copenhagen`
+- `LINKEDIN_E2E_MESSAGE_TARGET_PATTERN` — optional regex source used when live-discovering the approved inbox thread, defaults to `Simon Miller`
+- `LINKEDIN_E2E_CONNECTION_TARGET` — optional connection target slug used for preview coverage and connection confirms, defaults to `realsimonmiller`
+- `LINKEDIN_E2E_CONNECTION_CONFIRM_MODE` — optional connection confirm mode: `invite`, `accept`, or `withdraw`
+- `LINKEDIN_E2E_ENABLE_MESSAGE_CONFIRM` — optional, enables the real inbox confirm test
+- `LINKEDIN_E2E_ENABLE_CONNECTION_CONFIRM` — optional, enables the configured real connection confirm test
+- `LINKEDIN_E2E_ENABLE_LIKE_CONFIRM` — optional, enables the real like confirm test
+- `LINKEDIN_E2E_LIKE_POST_URL` — required only when `LINKEDIN_E2E_ENABLE_LIKE_CONFIRM=1`
+- `LINKEDIN_E2E_ENABLE_COMMENT_CONFIRM` — optional, enables the real comment confirm test
+- `LINKEDIN_E2E_COMMENT_POST_URL` — required only when `LINKEDIN_E2E_ENABLE_COMMENT_CONFIRM=1`
+- `LINKEDIN_ENABLE_POST_WRITE_E2E` — optional, enables real post publishing after explicit approval
 
 ## Fixture replay workflow
 
@@ -69,6 +109,12 @@ The CLI and MCP contract suites only need a few stable identifiers: a message
 thread id, a feed post URL, a job id, and a connection target. The runner can
 capture those into a small JSON file so you can replay the same targets while
 iterating on contract or output bugs.
+
+Fixture files are intentionally small and profile-aware. The helper records the
+fixture format version, capture timestamp, `LINKEDIN_E2E_PROFILE`, and the
+stable identifiers needed by the CLI/MCP suites. Replays fail fast when the
+saved format is unsupported or when the saved profile name does not match the
+current `LINKEDIN_E2E_PROFILE`.
 
 Capture or refresh the fixtures:
 
@@ -90,6 +136,11 @@ npm run test:e2e -- \
 If the replay file becomes stale or malformed, rerun with `--refresh-fixtures`
 to overwrite it with fresh live-discovery output.
 
+Live discovery uses `LINKEDIN_E2E_MESSAGE_TARGET_PATTERN`,
+`LINKEDIN_E2E_JOB_QUERY`, `LINKEDIN_E2E_JOB_LOCATION`, and
+`LINKEDIN_E2E_CONNECTION_TARGET`. Once a fixture file exists, the CLI and MCP
+contract suites can replay it without rediscovering those targets.
+
 ## Safe defaults
 
 The default E2E suite is read-only or preview-only for all outbound actions.
@@ -104,6 +155,10 @@ That means it can validate:
 By default, the suite does **not** send messages, likes, comments, posts, or
 connection changes.
 
+The opt-in write suite files still run their preview assertions by default, but
+the real confirm cases stay skipped until the matching environment variables
+are enabled.
+
 ## Approved targets and opt-in writes
 
 Real outbound confirms are opt-in and must only be used with approved targets.
@@ -111,6 +166,10 @@ Real outbound confirms are opt-in and must only be used with approved targets.
 ### Messages
 
 Safe target: Simon Miller (`linkedin.com/in/realsimonmiller`)
+
+If you are not replaying a saved fixture file, live discovery uses the
+`LINKEDIN_E2E_MESSAGE_TARGET_PATTERN` regex source to find the approved inbox
+thread.
 
 Enable:
 
@@ -121,6 +180,9 @@ LINKEDIN_E2E_ENABLE_MESSAGE_CONFIRM=1 npm run test:e2e
 ### Connections
 
 Safe target: Simon Miller unless an explicitly approved alternative is provided.
+
+`LINKEDIN_E2E_CONNECTION_TARGET` defaults to `realsimonmiller`. The selected
+target must already be in the correct state for the chosen confirm mode.
 
 Enable one confirm mode with a target that is already in the correct state:
 
@@ -141,6 +203,9 @@ Supported modes:
 
 Public actions require explicit approval before execution.
 
+The default lane still covers `prepareLikePost()` preview behavior without
+confirming the action.
+
 ```bash
 LINKEDIN_E2E_ENABLE_LIKE_CONFIRM=1 \
 LINKEDIN_E2E_LIKE_POST_URL='https://www.linkedin.com/feed/update/...' \
@@ -150,6 +215,9 @@ npm run test:e2e
 ### Comments
 
 Public actions require explicit approval before execution.
+
+The default lane still covers `prepareCommentOnPost()` preview behavior without
+confirming the action.
 
 ```bash
 LINKEDIN_E2E_ENABLE_COMMENT_CONFIRM=1 \
@@ -169,15 +237,49 @@ LINKEDIN_ENABLE_POST_WRITE_E2E=1 npm run test:e2e
 
 The E2E suite now covers:
 
+- Live runtime suites for auth, health, profile, search, jobs, inbox,
+  connections, feed, notifications, and preview coverage for outbound actions
 - CLI command groups: session, rate-limit, keepalive, inbox, connections,
   followups, feed, post, notifications, jobs, profile, selector audit,
-  health, and confirm entrypoints
-- MCP tools: session status/open-login/health, inbox, profile, search,
-  connections, followups, feed, post prepare, notifications, jobs,
-  and actions confirm
-- Two-phase commit confirm flows for messages, connections, likes, and comments
-  behind explicit opt-in flags
-- Error paths for expired tokens, rate limits, and UI drift detection
+  health, and both confirm entrypoints
+- MCP tools: session status/open-login/health, inbox list/get-thread/
+  prepare-reply, profile, search, connections list/pending/invite/accept/
+  withdraw, followup prepare-after-accept, feed list/view-post/like/comment,
+  post prepare-create, notifications, jobs search/view, and actions confirm
+- Real outbound confirm flows for messages, connections, likes, comments, and
+  posts behind explicit opt-in flags
+- Error paths for expired tokens, rate limits, UI drift detection, profile
+  mismatches, unknown confirm tokens, retry behavior, and timeout handling
+
+## Developer workflow
+
+### Architecture
+
+- `scripts/run-e2e.js` is the single entrypoint that probes CDP/authentication,
+  chooses skip versus fail behavior, prints configuration, and forwards the
+  remaining args to Vitest.
+- `packages/core/src/__tests__/e2e/setup.ts` owns the shared runtime,
+  temporary assistant home, stale-directory cleanup, and explicit skip helpers.
+  Use `setupE2ESuite()` plus `skipIfE2EUnavailable()` instead of re-implementing
+  per-test probes.
+- `packages/core/src/__tests__/e2e/helpers.ts` wraps CLI and MCP execution,
+  retries transient browser/process failures, extracts the last JSON object from
+  mixed output, and manages reusable fixture files.
+
+### Adding or changing coverage
+
+1. Start at the runtime layer when validating LinkedIn behavior.
+2. Add CLI or MCP tests only for transport and contract behavior.
+3. Keep new coverage read-only or prepare-only by default.
+4. Gate any real outbound confirm behind a dedicated environment flag and
+   document the approved target in the test file and this guide.
+5. Reuse `getCliCoverageFixtures()` for CLI/MCP suites unless the new coverage
+   truly needs a new live identifier.
+6. Update the runner `--help`, `README.md`, and this guide whenever you add a
+   new E2E environment variable, fixture field, or safety rule.
+7. Add or update non-live unit tests when changing `scripts/run-e2e.js`,
+   `packages/core/src/__tests__/e2e/setup.ts`, or
+   `packages/core/src/__tests__/e2e/helpers.ts`.
 
 ## Notes
 

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -2378,6 +2378,7 @@ async function runConfirmAction(input: {
   }
 }
 
+/** Creates the Commander program for the `linkedin` CLI. */
 export function createCliProgram(): Command {
   const program = new Command();
 
@@ -3221,6 +3222,7 @@ export function createCliProgram(): Command {
   return program;
 }
 
+/** Runs the `linkedin` CLI with the provided argument vector. */
 export async function runCli(argv: string[] = process.argv): Promise<void> {
   const originalArgv = process.argv;
   process.argv = argv;

--- a/packages/core/src/__tests__/e2e/helpers.ts
+++ b/packages/core/src/__tests__/e2e/helpers.ts
@@ -33,6 +33,7 @@ import {
 } from "../../../../mcp/src/index.js";
 import { getCdpUrl, withAssistantHome, withE2EEnvironment } from "./setup.js";
 
+/** Captured process result from invoking the CLI test surface. */
 export interface CapturedCommandResult {
   stdout: string;
   stderr: string;
@@ -40,11 +41,13 @@ export interface CapturedCommandResult {
   error?: unknown;
 }
 
+/** Normalized MCP tool result used by the contract assertions. */
 export interface MappedMcpResult {
   payload: Record<string, unknown>;
   isError: boolean;
 }
 
+/** Minimal prepared-action contract asserted across preview and confirm tests. */
 export interface PreparedActionResult {
   preparedActionId: string;
   confirmToken: string;
@@ -52,6 +55,7 @@ export interface PreparedActionResult {
   preview: Record<string, unknown>;
 }
 
+/** Shared live identifiers captured for the CLI and MCP contract suites. */
 export interface CliCoverageFixtures {
   threadId: string;
   postUrl: string;
@@ -59,6 +63,7 @@ export interface CliCoverageFixtures {
   connectionTarget: string;
 }
 
+/** Optional execution controls shared by the CLI and MCP wrapper helpers. */
 export interface CommandExecutionOptions {
   assistantHome?: string;
   timeoutMs?: number;
@@ -66,7 +71,10 @@ export interface CommandExecutionOptions {
   retryDelayMs?: number;
 }
 
+/** Test-local adapter used to invoke the CLI entrypoint directly. */
 export type CliRunner = (argv: string[]) => Promise<void>;
+
+/** Test-local adapter used to invoke one MCP tool call directly. */
 export type McpToolCaller = (
   name: string,
   args: Record<string, unknown>
@@ -446,6 +454,7 @@ function parseJsonObjectText(text: string, label: string): Record<string, unknow
   }
 }
 
+/** Normalizes raw MCP tool output into a payload plus `isError` bit. */
 export function mapMcpToolResult(name: string, rawResult: unknown): MappedMcpResult {
   const record = assertObjectRecord(rawResult, `Tool ${name} result`);
   const content = record.content;
@@ -475,14 +484,17 @@ export function mapMcpToolResult(name: string, rawResult: unknown): MappedMcpRes
   };
 }
 
+/** Returns the logical profile name used by the real-session E2E helpers. */
 export function getDefaultProfileName(): string {
   return readTrimmedEnv("LINKEDIN_E2E_PROFILE") ?? "default";
 }
 
+/** Returns the default connection target slug used by preview and confirm tests. */
 export function getDefaultConnectionTarget(): string {
   return readTrimmedEnv("LINKEDIN_E2E_CONNECTION_TARGET") ?? "realsimonmiller";
 }
 
+/** Returns the regex used to discover the approved message thread. */
 export function getDefaultMessageTargetPattern(): RegExp {
   return new RegExp(
     readTrimmedEnv("LINKEDIN_E2E_MESSAGE_TARGET_PATTERN") ?? "Simon Miller",
@@ -490,22 +502,30 @@ export function getDefaultMessageTargetPattern(): RegExp {
   );
 }
 
+/** Returns whether an opt-in E2E flag is enabled. */
 export function isOptInEnabled(name: string): boolean {
   return readEnabledFlag(name);
 }
 
+/** Returns the configured connection confirm mode for real outbound tests. */
 export function getConnectionConfirmMode(): string {
   return readTrimmedEnv("LINKEDIN_E2E_CONNECTION_CONFIRM_MODE") ?? "";
 }
 
+/** Returns the approved post URL used by the real like confirm test. */
 export function getOptInLikePostUrl(): string | undefined {
   return readTrimmedEnv("LINKEDIN_E2E_LIKE_POST_URL");
 }
 
+/** Returns the approved post URL used by the real comment confirm test. */
 export function getOptInCommentPostUrl(): string | undefined {
   return readTrimmedEnv("LINKEDIN_E2E_COMMENT_POST_URL");
 }
 
+/**
+ * Invokes the CLI entrypoint, applying optional retries, assistant-home
+ * overrides, and timeout handling.
+ */
 export async function runCliCommandWith(
   runner: CliRunner,
   args: string[],
@@ -554,6 +574,7 @@ export async function runCliCommandWith(
   };
 }
 
+/** Invokes the real CLI entrypoint used by the contract suites. */
 export async function runCliCommand(
   args: string[],
   options: CommandExecutionOptions = {}
@@ -561,9 +582,7 @@ export async function runCliCommand(
   return runCliCommandWith(runCli, args, options);
 }
 
-// The CLI emits human guidance plus JSON. Tests assert against the last JSON
-// object so command output can stay useful for operators without breaking
-// programmatic E2E checks.
+/** Extracts the last top-level JSON object from mixed CLI or MCP output. */
 export function getLastJsonObject(text: string): Record<string, unknown> {
   const objects = parseJsonObjects(text);
   const lastObject = objects.at(-1);
@@ -573,6 +592,10 @@ export function getLastJsonObject(text: string): Record<string, unknown> {
   return lastObject;
 }
 
+/**
+ * Invokes one MCP tool call with retries, optional assistant-home overrides,
+ * and timeout handling.
+ */
 export async function callMcpToolWith(
   caller: McpToolCaller,
   name: string,
@@ -619,6 +642,7 @@ export async function callMcpToolWith(
   throw lastError;
 }
 
+/** Invokes the real MCP tool handler used by the contract suites. */
 export async function callMcpTool(
   name: string,
   args: Record<string, unknown> = {},
@@ -635,6 +659,7 @@ function asRecord(value: unknown, label: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
+/** Asserts the minimal prepared-action contract returned by preview commands. */
 export function expectPreparedAction(prepared: PreparedActionResult): void {
   expect(prepared.preparedActionId).toMatch(/^pa_/);
   expect(prepared.confirmToken).toMatch(/^ct_/);
@@ -645,6 +670,7 @@ export function expectPreparedAction(prepared: PreparedActionResult): void {
   expect(prepared.preview).toHaveProperty("target");
 }
 
+/** Asserts that a prepared-action preview contains the expected outbound text. */
 export function expectPreparedOutboundText(
   prepared: PreparedActionResult,
   text: string
@@ -654,6 +680,7 @@ export function expectPreparedOutboundText(
   expect(outbound.text).toBe(text);
 }
 
+/** Asserts that a preview contains the expected rate-limit metadata. */
 export function expectRateLimitPreview(
   preview: Record<string, unknown>,
   counterKey: string
@@ -666,6 +693,7 @@ export function expectRateLimitPreview(
   expect(typeof rateLimit.allowed).toBe("boolean");
 }
 
+/** Creates a safe `test.echo` prepared action for generic confirm coverage. */
 export function prepareEchoAction(
   runtime: CoreRuntime,
   input: {
@@ -701,6 +729,7 @@ export function prepareEchoAction(
   });
 }
 
+/** Discovers the approved inbox thread used by live message coverage. */
 export async function getMessageThread(runtime: CoreRuntime): Promise<{
   thread_id: string;
   title: string;
@@ -727,6 +756,7 @@ export async function getMessageThread(runtime: CoreRuntime): Promise<{
   };
 }
 
+/** Discovers one feed post suitable for preview-only or approved write tests. */
 export async function getFeedPost(runtime: CoreRuntime): Promise<{
   post_id: string;
   post_url: string;
@@ -751,6 +781,7 @@ export async function getFeedPost(runtime: CoreRuntime): Promise<{
   };
 }
 
+/** Discovers one job result used by the CLI and MCP contract suites. */
 export async function getJob(runtime: CoreRuntime): Promise<{
   job_id: string;
   title: string;
@@ -792,9 +823,10 @@ async function discoverCliCoverageFixtures(runtime: CoreRuntime): Promise<CliCov
   };
 }
 
-// CLI and MCP surface tests only need a few stable identifiers. Keeping that
-// contract in one small fixture object makes it easy to capture once and replay
-// when iterating on contract bugs without rediscovering every LinkedIn target.
+/**
+ * Returns the shared live identifiers for CLI and MCP contract coverage,
+ * either by replaying a saved fixture file or by discovering fresh targets.
+ */
 export async function getCliCoverageFixtures(runtime: CoreRuntime): Promise<CliCoverageFixtures> {
   const fixtureFilePath = getFixtureFilePath();
 
@@ -811,6 +843,7 @@ export async function getCliCoverageFixtures(runtime: CoreRuntime): Promise<CliC
   return fixtures;
 }
 
+/** Canonical MCP tool names used by the E2E contract suites. */
 export const MCP_TOOL_NAMES = {
   sessionStatus: LINKEDIN_SESSION_STATUS_TOOL,
   sessionOpenLogin: LINKEDIN_SESSION_OPEN_LOGIN_TOOL,

--- a/packages/core/src/__tests__/e2e/setup.ts
+++ b/packages/core/src/__tests__/e2e/setup.ts
@@ -12,8 +12,13 @@ import path from "node:path";
 import { afterAll, beforeAll, type TestContext } from "vitest";
 import { createCoreRuntime, type CoreRuntime } from "../../runtime.js";
 
+/** Default CDP endpoint used by the shared real-session E2E harness. */
 export const DEFAULT_E2E_CDP_URL = "http://localhost:18800";
+
+/** Prefix used for temporary assistant-home directories created by E2E suites. */
 export const E2E_BASE_DIR_PREFIX = "linkedin-e2e-shared-";
+
+/** Metadata file stored inside each temporary E2E assistant-home directory. */
 export const E2E_OWNER_METADATA_FILE = ".owner.json";
 
 let sharedRuntime: CoreRuntime | undefined;
@@ -31,6 +36,9 @@ interface ErrnoLikeError extends Error {
   code?: string;
 }
 
+/**
+ * Cached availability result for the shared real-session E2E harness.
+ */
 export interface E2EAvailability {
   cdpAvailable: boolean;
   authenticated: boolean;
@@ -38,6 +46,10 @@ export interface E2EAvailability {
   reason: string;
 }
 
+/**
+ * Shared suite wrapper that exposes the live runtime, availability state, and
+ * any optional suite fixtures.
+ */
 export interface E2ESuite<TFixtures = void> {
   availability(): E2EAvailability;
   canRun(): boolean;
@@ -248,6 +260,10 @@ async function probeAuthentication(): Promise<{
   }
 }
 
+/**
+ * Returns the shared runtime instance used by all live E2E suites in the
+ * current process.
+ */
 export function getRuntime(): CoreRuntime {
   if (!sharedRuntime) {
     const cdpUrl = getCdpUrl();
@@ -264,10 +280,17 @@ export function getRuntime(): CoreRuntime {
   return sharedRuntime;
 }
 
+/**
+ * Resolves the effective CDP URL for the E2E harness.
+ */
 export function getCdpUrl(): string {
   return readConfiguredCdpUrl();
 }
 
+/**
+ * Returns the shared assistant-home directory used by the E2E harness,
+ * creating and ownership-tagging it on first use.
+ */
 export function getE2EBaseDir(): string {
   if (!sharedBaseDir) {
     cleanupStaleE2EBaseDirs();
@@ -280,6 +303,9 @@ export function getE2EBaseDir(): string {
   return sharedBaseDir;
 }
 
+/**
+ * Temporarily overrides `LINKEDIN_ASSISTANT_HOME` while executing `callback`.
+ */
 export async function withAssistantHome<T>(
   assistantHome: string,
   callback: () => Promise<T>
@@ -298,18 +324,32 @@ export async function withAssistantHome<T>(
   }
 }
 
+/**
+ * Runs `callback` inside the shared E2E assistant-home directory.
+ */
 export async function withE2EEnvironment<T>(callback: () => Promise<T>): Promise<T> {
   return withAssistantHome(getE2EBaseDir(), callback);
 }
 
+/**
+ * Probes whether the configured CDP endpoint is reachable.
+ */
 export async function checkCdpAvailable(): Promise<boolean> {
   return (await probeCdpEndpoint(getCdpUrl())).available;
 }
 
+/**
+ * Probes whether the configured CDP session is already authenticated with
+ * LinkedIn.
+ */
 export async function checkAuthenticated(): Promise<boolean> {
   return (await probeAuthentication()).authenticated;
 }
 
+/**
+ * Returns the cached E2E availability result, probing CDP and authentication on
+ * first access.
+ */
 export async function getE2EAvailability(): Promise<E2EAvailability> {
   if (sharedAvailability) {
     return sharedAvailability;
@@ -338,6 +378,10 @@ export async function getE2EAvailability(): Promise<E2EAvailability> {
   return sharedAvailability;
 }
 
+/**
+ * Registers a real-session E2E suite that shares one runtime and optional
+ * runtime-backed fixtures across all tests in the suite.
+ */
 export function setupE2ESuite<TFixtures = void>(
   options: E2ESuiteOptions<TFixtures> = {}
 ): E2ESuite<TFixtures> {
@@ -392,6 +436,9 @@ export function setupE2ESuite<TFixtures = void>(
   };
 }
 
+/**
+ * Skips the current test when the shared E2E prerequisites are unavailable.
+ */
 export function skipIfE2EUnavailable<TFixtures>(
   suite: E2ESuite<TFixtures>,
   context?: Pick<TestContext, "skip"> | null
@@ -413,6 +460,10 @@ export function skipIfE2EUnavailable<TFixtures>(
   return false;
 }
 
+/**
+ * Closes the shared runtime and removes the shared temporary assistant-home
+ * directory.
+ */
 export function cleanupRuntime(): void {
   const runtime = sharedRuntime;
   const baseDir = sharedBaseDir;

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -88,6 +88,7 @@ function summarizeSelectorLocaleInput(
   };
 }
 
+/** Options for constructing a fully wired LinkedIn Assistant runtime. */
 export interface CreateCoreRuntimeOptions {
   baseDir?: string;
   dbPath?: string;
@@ -97,6 +98,10 @@ export interface CreateCoreRuntimeOptions {
   selectorLocale?: string | LinkedInSelectorLocale;
 }
 
+/**
+ * Fully wired service graph used by the CLI, MCP server, and real-session E2E
+ * suites. `close()` is safe to call repeatedly.
+ */
 export interface CoreRuntime {
   paths: ConfigPaths;
   runId: string;
@@ -127,6 +132,10 @@ export interface CoreRuntime {
   close: () => void;
 }
 
+/**
+ * Creates the fully wired LinkedIn Assistant runtime and all supporting
+ * services for one execution context.
+ */
 export function createCoreRuntime(
   options: CreateCoreRuntimeOptions = {}
 ): CoreRuntime {

--- a/packages/mcp/src/bin/linkedin-mcp.ts
+++ b/packages/mcp/src/bin/linkedin-mcp.ts
@@ -1630,6 +1630,7 @@ const TOOL_HANDLERS: Record<string, ToolHandler> = {
   [LINKEDIN_ACTIONS_CONFIRM_TOOL]: handleConfirm
 };
 
+/** Dispatches one MCP tool call to the registered LinkedIn tool handlers. */
 export async function handleToolCall(
   name: string,
   args: ToolArgs = {}

--- a/scripts/run-e2e.js
+++ b/scripts/run-e2e.js
@@ -4,6 +4,10 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "playwright-core";
 
+/**
+ * Default CDP endpoint probed by the E2E runner when `LINKEDIN_CDP_URL` is
+ * unset.
+ */
 export const DEFAULT_CDP_URL = "http://localhost:18800";
 const LINKEDIN_FEED_URL = "https://www.linkedin.com/feed/";
 const RUNNER_PREFIX = "[linkedin:e2e]";
@@ -18,6 +22,9 @@ function logError(message) {
   process.stderr.write(`${RUNNER_PREFIX} ${message}\n`);
 }
 
+/**
+ * Converts unknown errors into a stable single-line message for runner logs.
+ */
 export function summarizeError(error) {
   if (error instanceof Error) {
     return error.message;
@@ -55,6 +62,10 @@ function parseFixtureFlag(argument) {
   return value;
 }
 
+/**
+ * Parses runner-specific flags while preserving any remaining arguments for
+ * direct Vitest forwarding.
+ */
 export function parseRunnerOptions(argv, env = process.env) {
   let showHelp = false;
   let requireSession = readEnabledFlag("LINKEDIN_E2E_REQUIRE_SESSION", env);
@@ -133,6 +144,9 @@ function getEnabledOptInLabels(env = process.env) {
   return labels;
 }
 
+/**
+ * Formats the effective runner configuration summary shown before each E2E run.
+ */
 export function formatRunnerConfiguration(options, env = process.env) {
   const profileName = readTrimmedEnv("LINKEDIN_E2E_PROFILE", env) ?? "default";
   const cdpUrl = readTrimmedEnv("LINKEDIN_CDP_URL", env) ?? DEFAULT_CDP_URL;
@@ -158,6 +172,9 @@ export function formatRunnerConfiguration(options, env = process.env) {
   ];
 }
 
+/**
+ * Returns the human-readable `npm run test:e2e -- --help` text.
+ */
 export function getRunnerHelpText() {
   return [
     "LinkedIn real-session E2E runner",
@@ -170,6 +187,10 @@ export function getRunnerHelpText() {
     "  --require-session      Fail instead of skipping when CDP/auth is unavailable.",
     "  --fixtures <file>      Read or record CLI/MCP coverage fixtures at <file>.",
     "  --refresh-fixtures     Re-discover fixtures and overwrite the fixture file.",
+    "",
+    "Safe defaults:",
+    "  Default runs stay read-only, preview-only, or use test.echo confirms.",
+    "  Real outbound confirms stay opt-in behind dedicated environment flags.",
     "",
     "Vitest examples:",
     "  npm run test:e2e -- packages/core/src/__tests__/e2e/cli.e2e.test.ts",
@@ -185,12 +206,30 @@ export function getRunnerHelpText() {
     "  LINKEDIN_E2E_REQUIRE_SESSION  Same as --require-session when set to 1/true",
     "  LINKEDIN_E2E_FIXTURE_FILE     Same as --fixtures <file>",
     "  LINKEDIN_E2E_REFRESH_FIXTURES Same as --refresh-fixtures when set to 1/true",
+    "  LINKEDIN_E2E_JOB_QUERY        Job query used for live fixture discovery",
+    "  LINKEDIN_E2E_JOB_LOCATION     Job location used for live fixture discovery",
+    "  LINKEDIN_E2E_MESSAGE_TARGET_PATTERN  Regex source for approved inbox-thread discovery",
+    "  LINKEDIN_E2E_CONNECTION_TARGET       Connection target slug (default: realsimonmiller)",
+    "",
+    "Opt-in write confirms:",
+    "  LINKEDIN_E2E_ENABLE_MESSAGE_CONFIRM     Enable the real message confirm test",
+    "  LINKEDIN_E2E_ENABLE_CONNECTION_CONFIRM  Enable one real connection confirm test",
+    "  LINKEDIN_E2E_CONNECTION_CONFIRM_MODE    invite | accept | withdraw",
+    "  LINKEDIN_E2E_ENABLE_LIKE_CONFIRM        Enable the real like confirm test",
+    "  LINKEDIN_E2E_LIKE_POST_URL              Approved post URL for like confirm",
+    "  LINKEDIN_E2E_ENABLE_COMMENT_CONFIRM     Enable the real comment confirm test",
+    "  LINKEDIN_E2E_COMMENT_POST_URL           Approved post URL for comment confirm",
+    "  LINKEDIN_ENABLE_POST_WRITE_E2E          Enable real post publishing after approval",
     "",
     "Docs:",
     "  docs/e2e-testing.md"
   ].join("\n");
 }
 
+/**
+ * Formats the guidance shown when CDP or LinkedIn authentication is
+ * unavailable.
+ */
 export function formatUnavailableGuidance(reason, options) {
   return [
     `${options.requireSession ? "LinkedIn E2E prerequisites are required but unavailable" : "Skipping LinkedIn E2E suite"}: ${reason}`,
@@ -283,6 +322,10 @@ function waitForExit(child) {
   });
 }
 
+/**
+ * Runs the E2E preflight checks and, when available, launches the Vitest E2E
+ * suite with the resolved runner configuration.
+ */
 export async function main(argv = process.argv.slice(2), env = process.env) {
   const options = parseRunnerOptions(argv, env);
 


### PR DESCRIPTION
## Summary
- update the README and docs/e2e-testing.md to reflect the shipped E2E runner, coverage lanes, fixture replay rules, and approved write flags
- expand npm run test:e2e -- --help and add API docs to the shared E2E runner, setup, helper, CLI, MCP, and runtime entrypoints
- add a changelog note for the documentation refresh

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #96
