### PR TITLE
fix: harden scheduled follow-up scheduler for #103

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -242,6 +242,7 @@ interface SchedulerState {
   pollIntervalMs: number;
   businessHours: SchedulerConfig["businessHours"];
   maxJobsPerTick: number;
+  maxActiveJobsPerProfile: number;
   consecutiveFailures: number;
   maxConsecutiveFailures: number;
   lastTickAt?: string;
@@ -1571,6 +1572,7 @@ async function runSchedulerStart(
     pollIntervalMs: schedulerConfig.pollIntervalMs,
     businessHours: schedulerConfig.businessHours,
     maxJobsPerTick: schedulerConfig.maxJobsPerTick,
+    maxActiveJobsPerProfile: schedulerConfig.maxActiveJobsPerProfile,
     consecutiveFailures: 0,
     maxConsecutiveFailures: SCHEDULER_DAEMON_MAX_CONSECUTIVE_FAILURES,
     ...(cdpUrl ? { cdpUrl } : {})
@@ -1710,6 +1712,7 @@ async function runSchedulerDaemon(
     pollIntervalMs: schedulerConfig.pollIntervalMs,
     businessHours: schedulerConfig.businessHours,
     maxJobsPerTick: schedulerConfig.maxJobsPerTick,
+    maxActiveJobsPerProfile: schedulerConfig.maxActiveJobsPerProfile,
     consecutiveFailures: 0,
     maxConsecutiveFailures: SCHEDULER_DAEMON_MAX_CONSECUTIVE_FAILURES,
     ...(cdpUrl ? { cdpUrl } : {})
@@ -1761,6 +1764,7 @@ async function runSchedulerDaemon(
             pollIntervalMs: schedulerConfig.pollIntervalMs,
             businessHours: schedulerConfig.businessHours,
             maxJobsPerTick: schedulerConfig.maxJobsPerTick,
+            maxActiveJobsPerProfile: schedulerConfig.maxActiveJobsPerProfile,
             consecutiveFailures,
             maxConsecutiveFailures: SCHEDULER_DAEMON_MAX_CONSECUTIVE_FAILURES,
             lastTickAt: tickAt,
@@ -1804,6 +1808,7 @@ async function runSchedulerDaemon(
           pollIntervalMs: schedulerConfig.pollIntervalMs,
           businessHours: schedulerConfig.businessHours,
           maxJobsPerTick: schedulerConfig.maxJobsPerTick,
+          maxActiveJobsPerProfile: schedulerConfig.maxActiveJobsPerProfile,
           consecutiveFailures,
           maxConsecutiveFailures: SCHEDULER_DAEMON_MAX_CONSECUTIVE_FAILURES,
           lastTickAt: tickAt,

--- a/packages/core/src/__tests__/scheduler.test.ts
+++ b/packages/core/src/__tests__/scheduler.test.ts
@@ -46,6 +46,7 @@ function createSchedulerConfig(
     enabled: true,
     pollIntervalMs: 5 * 60 * 1000,
     maxJobsPerTick: 2,
+    maxActiveJobsPerProfile: 100,
     leaseTtlMs: 60 * 1000,
     enabledLanes: ["followup_preparation"],
     businessHours,
@@ -1693,6 +1694,253 @@ describe("LinkedInSchedulerService", () => {
         last_error_code: "UNKNOWN",
         last_error_message: "scheduler row write failed"
       });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("fails tampered jobs whose target profile does not match the claimed profile", async () => {
+    const db = new AssistantDatabase(":memory:");
+    const connection = createAcceptedConnection();
+    insertSchedulerJob(db, {
+      id: "job_cross_profile_target",
+      targetJson: JSON.stringify({
+        profile_name: "other-profile",
+        profile_url_key: connection.profile_url_key
+      }),
+      dedupeKey: `followup_preparation:default:${connection.profile_url_key}`
+    });
+
+    const followups = {
+      listAcceptedConnections: vi.fn(async () => []),
+      prepareFollowupForAcceptedConnection: vi.fn(async () => null)
+    };
+
+    try {
+      const service = new LinkedInSchedulerService(
+        createRuntime({
+          db,
+          followups
+        })
+      );
+
+      const result = await service.runTick({
+        profileName: "default",
+        nowMs: FIXED_NOW,
+        workerId: "test-worker"
+      });
+
+      expect(result.failedJobs).toBe(1);
+      expect(followups.prepareFollowupForAcceptedConnection).not.toHaveBeenCalled();
+      expect(result.processedJobs).toEqual([
+        {
+          jobId: "job_cross_profile_target",
+          lane: "followup_preparation",
+          outcome: "failed",
+          errorCode: "ACTION_PRECONDITION_FAILED",
+          errorMessage:
+            "Scheduler job job_cross_profile_target target.profile_name does not match the claimed profile."
+        }
+      ]);
+      expect(db.getSchedulerJobById("job_cross_profile_target")).toMatchObject({
+        status: "failed",
+        attempt_count: 1,
+        last_error_code: "ACTION_PRECONDITION_FAILED"
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("tolerates duplicate enqueue races without rejecting the tick", async () => {
+    const db = new AssistantDatabase(":memory:");
+    const connection = createAcceptedConnection({
+      accepted_at_ms: FIXED_NOW,
+      first_seen_sent_at_ms: FIXED_NOW - 60_000,
+      last_seen_sent_at_ms: FIXED_NOW - 30_000
+    });
+
+    seedAcceptedInvitation({
+      db,
+      profileName: "default",
+      connection
+    });
+
+    const originalInsertSchedulerJob = db.insertSchedulerJob.bind(db);
+    vi.spyOn(db, "insertSchedulerJob").mockImplementation((input) => {
+      originalInsertSchedulerJob(input);
+      throw new Error("UNIQUE constraint failed: scheduler_job.dedupe_key");
+    });
+
+    const followups = {
+      listAcceptedConnections: vi.fn(async () => [connection]),
+      prepareFollowupForAcceptedConnection: vi.fn(async () => null)
+    };
+
+    try {
+      const service = new LinkedInSchedulerService(
+        createRuntime({
+          db,
+          followups
+        })
+      );
+
+      const result = await service.runTick({
+        profileName: "default",
+        nowMs: FIXED_NOW,
+        workerId: "test-worker"
+      });
+
+      expect(result.claimedJobs).toBe(0);
+      expect(result.queuedJobs).toBe(0);
+      expect(result.failedJobs).toBe(0);
+      expect(db.listSchedulerJobs({ profileName: "default" })).toHaveLength(1);
+      expect(db.getSchedulerJobByDedupeKey({
+        profileName: "default",
+        dedupeKey: `followup_preparation:default:${connection.profile_url_key}`
+      })).toMatchObject({
+        status: "pending",
+        dedupe_key: `followup_preparation:default:${connection.profile_url_key}`
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("keeps the tick running when terminal failure persistence throws", async () => {
+    const db = new AssistantDatabase(":memory:");
+    const connection = createAcceptedConnection();
+    seedAcceptedInvitation({
+      db,
+      profileName: "default",
+      connection
+    });
+    insertSchedulerJob(db, {
+      id: "job_failure_transition_write",
+      targetJson: JSON.stringify({
+        profile_name: "default",
+        profile_url_key: connection.profile_url_key
+      }),
+      dedupeKey: `followup_preparation:default:${connection.profile_url_key}`
+    });
+
+    vi.spyOn(db, "failSchedulerJob").mockImplementation(() => {
+      throw new Error("scheduler final write failed");
+    });
+
+    const followups = {
+      listAcceptedConnections: vi.fn(async () => []),
+      prepareFollowupForAcceptedConnection: vi.fn(async () => {
+        throw new LinkedInAssistantError(
+          "ACTION_PRECONDITION_FAILED",
+          "synthetic scheduler target failure"
+        );
+      })
+    };
+
+    try {
+      const service = new LinkedInSchedulerService(
+        createRuntime({
+          db,
+          followups
+        })
+      );
+
+      const result = await service.runTick({
+        profileName: "default",
+        nowMs: FIXED_NOW,
+        workerId: "test-worker"
+      });
+
+      expect(result.failedJobs).toBe(1);
+      expect(result.processedJobs).toEqual([
+        {
+          jobId: "job_failure_transition_write",
+          lane: "followup_preparation",
+          outcome: "failed",
+          errorCode: "UNKNOWN",
+          errorMessage: "scheduler final write failed"
+        }
+      ]);
+      expect(db.getSchedulerJobById("job_failure_transition_write")).toMatchObject({
+        status: "leased",
+        lease_owner: "test-worker"
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("caps the number of active jobs queued for a profile", async () => {
+    const db = new AssistantDatabase(":memory:");
+    const olderConnection = createAcceptedConnection({
+      profile_url_key: "https://www.linkedin.com/in/alice-smith/",
+      profile_url: "https://www.linkedin.com/in/alice-smith/",
+      vanity_name: "alice-smith",
+      full_name: "Alice Smith",
+      accepted_at_ms: FIXED_NOW - 3 * 60 * 60 * 1000,
+      first_seen_sent_at_ms: FIXED_NOW - 4 * 24 * 60 * 60 * 1000,
+      last_seen_sent_at_ms: FIXED_NOW - 3 * 24 * 60 * 60 * 1000
+    });
+    const newerConnection = createAcceptedConnection({
+      profile_url_key: "https://www.linkedin.com/in/bob-smith/",
+      profile_url: "https://www.linkedin.com/in/bob-smith/",
+      vanity_name: "bob-smith",
+      full_name: "Bob Smith",
+      accepted_at_ms: FIXED_NOW - 2 * 60 * 60 * 1000,
+      first_seen_sent_at_ms: FIXED_NOW - 3 * 24 * 60 * 60 * 1000,
+      last_seen_sent_at_ms: FIXED_NOW - 2 * 24 * 60 * 60 * 1000
+    });
+
+    seedAcceptedInvitation({
+      db,
+      profileName: "default",
+      connection: olderConnection
+    });
+    seedAcceptedInvitation({
+      db,
+      profileName: "default",
+      connection: newerConnection
+    });
+
+    const config = createSchedulerConfig({
+      maxJobsPerTick: 5,
+      maxActiveJobsPerProfile: 1
+    });
+    const followups = {
+      listAcceptedConnections: vi.fn(async () => [olderConnection, newerConnection]),
+      prepareFollowupForAcceptedConnection: vi.fn(async ({ profileUrlKey }) =>
+        createPreparedFollowupResult({
+          db,
+          profileName: "default",
+          connection:
+            profileUrlKey === olderConnection.profile_url_key
+              ? olderConnection
+              : newerConnection,
+          preparedAtMs: FIXED_NOW
+        })
+      )
+    };
+
+    try {
+      const service = new LinkedInSchedulerService(
+        createRuntime({
+          db,
+          followups,
+          schedulerConfig: config
+        })
+      );
+
+      const result = await service.runTick({
+        profileName: "default",
+        nowMs: FIXED_NOW,
+        workerId: "test-worker"
+      });
+
+      expect(result.preparedJobs).toBe(1);
+      expect(result.claimedJobs).toBe(1);
+      expect(db.listSchedulerJobs({ profileName: "default" })).toHaveLength(1);
+      expect(followups.prepareFollowupForAcceptedConnection).toHaveBeenCalledTimes(1);
     } finally {
       db.close();
     }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -9,6 +9,7 @@ import {
   type LinkedInSelectorLocaleResolution,
   type LinkedInSelectorLocale
 } from "./selectorLocale.js";
+import { LinkedInAssistantError } from "./errors.js";
 
 /**
  * Default directory used for tool-owned state when no custom home is configured.
@@ -56,6 +57,7 @@ export const DEFAULT_SCHEDULER_ENABLED_LANES: SchedulerLane[] = [
 
 export const DEFAULT_SCHEDULER_POLL_INTERVAL_MS = 5 * 60 * 1000;
 export const DEFAULT_SCHEDULER_MAX_JOBS_PER_TICK = 2;
+export const DEFAULT_SCHEDULER_MAX_ACTIVE_JOBS_PER_PROFILE = 100;
 export const DEFAULT_SCHEDULER_LEASE_TTL_MS = 2 * 60 * 1000;
 export const DEFAULT_SCHEDULER_FOLLOWUP_DELAY_MS = 15 * 60 * 1000;
 export const DEFAULT_SCHEDULER_FOLLOWUP_LOOKBACK_MS =
@@ -82,29 +84,13 @@ export interface SchedulerConfig {
   enabled: boolean;
   pollIntervalMs: number;
   maxJobsPerTick: number;
+  maxActiveJobsPerProfile: number;
   leaseTtlMs: number;
   enabledLanes: SchedulerLane[];
   businessHours: SchedulerBusinessHoursConfig;
   followupDelayMs: number;
   followupLookbackMs: number;
   retry: SchedulerRetryConfig;
-}
-
-function parseBoolean(value: string | undefined, fallback: boolean): boolean {
-  if (!value) {
-    return fallback;
-  }
-
-  const normalized = value.trim().toLowerCase();
-  if (["1", "true", "yes", "on"].includes(normalized)) {
-    return true;
-  }
-
-  if (["0", "false", "no", "off"].includes(normalized)) {
-    return false;
-  }
-
-  return fallback;
 }
 
 function isValidTimeZone(value: string | undefined): value is string {
@@ -166,41 +152,189 @@ function compareClockTimes(left: string, right: string): number {
   return leftHour * 60 + leftMinute - (rightHour * 60 + rightMinute);
 }
 
+function invalidSchedulerConfig(
+  message: string,
+  details: Record<string, unknown>
+): LinkedInAssistantError {
+  return new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    message,
+    details
+  );
+}
+
+function parseStrictBoolean(
+  value: string | undefined,
+  fallback: boolean,
+  envName: string
+): boolean {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+
+  if (["0", "false", "no", "off"].includes(normalized)) {
+    return false;
+  }
+
+  throw invalidSchedulerConfig(
+    `${envName} must be one of: 1, 0, true, false, yes, no, on, off.`,
+    {
+      env: envName,
+      value
+    }
+  );
+}
+
+function parseStrictPositiveInteger(input: {
+  envName: string;
+  fallback: number;
+  max?: number;
+  min?: number;
+}): number {
+  const rawValue = process.env[input.envName];
+  if (rawValue === undefined) {
+    return input.fallback;
+  }
+
+  const trimmed = rawValue.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    throw invalidSchedulerConfig(
+      `${input.envName} must be a positive integer.`,
+      {
+        env: input.envName,
+        value: rawValue
+      }
+    );
+  }
+
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw invalidSchedulerConfig(
+      `${input.envName} must be a positive integer.`,
+      {
+        env: input.envName,
+        value: rawValue
+      }
+    );
+  }
+
+  if (typeof input.min === "number" && parsed < input.min) {
+    throw invalidSchedulerConfig(
+      `${input.envName} must be at least ${input.min}.`,
+      {
+        env: input.envName,
+        min: input.min,
+        value: parsed
+      }
+    );
+  }
+
+  if (typeof input.max === "number" && parsed > input.max) {
+    throw invalidSchedulerConfig(
+      `${input.envName} must be at most ${input.max}.`,
+      {
+        env: input.envName,
+        max: input.max,
+        value: parsed
+      }
+    );
+  }
+
+  return parsed;
+}
+
+function parseStrictClockTime(
+  value: string | undefined,
+  fallback: string,
+  envName: string
+): string {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  const normalized = normalizeClockTime(value, "");
+  if (!normalized) {
+    throw invalidSchedulerConfig(
+      `${envName} must use HH:MM 24-hour clock formatting.`,
+      {
+        env: envName,
+        value
+      }
+    );
+  }
+
+  return normalized;
+}
+
 function parseSchedulerEnabledLanes(value: string | undefined): SchedulerLane[] {
-  if (!value) {
+  if (value === undefined) {
     return [...DEFAULT_SCHEDULER_ENABLED_LANES];
   }
 
   const supported = new Set<string>(SCHEDULER_LANES);
-  const parsed = value
+  const rawEntries = value
     .split(",")
     .map((entry) => entry.trim())
-    .filter((entry): entry is SchedulerLane => supported.has(entry));
+    .filter((entry) => entry.length > 0);
 
-  return parsed.length > 0 ? parsed : [...DEFAULT_SCHEDULER_ENABLED_LANES];
+  if (rawEntries.length === 0) {
+    return [];
+  }
+
+  const invalidEntries = rawEntries.filter((entry) => !supported.has(entry));
+  if (invalidEntries.length > 0) {
+    throw invalidSchedulerConfig(
+      "LINKEDIN_ASSISTANT_SCHEDULER_ENABLED_LANES contains unsupported scheduler lanes.",
+      {
+        env: "LINKEDIN_ASSISTANT_SCHEDULER_ENABLED_LANES",
+        invalid_lanes: invalidEntries,
+        supported_lanes: SCHEDULER_LANES
+      }
+    );
+  }
+
+  return [...new Set(rawEntries)] as SchedulerLane[];
 }
 
 function resolveSchedulerBusinessHours(): SchedulerBusinessHoursConfig {
-  const startTime = normalizeClockTime(
+  const startTime = parseStrictClockTime(
     process.env.LINKEDIN_ASSISTANT_SCHEDULER_BUSINESS_START,
-    DEFAULT_SCHEDULER_BUSINESS_START
+    DEFAULT_SCHEDULER_BUSINESS_START,
+    "LINKEDIN_ASSISTANT_SCHEDULER_BUSINESS_START"
   );
-  const endTime = normalizeClockTime(
+  const endTime = parseStrictClockTime(
     process.env.LINKEDIN_ASSISTANT_SCHEDULER_BUSINESS_END,
-    DEFAULT_SCHEDULER_BUSINESS_END
+    DEFAULT_SCHEDULER_BUSINESS_END,
+    "LINKEDIN_ASSISTANT_SCHEDULER_BUSINESS_END"
   );
-  const timeZone = isValidTimeZone(
-    process.env.LINKEDIN_ASSISTANT_SCHEDULER_TIMEZONE
-  )
-    ? process.env.LINKEDIN_ASSISTANT_SCHEDULER_TIMEZONE
-    : resolveDefaultSchedulerTimeZone();
+  const rawTimeZone = process.env.LINKEDIN_ASSISTANT_SCHEDULER_TIMEZONE;
+  const timeZone =
+    rawTimeZone === undefined ? resolveDefaultSchedulerTimeZone() : rawTimeZone.trim();
+
+  if (!timeZone || !isValidTimeZone(timeZone)) {
+    throw invalidSchedulerConfig(
+      "LINKEDIN_ASSISTANT_SCHEDULER_TIMEZONE must be a valid IANA timezone, such as UTC or Europe/Copenhagen.",
+      {
+        env: "LINKEDIN_ASSISTANT_SCHEDULER_TIMEZONE",
+        value: rawTimeZone
+      }
+    );
+  }
 
   if (compareClockTimes(startTime, endTime) >= 0) {
-    return {
-      timeZone,
-      startTime: DEFAULT_SCHEDULER_BUSINESS_START,
-      endTime: DEFAULT_SCHEDULER_BUSINESS_END
-    };
+    throw invalidSchedulerConfig(
+      "Scheduler business hours must end after they start on the same local day.",
+      {
+        start_time: startTime,
+        end_time: endTime,
+        time_zone: timeZone
+      }
+    );
   }
 
   return {
@@ -303,58 +437,105 @@ export function resolveConfirmFailureArtifactConfig(): ConfirmFailureArtifactCon
 }
 
 export function resolveSchedulerConfig(): SchedulerConfig {
+  const pollIntervalMs =
+    parseStrictPositiveInteger({
+      envName: "LINKEDIN_ASSISTANT_SCHEDULER_POLL_INTERVAL_SECONDS",
+      fallback: DEFAULT_SCHEDULER_POLL_INTERVAL_MS / 1_000,
+      max: 24 * 60 * 60
+    }) * 1_000;
+  const maxJobsPerTick = parseStrictPositiveInteger({
+    envName: "LINKEDIN_ASSISTANT_SCHEDULER_MAX_JOBS_PER_TICK",
+    fallback: DEFAULT_SCHEDULER_MAX_JOBS_PER_TICK,
+    max: 100
+  });
+  const maxActiveJobsPerProfile = parseStrictPositiveInteger({
+    envName: "LINKEDIN_ASSISTANT_SCHEDULER_MAX_ACTIVE_JOBS_PER_PROFILE",
+    fallback: DEFAULT_SCHEDULER_MAX_ACTIVE_JOBS_PER_PROFILE,
+    max: 10_000
+  });
+  const leaseTtlMs =
+    parseStrictPositiveInteger({
+      envName: "LINKEDIN_ASSISTANT_SCHEDULER_LEASE_SECONDS",
+      fallback: DEFAULT_SCHEDULER_LEASE_TTL_MS / 1_000,
+      max: 24 * 60 * 60
+    }) * 1_000;
+  const enabledLanes = parseSchedulerEnabledLanes(
+    process.env.LINKEDIN_ASSISTANT_SCHEDULER_ENABLED_LANES
+  );
+  const businessHours = resolveSchedulerBusinessHours();
+  const followupDelayMs =
+    parseStrictPositiveInteger({
+      envName: "LINKEDIN_ASSISTANT_SCHEDULER_FOLLOWUP_DELAY_MINUTES",
+      fallback: DEFAULT_SCHEDULER_FOLLOWUP_DELAY_MS / (60 * 1_000),
+      max: 30 * 24 * 60
+    }) *
+    60 *
+    1_000;
+  const followupLookbackMs =
+    parseStrictPositiveInteger({
+      envName: "LINKEDIN_ASSISTANT_SCHEDULER_FOLLOWUP_LOOKBACK_DAYS",
+      fallback: DEFAULT_SCHEDULER_FOLLOWUP_LOOKBACK_MS / (24 * 60 * 60 * 1_000),
+      max: 365
+    }) *
+    24 *
+    60 *
+    60 *
+    1_000;
+  const retry = {
+    maxAttempts: parseStrictPositiveInteger({
+      envName: "LINKEDIN_ASSISTANT_SCHEDULER_MAX_ATTEMPTS",
+      fallback: DEFAULT_SCHEDULER_MAX_ATTEMPTS,
+      max: 100
+    }),
+    initialBackoffMs:
+      parseStrictPositiveInteger({
+        envName: "LINKEDIN_ASSISTANT_SCHEDULER_INITIAL_BACKOFF_SECONDS",
+        fallback: DEFAULT_SCHEDULER_INITIAL_BACKOFF_MS / 1_000,
+        max: 30 * 24 * 60 * 60
+      }) * 1_000,
+    maxBackoffMs:
+      parseStrictPositiveInteger({
+        envName: "LINKEDIN_ASSISTANT_SCHEDULER_MAX_BACKOFF_SECONDS",
+        fallback: DEFAULT_SCHEDULER_MAX_BACKOFF_MS / 1_000,
+        max: 30 * 24 * 60 * 60
+      }) * 1_000
+  };
+
+  if (maxJobsPerTick > maxActiveJobsPerProfile) {
+    throw invalidSchedulerConfig(
+      "Scheduler max jobs per tick must not exceed the per-profile active job limit.",
+      {
+        max_jobs_per_tick: maxJobsPerTick,
+        max_active_jobs_per_profile: maxActiveJobsPerProfile
+      }
+    );
+  }
+
+  if (retry.maxBackoffMs < retry.initialBackoffMs) {
+    throw invalidSchedulerConfig(
+      "Scheduler max backoff must be greater than or equal to the initial backoff.",
+      {
+        initial_backoff_ms: retry.initialBackoffMs,
+        max_backoff_ms: retry.maxBackoffMs
+      }
+    );
+  }
+
   return {
-    enabled: parseBoolean(process.env.LINKEDIN_ASSISTANT_SCHEDULER_ENABLED, true),
-    pollIntervalMs:
-      parsePositiveInteger(
-        process.env.LINKEDIN_ASSISTANT_SCHEDULER_POLL_INTERVAL_SECONDS,
-        DEFAULT_SCHEDULER_POLL_INTERVAL_MS / 1_000
-      ) * 1_000,
-    maxJobsPerTick: parsePositiveInteger(
-      process.env.LINKEDIN_ASSISTANT_SCHEDULER_MAX_JOBS_PER_TICK,
-      DEFAULT_SCHEDULER_MAX_JOBS_PER_TICK
+    enabled: parseStrictBoolean(
+      process.env.LINKEDIN_ASSISTANT_SCHEDULER_ENABLED,
+      true,
+      "LINKEDIN_ASSISTANT_SCHEDULER_ENABLED"
     ),
-    leaseTtlMs:
-      parsePositiveInteger(
-        process.env.LINKEDIN_ASSISTANT_SCHEDULER_LEASE_SECONDS,
-        DEFAULT_SCHEDULER_LEASE_TTL_MS / 1_000
-      ) * 1_000,
-    enabledLanes: parseSchedulerEnabledLanes(
-      process.env.LINKEDIN_ASSISTANT_SCHEDULER_ENABLED_LANES
-    ),
-    businessHours: resolveSchedulerBusinessHours(),
-    followupDelayMs:
-      parsePositiveInteger(
-        process.env.LINKEDIN_ASSISTANT_SCHEDULER_FOLLOWUP_DELAY_MINUTES,
-        DEFAULT_SCHEDULER_FOLLOWUP_DELAY_MS / (60 * 1_000)
-      ) *
-      60 *
-      1_000,
-    followupLookbackMs:
-      parsePositiveInteger(
-        process.env.LINKEDIN_ASSISTANT_SCHEDULER_FOLLOWUP_LOOKBACK_DAYS,
-        DEFAULT_SCHEDULER_FOLLOWUP_LOOKBACK_MS / (24 * 60 * 60 * 1_000)
-      ) *
-      24 *
-      60 *
-      60 *
-      1_000,
-    retry: {
-      maxAttempts: parsePositiveInteger(
-        process.env.LINKEDIN_ASSISTANT_SCHEDULER_MAX_ATTEMPTS,
-        DEFAULT_SCHEDULER_MAX_ATTEMPTS
-      ),
-      initialBackoffMs:
-        parsePositiveInteger(
-          process.env.LINKEDIN_ASSISTANT_SCHEDULER_INITIAL_BACKOFF_SECONDS,
-          DEFAULT_SCHEDULER_INITIAL_BACKOFF_MS / 1_000
-        ) * 1_000,
-      maxBackoffMs:
-        parsePositiveInteger(
-          process.env.LINKEDIN_ASSISTANT_SCHEDULER_MAX_BACKOFF_SECONDS,
-          DEFAULT_SCHEDULER_MAX_BACKOFF_MS / 1_000
-        ) * 1_000
-    }
+    pollIntervalMs,
+    maxJobsPerTick,
+    maxActiveJobsPerProfile,
+    leaseTtlMs,
+    enabledLanes,
+    businessHours,
+    followupDelayMs,
+    followupLookbackMs,
+    retry
   };
 }
 

--- a/packages/core/src/db/database.ts
+++ b/packages/core/src/db/database.ts
@@ -237,6 +237,11 @@ export interface ClaimDueSchedulerJobsInput {
   leaseTtlMs: number;
 }
 
+export interface GetSchedulerJobByDedupeKeyInput {
+  profileName: string;
+  dedupeKey: string;
+}
+
 export interface UpdateSchedulerJobScheduleInput {
   id: string;
   scheduledAtMs: number;
@@ -947,6 +952,23 @@ LIMIT 1
 `
       )
       .get(id);
+  }
+
+  getSchedulerJobByDedupeKey(
+    input: GetSchedulerJobByDedupeKeyInput
+  ): SchedulerJobRow | undefined {
+    return this.db
+      .prepare<GetSchedulerJobByDedupeKeyInput, SchedulerJobRow>(
+        `
+SELECT
+${SCHEDULER_JOB_SELECT_COLUMNS}
+FROM scheduler_job
+WHERE profile_name = @profileName
+  AND dedupe_key = @dedupeKey
+LIMIT 1
+`
+      )
+      .get(input);
   }
 
   listSchedulerJobs(input: { profileName: string }): SchedulerJobRow[] {

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -19,6 +19,7 @@ import {
   type PreparedAcceptedConnectionFollowup,
   type PrepareAcceptedConnectionFollowupInput
 } from "./linkedinFollowups.js";
+import { normalizeLinkedInProfileUrl } from "./linkedinProfile.js";
 import type { JsonEventLogger } from "./logging.js";
 import { createRunId } from "./run.js";
 
@@ -273,6 +274,17 @@ function buildFollowupSchedulerDedupeKey(
   return `${FOLLOWUP_PREPARATION_LANE}:${profileName}:${profileUrlKey}`;
 }
 
+function isActiveSchedulerJobStatus(status: SchedulerJobRow["status"]): boolean {
+  return status === "pending" || status === "leased" || status === "prepared";
+}
+
+function isDuplicateSchedulerJobError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    /unique constraint failed:\s*scheduler_job\.dedupe_key/i.test(error.message)
+  );
+}
+
 function createSchedulerJobId(): string {
   return `scheduler_job_${createRunId()}`;
 }
@@ -340,9 +352,24 @@ function parseFollowupSchedulerTarget(job: SchedulerJobRow): {
     );
   }
 
+  const targetProfileName = getRequiredTargetField(parsed, "profile_name", job.id);
+  if (targetProfileName !== job.profile_name) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `Scheduler job ${job.id} target.profile_name does not match the claimed profile.`,
+      {
+        job_id: job.id,
+        job_profile_name: job.profile_name,
+        target_profile_name: targetProfileName
+      }
+    );
+  }
+
   return {
-    profileName: getRequiredTargetField(parsed, "profile_name", job.id),
-    profileUrlKey: getRequiredTargetField(parsed, "profile_url_key", job.id)
+    profileName: job.profile_name,
+    profileUrlKey: normalizeLinkedInProfileUrl(
+      getRequiredTargetField(parsed, "profile_url_key", job.id)
+    )
   };
 }
 
@@ -559,23 +586,27 @@ export class LinkedInSchedulerService {
         left.first_seen_sent_at_ms - right.first_seen_sent_at_ms
       );
     });
-    const existingJobsByDedupeKey = new Map(
-      this.runtime.db
-        .listSchedulerJobs({ profileName: input.profileName })
-        .map((job) => [job.dedupe_key, job])
-    );
-
     let queuedJobs = 0;
     let updatedJobs = 0;
     let reopenedJobs = 0;
     let cancelledJobs = 0;
+
+    const existingJobs = this.runtime.db.listSchedulerJobs({
+      profileName: input.profileName
+    });
+    const existingJobsByDedupeKey = new Map(
+      existingJobs.map((job) => [job.dedupe_key, job])
+    );
+    let activeJobCount = existingJobs.filter((job) =>
+      isActiveSchedulerJobStatus(job.status)
+    ).length;
 
     for (const connection of candidates) {
       const dedupeKey = buildFollowupSchedulerDedupeKey(
         input.profileName,
         connection.profile_url_key
       );
-      const existing = existingJobsByDedupeKey.get(dedupeKey);
+      let existing = existingJobsByDedupeKey.get(dedupeKey);
 
       if (!isFollowupPreparationCandidate(connection)) {
         if (existing?.status === "pending") {
@@ -586,6 +617,19 @@ export class LinkedInSchedulerService {
           });
           if (cancelled) {
             cancelledJobs += 1;
+            activeJobCount = Math.max(0, activeJobCount - 1);
+            existingJobsByDedupeKey.set(dedupeKey, {
+              ...existing,
+              status: "cancelled",
+              lease_owner: null,
+              leased_at: null,
+              lease_expires_at: null,
+              last_error_code: null,
+              last_error_message: `Follow-up already ${connection.followup_status}.`,
+              last_attempt_at: input.nowMs,
+              completed_at: input.nowMs,
+              updated_at: input.nowMs
+            });
           }
         }
         continue;
@@ -602,6 +646,16 @@ export class LinkedInSchedulerService {
       });
 
       if (!existing) {
+        if (activeJobCount >= this.config.maxActiveJobsPerProfile) {
+          this.runtime.logger.log("warn", "scheduler.queue.limit_reached", {
+            profile_name: input.profileName,
+            max_active_jobs_per_profile: this.config.maxActiveJobsPerProfile,
+            target_profile_url_key: connection.profile_url_key,
+            lane: FOLLOWUP_PREPARATION_LANE
+          });
+          continue;
+        }
+
         const insertedJob: SchedulerJobRow = {
           id: createSchedulerJobId(),
           profile_name: input.profileName,
@@ -625,21 +679,39 @@ export class LinkedInSchedulerService {
           updated_at: input.nowMs
         };
 
-        this.runtime.db.insertSchedulerJob({
-          id: insertedJob.id,
-          profileName: insertedJob.profile_name,
-          lane: insertedJob.lane,
-          actionType: insertedJob.action_type,
-          targetJson: insertedJob.target_json,
-          dedupeKey: insertedJob.dedupe_key,
-          scheduledAtMs: insertedJob.scheduled_at,
-          maxAttempts: insertedJob.max_attempts,
-          createdAtMs: insertedJob.created_at,
-          updatedAtMs: insertedJob.updated_at
-        });
-        existingJobsByDedupeKey.set(dedupeKey, insertedJob);
-        queuedJobs += 1;
-        continue;
+        try {
+          this.runtime.db.insertSchedulerJob({
+            id: insertedJob.id,
+            profileName: insertedJob.profile_name,
+            lane: insertedJob.lane,
+            actionType: insertedJob.action_type,
+            targetJson: insertedJob.target_json,
+            dedupeKey: insertedJob.dedupe_key,
+            scheduledAtMs: insertedJob.scheduled_at,
+            maxAttempts: insertedJob.max_attempts,
+            createdAtMs: insertedJob.created_at,
+            updatedAtMs: insertedJob.updated_at
+          });
+          existingJobsByDedupeKey.set(dedupeKey, insertedJob);
+          queuedJobs += 1;
+          activeJobCount += 1;
+          continue;
+        } catch (error) {
+          if (!isDuplicateSchedulerJobError(error)) {
+            throw error;
+          }
+
+          existing = this.runtime.db.getSchedulerJobByDedupeKey({
+            profileName: input.profileName,
+            dedupeKey
+          });
+
+          if (!existing) {
+            throw error;
+          }
+
+          existingJobsByDedupeKey.set(dedupeKey, existing);
+        }
       }
 
       if (existing.status === "pending") {
@@ -652,6 +724,12 @@ export class LinkedInSchedulerService {
           });
           if (updated) {
             updatedJobs += 1;
+            existingJobsByDedupeKey.set(dedupeKey, {
+              ...existing,
+              scheduled_at: scheduledAtMs,
+              target_json: targetJson,
+              updated_at: input.nowMs
+            });
           }
         }
         continue;
@@ -661,6 +739,21 @@ export class LinkedInSchedulerService {
         existing.status === "cancelled" ||
         (existing.status === "prepared" && connection.followup_status !== "prepared" && connection.followup_status !== "executed")
       ) {
+        const requiresActiveSlot = existing.status === "cancelled";
+        if (
+          requiresActiveSlot &&
+          activeJobCount >= this.config.maxActiveJobsPerProfile
+        ) {
+          this.runtime.logger.log("warn", "scheduler.queue.limit_reached", {
+            profile_name: input.profileName,
+            max_active_jobs_per_profile: this.config.maxActiveJobsPerProfile,
+            target_profile_url_key: connection.profile_url_key,
+            lane: FOLLOWUP_PREPARATION_LANE,
+            existing_status: existing.status
+          });
+          continue;
+        }
+
         const reopened = this.runtime.db.requeueSchedulerJob({
           id: existing.id,
           scheduledAtMs,
@@ -669,6 +762,23 @@ export class LinkedInSchedulerService {
         });
         if (reopened) {
           reopenedJobs += 1;
+          if (requiresActiveSlot) {
+            activeJobCount += 1;
+          }
+          existingJobsByDedupeKey.set(dedupeKey, {
+            ...existing,
+            status: "pending",
+            scheduled_at: scheduledAtMs,
+            target_json: targetJson,
+            lease_owner: null,
+            leased_at: null,
+            lease_expires_at: null,
+            prepared_action_id: null,
+            last_error_code: null,
+            last_error_message: null,
+            completed_at: null,
+            updated_at: input.nowMs
+          });
         }
       }
     }
@@ -714,7 +824,7 @@ export class LinkedInSchedulerService {
     try {
       const target = parseFollowupSchedulerTarget(job);
       const prepared = await this.runtime.followups.prepareFollowupForAcceptedConnection({
-        profileName: target.profileName,
+        profileName: job.profile_name,
         profileUrlKey: target.profileUrlKey,
         operatorNote: SCHEDULER_OPERATOR_NOTE,
         refreshState: false
@@ -789,29 +899,71 @@ export class LinkedInSchedulerService {
       const normalizedError = normalizeSchedulerError(error);
       const nextAttempt = job.attempt_count + 1;
 
-      if (normalizedError.retryable && nextAttempt < job.max_attempts) {
-        const backoffMs = calculateSchedulerBackoffMs(nextAttempt, this.config.retry);
-        const scheduledAtMs = alignToBusinessHours(
-          nowMs + backoffMs,
-          this.config.businessHours
-        );
+      try {
+        if (normalizedError.retryable && nextAttempt < job.max_attempts) {
+          const backoffMs = calculateSchedulerBackoffMs(nextAttempt, this.config.retry);
+          const scheduledAtMs = alignToBusinessHours(
+            nowMs + backoffMs,
+            this.config.businessHours
+          );
 
-        const rescheduled = this.runtime.db.rescheduleSchedulerJob({
+          const rescheduled = this.runtime.db.rescheduleSchedulerJob({
+            id: job.id,
+            scheduledAtMs,
+            nowMs,
+            leaseOwner,
+            errorCode: normalizedError.code,
+            errorMessage: normalizedError.message
+          });
+
+          if (!rescheduled) {
+            this.runtime.logger.log("info", "scheduler.job.superseded", {
+              job_id: job.id,
+              lane: job.lane,
+              lease_owner: leaseOwner,
+              error_code: normalizedError.code,
+              outcome: "rescheduled"
+            });
+            return {
+              jobId: job.id,
+              lane: job.lane,
+              outcome: "cancelled"
+            };
+          }
+
+          this.runtime.logger.log("warn", "scheduler.job.rescheduled", {
+            job_id: job.id,
+            lane: job.lane,
+            error_code: normalizedError.code,
+            error_message: normalizedError.message,
+            next_attempt: nextAttempt,
+            scheduled_at: new Date(scheduledAtMs).toISOString()
+          });
+          return {
+            jobId: job.id,
+            lane: job.lane,
+            outcome: "rescheduled",
+            errorCode: normalizedError.code,
+            errorMessage: normalizedError.message,
+            scheduledAtMs
+          };
+        }
+
+        const failed = this.runtime.db.failSchedulerJob({
           id: job.id,
-          scheduledAtMs,
           nowMs,
           leaseOwner,
           errorCode: normalizedError.code,
           errorMessage: normalizedError.message
         });
 
-        if (!rescheduled) {
+        if (!failed) {
           this.runtime.logger.log("info", "scheduler.job.superseded", {
             job_id: job.id,
             lane: job.lane,
             lease_owner: leaseOwner,
             error_code: normalizedError.code,
-            outcome: "rescheduled"
+            outcome: "failed"
           });
           return {
             jobId: job.id,
@@ -820,62 +972,45 @@ export class LinkedInSchedulerService {
           };
         }
 
-        this.runtime.logger.log("warn", "scheduler.job.rescheduled", {
+        this.runtime.logger.log("error", "scheduler.job.failed", {
           job_id: job.id,
           lane: job.lane,
           error_code: normalizedError.code,
           error_message: normalizedError.message,
-          next_attempt: nextAttempt,
-          scheduled_at: new Date(scheduledAtMs).toISOString()
+          attempt_count: nextAttempt,
+          max_attempts: job.max_attempts,
+          dead_lettered: true
         });
         return {
           jobId: job.id,
           lane: job.lane,
-          outcome: "rescheduled",
+          outcome: "failed",
           errorCode: normalizedError.code,
-          errorMessage: normalizedError.message,
-          scheduledAtMs
+          errorMessage: normalizedError.message
         };
-      }
+      } catch (transitionError) {
+        const transitionFailure = asLinkedInAssistantError(transitionError);
 
-      const failed = this.runtime.db.failSchedulerJob({
-        id: job.id,
-        nowMs,
-        leaseOwner,
-        errorCode: normalizedError.code,
-        errorMessage: normalizedError.message
-      });
-
-      if (!failed) {
-        this.runtime.logger.log("info", "scheduler.job.superseded", {
+        this.runtime.logger.log("error", "scheduler.job.transition_failed", {
           job_id: job.id,
           lane: job.lane,
           lease_owner: leaseOwner,
-          error_code: normalizedError.code,
-          outcome: "failed"
+          original_error_code: normalizedError.code,
+          original_error_message: normalizedError.message,
+          transition_error_code: transitionFailure.code,
+          transition_error_message: transitionFailure.message,
+          attempt_count: nextAttempt,
+          max_attempts: job.max_attempts
         });
+
         return {
           jobId: job.id,
           lane: job.lane,
-          outcome: "cancelled"
+          outcome: "failed",
+          errorCode: transitionFailure.code,
+          errorMessage: transitionFailure.message
         };
       }
-
-      this.runtime.logger.log("error", "scheduler.job.failed", {
-        job_id: job.id,
-        lane: job.lane,
-        error_code: normalizedError.code,
-        error_message: normalizedError.message,
-        attempt_count: nextAttempt,
-        max_attempts: job.max_attempts
-      });
-      return {
-        jobId: job.id,
-        lane: job.lane,
-        outcome: "failed",
-        errorCode: normalizedError.code,
-        errorMessage: normalizedError.message
-      };
     }
   }
 }

--- a/packages/core/test/schedulerConfig.test.ts
+++ b/packages/core/test/schedulerConfig.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveSchedulerConfig } from "../src/index.js";
+
+const SCHEDULER_ENV_KEYS = [
+  "LINKEDIN_ASSISTANT_SCHEDULER_TIMEZONE",
+  "LINKEDIN_ASSISTANT_SCHEDULER_MAX_JOBS_PER_TICK",
+  "LINKEDIN_ASSISTANT_SCHEDULER_MAX_ACTIVE_JOBS_PER_PROFILE"
+] as const;
+
+describe("resolveSchedulerConfig", () => {
+  const previousEnv = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    previousEnv.clear();
+    for (const key of SCHEDULER_ENV_KEYS) {
+      previousEnv.set(key, process.env[key]);
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of SCHEDULER_ENV_KEYS) {
+      const previousValue = previousEnv.get(key);
+      if (typeof previousValue === "string") {
+        process.env[key] = previousValue;
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  it("rejects invalid scheduler timezones", () => {
+    process.env.LINKEDIN_ASSISTANT_SCHEDULER_TIMEZONE = "Mars/Olympus";
+
+    expect(() => resolveSchedulerConfig()).toThrowError(
+      /must be a valid IANA timezone/i
+    );
+  });
+
+  it("rejects per-tick limits that exceed the per-profile active job cap", () => {
+    process.env.LINKEDIN_ASSISTANT_SCHEDULER_MAX_JOBS_PER_TICK = "5";
+    process.env.LINKEDIN_ASSISTANT_SCHEDULER_MAX_ACTIVE_JOBS_PER_PROFILE = "4";
+
+    expect(() => resolveSchedulerConfig()).toThrowError(
+      /must not exceed the per-profile active job limit/i
+    );
+  });
+
+  it("parses the per-profile active job cap from the environment", () => {
+    process.env.LINKEDIN_ASSISTANT_SCHEDULER_MAX_ACTIVE_JOBS_PER_PROFILE = "7";
+
+    expect(resolveSchedulerConfig().maxActiveJobsPerProfile).toBe(7);
+  });
+});


### PR DESCRIPTION
## Summary
- reject tampered scheduler targets that try to cross profile boundaries, normalize queued profile URL keys before execution, and handle duplicate `dedupe_key` enqueue races safely
- keep scheduler ticks alive when terminal DB transition writes fail so leased jobs degrade to TTL-based recovery instead of aborting the whole tick
- add strict scheduler config validation for malformed env values and cap active scheduler jobs per profile, surfacing that limit in scheduler daemon state for easier operational debugging
- add regression coverage for cross-profile tampering, duplicate enqueue races, terminal write failures, strict config handling, and queue caps

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

Closes #103
