### PR TITLE
fix: harden scheduled follow-up state flow for #99

### DIFF
--- a/packages/core/src/__tests__/scheduler.test.ts
+++ b/packages/core/src/__tests__/scheduler.test.ts
@@ -245,6 +245,152 @@ describe("scheduler DB helpers", () => {
       db.close();
     }
   });
+
+  it("only lets the active lease owner finalize leased jobs", () => {
+    const db = new AssistantDatabase(":memory:");
+
+    try {
+      for (const id of [
+        "job_prepare",
+        "job_reschedule",
+        "job_fail",
+        "job_cancel"
+      ]) {
+        db.insertSchedulerJob({
+          id,
+          profileName: "default",
+          lane: "followup_preparation",
+          actionType: "scheduler.test",
+          targetJson: "{}",
+          dedupeKey: `followup_preparation:default:${id}`,
+          scheduledAtMs: FIXED_NOW,
+          maxAttempts: 5,
+          createdAtMs: FIXED_NOW,
+          updatedAtMs: FIXED_NOW
+        });
+      }
+
+      const firstClaimed = db.claimDueSchedulerJobs({
+        profileName: "default",
+        nowMs: FIXED_NOW,
+        limit: 4,
+        leaseOwner: "worker-1",
+        leaseTtlMs: 60_000
+      });
+      expect(firstClaimed).toHaveLength(4);
+
+      const reclaimAtMs = FIXED_NOW + 61_000;
+      const reclaimed = db.claimDueSchedulerJobs({
+        profileName: "default",
+        nowMs: reclaimAtMs,
+        limit: 4,
+        leaseOwner: "worker-2",
+        leaseTtlMs: 60_000
+      });
+      expect(reclaimed).toHaveLength(4);
+
+      expect(
+        db.markSchedulerJobPrepared({
+          id: "job_prepare",
+          nowMs: reclaimAtMs,
+          preparedActionId: "prepared_action",
+          leaseOwner: "worker-1"
+        })
+      ).toBe(false);
+      expect(
+        db.markSchedulerJobPrepared({
+          id: "job_prepare",
+          nowMs: reclaimAtMs,
+          preparedActionId: "prepared_action",
+          leaseOwner: "worker-2"
+        })
+      ).toBe(true);
+
+      expect(
+        db.rescheduleSchedulerJob({
+          id: "job_reschedule",
+          scheduledAtMs: reclaimAtMs + 60_000,
+          nowMs: reclaimAtMs,
+          leaseOwner: "worker-1",
+          errorMessage: "retry later"
+        })
+      ).toBe(false);
+      expect(
+        db.rescheduleSchedulerJob({
+          id: "job_reschedule",
+          scheduledAtMs: reclaimAtMs + 60_000,
+          nowMs: reclaimAtMs,
+          leaseOwner: "worker-2",
+          errorMessage: "retry later"
+        })
+      ).toBe(true);
+
+      expect(
+        db.failSchedulerJob({
+          id: "job_fail",
+          nowMs: reclaimAtMs,
+          leaseOwner: "worker-1",
+          errorMessage: "give up"
+        })
+      ).toBe(false);
+      expect(
+        db.failSchedulerJob({
+          id: "job_fail",
+          nowMs: reclaimAtMs,
+          leaseOwner: "worker-2",
+          errorMessage: "give up"
+        })
+      ).toBe(true);
+
+      expect(
+        db.cancelSchedulerJob({
+          id: "job_cancel",
+          nowMs: reclaimAtMs,
+          reason: "not needed",
+          leaseOwner: "worker-1"
+        })
+      ).toBe(false);
+      expect(
+        db.cancelSchedulerJob({
+          id: "job_cancel",
+          nowMs: reclaimAtMs,
+          reason: "not needed",
+          leaseOwner: "worker-2"
+        })
+      ).toBe(true);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("still cancels pending jobs without a lease owner", () => {
+    const db = new AssistantDatabase(":memory:");
+
+    try {
+      db.insertSchedulerJob({
+        id: "job_pending_cancel",
+        profileName: "default",
+        lane: "followup_preparation",
+        actionType: "scheduler.test",
+        targetJson: "{}",
+        dedupeKey: "followup_preparation:default:job_pending_cancel",
+        scheduledAtMs: FIXED_NOW,
+        maxAttempts: 5,
+        createdAtMs: FIXED_NOW,
+        updatedAtMs: FIXED_NOW
+      });
+
+      expect(
+        db.cancelSchedulerJob({
+          id: "job_pending_cancel",
+          nowMs: FIXED_NOW,
+          reason: "obsolete"
+        })
+      ).toBe(true);
+    } finally {
+      db.close();
+    }
+  });
 });
 
 describe("LinkedInSchedulerService", () => {

--- a/packages/core/src/db/database.ts
+++ b/packages/core/src/db/database.ts
@@ -255,12 +255,14 @@ export interface CompleteSchedulerJobInput {
   id: string;
   nowMs: number;
   preparedActionId: string;
+  leaseOwner: string;
 }
 
 export interface RescheduleSchedulerJobInput {
   id: string;
   scheduledAtMs: number;
   nowMs: number;
+  leaseOwner: string;
   errorCode?: string | null;
   errorMessage: string;
 }
@@ -268,6 +270,7 @@ export interface RescheduleSchedulerJobInput {
 export interface FailSchedulerJobInput {
   id: string;
   nowMs: number;
+  leaseOwner: string;
   errorCode?: string | null;
   errorMessage: string;
 }
@@ -276,7 +279,66 @@ export interface CancelSchedulerJobInput {
   id: string;
   nowMs: number;
   reason: string;
+  leaseOwner?: string | null;
 }
+
+const PREPARED_ACTION_SELECT_COLUMNS = `
+  id,
+  action_type,
+  target_json,
+  sealed_target_json,
+  payload_json,
+  sealed_payload_json,
+  preview_json,
+  payload_hash,
+  preview_hash,
+  status,
+  confirm_token_hash,
+  expires_at,
+  created_at,
+  confirmed_at,
+  operator_note,
+  executed_at,
+  execution_result_json,
+  error_code,
+  error_message
+`;
+
+const SCHEDULER_JOB_SELECT_COLUMNS = `
+  id,
+  profile_name,
+  lane,
+  action_type,
+  target_json,
+  dedupe_key,
+  scheduled_at,
+  status,
+  attempt_count,
+  max_attempts,
+  lease_owner,
+  leased_at,
+  lease_expires_at,
+  prepared_action_id,
+  last_error_code,
+  last_error_message,
+  last_attempt_at,
+  completed_at,
+  created_at,
+  updated_at
+`;
+
+const SCHEDULER_JOB_ORDER_BY = `
+ORDER BY
+  CASE lane
+    WHEN 'inbox_triage' THEN 0
+    WHEN 'pending_invite_checks' THEN 1
+    WHEN 'followup_preparation' THEN 2
+    WHEN 'feed_engagement' THEN 3
+    ELSE 99
+  END ASC,
+  scheduled_at ASC,
+  created_at ASC
+`;
 
 export class AssistantDatabase {
   private readonly db: Database.Database;
@@ -367,30 +429,31 @@ VALUES (
       .prepare<unknown[], PreparedActionRow>(
         `
 SELECT
-  id,
-  action_type,
-  target_json,
-  sealed_target_json,
-  payload_json,
-  sealed_payload_json,
-  preview_json,
-  payload_hash,
-  preview_hash,
-  status,
-  confirm_token_hash,
-  expires_at,
-  created_at,
-  confirmed_at,
-  operator_note,
-  executed_at,
-  execution_result_json,
-  error_code,
-  error_message
+${PREPARED_ACTION_SELECT_COLUMNS}
 FROM prepared_action
 WHERE id = ?
 `
       )
       .get(id);
+  }
+
+  listPreparedActionsByIds(ids: string[]): PreparedActionRow[] {
+    if (ids.length === 0) {
+      return [];
+    }
+
+    const placeholders = ids.map(() => "?").join(", ");
+
+    return this.db
+      .prepare<unknown[], PreparedActionRow>(
+        `
+SELECT
+${PREPARED_ACTION_SELECT_COLUMNS}
+FROM prepared_action
+WHERE id IN (${placeholders})
+`
+      )
+      .all(...ids);
   }
 
   getPreparedActionByConfirmTokenHash(
@@ -400,25 +463,7 @@ WHERE id = ?
       .prepare<unknown[], PreparedActionRow>(
         `
 SELECT
-  id,
-  action_type,
-  target_json,
-  sealed_target_json,
-  payload_json,
-  sealed_payload_json,
-  preview_json,
-  payload_hash,
-  preview_hash,
-  status,
-  confirm_token_hash,
-  expires_at,
-  created_at,
-  confirmed_at,
-  operator_note,
-  executed_at,
-  execution_result_json,
-  error_code,
-  error_message
+${PREPARED_ACTION_SELECT_COLUMNS}
 FROM prepared_action
 WHERE confirm_token_hash = ?
 ORDER BY created_at DESC
@@ -895,26 +940,7 @@ VALUES (
       .prepare<unknown[], SchedulerJobRow>(
         `
 SELECT
-  id,
-  profile_name,
-  lane,
-  action_type,
-  target_json,
-  dedupe_key,
-  scheduled_at,
-  status,
-  attempt_count,
-  max_attempts,
-  lease_owner,
-  leased_at,
-  lease_expires_at,
-  prepared_action_id,
-  last_error_code,
-  last_error_message,
-  last_attempt_at,
-  completed_at,
-  created_at,
-  updated_at
+${SCHEDULER_JOB_SELECT_COLUMNS}
 FROM scheduler_job
 WHERE id = ?
 LIMIT 1
@@ -923,76 +949,15 @@ LIMIT 1
       .get(id);
   }
 
-  getSchedulerJobByDedupeKey(dedupeKey: string): SchedulerJobRow | undefined {
-    return this.db
-      .prepare<unknown[], SchedulerJobRow>(
-        `
-SELECT
-  id,
-  profile_name,
-  lane,
-  action_type,
-  target_json,
-  dedupe_key,
-  scheduled_at,
-  status,
-  attempt_count,
-  max_attempts,
-  lease_owner,
-  leased_at,
-  lease_expires_at,
-  prepared_action_id,
-  last_error_code,
-  last_error_message,
-  last_attempt_at,
-  completed_at,
-  created_at,
-  updated_at
-FROM scheduler_job
-WHERE dedupe_key = ?
-LIMIT 1
-`
-      )
-      .get(dedupeKey);
-  }
-
   listSchedulerJobs(input: { profileName: string }): SchedulerJobRow[] {
     return this.db
       .prepare<{ profileName: string }, SchedulerJobRow>(
         `
 SELECT
-  id,
-  profile_name,
-  lane,
-  action_type,
-  target_json,
-  dedupe_key,
-  scheduled_at,
-  status,
-  attempt_count,
-  max_attempts,
-  lease_owner,
-  leased_at,
-  lease_expires_at,
-  prepared_action_id,
-  last_error_code,
-  last_error_message,
-  last_attempt_at,
-  completed_at,
-  created_at,
-  updated_at
+${SCHEDULER_JOB_SELECT_COLUMNS}
 FROM scheduler_job
 WHERE profile_name = @profileName
-ORDER BY
-  CASE lane
-    WHEN 'inbox_triage' THEN 0
-    WHEN 'pending_invite_checks' THEN 1
-    WHEN 'followup_preparation' THEN 2
-    WHEN 'feed_engagement' THEN 3
-    ELSE 99
-  END ASC,
-  scheduled_at ASC,
-  created_at ASC
+${SCHEDULER_JOB_ORDER_BY}
 `
       )
       .all(input);
@@ -1057,26 +1022,7 @@ WHERE id = @id
           .prepare<ClaimDueSchedulerJobsInput, SchedulerJobRow>(
             `
 SELECT
-  id,
-  profile_name,
-  lane,
-  action_type,
-  target_json,
-  dedupe_key,
-  scheduled_at,
-  status,
-  attempt_count,
-  max_attempts,
-  lease_owner,
-  leased_at,
-  lease_expires_at,
-  prepared_action_id,
-  last_error_code,
-  last_error_message,
-  last_attempt_at,
-  completed_at,
-  created_at,
-  updated_at
+${SCHEDULER_JOB_SELECT_COLUMNS}
 FROM scheduler_job
 WHERE profile_name = @profileName
   AND scheduled_at <= @nowMs
@@ -1084,16 +1030,7 @@ WHERE profile_name = @profileName
     status = 'pending'
     OR (status = 'leased' AND lease_expires_at IS NOT NULL AND lease_expires_at < @nowMs)
   )
-ORDER BY
-  CASE lane
-    WHEN 'inbox_triage' THEN 0
-    WHEN 'pending_invite_checks' THEN 1
-    WHEN 'followup_preparation' THEN 2
-    WHEN 'feed_engagement' THEN 3
-    ELSE 99
-  END ASC,
-  scheduled_at ASC,
-  created_at ASC
+${SCHEDULER_JOB_ORDER_BY}
 LIMIT @limit
 `
           )
@@ -1165,6 +1102,7 @@ SET
   updated_at = @nowMs
 WHERE id = @id
   AND status = 'leased'
+  AND lease_owner = @leaseOwner
 `
       )
       .run(input);
@@ -1191,6 +1129,7 @@ SET
   updated_at = @nowMs
 WHERE id = @id
   AND status = 'leased'
+  AND lease_owner = @leaseOwner
 `
       )
       .run({
@@ -1219,6 +1158,7 @@ SET
   updated_at = @nowMs
 WHERE id = @id
   AND status = 'leased'
+  AND lease_owner = @leaseOwner
 `
       )
       .run({
@@ -1245,10 +1185,16 @@ SET
   completed_at = @nowMs,
   updated_at = @nowMs
 WHERE id = @id
-  AND (status = 'pending' OR status = 'leased')
+  AND (
+    (status = 'pending' AND @leaseOwner IS NULL)
+    OR (status = 'leased' AND lease_owner = @leaseOwner)
+  )
 `
       )
-      .run(input);
+      .run({
+        ...input,
+        leaseOwner: input.leaseOwner ?? null
+      });
 
     return result.changes === 1;
   }

--- a/packages/core/src/linkedinFollowups.ts
+++ b/packages/core/src/linkedinFollowups.ts
@@ -6,7 +6,11 @@ import {
 } from "playwright-core";
 import type { ArtifactHelpers } from "./artifacts.js";
 import type { LinkedInAuthService } from "./auth/session.js";
-import type { AssistantDatabase, SentInvitationStateRow } from "./db/database.js";
+import type {
+  AssistantDatabase,
+  PreparedActionRow,
+  SentInvitationStateRow
+} from "./db/database.js";
 import {
   LinkedInAssistantError,
   asLinkedInAssistantError
@@ -761,13 +765,10 @@ async function validateMessageSurfaceTarget(
 }
 
 function mapAcceptedConnection(
-  runtime: Pick<LinkedInFollowupsRuntime, "db">,
   state: SentInvitationStateRow,
-  nowMs: number
+  nowMs: number,
+  preparedAction?: Pick<PreparedActionRow, "status" | "expires_at">
 ): LinkedInAcceptedConnection {
-  const preparedAction = state.followup_prepared_action_id
-    ? runtime.db.getPreparedActionById(state.followup_prepared_action_id)
-    : undefined;
 
   return {
     profile_url_key: state.profile_url_key,
@@ -790,6 +791,35 @@ function mapAcceptedConnection(
     followup_confirmed_at_ms: state.followup_confirmed_at,
     followup_expires_at_ms: preparedAction?.expires_at ?? null
   };
+}
+
+function mapAcceptedConnections(
+  db: Pick<AssistantDatabase, "listPreparedActionsByIds">,
+  states: SentInvitationStateRow[],
+  nowMs: number
+): LinkedInAcceptedConnection[] {
+  const preparedActionIds = [...new Set(
+    states
+      .map((state) => state.followup_prepared_action_id)
+      .filter((preparedActionId): preparedActionId is string =>
+        typeof preparedActionId === "string" && preparedActionId.length > 0
+      )
+  )];
+  const preparedActionsById = new Map(
+    db
+      .listPreparedActionsByIds(preparedActionIds)
+      .map((preparedAction) => [preparedAction.id, preparedAction])
+  );
+
+  return states.map((state) =>
+    mapAcceptedConnection(
+      state,
+      nowMs,
+      state.followup_prepared_action_id
+        ? preparedActionsById.get(state.followup_prepared_action_id)
+        : undefined
+    )
+  );
 }
 
 export class FollowupAfterAcceptActionExecutor
@@ -1081,6 +1111,30 @@ export function createFollowupActionExecutors(): Record<
 export class LinkedInFollowupsService {
   constructor(private readonly runtime: LinkedInFollowupsRuntime) {}
 
+  private loadAcceptedConnections(input: {
+    profileName: string;
+    cutoffMs: number;
+    nowMs?: number;
+  }): {
+    acceptedStates: SentInvitationStateRow[];
+    acceptedConnections: LinkedInAcceptedConnection[];
+  } {
+    const acceptedStates = this.runtime.db.listAcceptedSentInvitations({
+      profileName: input.profileName,
+      sinceMs: input.cutoffMs
+    });
+    const acceptedConnections = mapAcceptedConnections(
+      this.runtime.db,
+      acceptedStates,
+      input.nowMs ?? Date.now()
+    );
+
+    return {
+      acceptedStates,
+      acceptedConnections
+    };
+  }
+
   async listAcceptedConnections(
     input: ListAcceptedConnectionsInput = {}
   ): Promise<LinkedInAcceptedConnection[]> {
@@ -1089,13 +1143,10 @@ export class LinkedInFollowupsService {
 
     await this.refreshAcceptanceState(profileName);
 
-    const nowMs = Date.now();
-    return this.runtime.db
-      .listAcceptedSentInvitations({
-        profileName,
-        sinceMs: cutoffMs
-      })
-      .map((state) => mapAcceptedConnection(this.runtime, state, nowMs));
+    return this.loadAcceptedConnections({
+      profileName,
+      cutoffMs
+    }).acceptedConnections;
   }
 
   async prepareFollowupsAfterAccept(
@@ -1106,14 +1157,10 @@ export class LinkedInFollowupsService {
 
     await this.refreshAcceptanceState(profileName);
 
-    const nowMs = Date.now();
-    const acceptedStates = this.runtime.db.listAcceptedSentInvitations({
+    const { acceptedStates, acceptedConnections } = this.loadAcceptedConnections({
       profileName,
-      sinceMs: cutoffMs
+      cutoffMs
     });
-    const acceptedConnections = acceptedStates.map((state) =>
-      mapAcceptedConnection(this.runtime, state, nowMs)
-    );
 
     const stateByKey = new Map(
       acceptedStates.map((state) => [state.profile_url_key, state])
@@ -1164,7 +1211,11 @@ export class LinkedInFollowupsService {
       return null;
     }
 
-    const connection = mapAcceptedConnection(this.runtime, state, Date.now());
+    const connection = mapAcceptedConnections(this.runtime.db, [state], Date.now())[0];
+    if (!connection) {
+      return null;
+    }
+
     if (!shouldPrepareAcceptedConnectionFollowup(connection.followup_status)) {
       return null;
     }

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -346,6 +346,22 @@ function parseFollowupSchedulerTarget(job: SchedulerJobRow): {
   };
 }
 
+function getSchedulerJobLeaseOwner(job: SchedulerJobRow): string {
+  if (typeof job.lease_owner === "string" && job.lease_owner.length > 0) {
+    return job.lease_owner;
+  }
+
+  throw new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    `Scheduler job ${job.id} is missing an active lease owner.`,
+    {
+      job_id: job.id,
+      lane: job.lane,
+      status: job.status
+    }
+  );
+}
+
 function isProfileBusyError(error: unknown): boolean {
   return (
     error instanceof Error &&
@@ -543,6 +559,11 @@ export class LinkedInSchedulerService {
         left.first_seen_sent_at_ms - right.first_seen_sent_at_ms
       );
     });
+    const existingJobsByDedupeKey = new Map(
+      this.runtime.db
+        .listSchedulerJobs({ profileName: input.profileName })
+        .map((job) => [job.dedupe_key, job])
+    );
 
     let queuedJobs = 0;
     let updatedJobs = 0;
@@ -554,7 +575,7 @@ export class LinkedInSchedulerService {
         input.profileName,
         connection.profile_url_key
       );
-      const existing = this.runtime.db.getSchedulerJobByDedupeKey(dedupeKey);
+      const existing = existingJobsByDedupeKey.get(dedupeKey);
 
       if (!isFollowupPreparationCandidate(connection)) {
         if (existing?.status === "pending") {
@@ -581,18 +602,42 @@ export class LinkedInSchedulerService {
       });
 
       if (!existing) {
-        this.runtime.db.insertSchedulerJob({
+        const insertedJob: SchedulerJobRow = {
           id: createSchedulerJobId(),
-          profileName: input.profileName,
+          profile_name: input.profileName,
           lane: FOLLOWUP_PREPARATION_LANE,
-          actionType: FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE,
-          targetJson,
-          dedupeKey,
-          scheduledAtMs,
-          maxAttempts: this.config.retry.maxAttempts,
-          createdAtMs: input.nowMs,
-          updatedAtMs: input.nowMs
+          action_type: FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE,
+          target_json: targetJson,
+          dedupe_key: dedupeKey,
+          scheduled_at: scheduledAtMs,
+          status: "pending",
+          attempt_count: 0,
+          max_attempts: this.config.retry.maxAttempts,
+          lease_owner: null,
+          leased_at: null,
+          lease_expires_at: null,
+          prepared_action_id: null,
+          last_error_code: null,
+          last_error_message: null,
+          last_attempt_at: null,
+          completed_at: null,
+          created_at: input.nowMs,
+          updated_at: input.nowMs
+        };
+
+        this.runtime.db.insertSchedulerJob({
+          id: insertedJob.id,
+          profileName: insertedJob.profile_name,
+          lane: insertedJob.lane,
+          actionType: insertedJob.action_type,
+          targetJson: insertedJob.target_json,
+          dedupeKey: insertedJob.dedupe_key,
+          scheduledAtMs: insertedJob.scheduled_at,
+          maxAttempts: insertedJob.max_attempts,
+          createdAtMs: insertedJob.created_at,
+          updatedAtMs: insertedJob.updated_at
         });
+        existingJobsByDedupeKey.set(dedupeKey, insertedJob);
         queuedJobs += 1;
         continue;
       }
@@ -640,12 +685,25 @@ export class LinkedInSchedulerService {
     job: SchedulerJobRow,
     nowMs: number
   ): Promise<SchedulerTickJobResult> {
+    const leaseOwner = getSchedulerJobLeaseOwner(job);
+
     if (job.lane !== FOLLOWUP_PREPARATION_LANE) {
-      this.runtime.db.cancelSchedulerJob({
+      const cancelled = this.runtime.db.cancelSchedulerJob({
         id: job.id,
         nowMs,
-        reason: `Lane ${job.lane} is not executable in this scheduler build.`
+        reason: `Lane ${job.lane} is not executable in this scheduler build.`,
+        leaseOwner
       });
+
+      if (!cancelled) {
+        this.runtime.logger.log("info", "scheduler.job.superseded", {
+          job_id: job.id,
+          lane: job.lane,
+          lease_owner: leaseOwner,
+          outcome: "cancelled_unsupported_lane"
+        });
+      }
+
       return {
         jobId: job.id,
         lane: job.lane,
@@ -663,11 +721,22 @@ export class LinkedInSchedulerService {
       });
 
       if (!prepared) {
-        this.runtime.db.cancelSchedulerJob({
+        const cancelled = this.runtime.db.cancelSchedulerJob({
           id: job.id,
           nowMs,
-          reason: "Follow-up no longer needs preparation."
+          reason: "Follow-up no longer needs preparation.",
+          leaseOwner
         });
+
+        if (!cancelled) {
+          this.runtime.logger.log("info", "scheduler.job.superseded", {
+            job_id: job.id,
+            lane: job.lane,
+            lease_owner: leaseOwner,
+            outcome: "cancelled_no_longer_needed"
+          });
+        }
+
         this.runtime.logger.log("info", "scheduler.job.cancelled", {
           job_id: job.id,
           lane: job.lane,
@@ -682,11 +751,28 @@ export class LinkedInSchedulerService {
         };
       }
 
-      this.runtime.db.markSchedulerJobPrepared({
+      const markedPrepared = this.runtime.db.markSchedulerJobPrepared({
         id: job.id,
         nowMs,
-        preparedActionId: prepared.preparedActionId
+        preparedActionId: prepared.preparedActionId,
+        leaseOwner
       });
+
+      if (!markedPrepared) {
+        this.runtime.logger.log("info", "scheduler.job.superseded", {
+          job_id: job.id,
+          lane: job.lane,
+          lease_owner: leaseOwner,
+          prepared_action_id: prepared.preparedActionId,
+          outcome: "prepared"
+        });
+        return {
+          jobId: job.id,
+          lane: job.lane,
+          outcome: "cancelled"
+        };
+      }
+
       this.runtime.logger.log("info", "scheduler.job.prepared", {
         job_id: job.id,
         lane: job.lane,
@@ -710,13 +796,30 @@ export class LinkedInSchedulerService {
           this.config.businessHours
         );
 
-        this.runtime.db.rescheduleSchedulerJob({
+        const rescheduled = this.runtime.db.rescheduleSchedulerJob({
           id: job.id,
           scheduledAtMs,
           nowMs,
+          leaseOwner,
           errorCode: normalizedError.code,
           errorMessage: normalizedError.message
         });
+
+        if (!rescheduled) {
+          this.runtime.logger.log("info", "scheduler.job.superseded", {
+            job_id: job.id,
+            lane: job.lane,
+            lease_owner: leaseOwner,
+            error_code: normalizedError.code,
+            outcome: "rescheduled"
+          });
+          return {
+            jobId: job.id,
+            lane: job.lane,
+            outcome: "cancelled"
+          };
+        }
+
         this.runtime.logger.log("warn", "scheduler.job.rescheduled", {
           job_id: job.id,
           lane: job.lane,
@@ -735,12 +838,29 @@ export class LinkedInSchedulerService {
         };
       }
 
-      this.runtime.db.failSchedulerJob({
+      const failed = this.runtime.db.failSchedulerJob({
         id: job.id,
         nowMs,
+        leaseOwner,
         errorCode: normalizedError.code,
         errorMessage: normalizedError.message
       });
+
+      if (!failed) {
+        this.runtime.logger.log("info", "scheduler.job.superseded", {
+          job_id: job.id,
+          lane: job.lane,
+          lease_owner: leaseOwner,
+          error_code: normalizedError.code,
+          outcome: "failed"
+        });
+        return {
+          jobId: job.id,
+          lane: job.lane,
+          outcome: "cancelled"
+        };
+      }
+
       this.runtime.logger.log("error", "scheduler.job.failed", {
         job_id: job.id,
         lane: job.lane,


### PR DESCRIPTION
## Summary
- enforce scheduler lease ownership before leased jobs can be prepared, rescheduled, failed, or cancelled
- batch prepared-action and scheduler job lookups so follow-up ticks stay linear and the state-loading code is simpler
- add regression coverage for reclaimed leases while preserving pending-job cancellation behavior

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #99