### PR TITLE
feat: add local scheduler for scheduled follow-ups

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -30,6 +30,7 @@ import {
   LINKEDIN_POST_VISIBILITY_TYPES,
   LINKEDIN_SELECTOR_LOCALES,
   LinkedInAssistantError,
+  LinkedInSchedulerService,
   createCoreRuntime,
   deleteLocalData,
   normalizeLinkedInFeedReaction,
@@ -43,9 +44,12 @@ import {
   resolveKeepAliveDir,
   resolveLegacyRateLimitStateFilePath,
   resolvePrivacyConfig,
+  resolveSchedulerConfig,
   toLinkedInAssistantErrorPayload,
   type DraftQualityReport,
   type LocalDataDeletionFailure,
+  type SchedulerConfig,
+  type SchedulerTickResult,
   type SearchCategory,
   type SelectorAuditReport
 } from "@linkedin-assistant/core";
@@ -215,6 +219,49 @@ interface KeepAliveFiles {
   logPath: string;
 }
 
+type SchedulerStateSummary = Pick<
+  SchedulerTickResult,
+  | "skippedReason"
+  | "discoveredAcceptedConnections"
+  | "queuedJobs"
+  | "updatedJobs"
+  | "reopenedJobs"
+  | "cancelledJobs"
+  | "claimedJobs"
+  | "preparedJobs"
+  | "rescheduledJobs"
+  | "failedJobs"
+>;
+
+interface SchedulerState {
+  pid: number;
+  profileName: string;
+  startedAt: string;
+  updatedAt: string;
+  status: "starting" | "running" | "idle" | "degraded" | "stopped";
+  pollIntervalMs: number;
+  businessHours: SchedulerConfig["businessHours"];
+  maxJobsPerTick: number;
+  consecutiveFailures: number;
+  maxConsecutiveFailures: number;
+  lastTickAt?: string;
+  lastSuccessfulTickAt?: string;
+  lastPreparedAt?: string;
+  lastSummary?: SchedulerStateSummary;
+  lastError?: string;
+  cdpUrl?: string;
+  stoppedAt?: string;
+}
+
+interface SchedulerFiles {
+  dir: string;
+  pidPath: string;
+  statePath: string;
+  logPath: string;
+}
+
+const SCHEDULER_DAEMON_MAX_CONSECUTIVE_FAILURES = 5;
+
 function profileSlug(profileName: string): string {
   return profileName.replace(/[^a-zA-Z0-9_-]/g, "_");
 }
@@ -230,7 +277,22 @@ function getKeepAliveFiles(profileName: string): KeepAliveFiles {
   };
 }
 
+function getSchedulerFiles(profileName: string): SchedulerFiles {
+  const slug = profileSlug(profileName);
+  const dir = path.join(resolveConfigPaths().baseDir, "scheduler");
+  return {
+    dir,
+    pidPath: path.join(dir, `${slug}.pid`),
+    statePath: path.join(dir, `${slug}.state.json`),
+    logPath: path.join(dir, `${slug}.events.jsonl`)
+  };
+}
+
 async function ensureKeepAliveDir(files: KeepAliveFiles): Promise<void> {
+  await mkdir(files.dir, { recursive: true });
+}
+
+async function ensureSchedulerDir(files: SchedulerFiles): Promise<void> {
   await mkdir(files.dir, { recursive: true });
 }
 
@@ -418,6 +480,71 @@ async function appendKeepAliveEvent(
 ): Promise<void> {
   const files = getKeepAliveFiles(profileName);
   await ensureKeepAliveDir(files);
+  await appendFile(files.logPath, `${JSON.stringify(event)}\n`, "utf8");
+}
+
+async function readSchedulerPid(profileName: string): Promise<number | null> {
+  const files = getSchedulerFiles(profileName);
+  try {
+    const raw = await readFile(files.pidPath, "utf8");
+    const pid = Number.parseInt(raw.trim(), 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function writeSchedulerPid(profileName: string, pid: number): Promise<void> {
+  const files = getSchedulerFiles(profileName);
+  await ensureSchedulerDir(files);
+  await writeFile(files.pidPath, `${pid}\n`, "utf8");
+}
+
+async function removeSchedulerPid(profileName: string): Promise<void> {
+  const files = getSchedulerFiles(profileName);
+  try {
+    await unlink(files.pidPath);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return;
+    }
+    throw error;
+  }
+}
+
+async function readSchedulerState(
+  profileName: string
+): Promise<SchedulerState | null> {
+  const files = getSchedulerFiles(profileName);
+  return readJsonFile<SchedulerState>(files.statePath);
+}
+
+async function writeSchedulerState(
+  profileName: string,
+  state: SchedulerState
+): Promise<void> {
+  const files = getSchedulerFiles(profileName);
+  await ensureSchedulerDir(files);
+  await writeJsonFile(files.statePath, state);
+}
+
+async function appendSchedulerEvent(
+  profileName: string,
+  event: Record<string, unknown>
+): Promise<void> {
+  const files = getSchedulerFiles(profileName);
+  await ensureSchedulerDir(files);
   await appendFile(files.logPath, `${JSON.stringify(event)}\n`, "utf8");
 }
 
@@ -1332,6 +1459,397 @@ async function runKeepAliveDaemon(input: {
 
     await removeKeepAlivePid(profileName).catch(() => undefined);
     runtime.close();
+  }
+}
+
+function summarizeSchedulerTick(result: SchedulerTickResult): SchedulerStateSummary {
+  return {
+    skippedReason: result.skippedReason,
+    discoveredAcceptedConnections: result.discoveredAcceptedConnections,
+    queuedJobs: result.queuedJobs,
+    updatedJobs: result.updatedJobs,
+    reopenedJobs: result.reopenedJobs,
+    cancelledJobs: result.cancelledJobs,
+    claimedJobs: result.claimedJobs,
+    preparedJobs: result.preparedJobs,
+    rescheduledJobs: result.rescheduledJobs,
+    failedJobs: result.failedJobs
+  };
+}
+
+async function runSchedulerRunOnce(
+  profileName: string,
+  cdpUrl?: string
+): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+  const schedulerConfig = resolveSchedulerConfig();
+
+  try {
+    const scheduler = new LinkedInSchedulerService({
+      db: runtime.db,
+      logger: runtime.logger,
+      followups: runtime.followups,
+      schedulerConfig
+    });
+    const result = await scheduler.runTick({
+      profileName,
+      workerId: `cli:${runtime.runId}`
+    });
+
+    printJson({
+      run_id: runtime.runId,
+      scheduler_config: schedulerConfig,
+      ...result
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function runSchedulerStart(
+  profileName: string,
+  cdpUrl?: string
+): Promise<void> {
+  const existingPid = await readSchedulerPid(profileName);
+  if (existingPid && isProcessRunning(existingPid)) {
+    const currentState = await readSchedulerState(profileName);
+    printJson({
+      started: false,
+      reason: "Scheduler daemon is already running for this profile.",
+      profile_name: profileName,
+      pid: existingPid,
+      state: currentState
+    });
+    return;
+  }
+
+  if (existingPid && !isProcessRunning(existingPid)) {
+    await removeSchedulerPid(profileName);
+  }
+
+  maybeWarnAboutSelectorLocaleConfig(cliSelectorLocale);
+
+  const schedulerConfig = resolveSchedulerConfig();
+  const cliEntrypoint = resolveKeepAliveCliEntrypoint();
+  if (!cliEntrypoint) {
+    throw new LinkedInAssistantError(
+      "UNKNOWN",
+      "Could not resolve CLI entrypoint for scheduler daemon startup."
+    );
+  }
+
+  const daemonArgs = [cliEntrypoint];
+  if (cdpUrl) {
+    daemonArgs.push("--cdp-url", cdpUrl);
+  }
+  if (cliSelectorLocale) {
+    daemonArgs.push("--selector-locale", cliSelectorLocale);
+  }
+  daemonArgs.push("scheduler", "__run", "--profile", profileName);
+
+  const daemon = spawn(process.execPath, daemonArgs, {
+    detached: true,
+    stdio: "ignore",
+    env: process.env
+  });
+  daemon.unref();
+
+  if (!daemon.pid) {
+    throw new LinkedInAssistantError(
+      "UNKNOWN",
+      "Scheduler daemon did not return a process id."
+    );
+  }
+
+  const now = new Date().toISOString();
+  const initialState: SchedulerState = {
+    pid: daemon.pid,
+    profileName,
+    startedAt: now,
+    updatedAt: now,
+    status: "starting",
+    pollIntervalMs: schedulerConfig.pollIntervalMs,
+    businessHours: schedulerConfig.businessHours,
+    maxJobsPerTick: schedulerConfig.maxJobsPerTick,
+    consecutiveFailures: 0,
+    maxConsecutiveFailures: SCHEDULER_DAEMON_MAX_CONSECUTIVE_FAILURES,
+    ...(cdpUrl ? { cdpUrl } : {})
+  };
+
+  await writeSchedulerPid(profileName, daemon.pid);
+  await writeSchedulerState(profileName, initialState);
+
+  printJson({
+    started: true,
+    profile_name: profileName,
+    pid: daemon.pid,
+    state_path: getSchedulerFiles(profileName).statePath,
+    scheduler_config: schedulerConfig
+  });
+}
+
+async function runSchedulerStatus(profileName: string): Promise<void> {
+  const pid = await readSchedulerPid(profileName);
+  const state = await readSchedulerState(profileName);
+  const running = typeof pid === "number" ? isProcessRunning(pid) : false;
+
+  printJson({
+    profile_name: profileName,
+    running,
+    pid,
+    state,
+    stale_pid_file: Boolean(pid && !running)
+  });
+}
+
+async function runSchedulerStop(profileName: string): Promise<void> {
+  const pid = await readSchedulerPid(profileName);
+  const previousState = await readSchedulerState(profileName);
+
+  if (!pid) {
+    printJson({
+      stopped: false,
+      profile_name: profileName,
+      reason: "No scheduler daemon pid file found."
+    });
+    return;
+  }
+
+  if (!isProcessRunning(pid)) {
+    await removeSchedulerPid(profileName);
+    const now = new Date().toISOString();
+    if (previousState) {
+      await writeSchedulerState(profileName, {
+        ...previousState,
+        status: "stopped",
+        updatedAt: now,
+        stoppedAt: now,
+        lastError: "Recovered from stale pid file."
+      });
+    }
+    printJson({
+      stopped: true,
+      profile_name: profileName,
+      pid,
+      reason: "Recovered stale scheduler pid file."
+    });
+    return;
+  }
+
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch (error) {
+    throw new LinkedInAssistantError(
+      "UNKNOWN",
+      "Failed to send SIGTERM to scheduler daemon.",
+      {
+        profile_name: profileName,
+        pid,
+        cause: error instanceof Error ? error.message : String(error)
+      }
+    );
+  }
+
+  const deadline = Date.now() + 5_000;
+  let running = true;
+  while (Date.now() < deadline) {
+    await sleep(200);
+    running = isProcessRunning(pid);
+    if (!running) {
+      break;
+    }
+  }
+
+  if (running) {
+    process.kill(pid, "SIGKILL");
+  }
+
+  await removeSchedulerPid(profileName);
+  const now = new Date().toISOString();
+  if (previousState) {
+    await writeSchedulerState(profileName, {
+      ...previousState,
+      status: "stopped",
+      updatedAt: now,
+      stoppedAt: now,
+      ...(running
+        ? { lastError: "Scheduler daemon required SIGKILL to stop." }
+        : {})
+    });
+  }
+
+  printJson({
+    stopped: true,
+    profile_name: profileName,
+    pid,
+    forced: running
+  });
+}
+
+async function runSchedulerDaemon(
+  profileName: string,
+  cdpUrl?: string
+): Promise<void> {
+  const schedulerConfig = resolveSchedulerConfig();
+  let stopRequested = false;
+  let consecutiveFailures = 0;
+
+  const requestStop = () => {
+    stopRequested = true;
+  };
+  process.on("SIGTERM", requestStop);
+  process.on("SIGINT", requestStop);
+
+  const startedAt = new Date().toISOString();
+  const initialState: SchedulerState = {
+    pid: process.pid,
+    profileName,
+    startedAt,
+    updatedAt: startedAt,
+    status: "running",
+    pollIntervalMs: schedulerConfig.pollIntervalMs,
+    businessHours: schedulerConfig.businessHours,
+    maxJobsPerTick: schedulerConfig.maxJobsPerTick,
+    consecutiveFailures: 0,
+    maxConsecutiveFailures: SCHEDULER_DAEMON_MAX_CONSECUTIVE_FAILURES,
+    ...(cdpUrl ? { cdpUrl } : {})
+  };
+
+  await writeSchedulerPid(profileName, process.pid);
+  await writeSchedulerState(profileName, initialState);
+  await appendSchedulerEvent(profileName, {
+    ts: startedAt,
+    event: "scheduler.daemon.started",
+    pid: process.pid,
+    profile_name: profileName,
+    cdp_url: cdpUrl ?? null,
+    scheduler_config: schedulerConfig
+  });
+
+  try {
+    while (!stopRequested) {
+      const tickAt = new Date().toISOString();
+
+      try {
+        const runtime = createRuntime(cdpUrl);
+
+        try {
+          const scheduler = new LinkedInSchedulerService({
+            db: runtime.db,
+            logger: runtime.logger,
+            followups: runtime.followups,
+            schedulerConfig
+          });
+          const result = await scheduler.runTick({
+            profileName,
+            workerId: `scheduler-daemon:${process.pid}`
+          });
+
+          consecutiveFailures = 0;
+          const nextState: SchedulerState = {
+            ...(await readSchedulerState(profileName)) ?? initialState,
+            pid: process.pid,
+            profileName,
+            updatedAt: tickAt,
+            status:
+              result.skippedReason === "outside_business_hours" ||
+              result.skippedReason === "profile_busy" ||
+              result.skippedReason === "disabled" ||
+              result.claimedJobs === 0
+                ? "idle"
+                : "running",
+            pollIntervalMs: schedulerConfig.pollIntervalMs,
+            businessHours: schedulerConfig.businessHours,
+            maxJobsPerTick: schedulerConfig.maxJobsPerTick,
+            consecutiveFailures,
+            maxConsecutiveFailures: SCHEDULER_DAEMON_MAX_CONSECUTIVE_FAILURES,
+            lastTickAt: tickAt,
+            lastSuccessfulTickAt: tickAt,
+            lastSummary: summarizeSchedulerTick(result)
+          };
+          if (result.preparedJobs > 0) {
+            nextState.lastPreparedAt = tickAt;
+          }
+          delete nextState.lastError;
+
+          await writeSchedulerState(profileName, nextState);
+          await appendSchedulerEvent(profileName, {
+            ts: tickAt,
+            event:
+              result.skippedReason === null ? "scheduler.tick" : "scheduler.tick.skipped",
+            profile_name: profileName,
+            summary: summarizeSchedulerTick(result),
+            skipped_reason: result.skippedReason,
+            next_window_start_at: result.nextWindowStartAt
+          });
+        } finally {
+          runtime.close();
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const lockHeld = isProfileLockHeldError(error);
+        if (!lockHeld) {
+          consecutiveFailures += 1;
+        }
+
+        const nextState: SchedulerState = {
+          ...(await readSchedulerState(profileName)) ?? initialState,
+          pid: process.pid,
+          profileName,
+          updatedAt: tickAt,
+          status:
+            consecutiveFailures >= SCHEDULER_DAEMON_MAX_CONSECUTIVE_FAILURES
+              ? "degraded"
+              : "running",
+          pollIntervalMs: schedulerConfig.pollIntervalMs,
+          businessHours: schedulerConfig.businessHours,
+          maxJobsPerTick: schedulerConfig.maxJobsPerTick,
+          consecutiveFailures,
+          maxConsecutiveFailures: SCHEDULER_DAEMON_MAX_CONSECUTIVE_FAILURES,
+          lastTickAt: tickAt,
+          lastError: message
+        };
+        await writeSchedulerState(profileName, nextState);
+        await appendSchedulerEvent(profileName, {
+          ts: tickAt,
+          event: lockHeld ? "scheduler.tick.skipped" : "scheduler.tick.error",
+          profile_name: profileName,
+          consecutive_failures: consecutiveFailures,
+          error: message,
+          ...(lockHeld ? { reason: "profile_lock_held" } : {})
+        });
+      }
+
+      if (stopRequested) {
+        break;
+      }
+
+      let sleepRemainingMs = Math.max(1_000, schedulerConfig.pollIntervalMs);
+      while (!stopRequested && sleepRemainingMs > 0) {
+        const chunkMs = Math.min(500, sleepRemainingMs);
+        await sleep(chunkMs);
+        sleepRemainingMs -= chunkMs;
+      }
+    }
+  } finally {
+    const now = new Date().toISOString();
+    const lastState = (await readSchedulerState(profileName)) ?? initialState;
+    await writeSchedulerState(profileName, {
+      ...lastState,
+      pid: process.pid,
+      profileName,
+      status: "stopped",
+      updatedAt: now,
+      stoppedAt: now
+    });
+    await appendSchedulerEvent(profileName, {
+      ts: now,
+      event: "scheduler.daemon.stopped",
+      pid: process.pid,
+      profile_name: profileName
+    });
+
+    await removeSchedulerPid(profileName).catch(() => undefined);
   }
 }
 
@@ -2610,6 +3128,50 @@ export function createCliProgram(): Command {
         );
       }
     );
+
+  const schedulerCommand = program
+    .command("scheduler")
+    .description("Run and manage the local follow-up scheduler daemon");
+
+  schedulerCommand
+    .command("start")
+    .description("Start the scheduler daemon for a profile")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .action(async (options: { profile: string }) => {
+      await runSchedulerStart(options.profile, readCdpUrl());
+    });
+
+  schedulerCommand
+    .command("status")
+    .description("Show scheduler daemon status for a profile")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .action(async (options: { profile: string }) => {
+      await runSchedulerStatus(options.profile);
+    });
+
+  schedulerCommand
+    .command("stop")
+    .description("Stop the scheduler daemon for a profile")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .action(async (options: { profile: string }) => {
+      await runSchedulerStop(options.profile);
+    });
+
+  schedulerCommand
+    .command("run-once")
+    .description("Run one scheduler tick immediately")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .action(async (options: { profile: string }) => {
+      await runSchedulerRunOnce(options.profile, readCdpUrl());
+    });
+
+  schedulerCommand
+    .command("__run", { hidden: true })
+    .description("Internal daemon command")
+    .requiredOption("-p, --profile <profile>", "Profile name")
+    .action(async (options: { profile: string }) => {
+      await runSchedulerDaemon(options.profile, readCdpUrl());
+    });
 
   program
     .command("login")

--- a/packages/core/src/__tests__/linkedinFollowups.test.ts
+++ b/packages/core/src/__tests__/linkedinFollowups.test.ts
@@ -340,4 +340,131 @@ describe("LinkedInFollowupsService", () => {
       db.close();
     }
   });
+
+  it("prepares a single accepted-connection follow-up by profile key", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+
+    const db = new AssistantDatabase(":memory:");
+
+    try {
+      seedAcceptedInvitation({
+        db,
+        profileName: "default",
+        profileUrl: "https://www.linkedin.com/in/jane-doe/",
+        vanityName: "jane-doe",
+        fullName: "Jane Doe",
+        headline: "Product Manager",
+        firstSeenSentAtMs: FIXED_NOW.getTime() - 3 * 24 * 60 * 60 * 1000,
+        lastSeenSentAtMs: FIXED_NOW.getTime() - 2 * 24 * 60 * 60 * 1000,
+        acceptedAtMs: FIXED_NOW.getTime() - 12 * 60 * 60 * 1000
+      });
+
+      const runtime = createTestRuntime(db);
+      const service = new LinkedInFollowupsService(runtime);
+      const refreshSpy = vi.spyOn(
+        service as unknown as { refreshAcceptanceState: () => Promise<void> },
+        "refreshAcceptanceState"
+      ).mockResolvedValue(undefined);
+
+      const preparedFollowup: PreparedAcceptedConnectionFollowup = {
+        connection: {
+          profile_url_key: "https://www.linkedin.com/in/jane-doe/",
+          profile_url: "https://www.linkedin.com/in/jane-doe/",
+          vanity_name: "jane-doe",
+          full_name: "Jane Doe",
+          headline: "Product Manager",
+          first_seen_sent_at_ms: FIXED_NOW.getTime() - 3 * 24 * 60 * 60 * 1000,
+          last_seen_sent_at_ms: FIXED_NOW.getTime() - 2 * 24 * 60 * 60 * 1000,
+          accepted_at_ms: FIXED_NOW.getTime() - 12 * 60 * 60 * 1000,
+          accepted_detection: "topcard-message-role",
+          followup_status: "prepared",
+          followup_prepared_action_id: "pa_followup_jane",
+          followup_prepared_at_ms: FIXED_NOW.getTime(),
+          followup_confirmed_at_ms: null,
+          followup_expires_at_ms: FIXED_NOW.getTime() + 30 * 60 * 1000
+        },
+        preparedActionId: "pa_followup_jane",
+        confirmToken: "ct_followup_jane",
+        expiresAtMs: FIXED_NOW.getTime() + 30 * 60 * 1000,
+        preview: {
+          summary: "Send accepted-connection follow-up to Jane Doe"
+        }
+      };
+
+      const prepareSpy = vi.spyOn(
+        service as unknown as {
+          prepareAcceptedConnections: (
+            profileName: string,
+            connections: LinkedInAcceptedConnection[]
+          ) => Promise<PreparedAcceptedConnectionFollowup[]>;
+        },
+        "prepareAcceptedConnections"
+      ).mockResolvedValue([preparedFollowup]);
+
+      const result = await service.prepareFollowupForAcceptedConnection({
+        profileName: "default",
+        profileUrlKey: "https://www.linkedin.com/in/jane-doe/"
+      });
+
+      expect(refreshSpy).not.toHaveBeenCalled();
+      expect(prepareSpy).toHaveBeenCalledTimes(1);
+      expect(prepareSpy.mock.calls[0]?.[1]).toHaveLength(1);
+      expect(prepareSpy.mock.calls[0]?.[1]?.[0]?.full_name).toBe("Jane Doe");
+      expect(result).toEqual(preparedFollowup);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("returns null when a single accepted connection no longer needs preparation", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+
+    const db = new AssistantDatabase(":memory:");
+
+    try {
+      seedAcceptedInvitation({
+        db,
+        profileName: "default",
+        profileUrl: "https://www.linkedin.com/in/jane-doe/",
+        vanityName: "jane-doe",
+        fullName: "Jane Doe",
+        headline: "Product Manager",
+        firstSeenSentAtMs: FIXED_NOW.getTime() - 3 * 24 * 60 * 60 * 1000,
+        lastSeenSentAtMs: FIXED_NOW.getTime() - 2 * 24 * 60 * 60 * 1000,
+        acceptedAtMs: FIXED_NOW.getTime() - 12 * 60 * 60 * 1000
+      });
+
+      seedPreparedFollowup({
+        db,
+        profileName: "default",
+        profileUrl: "https://www.linkedin.com/in/jane-doe/",
+        fullName: "Jane Doe",
+        preparedAtMs: FIXED_NOW.getTime() - 10 * 60 * 1000
+      });
+
+      const runtime = createTestRuntime(db);
+      const service = new LinkedInFollowupsService(runtime);
+      const prepareSpy = vi.spyOn(
+        service as unknown as {
+          prepareAcceptedConnections: (
+            profileName: string,
+            connections: LinkedInAcceptedConnection[]
+          ) => Promise<PreparedAcceptedConnectionFollowup[]>;
+        },
+        "prepareAcceptedConnections"
+      );
+
+      const result = await service.prepareFollowupForAcceptedConnection({
+        profileName: "default",
+        profileUrlKey: "https://www.linkedin.com/in/jane-doe/"
+      });
+
+      expect(prepareSpy).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    } finally {
+      db.close();
+    }
+  });
 });

--- a/packages/core/src/__tests__/scheduler.test.ts
+++ b/packages/core/src/__tests__/scheduler.test.ts
@@ -1,0 +1,466 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SchedulerConfig } from "../config.js";
+import { AssistantDatabase } from "../db/database.js";
+import { LinkedInAssistantError } from "../errors.js";
+import {
+  FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE,
+  type LinkedInAcceptedConnection,
+  type PreparedAcceptedConnectionFollowup
+} from "../linkedinFollowups.js";
+import {
+  LinkedInSchedulerService,
+  alignToBusinessHours,
+  calculateSchedulerBackoffMs,
+  isWithinBusinessHours,
+  type LinkedInSchedulerRuntime
+} from "../scheduler.js";
+import { TwoPhaseCommitService } from "../twoPhaseCommit.js";
+
+const FIXED_NOW = new Date("2026-03-08T10:00:00Z").getTime();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function createSchedulerConfig(
+  overrides: Partial<SchedulerConfig> = {}
+): SchedulerConfig {
+  const businessHours = {
+    timeZone: "UTC",
+    startTime: "09:00",
+    endTime: "17:00",
+    ...overrides.businessHours
+  };
+  const retry = {
+    maxAttempts: 5,
+    initialBackoffMs: 5 * 60 * 1000,
+    maxBackoffMs: 60 * 60 * 1000,
+    ...overrides.retry
+  };
+
+  const base: SchedulerConfig = {
+    enabled: true,
+    pollIntervalMs: 5 * 60 * 1000,
+    maxJobsPerTick: 2,
+    leaseTtlMs: 60 * 1000,
+    enabledLanes: ["followup_preparation"],
+    businessHours,
+    followupDelayMs: 15 * 60 * 1000,
+    followupLookbackMs: 30 * 24 * 60 * 60 * 1000,
+    retry
+  };
+
+  return {
+    ...base,
+    ...overrides,
+    businessHours,
+    retry
+  };
+}
+
+function createAcceptedConnection(
+  overrides: Partial<LinkedInAcceptedConnection> = {}
+): LinkedInAcceptedConnection {
+  return {
+    profile_url_key: "https://www.linkedin.com/in/jane-doe/",
+    profile_url: "https://www.linkedin.com/in/jane-doe/",
+    vanity_name: "jane-doe",
+    full_name: "Jane Doe",
+    headline: "Product Manager",
+    first_seen_sent_at_ms: FIXED_NOW - 3 * 24 * 60 * 60 * 1000,
+    last_seen_sent_at_ms: FIXED_NOW - 2 * 24 * 60 * 60 * 1000,
+    accepted_at_ms: FIXED_NOW - 2 * 60 * 60 * 1000,
+    accepted_detection: "topcard-message-role",
+    followup_status: "not_prepared",
+    followup_prepared_action_id: null,
+    followup_prepared_at_ms: null,
+    followup_confirmed_at_ms: null,
+    followup_expires_at_ms: null,
+    ...overrides
+  };
+}
+
+function seedAcceptedInvitation(input: {
+  db: AssistantDatabase;
+  profileName: string;
+  connection: LinkedInAcceptedConnection;
+}): void {
+  input.db.upsertSentInvitationState({
+    profileName: input.profileName,
+    profileUrlKey: input.connection.profile_url_key,
+    vanityName: input.connection.vanity_name,
+    fullName: input.connection.full_name,
+    headline: input.connection.headline,
+    profileUrl: input.connection.profile_url,
+    firstSeenSentAtMs: input.connection.first_seen_sent_at_ms,
+    lastSeenSentAtMs: input.connection.last_seen_sent_at_ms,
+    createdAtMs: input.connection.first_seen_sent_at_ms,
+    updatedAtMs: input.connection.last_seen_sent_at_ms
+  });
+
+  const updated = input.db.markSentInvitationAccepted({
+    profileName: input.profileName,
+    profileUrlKey: input.connection.profile_url_key,
+    vanityName: input.connection.vanity_name,
+    fullName: input.connection.full_name,
+    headline: input.connection.headline,
+    profileUrl: input.connection.profile_url,
+    acceptedAtMs: input.connection.accepted_at_ms,
+    acceptedDetection: input.connection.accepted_detection,
+    updatedAtMs: input.connection.accepted_at_ms
+  });
+
+  expect(updated).toBe(true);
+}
+
+function createPreparedFollowupResult(input: {
+  db: AssistantDatabase;
+  profileName: string;
+  connection: LinkedInAcceptedConnection;
+  preparedAtMs: number;
+}): PreparedAcceptedConnectionFollowup {
+  const twoPhaseCommit = new TwoPhaseCommitService(input.db);
+  const prepared = twoPhaseCommit.prepare({
+    actionType: FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE,
+    target: {
+      profile_name: input.profileName,
+      profile_url_key: input.connection.profile_url_key,
+      target_profile_url: input.connection.profile_url,
+      vanity_name: input.connection.vanity_name,
+      full_name: input.connection.full_name,
+      headline: input.connection.headline
+    },
+    payload: {
+      text: `Hi ${input.connection.full_name}`
+    },
+    preview: {
+      summary: `Send accepted-connection follow-up to ${input.connection.full_name}`
+    },
+    nowMs: input.preparedAtMs
+  });
+
+  const updated = input.db.markSentInvitationFollowupPrepared({
+    profileName: input.profileName,
+    profileUrlKey: input.connection.profile_url_key,
+    preparedAtMs: input.preparedAtMs,
+    preparedActionId: prepared.preparedActionId,
+    updatedAtMs: input.preparedAtMs
+  });
+  expect(updated).toBe(true);
+
+  return {
+    connection: {
+      ...input.connection,
+      followup_status: "prepared",
+      followup_prepared_action_id: prepared.preparedActionId,
+      followup_prepared_at_ms: input.preparedAtMs,
+      followup_expires_at_ms: prepared.expiresAtMs
+    },
+    preparedActionId: prepared.preparedActionId,
+    confirmToken: prepared.confirmToken,
+    expiresAtMs: prepared.expiresAtMs,
+    preview: prepared.preview
+  };
+}
+
+describe("scheduler helpers", () => {
+  it("aligns due work to the next business window", () => {
+    const businessHours = {
+      timeZone: "Europe/Copenhagen",
+      startTime: "09:00",
+      endTime: "17:00"
+    };
+
+    expect(
+      isWithinBusinessHours(
+        Date.parse("2026-03-08T09:30:00Z"),
+        businessHours
+      )
+    ).toBe(true);
+    expect(
+      alignToBusinessHours(
+        Date.parse("2026-03-08T06:30:00Z"),
+        businessHours
+      )
+    ).toBe(Date.parse("2026-03-08T08:00:00Z"));
+    expect(
+      alignToBusinessHours(
+        Date.parse("2026-03-08T18:30:00Z"),
+        businessHours
+      )
+    ).toBe(Date.parse("2026-03-09T08:00:00Z"));
+  });
+
+  it("uses exponential retry backoff with a cap", () => {
+    const backoff = calculateSchedulerBackoffMs(4, {
+      maxAttempts: 5,
+      initialBackoffMs: 60_000,
+      maxBackoffMs: 5 * 60_000
+    });
+
+    expect(backoff).toBe(5 * 60_000);
+  });
+});
+
+describe("scheduler DB helpers", () => {
+  it("claims due jobs in lane priority order", () => {
+    const db = new AssistantDatabase(":memory:");
+
+    try {
+      for (const [lane, id] of [
+        ["feed_engagement", "job_feed"],
+        ["followup_preparation", "job_followup"],
+        ["pending_invite_checks", "job_pending"],
+        ["inbox_triage", "job_inbox"]
+      ] as const) {
+        db.insertSchedulerJob({
+          id,
+          profileName: "default",
+          lane,
+          actionType: "scheduler.test",
+          targetJson: "{}",
+          dedupeKey: `${lane}:default`,
+          scheduledAtMs: FIXED_NOW,
+          maxAttempts: 5,
+          createdAtMs: FIXED_NOW,
+          updatedAtMs: FIXED_NOW
+        });
+      }
+
+      const claimed = db.claimDueSchedulerJobs({
+        profileName: "default",
+        nowMs: FIXED_NOW,
+        limit: 4,
+        leaseOwner: "worker",
+        leaseTtlMs: 60_000
+      });
+
+      expect(claimed.map((job) => job.lane)).toEqual([
+        "inbox_triage",
+        "pending_invite_checks",
+        "followup_preparation",
+        "feed_engagement"
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe("LinkedInSchedulerService", () => {
+  it("queues and prepares due follow-up jobs during business hours", async () => {
+    const db = new AssistantDatabase(":memory:");
+    const connection = createAcceptedConnection();
+    seedAcceptedInvitation({
+      db,
+      profileName: "default",
+      connection
+    });
+
+    const followups = {
+      listAcceptedConnections: vi.fn(async () => [connection]),
+      prepareFollowupForAcceptedConnection: vi.fn(
+        async () =>
+          createPreparedFollowupResult({
+            db,
+            profileName: "default",
+            connection,
+            preparedAtMs: FIXED_NOW
+          })
+      )
+    };
+    const runtime: LinkedInSchedulerRuntime = {
+      db,
+      logger: {
+        log: vi.fn()
+      } as LinkedInSchedulerRuntime["logger"],
+      followups,
+      schedulerConfig: createSchedulerConfig()
+    };
+
+    try {
+      const service = new LinkedInSchedulerService(runtime);
+      const result = await service.runTick({
+        profileName: "default",
+        nowMs: FIXED_NOW,
+        workerId: "test-worker"
+      });
+
+      expect(result.skippedReason).toBeNull();
+      expect(result.queuedJobs).toBe(1);
+      expect(result.claimedJobs).toBe(1);
+      expect(result.preparedJobs).toBe(1);
+      expect(followups.prepareFollowupForAcceptedConnection).toHaveBeenCalledWith({
+        profileName: "default",
+        profileUrlKey: connection.profile_url_key,
+        operatorNote: "Prepared by local scheduler.",
+        refreshState: false
+      });
+
+      const jobs = db.listSchedulerJobs({ profileName: "default" });
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0]?.status).toBe("prepared");
+      expect(jobs[0]?.prepared_action_id).toBeTruthy();
+
+      const preparedActionId = jobs[0]?.prepared_action_id;
+      expect(preparedActionId).toBeTruthy();
+      expect(db.getPreparedActionById(preparedActionId ?? "")?.status).toBe(
+        "prepared"
+      );
+
+      const state = db.getSentInvitationState({
+        profileName: "default",
+        profileUrlKey: connection.profile_url_key
+      });
+      expect(state?.followup_prepared_action_id).toBe(preparedActionId);
+      expect(state?.followup_confirmed_at).toBeNull();
+    } finally {
+      db.close();
+    }
+  });
+
+  it("skips scheduler work outside business hours", async () => {
+    const db = new AssistantDatabase(":memory:");
+    const followups = {
+      listAcceptedConnections: vi.fn(async () => []),
+      prepareFollowupForAcceptedConnection: vi.fn()
+    };
+
+    try {
+      const service = new LinkedInSchedulerService({
+        db,
+        logger: {
+          log: vi.fn()
+        } as LinkedInSchedulerRuntime["logger"],
+        followups,
+        schedulerConfig: createSchedulerConfig({
+          businessHours: {
+            timeZone: "UTC",
+            startTime: "09:00",
+            endTime: "17:00"
+          }
+        })
+      });
+      const result = await service.runTick({
+        profileName: "default",
+        nowMs: Date.parse("2026-03-08T08:30:00Z")
+      });
+
+      expect(result.skippedReason).toBe("outside_business_hours");
+      expect(followups.listAcceptedConnections).not.toHaveBeenCalled();
+    } finally {
+      db.close();
+    }
+  });
+
+  it("backs off transient job failures", async () => {
+    const db = new AssistantDatabase(":memory:");
+    const connection = createAcceptedConnection();
+    seedAcceptedInvitation({
+      db,
+      profileName: "default",
+      connection
+    });
+    const config = createSchedulerConfig();
+    const followups = {
+      listAcceptedConnections: vi.fn(async () => [connection]),
+      prepareFollowupForAcceptedConnection: vi.fn(async () => {
+        throw new LinkedInAssistantError("NETWORK_ERROR", "Temporary network issue.");
+      })
+    };
+
+    try {
+      const service = new LinkedInSchedulerService({
+        db,
+        logger: {
+          log: vi.fn()
+        } as LinkedInSchedulerRuntime["logger"],
+        followups,
+        schedulerConfig: config
+      });
+      const result = await service.runTick({
+        profileName: "default",
+        nowMs: FIXED_NOW,
+        workerId: "test-worker"
+      });
+
+      expect(result.rescheduledJobs).toBe(1);
+
+      const jobs = db.listSchedulerJobs({ profileName: "default" });
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0]?.status).toBe("pending");
+      expect(jobs[0]?.attempt_count).toBe(1);
+      expect(jobs[0]?.last_error_code).toBe("NETWORK_ERROR");
+      expect(jobs[0]?.scheduled_at).toBe(
+        FIXED_NOW + config.retry.initialBackoffMs
+      );
+    } finally {
+      db.close();
+    }
+  });
+
+  it("marks jobs failed after the final retry", async () => {
+    const db = new AssistantDatabase(":memory:");
+    const connection = createAcceptedConnection();
+    seedAcceptedInvitation({
+      db,
+      profileName: "default",
+      connection
+    });
+    const config = createSchedulerConfig({
+      retry: {
+        maxAttempts: 2,
+        initialBackoffMs: 5 * 60 * 1000,
+        maxBackoffMs: 30 * 60 * 1000
+      }
+    });
+    db.insertSchedulerJob({
+      id: "job_followup_retry",
+      profileName: "default",
+      lane: "followup_preparation",
+      actionType: FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE,
+      targetJson: JSON.stringify({
+        profile_name: "default",
+        profile_url_key: connection.profile_url_key
+      }),
+      dedupeKey: `followup_preparation:default:${connection.profile_url_key}`,
+      scheduledAtMs: FIXED_NOW,
+      attemptCount: 1,
+      maxAttempts: 2,
+      createdAtMs: FIXED_NOW - 60_000,
+      updatedAtMs: FIXED_NOW - 60_000
+    });
+    const followups = {
+      listAcceptedConnections: vi.fn(async () => [connection]),
+      prepareFollowupForAcceptedConnection: vi.fn(async () => {
+        throw new LinkedInAssistantError("NETWORK_ERROR", "Still failing.");
+      })
+    };
+
+    try {
+      const service = new LinkedInSchedulerService({
+        db,
+        logger: {
+          log: vi.fn()
+        } as LinkedInSchedulerRuntime["logger"],
+        followups,
+        schedulerConfig: config
+      });
+      const result = await service.runTick({
+        profileName: "default",
+        nowMs: FIXED_NOW,
+        workerId: "test-worker"
+      });
+
+      expect(result.failedJobs).toBe(1);
+
+      const jobs = db.listSchedulerJobs({ profileName: "default" });
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0]?.status).toBe("failed");
+      expect(jobs[0]?.attempt_count).toBe(2);
+      expect(jobs[0]?.last_error_code).toBe("NETWORK_ERROR");
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -41,6 +41,175 @@ export interface ConfirmFailureArtifactConfig {
   traceMaxBytes: number;
 }
 
+export const SCHEDULER_LANES = [
+  "inbox_triage",
+  "pending_invite_checks",
+  "followup_preparation",
+  "feed_engagement"
+] as const;
+
+export type SchedulerLane = (typeof SCHEDULER_LANES)[number];
+
+export const DEFAULT_SCHEDULER_ENABLED_LANES: SchedulerLane[] = [
+  "followup_preparation"
+];
+
+export const DEFAULT_SCHEDULER_POLL_INTERVAL_MS = 5 * 60 * 1000;
+export const DEFAULT_SCHEDULER_MAX_JOBS_PER_TICK = 2;
+export const DEFAULT_SCHEDULER_LEASE_TTL_MS = 2 * 60 * 1000;
+export const DEFAULT_SCHEDULER_FOLLOWUP_DELAY_MS = 15 * 60 * 1000;
+export const DEFAULT_SCHEDULER_FOLLOWUP_LOOKBACK_MS =
+  30 * 24 * 60 * 60 * 1000;
+export const DEFAULT_SCHEDULER_MAX_ATTEMPTS = 5;
+export const DEFAULT_SCHEDULER_INITIAL_BACKOFF_MS = 5 * 60 * 1000;
+export const DEFAULT_SCHEDULER_MAX_BACKOFF_MS = 6 * 60 * 60 * 1000;
+export const DEFAULT_SCHEDULER_BUSINESS_START = "09:00";
+export const DEFAULT_SCHEDULER_BUSINESS_END = "17:00";
+
+export interface SchedulerBusinessHoursConfig {
+  timeZone: string;
+  startTime: string;
+  endTime: string;
+}
+
+export interface SchedulerRetryConfig {
+  maxAttempts: number;
+  initialBackoffMs: number;
+  maxBackoffMs: number;
+}
+
+export interface SchedulerConfig {
+  enabled: boolean;
+  pollIntervalMs: number;
+  maxJobsPerTick: number;
+  leaseTtlMs: number;
+  enabledLanes: SchedulerLane[];
+  businessHours: SchedulerBusinessHoursConfig;
+  followupDelayMs: number;
+  followupLookbackMs: number;
+  retry: SchedulerRetryConfig;
+}
+
+function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (!value) {
+    return fallback;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+
+  if (["0", "false", "no", "off"].includes(normalized)) {
+    return false;
+  }
+
+  return fallback;
+}
+
+function isValidTimeZone(value: string | undefined): value is string {
+  if (!value) {
+    return false;
+  }
+
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: value }).format(new Date());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveDefaultSchedulerTimeZone(): string {
+  const systemTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  return isValidTimeZone(systemTimeZone) ? systemTimeZone : "UTC";
+}
+
+function normalizeClockTime(
+  value: string | undefined,
+  fallback: string
+): string {
+  if (!value) {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  const match = /^(\d{1,2}):(\d{2})$/.exec(trimmed);
+  if (!match) {
+    return fallback;
+  }
+
+  const hour = Number.parseInt(match[1] ?? "", 10);
+  const minute = Number.parseInt(match[2] ?? "", 10);
+  if (
+    !Number.isFinite(hour) ||
+    !Number.isFinite(minute) ||
+    hour < 0 ||
+    hour > 23 ||
+    minute < 0 ||
+    minute > 59
+  ) {
+    return fallback;
+  }
+
+  return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+}
+
+function compareClockTimes(left: string, right: string): number {
+  const [leftHourText = "0", leftMinuteText = "0"] = left.split(":");
+  const [rightHourText = "0", rightMinuteText = "0"] = right.split(":");
+  const leftHour = Number.parseInt(leftHourText, 10);
+  const leftMinute = Number.parseInt(leftMinuteText, 10);
+  const rightHour = Number.parseInt(rightHourText, 10);
+  const rightMinute = Number.parseInt(rightMinuteText, 10);
+
+  return leftHour * 60 + leftMinute - (rightHour * 60 + rightMinute);
+}
+
+function parseSchedulerEnabledLanes(value: string | undefined): SchedulerLane[] {
+  if (!value) {
+    return [...DEFAULT_SCHEDULER_ENABLED_LANES];
+  }
+
+  const supported = new Set<string>(SCHEDULER_LANES);
+  const parsed = value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry): entry is SchedulerLane => supported.has(entry));
+
+  return parsed.length > 0 ? parsed : [...DEFAULT_SCHEDULER_ENABLED_LANES];
+}
+
+function resolveSchedulerBusinessHours(): SchedulerBusinessHoursConfig {
+  const startTime = normalizeClockTime(
+    process.env.LINKEDIN_ASSISTANT_SCHEDULER_BUSINESS_START,
+    DEFAULT_SCHEDULER_BUSINESS_START
+  );
+  const endTime = normalizeClockTime(
+    process.env.LINKEDIN_ASSISTANT_SCHEDULER_BUSINESS_END,
+    DEFAULT_SCHEDULER_BUSINESS_END
+  );
+  const timeZone = isValidTimeZone(
+    process.env.LINKEDIN_ASSISTANT_SCHEDULER_TIMEZONE
+  )
+    ? process.env.LINKEDIN_ASSISTANT_SCHEDULER_TIMEZONE
+    : resolveDefaultSchedulerTimeZone();
+
+  if (compareClockTimes(startTime, endTime) >= 0) {
+    return {
+      timeZone,
+      startTime: DEFAULT_SCHEDULER_BUSINESS_START,
+      endTime: DEFAULT_SCHEDULER_BUSINESS_END
+    };
+  }
+
+  return {
+    timeZone,
+    startTime,
+    endTime
+  };
+}
+
 /**
  * Environment variable that sets the default selector locale for the current
  * shell or process tree.
@@ -130,6 +299,62 @@ export function resolveConfirmFailureArtifactConfig(): ConfirmFailureArtifactCon
       process.env.LINKEDIN_ASSISTANT_CONFIRM_TRACE_MAX_BYTES,
       DEFAULT_CONFIRM_TRACE_MAX_BYTES
     )
+  };
+}
+
+export function resolveSchedulerConfig(): SchedulerConfig {
+  return {
+    enabled: parseBoolean(process.env.LINKEDIN_ASSISTANT_SCHEDULER_ENABLED, true),
+    pollIntervalMs:
+      parsePositiveInteger(
+        process.env.LINKEDIN_ASSISTANT_SCHEDULER_POLL_INTERVAL_SECONDS,
+        DEFAULT_SCHEDULER_POLL_INTERVAL_MS / 1_000
+      ) * 1_000,
+    maxJobsPerTick: parsePositiveInteger(
+      process.env.LINKEDIN_ASSISTANT_SCHEDULER_MAX_JOBS_PER_TICK,
+      DEFAULT_SCHEDULER_MAX_JOBS_PER_TICK
+    ),
+    leaseTtlMs:
+      parsePositiveInteger(
+        process.env.LINKEDIN_ASSISTANT_SCHEDULER_LEASE_SECONDS,
+        DEFAULT_SCHEDULER_LEASE_TTL_MS / 1_000
+      ) * 1_000,
+    enabledLanes: parseSchedulerEnabledLanes(
+      process.env.LINKEDIN_ASSISTANT_SCHEDULER_ENABLED_LANES
+    ),
+    businessHours: resolveSchedulerBusinessHours(),
+    followupDelayMs:
+      parsePositiveInteger(
+        process.env.LINKEDIN_ASSISTANT_SCHEDULER_FOLLOWUP_DELAY_MINUTES,
+        DEFAULT_SCHEDULER_FOLLOWUP_DELAY_MS / (60 * 1_000)
+      ) *
+      60 *
+      1_000,
+    followupLookbackMs:
+      parsePositiveInteger(
+        process.env.LINKEDIN_ASSISTANT_SCHEDULER_FOLLOWUP_LOOKBACK_DAYS,
+        DEFAULT_SCHEDULER_FOLLOWUP_LOOKBACK_MS / (24 * 60 * 60 * 1_000)
+      ) *
+      24 *
+      60 *
+      60 *
+      1_000,
+    retry: {
+      maxAttempts: parsePositiveInteger(
+        process.env.LINKEDIN_ASSISTANT_SCHEDULER_MAX_ATTEMPTS,
+        DEFAULT_SCHEDULER_MAX_ATTEMPTS
+      ),
+      initialBackoffMs:
+        parsePositiveInteger(
+          process.env.LINKEDIN_ASSISTANT_SCHEDULER_INITIAL_BACKOFF_SECONDS,
+          DEFAULT_SCHEDULER_INITIAL_BACKOFF_MS / 1_000
+        ) * 1_000,
+      maxBackoffMs:
+        parsePositiveInteger(
+          process.env.LINKEDIN_ASSISTANT_SCHEDULER_MAX_BACKOFF_SECONDS,
+          DEFAULT_SCHEDULER_MAX_BACKOFF_MS / 1_000
+        ) * 1_000
+    }
   };
 }
 

--- a/packages/core/src/db/database.ts
+++ b/packages/core/src/db/database.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import Database from "better-sqlite3";
+import type { SchedulerLane } from "../config.js";
 import { migrations, type Migration } from "./migrations.js";
 
 interface MigrationRow {
@@ -170,6 +171,111 @@ export interface SentInvitationFollowupConfirmedUpdate {
   confirmedAtMs: number;
   preparedActionId: string;
   updatedAtMs: number;
+}
+
+export const SCHEDULER_JOB_STATUSES = [
+  "pending",
+  "leased",
+  "prepared",
+  "failed",
+  "cancelled"
+] as const;
+
+export type SchedulerJobStatus = (typeof SCHEDULER_JOB_STATUSES)[number];
+
+export interface SchedulerJobInsert {
+  id: string;
+  profileName: string;
+  lane: SchedulerLane;
+  actionType: string;
+  targetJson: string;
+  dedupeKey: string;
+  scheduledAtMs: number;
+  status?: SchedulerJobStatus;
+  attemptCount?: number;
+  maxAttempts: number;
+  leaseOwner?: string | null;
+  leasedAtMs?: number | null;
+  leaseExpiresAtMs?: number | null;
+  preparedActionId?: string | null;
+  lastErrorCode?: string | null;
+  lastErrorMessage?: string | null;
+  lastAttemptAtMs?: number | null;
+  completedAtMs?: number | null;
+  createdAtMs: number;
+  updatedAtMs: number;
+}
+
+export interface SchedulerJobRow {
+  id: string;
+  profile_name: string;
+  lane: SchedulerLane;
+  action_type: string;
+  target_json: string;
+  dedupe_key: string;
+  scheduled_at: number;
+  status: SchedulerJobStatus;
+  attempt_count: number;
+  max_attempts: number;
+  lease_owner: string | null;
+  leased_at: number | null;
+  lease_expires_at: number | null;
+  prepared_action_id: string | null;
+  last_error_code: string | null;
+  last_error_message: string | null;
+  last_attempt_at: number | null;
+  completed_at: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface ClaimDueSchedulerJobsInput {
+  profileName: string;
+  nowMs: number;
+  limit: number;
+  leaseOwner: string;
+  leaseTtlMs: number;
+}
+
+export interface UpdateSchedulerJobScheduleInput {
+  id: string;
+  scheduledAtMs: number;
+  targetJson?: string;
+  updatedAtMs: number;
+}
+
+export interface RequeueSchedulerJobInput {
+  id: string;
+  scheduledAtMs: number;
+  targetJson?: string;
+  updatedAtMs: number;
+}
+
+export interface CompleteSchedulerJobInput {
+  id: string;
+  nowMs: number;
+  preparedActionId: string;
+}
+
+export interface RescheduleSchedulerJobInput {
+  id: string;
+  scheduledAtMs: number;
+  nowMs: number;
+  errorCode?: string | null;
+  errorMessage: string;
+}
+
+export interface FailSchedulerJobInput {
+  id: string;
+  nowMs: number;
+  errorCode?: string | null;
+  errorMessage: string;
+}
+
+export interface CancelSchedulerJobInput {
+  id: string;
+  nowMs: number;
+  reason: string;
 }
 
 export class AssistantDatabase {
@@ -672,6 +778,474 @@ SET
 WHERE profile_name = @profileName
   AND profile_url_key = @profileUrlKey
   AND followup_prepared_action_id = @preparedActionId
+`
+      )
+      .run(input);
+
+    return result.changes === 1;
+  }
+
+  getSentInvitationState(input: {
+    profileName: string;
+    profileUrlKey: string;
+  }): SentInvitationStateRow | undefined {
+    return this.db
+      .prepare<
+        {
+          profileName: string;
+          profileUrlKey: string;
+        },
+        SentInvitationStateRow
+      >(
+        `
+SELECT
+  profile_name,
+  profile_url_key,
+  vanity_name,
+  full_name,
+  headline,
+  profile_url,
+  first_seen_sent_at,
+  last_seen_sent_at,
+  closed_at,
+  closed_reason,
+  accepted_at,
+  accepted_detection,
+  followup_prepared_at,
+  followup_prepared_action_id,
+  followup_confirmed_at,
+  created_at,
+  updated_at
+FROM sent_invitation_state
+WHERE profile_name = @profileName
+  AND profile_url_key = @profileUrlKey
+LIMIT 1
+`
+      )
+      .get(input);
+  }
+
+  insertSchedulerJob(input: SchedulerJobInsert): void {
+    this.db
+      .prepare(
+        `
+INSERT INTO scheduler_job (
+  id,
+  profile_name,
+  lane,
+  action_type,
+  target_json,
+  dedupe_key,
+  scheduled_at,
+  status,
+  attempt_count,
+  max_attempts,
+  lease_owner,
+  leased_at,
+  lease_expires_at,
+  prepared_action_id,
+  last_error_code,
+  last_error_message,
+  last_attempt_at,
+  completed_at,
+  created_at,
+  updated_at
+)
+VALUES (
+  @id,
+  @profileName,
+  @lane,
+  @actionType,
+  @targetJson,
+  @dedupeKey,
+  @scheduledAtMs,
+  @status,
+  @attemptCount,
+  @maxAttempts,
+  @leaseOwner,
+  @leasedAtMs,
+  @leaseExpiresAtMs,
+  @preparedActionId,
+  @lastErrorCode,
+  @lastErrorMessage,
+  @lastAttemptAtMs,
+  @completedAtMs,
+  @createdAtMs,
+  @updatedAtMs
+)
+`
+      )
+      .run({
+        ...input,
+        attemptCount: input.attemptCount ?? 0,
+        status: input.status ?? "pending",
+        leaseOwner: input.leaseOwner ?? null,
+        leasedAtMs: input.leasedAtMs ?? null,
+        leaseExpiresAtMs: input.leaseExpiresAtMs ?? null,
+        preparedActionId: input.preparedActionId ?? null,
+        lastErrorCode: input.lastErrorCode ?? null,
+        lastErrorMessage: input.lastErrorMessage ?? null,
+        lastAttemptAtMs: input.lastAttemptAtMs ?? null,
+        completedAtMs: input.completedAtMs ?? null
+      });
+  }
+
+  getSchedulerJobById(id: string): SchedulerJobRow | undefined {
+    return this.db
+      .prepare<unknown[], SchedulerJobRow>(
+        `
+SELECT
+  id,
+  profile_name,
+  lane,
+  action_type,
+  target_json,
+  dedupe_key,
+  scheduled_at,
+  status,
+  attempt_count,
+  max_attempts,
+  lease_owner,
+  leased_at,
+  lease_expires_at,
+  prepared_action_id,
+  last_error_code,
+  last_error_message,
+  last_attempt_at,
+  completed_at,
+  created_at,
+  updated_at
+FROM scheduler_job
+WHERE id = ?
+LIMIT 1
+`
+      )
+      .get(id);
+  }
+
+  getSchedulerJobByDedupeKey(dedupeKey: string): SchedulerJobRow | undefined {
+    return this.db
+      .prepare<unknown[], SchedulerJobRow>(
+        `
+SELECT
+  id,
+  profile_name,
+  lane,
+  action_type,
+  target_json,
+  dedupe_key,
+  scheduled_at,
+  status,
+  attempt_count,
+  max_attempts,
+  lease_owner,
+  leased_at,
+  lease_expires_at,
+  prepared_action_id,
+  last_error_code,
+  last_error_message,
+  last_attempt_at,
+  completed_at,
+  created_at,
+  updated_at
+FROM scheduler_job
+WHERE dedupe_key = ?
+LIMIT 1
+`
+      )
+      .get(dedupeKey);
+  }
+
+  listSchedulerJobs(input: { profileName: string }): SchedulerJobRow[] {
+    return this.db
+      .prepare<{ profileName: string }, SchedulerJobRow>(
+        `
+SELECT
+  id,
+  profile_name,
+  lane,
+  action_type,
+  target_json,
+  dedupe_key,
+  scheduled_at,
+  status,
+  attempt_count,
+  max_attempts,
+  lease_owner,
+  leased_at,
+  lease_expires_at,
+  prepared_action_id,
+  last_error_code,
+  last_error_message,
+  last_attempt_at,
+  completed_at,
+  created_at,
+  updated_at
+FROM scheduler_job
+WHERE profile_name = @profileName
+ORDER BY
+  CASE lane
+    WHEN 'inbox_triage' THEN 0
+    WHEN 'pending_invite_checks' THEN 1
+    WHEN 'followup_preparation' THEN 2
+    WHEN 'feed_engagement' THEN 3
+    ELSE 99
+  END ASC,
+  scheduled_at ASC,
+  created_at ASC
+`
+      )
+      .all(input);
+  }
+
+  updateSchedulerJobSchedule(
+    input: UpdateSchedulerJobScheduleInput
+  ): boolean {
+    const result = this.db
+      .prepare(
+        `
+UPDATE scheduler_job
+SET
+  scheduled_at = @scheduledAtMs,
+  target_json = COALESCE(@targetJson, target_json),
+  updated_at = @updatedAtMs
+WHERE id = @id
+  AND status = 'pending'
+`
+      )
+      .run({
+        ...input,
+        targetJson: input.targetJson ?? null
+      });
+
+    return result.changes === 1;
+  }
+
+  requeueSchedulerJob(input: RequeueSchedulerJobInput): boolean {
+    const result = this.db
+      .prepare(
+        `
+UPDATE scheduler_job
+SET
+  status = 'pending',
+  scheduled_at = @scheduledAtMs,
+  target_json = COALESCE(@targetJson, target_json),
+  lease_owner = NULL,
+  leased_at = NULL,
+  lease_expires_at = NULL,
+  prepared_action_id = NULL,
+  last_error_code = NULL,
+  last_error_message = NULL,
+  completed_at = NULL,
+  updated_at = @updatedAtMs
+WHERE id = @id
+  AND (status = 'prepared' OR status = 'cancelled')
+`
+      )
+      .run({
+        ...input,
+        targetJson: input.targetJson ?? null
+      });
+
+    return result.changes === 1;
+  }
+
+  claimDueSchedulerJobs(input: ClaimDueSchedulerJobsInput): SchedulerJobRow[] {
+    const claimJobs = this.db.transaction(
+      (claimInput: ClaimDueSchedulerJobsInput): SchedulerJobRow[] => {
+        const candidates = this.db
+          .prepare<ClaimDueSchedulerJobsInput, SchedulerJobRow>(
+            `
+SELECT
+  id,
+  profile_name,
+  lane,
+  action_type,
+  target_json,
+  dedupe_key,
+  scheduled_at,
+  status,
+  attempt_count,
+  max_attempts,
+  lease_owner,
+  leased_at,
+  lease_expires_at,
+  prepared_action_id,
+  last_error_code,
+  last_error_message,
+  last_attempt_at,
+  completed_at,
+  created_at,
+  updated_at
+FROM scheduler_job
+WHERE profile_name = @profileName
+  AND scheduled_at <= @nowMs
+  AND (
+    status = 'pending'
+    OR (status = 'leased' AND lease_expires_at IS NOT NULL AND lease_expires_at < @nowMs)
+  )
+ORDER BY
+  CASE lane
+    WHEN 'inbox_triage' THEN 0
+    WHEN 'pending_invite_checks' THEN 1
+    WHEN 'followup_preparation' THEN 2
+    WHEN 'feed_engagement' THEN 3
+    ELSE 99
+  END ASC,
+  scheduled_at ASC,
+  created_at ASC
+LIMIT @limit
+`
+          )
+          .all(claimInput);
+
+        const claimed: SchedulerJobRow[] = [];
+        const leaseExpiresAtMs = claimInput.nowMs + claimInput.leaseTtlMs;
+
+        for (const candidate of candidates) {
+          const result = this.db
+            .prepare(
+              `
+UPDATE scheduler_job
+SET
+  status = 'leased',
+  lease_owner = @leaseOwner,
+  leased_at = @nowMs,
+  lease_expires_at = @leaseExpiresAtMs,
+  updated_at = @nowMs
+WHERE id = @id
+  AND scheduled_at <= @nowMs
+  AND (
+    status = 'pending'
+    OR (status = 'leased' AND lease_expires_at IS NOT NULL AND lease_expires_at < @nowMs)
+  )
+`
+            )
+            .run({
+              id: candidate.id,
+              leaseExpiresAtMs,
+              leaseOwner: claimInput.leaseOwner,
+              nowMs: claimInput.nowMs
+            });
+
+          if (result.changes === 1) {
+            claimed.push({
+              ...candidate,
+              status: "leased",
+              lease_owner: claimInput.leaseOwner,
+              leased_at: claimInput.nowMs,
+              lease_expires_at: leaseExpiresAtMs,
+              updated_at: claimInput.nowMs
+            });
+          }
+        }
+
+        return claimed;
+      }
+    );
+
+    return claimJobs(input);
+  }
+
+  markSchedulerJobPrepared(input: CompleteSchedulerJobInput): boolean {
+    const result = this.db
+      .prepare(
+        `
+UPDATE scheduler_job
+SET
+  status = 'prepared',
+  prepared_action_id = @preparedActionId,
+  lease_owner = NULL,
+  leased_at = NULL,
+  lease_expires_at = NULL,
+  last_error_code = NULL,
+  last_error_message = NULL,
+  last_attempt_at = @nowMs,
+  completed_at = @nowMs,
+  updated_at = @nowMs
+WHERE id = @id
+  AND status = 'leased'
+`
+      )
+      .run(input);
+
+    return result.changes === 1;
+  }
+
+  rescheduleSchedulerJob(input: RescheduleSchedulerJobInput): boolean {
+    const result = this.db
+      .prepare(
+        `
+UPDATE scheduler_job
+SET
+  status = 'pending',
+  attempt_count = attempt_count + 1,
+  scheduled_at = @scheduledAtMs,
+  lease_owner = NULL,
+  leased_at = NULL,
+  lease_expires_at = NULL,
+  last_error_code = @errorCode,
+  last_error_message = @errorMessage,
+  last_attempt_at = @nowMs,
+  completed_at = NULL,
+  updated_at = @nowMs
+WHERE id = @id
+  AND status = 'leased'
+`
+      )
+      .run({
+        ...input,
+        errorCode: input.errorCode ?? null
+      });
+
+    return result.changes === 1;
+  }
+
+  failSchedulerJob(input: FailSchedulerJobInput): boolean {
+    const result = this.db
+      .prepare(
+        `
+UPDATE scheduler_job
+SET
+  status = 'failed',
+  attempt_count = attempt_count + 1,
+  lease_owner = NULL,
+  leased_at = NULL,
+  lease_expires_at = NULL,
+  last_error_code = @errorCode,
+  last_error_message = @errorMessage,
+  last_attempt_at = @nowMs,
+  completed_at = @nowMs,
+  updated_at = @nowMs
+WHERE id = @id
+  AND status = 'leased'
+`
+      )
+      .run({
+        ...input,
+        errorCode: input.errorCode ?? null
+      });
+
+    return result.changes === 1;
+  }
+
+  cancelSchedulerJob(input: CancelSchedulerJobInput): boolean {
+    const result = this.db
+      .prepare(
+        `
+UPDATE scheduler_job
+SET
+  status = 'cancelled',
+  lease_owner = NULL,
+  leased_at = NULL,
+  lease_expires_at = NULL,
+  last_error_code = NULL,
+  last_error_message = @reason,
+  last_attempt_at = @nowMs,
+  completed_at = @nowMs,
+  updated_at = @nowMs
+WHERE id = @id
+  AND (status = 'pending' OR status = 'leased')
 `
       )
       .run(input);

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -177,5 +177,44 @@ CREATE INDEX IF NOT EXISTS sent_invitation_state_followup_action_idx
 ALTER TABLE prepared_action ADD COLUMN sealed_target_json TEXT;
 ALTER TABLE prepared_action ADD COLUMN sealed_payload_json TEXT;
 `
+  },
+  {
+    id: "005_scheduler_jobs",
+    sql: `
+CREATE TABLE IF NOT EXISTS scheduler_job (
+  id TEXT PRIMARY KEY,
+  profile_name TEXT NOT NULL,
+  lane TEXT NOT NULL,
+  action_type TEXT NOT NULL,
+  target_json TEXT NOT NULL,
+  dedupe_key TEXT NOT NULL UNIQUE,
+  scheduled_at INTEGER NOT NULL,
+  status TEXT NOT NULL,
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  max_attempts INTEGER NOT NULL DEFAULT 5,
+  lease_owner TEXT,
+  leased_at INTEGER,
+  lease_expires_at INTEGER,
+  prepared_action_id TEXT,
+  last_error_code TEXT,
+  last_error_message TEXT,
+  last_attempt_at INTEGER,
+  completed_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS scheduler_job_profile_status_schedule_idx
+  ON scheduler_job(profile_name, status, scheduled_at);
+
+CREATE INDEX IF NOT EXISTS scheduler_job_status_schedule_idx
+  ON scheduler_job(status, scheduled_at);
+
+CREATE INDEX IF NOT EXISTS scheduler_job_lane_schedule_idx
+  ON scheduler_job(lane, scheduled_at);
+
+CREATE INDEX IF NOT EXISTS scheduler_job_prepared_action_idx
+  ON scheduler_job(prepared_action_id);
+`
   }
 ];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,3 +30,5 @@ export * from "./runtime.js";
 export * from "./selectorLocale.js";
 export * from "./selectorAudit.js";
 export * from "./twoPhaseCommit.js";
+
+export * from "./scheduler.js";

--- a/packages/core/src/linkedinFollowups.ts
+++ b/packages/core/src/linkedinFollowups.ts
@@ -92,6 +92,13 @@ export interface PrepareFollowupsAfterAcceptInput {
   operatorNote?: string;
 }
 
+export interface PrepareAcceptedConnectionFollowupInput {
+  profileName?: string;
+  profileUrlKey: string;
+  operatorNote?: string;
+  refreshState?: boolean;
+}
+
 export interface PreparedAcceptedConnectionFollowup {
   connection: LinkedInAcceptedConnection;
   preparedActionId: string;
@@ -376,6 +383,12 @@ function deriveFollowupStatus(input: {
   }
 
   return "not_prepared";
+}
+
+function shouldPrepareAcceptedConnectionFollowup(
+  status: FollowupPreparationStatus
+): boolean {
+  return status === "not_prepared" || status === "failed" || status === "expired";
 }
 
 async function getOrCreatePage(context: BrowserContext): Promise<Page> {
@@ -1105,13 +1118,9 @@ export class LinkedInFollowupsService {
     const stateByKey = new Map(
       acceptedStates.map((state) => [state.profile_url_key, state])
     );
-    const candidates = acceptedConnections.filter((connection) => {
-      return (
-        connection.followup_status === "not_prepared" ||
-        connection.followup_status === "failed" ||
-        connection.followup_status === "expired"
-      );
-    });
+    const candidates = acceptedConnections.filter((connection) =>
+      shouldPrepareAcceptedConnectionFollowup(connection.followup_status)
+    );
 
     const preparedFollowups =
       candidates.length > 0
@@ -1137,6 +1146,37 @@ export class LinkedInFollowupsService {
       ),
       preparedFollowups
     };
+  }
+
+  async prepareFollowupForAcceptedConnection(
+    input: PrepareAcceptedConnectionFollowupInput
+  ): Promise<PreparedAcceptedConnectionFollowup | null> {
+    const profileName = input.profileName ?? "default";
+    if (input.refreshState) {
+      await this.refreshAcceptanceState(profileName);
+    }
+
+    const state = this.runtime.db.getSentInvitationState({
+      profileName,
+      profileUrlKey: input.profileUrlKey
+    });
+    if (!state || state.closed_at !== null || state.accepted_at === null) {
+      return null;
+    }
+
+    const connection = mapAcceptedConnection(this.runtime, state, Date.now());
+    if (!shouldPrepareAcceptedConnectionFollowup(connection.followup_status)) {
+      return null;
+    }
+
+    const prepared = await this.prepareAcceptedConnections(
+      profileName,
+      [connection],
+      new Map([[state.profile_url_key, state]]),
+      input.operatorNote
+    );
+
+    return prepared[0] ?? null;
   }
 
   private async refreshAcceptanceState(profileName: string): Promise<void> {

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -1,0 +1,761 @@
+import {
+  resolveSchedulerConfig,
+  type SchedulerBusinessHoursConfig,
+  type SchedulerConfig,
+  type SchedulerLane
+} from "./config.js";
+import type {
+  AssistantDatabase,
+  SchedulerJobRow
+} from "./db/database.js";
+import {
+  LinkedInAssistantError,
+  asLinkedInAssistantError,
+  type LinkedInAssistantErrorCode
+} from "./errors.js";
+import {
+  FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE,
+  type LinkedInAcceptedConnection,
+  type PreparedAcceptedConnectionFollowup,
+  type PrepareAcceptedConnectionFollowupInput
+} from "./linkedinFollowups.js";
+import type { JsonEventLogger } from "./logging.js";
+import { createRunId } from "./run.js";
+
+const FOLLOWUP_PREPARATION_LANE = "followup_preparation";
+const SCHEDULER_OPERATOR_NOTE = "Prepared by local scheduler.";
+
+interface TimeZoneDateTimeParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+}
+
+interface TimeOfDay {
+  hour: number;
+  minute: number;
+}
+
+interface SchedulerFollowupService {
+  listAcceptedConnections(input: {
+    profileName?: string;
+    sinceMs?: number;
+  }): Promise<LinkedInAcceptedConnection[]>;
+  prepareFollowupForAcceptedConnection(
+    input: PrepareAcceptedConnectionFollowupInput
+  ): Promise<PreparedAcceptedConnectionFollowup | null>;
+}
+
+export interface LinkedInSchedulerRuntime {
+  db: AssistantDatabase;
+  logger: JsonEventLogger;
+  followups: SchedulerFollowupService;
+  schedulerConfig?: SchedulerConfig;
+}
+
+export interface SchedulerTickJobResult {
+  jobId: string;
+  lane: SchedulerLane;
+  outcome: "prepared" | "rescheduled" | "failed" | "cancelled";
+  preparedActionId?: string;
+  errorCode?: string | null;
+  errorMessage?: string;
+  scheduledAtMs?: number;
+}
+
+export type SchedulerTickSkippedReason =
+  | "disabled"
+  | "outside_business_hours"
+  | "profile_busy"
+  | null;
+
+export interface SchedulerTickResult {
+  profileName: string;
+  workerId: string;
+  windowOpen: boolean;
+  nextWindowStartAt: string | null;
+  skippedReason: SchedulerTickSkippedReason;
+  discoveredAcceptedConnections: number;
+  queuedJobs: number;
+  updatedJobs: number;
+  reopenedJobs: number;
+  cancelledJobs: number;
+  claimedJobs: number;
+  preparedJobs: number;
+  rescheduledJobs: number;
+  failedJobs: number;
+  processedJobs: SchedulerTickJobResult[];
+}
+
+const timeFormatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function getTimeFormatter(timeZone: string): Intl.DateTimeFormat {
+  const cached = timeFormatterCache.get(timeZone);
+  if (cached) {
+    return cached;
+  }
+
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23"
+  });
+  timeFormatterCache.set(timeZone, formatter);
+  return formatter;
+}
+
+function getTimeZoneDateTimeParts(
+  utcMs: number,
+  timeZone: string
+): TimeZoneDateTimeParts {
+  const parts = getTimeFormatter(timeZone).formatToParts(new Date(utcMs));
+  const entries = Object.fromEntries(
+    parts
+      .filter((part) => part.type !== "literal")
+      .map((part) => [part.type, part.value])
+  );
+
+  return {
+    year: Number.parseInt(entries.year ?? "0", 10),
+    month: Number.parseInt(entries.month ?? "0", 10),
+    day: Number.parseInt(entries.day ?? "0", 10),
+    hour: Number.parseInt(entries.hour ?? "0", 10),
+    minute: Number.parseInt(entries.minute ?? "0", 10),
+    second: Number.parseInt(entries.second ?? "0", 10)
+  };
+}
+
+function getTimeZoneOffsetMs(utcMs: number, timeZone: string): number {
+  const parts = getTimeZoneDateTimeParts(utcMs, timeZone);
+  const asUtcMs = Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour,
+    parts.minute,
+    parts.second
+  );
+
+  return asUtcMs - utcMs;
+}
+
+function resolveUtcMsForLocalTime(
+  localDateTime: TimeZoneDateTimeParts,
+  timeZone: string
+): number {
+  const initialGuess = Date.UTC(
+    localDateTime.year,
+    localDateTime.month - 1,
+    localDateTime.day,
+    localDateTime.hour,
+    localDateTime.minute,
+    localDateTime.second
+  );
+  const firstOffset = getTimeZoneOffsetMs(initialGuess, timeZone);
+  let resolvedMs = initialGuess - firstOffset;
+  const secondOffset = getTimeZoneOffsetMs(resolvedMs, timeZone);
+
+  if (secondOffset !== firstOffset) {
+    resolvedMs = initialGuess - secondOffset;
+  }
+
+  return resolvedMs;
+}
+
+function addDays(
+  parts: Pick<TimeZoneDateTimeParts, "year" | "month" | "day">,
+  days: number
+): Pick<TimeZoneDateTimeParts, "year" | "month" | "day"> {
+  const shifted = new Date(Date.UTC(parts.year, parts.month - 1, parts.day + days));
+  return {
+    year: shifted.getUTCFullYear(),
+    month: shifted.getUTCMonth() + 1,
+    day: shifted.getUTCDate()
+  };
+}
+
+function parseClockTime(value: string): TimeOfDay {
+  const [hourText, minuteText] = value.split(":");
+  return {
+    hour: Number.parseInt(hourText ?? "0", 10),
+    minute: Number.parseInt(minuteText ?? "0", 10)
+  };
+}
+
+function toMinutesSinceMidnight(value: TimeOfDay): number {
+  return value.hour * 60 + value.minute;
+}
+
+function getLocalMinutesSinceMidnight(
+  utcMs: number,
+  businessHours: SchedulerBusinessHoursConfig
+): number {
+  const parts = getTimeZoneDateTimeParts(utcMs, businessHours.timeZone);
+  return parts.hour * 60 + parts.minute;
+}
+
+export function isWithinBusinessHours(
+  utcMs: number,
+  businessHours: SchedulerBusinessHoursConfig
+): boolean {
+  const currentMinutes = getLocalMinutesSinceMidnight(utcMs, businessHours);
+  const startMinutes = toMinutesSinceMidnight(parseClockTime(businessHours.startTime));
+  const endMinutes = toMinutesSinceMidnight(parseClockTime(businessHours.endTime));
+
+  return currentMinutes >= startMinutes && currentMinutes < endMinutes;
+}
+
+export function alignToBusinessHours(
+  utcMs: number,
+  businessHours: SchedulerBusinessHoursConfig
+): number {
+  if (isWithinBusinessHours(utcMs, businessHours)) {
+    return utcMs;
+  }
+
+  const local = getTimeZoneDateTimeParts(utcMs, businessHours.timeZone);
+  const currentMinutes = local.hour * 60 + local.minute;
+  const start = parseClockTime(businessHours.startTime);
+  const startMinutes = toMinutesSinceMidnight(start);
+
+  const nextDate =
+    currentMinutes < startMinutes
+      ? { year: local.year, month: local.month, day: local.day }
+      : addDays(local, 1);
+
+  return resolveUtcMsForLocalTime(
+    {
+      ...nextDate,
+      hour: start.hour,
+      minute: start.minute,
+      second: 0
+    },
+    businessHours.timeZone
+  );
+}
+
+export function calculateSchedulerBackoffMs(
+  failureCount: number,
+  retry: SchedulerConfig["retry"]
+): number {
+  const exponent = Math.max(0, failureCount - 1);
+  return Math.min(retry.maxBackoffMs, retry.initialBackoffMs * 2 ** exponent);
+}
+
+export function scheduleAcceptedConnectionFollowupAtMs(input: {
+  connection: LinkedInAcceptedConnection;
+  nowMs: number;
+  config: SchedulerConfig;
+}): number {
+  const baseMs =
+    input.connection.followup_status === "not_prepared"
+      ? input.connection.accepted_at_ms + input.config.followupDelayMs
+      : input.nowMs;
+
+  return alignToBusinessHours(
+    Math.max(baseMs, input.nowMs),
+    input.config.businessHours
+  );
+}
+
+function buildFollowupSchedulerDedupeKey(
+  profileName: string,
+  profileUrlKey: string
+): string {
+  return `${FOLLOWUP_PREPARATION_LANE}:${profileName}:${profileUrlKey}`;
+}
+
+function createSchedulerJobId(): string {
+  return `scheduler_job_${createRunId()}`;
+}
+
+function isFollowupPreparationCandidate(
+  connection: LinkedInAcceptedConnection
+): boolean {
+  return (
+    connection.followup_status === "not_prepared" ||
+    connection.followup_status === "failed" ||
+    connection.followup_status === "expired"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function getRequiredTargetField(
+  target: Record<string, unknown>,
+  key: string,
+  jobId: string
+): string {
+  const value = target[key];
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  throw new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    `Scheduler job ${jobId} is missing target.${key}.`,
+    {
+      job_id: jobId,
+      key
+    }
+  );
+}
+
+function parseFollowupSchedulerTarget(job: SchedulerJobRow): {
+  profileName: string;
+  profileUrlKey: string;
+} {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(job.target_json);
+  } catch (error) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `Scheduler job ${job.id} target_json is not valid JSON.`,
+      {
+        job_id: job.id,
+        cause: error instanceof Error ? error.message : String(error)
+      }
+    );
+  }
+
+  if (!isRecord(parsed)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `Scheduler job ${job.id} target_json must be an object.`,
+      {
+        job_id: job.id
+      }
+    );
+  }
+
+  return {
+    profileName: getRequiredTargetField(parsed, "profile_name", job.id),
+    profileUrlKey: getRequiredTargetField(parsed, "profile_url_key", job.id)
+  };
+}
+
+function isProfileBusyError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    /profile is busy|lock file is already being held/i.test(error.message)
+  );
+}
+
+function normalizeSchedulerError(error: unknown): {
+  code: LinkedInAssistantErrorCode | null;
+  message: string;
+  retryable: boolean;
+} {
+  const normalized = asLinkedInAssistantError(error);
+  const retryableCodes: LinkedInAssistantErrorCode[] = [
+    "AUTH_REQUIRED",
+    "CAPTCHA_OR_CHALLENGE",
+    "RATE_LIMITED",
+    "NETWORK_ERROR",
+    "TIMEOUT"
+  ];
+
+  if (retryableCodes.includes(normalized.code)) {
+    return {
+      code: normalized.code,
+      message: normalized.message,
+      retryable: true
+    };
+  }
+
+  if (normalized.code === "ACTION_PRECONDITION_FAILED" && isProfileBusyError(error)) {
+    return {
+      code: normalized.code,
+      message: normalized.message,
+      retryable: true
+    };
+  }
+
+  return {
+    code: normalized.code,
+    message: normalized.message,
+    retryable: false
+  };
+}
+
+function toIsoStringOrNull(utcMs: number | null): string | null {
+  return utcMs === null ? null : new Date(utcMs).toISOString();
+}
+
+export class LinkedInSchedulerService {
+  private readonly config: SchedulerConfig;
+
+  constructor(private readonly runtime: LinkedInSchedulerRuntime) {
+    this.config = runtime.schedulerConfig ?? resolveSchedulerConfig();
+  }
+
+  async runTick(input: {
+    profileName?: string;
+    nowMs?: number;
+    workerId?: string;
+  } = {}): Promise<SchedulerTickResult> {
+    const profileName = input.profileName ?? "default";
+    const nowMs = input.nowMs ?? Date.now();
+    const workerId = input.workerId ?? `scheduler:${createRunId()}`;
+    const windowOpen = isWithinBusinessHours(nowMs, this.config.businessHours);
+    const nextWindowStartMs = windowOpen
+      ? null
+      : alignToBusinessHours(nowMs, this.config.businessHours);
+
+    const summary: SchedulerTickResult = {
+      profileName,
+      workerId,
+      windowOpen,
+      nextWindowStartAt: toIsoStringOrNull(nextWindowStartMs),
+      skippedReason: null,
+      discoveredAcceptedConnections: 0,
+      queuedJobs: 0,
+      updatedJobs: 0,
+      reopenedJobs: 0,
+      cancelledJobs: 0,
+      claimedJobs: 0,
+      preparedJobs: 0,
+      rescheduledJobs: 0,
+      failedJobs: 0,
+      processedJobs: []
+    };
+
+    if (
+      !this.config.enabled ||
+      !this.config.enabledLanes.includes(FOLLOWUP_PREPARATION_LANE)
+    ) {
+      summary.skippedReason = "disabled";
+      return summary;
+    }
+
+    if (!windowOpen) {
+      summary.skippedReason = "outside_business_hours";
+      return summary;
+    }
+
+    this.runtime.logger.log("info", "scheduler.tick.start", {
+      profile_name: profileName,
+      worker_id: workerId,
+      business_hours: this.config.businessHours,
+      max_jobs_per_tick: this.config.maxJobsPerTick
+    });
+
+    let acceptedConnections: LinkedInAcceptedConnection[];
+
+    try {
+      acceptedConnections = await this.runtime.followups.listAcceptedConnections({
+        profileName,
+        sinceMs: this.config.followupLookbackMs
+      });
+    } catch (error) {
+      if (isProfileBusyError(error)) {
+        this.runtime.logger.log("info", "scheduler.tick.skipped_profile_busy", {
+          profile_name: profileName,
+          worker_id: workerId,
+          message: error instanceof Error ? error.message : String(error)
+        });
+        summary.skippedReason = "profile_busy";
+        return summary;
+      }
+
+      throw error;
+    }
+
+    summary.discoveredAcceptedConnections = acceptedConnections.length;
+
+    const syncResult = this.syncFollowupJobs({
+      acceptedConnections,
+      nowMs,
+      profileName
+    });
+    summary.queuedJobs = syncResult.queuedJobs;
+    summary.updatedJobs = syncResult.updatedJobs;
+    summary.reopenedJobs = syncResult.reopenedJobs;
+    summary.cancelledJobs = syncResult.cancelledJobs;
+
+    const claimedJobs = this.runtime.db.claimDueSchedulerJobs({
+      profileName,
+      nowMs,
+      limit: this.config.maxJobsPerTick,
+      leaseOwner: workerId,
+      leaseTtlMs: this.config.leaseTtlMs
+    });
+    summary.claimedJobs = claimedJobs.length;
+
+    for (const job of claimedJobs) {
+      const result = await this.processClaimedJob(job, nowMs);
+      summary.processedJobs.push(result);
+
+      if (result.outcome === "prepared") {
+        summary.preparedJobs += 1;
+      } else if (result.outcome === "rescheduled") {
+        summary.rescheduledJobs += 1;
+      } else if (result.outcome === "failed") {
+        summary.failedJobs += 1;
+      } else if (result.outcome === "cancelled") {
+        summary.cancelledJobs += 1;
+      }
+    }
+
+    this.runtime.logger.log("info", "scheduler.tick.done", {
+      profile_name: profileName,
+      worker_id: workerId,
+      queued_jobs: summary.queuedJobs,
+      updated_jobs: summary.updatedJobs,
+      reopened_jobs: summary.reopenedJobs,
+      cancelled_jobs: summary.cancelledJobs,
+      claimed_jobs: summary.claimedJobs,
+      prepared_jobs: summary.preparedJobs,
+      rescheduled_jobs: summary.rescheduledJobs,
+      failed_jobs: summary.failedJobs,
+      discovered_accepted_connections: summary.discoveredAcceptedConnections,
+      skipped_reason: summary.skippedReason
+    });
+
+    return summary;
+  }
+
+  private syncFollowupJobs(input: {
+    acceptedConnections: LinkedInAcceptedConnection[];
+    nowMs: number;
+    profileName: string;
+  }): {
+    queuedJobs: number;
+    updatedJobs: number;
+    reopenedJobs: number;
+    cancelledJobs: number;
+  } {
+    const candidates = [...input.acceptedConnections].sort((left, right) => {
+      return (
+        left.accepted_at_ms - right.accepted_at_ms ||
+        left.first_seen_sent_at_ms - right.first_seen_sent_at_ms
+      );
+    });
+
+    let queuedJobs = 0;
+    let updatedJobs = 0;
+    let reopenedJobs = 0;
+    let cancelledJobs = 0;
+
+    for (const connection of candidates) {
+      const dedupeKey = buildFollowupSchedulerDedupeKey(
+        input.profileName,
+        connection.profile_url_key
+      );
+      const existing = this.runtime.db.getSchedulerJobByDedupeKey(dedupeKey);
+
+      if (!isFollowupPreparationCandidate(connection)) {
+        if (existing?.status === "pending") {
+          const cancelled = this.runtime.db.cancelSchedulerJob({
+            id: existing.id,
+            nowMs: input.nowMs,
+            reason: `Follow-up already ${connection.followup_status}.`
+          });
+          if (cancelled) {
+            cancelledJobs += 1;
+          }
+        }
+        continue;
+      }
+
+      const scheduledAtMs = scheduleAcceptedConnectionFollowupAtMs({
+        connection,
+        nowMs: input.nowMs,
+        config: this.config
+      });
+      const targetJson = JSON.stringify({
+        profile_name: input.profileName,
+        profile_url_key: connection.profile_url_key
+      });
+
+      if (!existing) {
+        this.runtime.db.insertSchedulerJob({
+          id: createSchedulerJobId(),
+          profileName: input.profileName,
+          lane: FOLLOWUP_PREPARATION_LANE,
+          actionType: FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE,
+          targetJson,
+          dedupeKey,
+          scheduledAtMs,
+          maxAttempts: this.config.retry.maxAttempts,
+          createdAtMs: input.nowMs,
+          updatedAtMs: input.nowMs
+        });
+        queuedJobs += 1;
+        continue;
+      }
+
+      if (existing.status === "pending") {
+        if (scheduledAtMs < existing.scheduled_at || targetJson !== existing.target_json) {
+          const updated = this.runtime.db.updateSchedulerJobSchedule({
+            id: existing.id,
+            scheduledAtMs,
+            targetJson,
+            updatedAtMs: input.nowMs
+          });
+          if (updated) {
+            updatedJobs += 1;
+          }
+        }
+        continue;
+      }
+
+      if (
+        existing.status === "cancelled" ||
+        (existing.status === "prepared" && connection.followup_status !== "prepared" && connection.followup_status !== "executed")
+      ) {
+        const reopened = this.runtime.db.requeueSchedulerJob({
+          id: existing.id,
+          scheduledAtMs,
+          targetJson,
+          updatedAtMs: input.nowMs
+        });
+        if (reopened) {
+          reopenedJobs += 1;
+        }
+      }
+    }
+
+    return {
+      queuedJobs,
+      updatedJobs,
+      reopenedJobs,
+      cancelledJobs
+    };
+  }
+
+  private async processClaimedJob(
+    job: SchedulerJobRow,
+    nowMs: number
+  ): Promise<SchedulerTickJobResult> {
+    if (job.lane !== FOLLOWUP_PREPARATION_LANE) {
+      this.runtime.db.cancelSchedulerJob({
+        id: job.id,
+        nowMs,
+        reason: `Lane ${job.lane} is not executable in this scheduler build.`
+      });
+      return {
+        jobId: job.id,
+        lane: job.lane,
+        outcome: "cancelled"
+      };
+    }
+
+    try {
+      const target = parseFollowupSchedulerTarget(job);
+      const prepared = await this.runtime.followups.prepareFollowupForAcceptedConnection({
+        profileName: target.profileName,
+        profileUrlKey: target.profileUrlKey,
+        operatorNote: SCHEDULER_OPERATOR_NOTE,
+        refreshState: false
+      });
+
+      if (!prepared) {
+        this.runtime.db.cancelSchedulerJob({
+          id: job.id,
+          nowMs,
+          reason: "Follow-up no longer needs preparation."
+        });
+        this.runtime.logger.log("info", "scheduler.job.cancelled", {
+          job_id: job.id,
+          lane: job.lane,
+          profile_name: target.profileName,
+          profile_url_key: target.profileUrlKey,
+          reason: "Follow-up no longer needs preparation."
+        });
+        return {
+          jobId: job.id,
+          lane: job.lane,
+          outcome: "cancelled"
+        };
+      }
+
+      this.runtime.db.markSchedulerJobPrepared({
+        id: job.id,
+        nowMs,
+        preparedActionId: prepared.preparedActionId
+      });
+      this.runtime.logger.log("info", "scheduler.job.prepared", {
+        job_id: job.id,
+        lane: job.lane,
+        prepared_action_id: prepared.preparedActionId,
+        target_profile_url_key: target.profileUrlKey
+      });
+      return {
+        jobId: job.id,
+        lane: job.lane,
+        outcome: "prepared",
+        preparedActionId: prepared.preparedActionId
+      };
+    } catch (error) {
+      const normalizedError = normalizeSchedulerError(error);
+      const nextAttempt = job.attempt_count + 1;
+
+      if (normalizedError.retryable && nextAttempt < job.max_attempts) {
+        const backoffMs = calculateSchedulerBackoffMs(nextAttempt, this.config.retry);
+        const scheduledAtMs = alignToBusinessHours(
+          nowMs + backoffMs,
+          this.config.businessHours
+        );
+
+        this.runtime.db.rescheduleSchedulerJob({
+          id: job.id,
+          scheduledAtMs,
+          nowMs,
+          errorCode: normalizedError.code,
+          errorMessage: normalizedError.message
+        });
+        this.runtime.logger.log("warn", "scheduler.job.rescheduled", {
+          job_id: job.id,
+          lane: job.lane,
+          error_code: normalizedError.code,
+          error_message: normalizedError.message,
+          next_attempt: nextAttempt,
+          scheduled_at: new Date(scheduledAtMs).toISOString()
+        });
+        return {
+          jobId: job.id,
+          lane: job.lane,
+          outcome: "rescheduled",
+          errorCode: normalizedError.code,
+          errorMessage: normalizedError.message,
+          scheduledAtMs
+        };
+      }
+
+      this.runtime.db.failSchedulerJob({
+        id: job.id,
+        nowMs,
+        errorCode: normalizedError.code,
+        errorMessage: normalizedError.message
+      });
+      this.runtime.logger.log("error", "scheduler.job.failed", {
+        job_id: job.id,
+        lane: job.lane,
+        error_code: normalizedError.code,
+        error_message: normalizedError.message,
+        attempt_count: nextAttempt,
+        max_attempts: job.max_attempts
+      });
+      return {
+        jobId: job.id,
+        lane: job.lane,
+        outcome: "failed",
+        errorCode: normalizedError.code,
+        errorMessage: normalizedError.message
+      };
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a SQLite-backed `scheduler_job` queue with leasing, dedupe, and retry/backoff helpers
- add a local scheduler service that respects business hours and only prepares follow-up actions for manual confirmation
- add `linkedin scheduler start|status|stop|run-once` plus focused scheduler and single-target follow-up tests

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #5