### PR TITLE
feat: polish scheduler CLI UX for #105

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -20,6 +20,8 @@ import { Command } from "commander";
 import {
   DEFAULT_FOLLOWUP_SINCE,
   LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV,
+  AssistantDatabase,
+  alignToBusinessHours,
   asLinkedInAssistantError,
   clearRateLimitState,
   createLocalDataDeletionPlan,
@@ -49,6 +51,7 @@ import {
   type DraftQualityReport,
   type LocalDataDeletionFailure,
   type SchedulerConfig,
+  type SchedulerJobRow,
   type SchedulerTickResult,
   type SearchCategory,
   type SelectorAuditReport
@@ -65,6 +68,21 @@ import {
   resolveSelectorAuditOutputMode,
   SelectorAuditProgressReporter
 } from "../selectorAuditOutput.js";
+import {
+  formatSchedulerError,
+  formatSchedulerRunOnceReport,
+  formatSchedulerStartReport,
+  formatSchedulerStatusReport,
+  formatSchedulerStopReport,
+  resolveSchedulerOutputMode,
+  type SchedulerJobCounts,
+  type SchedulerJobPreview,
+  type SchedulerOutputMode,
+  type SchedulerRunOnceReport,
+  type SchedulerStartReport,
+  type SchedulerStatusReport,
+  type SchedulerStopReport
+} from "../schedulerOutput.js";
 
 const cliPrivacyConfig = resolvePrivacyConfig();
 const SELECTOR_AUDIT_DOC_PATH = "docs/selector-audit.md";
@@ -248,6 +266,7 @@ interface SchedulerState {
   lastTickAt?: string;
   lastSuccessfulTickAt?: string;
   lastPreparedAt?: string;
+  nextWindowStartAt?: string | null;
   lastSummary?: SchedulerStateSummary;
   lastError?: string;
   cdpUrl?: string;
@@ -262,6 +281,7 @@ interface SchedulerFiles {
 }
 
 const SCHEDULER_DAEMON_MAX_CONSECUTIVE_FAILURES = 5;
+const DEFAULT_SCHEDULER_STATUS_JOB_LIMIT = 5;
 
 function profileSlug(profileName: string): string {
   return profileName.replace(/[^a-zA-Z0-9_-]/g, "_");
@@ -1478,10 +1498,318 @@ function summarizeSchedulerTick(result: SchedulerTickResult): SchedulerStateSumm
   };
 }
 
+function writeSchedulerProgressNotice(
+  outputMode: SchedulerOutputMode,
+  message: string
+): void {
+  if (outputMode === "human" && process.stderr.isTTY) {
+    writeCliNotice(message);
+  }
+}
+
+function tryParseSchedulerJobTargetLabel(job: SchedulerJobRow): string | undefined {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(job.target_json) as unknown;
+  } catch {
+    return undefined;
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    return undefined;
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const profileUrlKey = record.profile_url_key;
+  if (typeof profileUrlKey === "string" && profileUrlKey.trim().length > 0) {
+    return profileUrlKey.trim();
+  }
+
+  const profileName = record.profile_name;
+  if (typeof profileName === "string" && profileName.trim().length > 0) {
+    return profileName.trim();
+  }
+
+  return undefined;
+}
+
+function createSchedulerJobPreview(job: SchedulerJobRow): SchedulerJobPreview {
+  const targetLabel = tryParseSchedulerJobTargetLabel(job);
+
+  return {
+    id: job.id,
+    lane: job.lane,
+    status: job.status,
+    ...(targetLabel ? { targetLabel } : {}),
+    scheduledAt: new Date(job.scheduled_at).toISOString(),
+    updatedAt: new Date(job.updated_at).toISOString(),
+    attemptCount: job.attempt_count,
+    maxAttempts: job.max_attempts,
+    preparedActionId: job.prepared_action_id,
+    lastErrorCode: job.last_error_code,
+    lastErrorMessage: job.last_error_message
+  };
+}
+
+function createEmptySchedulerJobCounts(): SchedulerJobCounts {
+  return {
+    total: 0,
+    pending: 0,
+    pendingDueNow: 0,
+    pendingLater: 0,
+    leased: 0,
+    prepared: 0,
+    failed: 0,
+    cancelled: 0
+  };
+}
+
+async function listSchedulerJobRows(profileName: string): Promise<SchedulerJobRow[]> {
+  const { dbPath } = resolveConfigPaths();
+  if (!(await pathExists(dbPath))) {
+    return [];
+  }
+
+  const db = new AssistantDatabase(dbPath);
+  try {
+    return db.listSchedulerJobs({ profileName });
+  } finally {
+    db.close();
+  }
+}
+
+function summarizeSchedulerJobRows(input: {
+  jobs: SchedulerJobRow[];
+  nowMs: number;
+  jobLimit: number;
+}): Pick<SchedulerStatusReport, "job_counts" | "next_jobs" | "recent_jobs"> {
+  const jobCounts = createEmptySchedulerJobCounts();
+
+  for (const job of input.jobs) {
+    jobCounts.total += 1;
+    if (job.status === "pending") {
+      jobCounts.pending += 1;
+      if (job.scheduled_at <= input.nowMs) {
+        jobCounts.pendingDueNow += 1;
+      } else {
+        jobCounts.pendingLater += 1;
+      }
+      continue;
+    }
+
+    if (job.status === "leased") {
+      jobCounts.leased += 1;
+      continue;
+    }
+
+    if (job.status === "prepared") {
+      jobCounts.prepared += 1;
+      continue;
+    }
+
+    if (job.status === "failed") {
+      jobCounts.failed += 1;
+      continue;
+    }
+
+    if (job.status === "cancelled") {
+      jobCounts.cancelled += 1;
+    }
+  }
+
+  const next_jobs = input.jobs
+    .filter((job) => job.status === "pending" || job.status === "leased")
+    .sort((left, right) => left.scheduled_at - right.scheduled_at)
+    .slice(0, input.jobLimit)
+    .map((job) => createSchedulerJobPreview(job));
+  const recent_jobs = input.jobs
+    .filter(
+      (job) =>
+        job.status === "prepared" || job.status === "failed" || job.status === "cancelled"
+    )
+    .sort((left, right) => right.updated_at - left.updated_at)
+    .slice(0, input.jobLimit)
+    .map((job) => createSchedulerJobPreview(job));
+
+  return {
+    job_counts: jobCounts,
+    next_jobs,
+    recent_jobs
+  };
+}
+
+function resolveSchedulerStatusConfig(): Pick<
+  SchedulerStatusReport,
+  "scheduler_config" | "scheduler_config_error"
+> {
+  try {
+    return {
+      scheduler_config: resolveSchedulerConfig()
+    };
+  } catch (error) {
+    return {
+      scheduler_config_error: toLinkedInAssistantErrorPayload(error, cliPrivacyConfig)
+    };
+  }
+}
+
+function inferSchedulerNextWindowStartAt(
+  state: SchedulerState | null,
+  schedulerConfig?: SchedulerConfig
+): string | undefined {
+  if (!state) {
+    return undefined;
+  }
+
+  if (typeof state.nextWindowStartAt === "string" || state.nextWindowStartAt === null) {
+    return state.nextWindowStartAt ?? undefined;
+  }
+
+  const nowMs = Date.now();
+  const alignedAtMs = alignToBusinessHours(
+    nowMs,
+    schedulerConfig?.businessHours ?? state.businessHours
+  );
+  return alignedAtMs > nowMs ? new Date(alignedAtMs).toISOString() : undefined;
+}
+
+async function buildSchedulerStatusReport(
+  profileName: string,
+  jobLimit: number
+): Promise<SchedulerStatusReport> {
+  const pid = await readSchedulerPid(profileName);
+  const state = await readSchedulerState(profileName);
+  const running = typeof pid === "number" ? isProcessRunning(pid) : false;
+  const files = getSchedulerFiles(profileName);
+  const configInfo = resolveSchedulerStatusConfig();
+  const jobs = await listSchedulerJobRows(profileName);
+  const jobSummary = summarizeSchedulerJobRows({
+    jobs,
+    nowMs: Date.now(),
+    jobLimit
+  });
+
+  const nextWindowStartAt = inferSchedulerNextWindowStartAt(
+    state,
+    configInfo.scheduler_config
+  );
+
+  return {
+    profile_name: profileName,
+    running,
+    pid: typeof pid === "number" ? pid : null,
+    state:
+      state === null
+        ? null
+        : {
+            ...state,
+            ...(nextWindowStartAt !== undefined ? { nextWindowStartAt } : {})
+          },
+    stale_pid_file: Boolean(pid && !running),
+    state_path: files.statePath,
+    log_path: files.logPath,
+    ...configInfo,
+    ...jobSummary
+  };
+}
+
+function emitSchedulerStartReport(
+  report: SchedulerStartReport,
+  outputMode: SchedulerOutputMode
+): void {
+  if (outputMode === "json") {
+    printJson(report);
+    return;
+  }
+
+  console.log(
+    formatSchedulerStartReport(
+      redactStructuredValue(report, cliPrivacyConfig, "cli") as SchedulerStartReport
+    )
+  );
+}
+
+function emitSchedulerStatusReport(
+  report: SchedulerStatusReport,
+  outputMode: SchedulerOutputMode
+): void {
+  if (outputMode === "json") {
+    printJson(report);
+    return;
+  }
+
+  console.log(
+    formatSchedulerStatusReport(
+      redactStructuredValue(report, cliPrivacyConfig, "cli") as SchedulerStatusReport
+    )
+  );
+}
+
+function emitSchedulerStopReport(
+  report: SchedulerStopReport,
+  outputMode: SchedulerOutputMode
+): void {
+  if (outputMode === "json") {
+    printJson(report);
+    return;
+  }
+
+  console.log(
+    formatSchedulerStopReport(
+      redactStructuredValue(report, cliPrivacyConfig, "cli") as SchedulerStopReport
+    )
+  );
+}
+
+function emitSchedulerRunOnceReport(
+  report: SchedulerRunOnceReport,
+  outputMode: SchedulerOutputMode
+): void {
+  if (outputMode === "json") {
+    printJson(report);
+    return;
+  }
+
+  console.log(
+    formatSchedulerRunOnceReport(
+      redactStructuredValue(report, cliPrivacyConfig, "cli") as SchedulerRunOnceReport
+    )
+  );
+}
+
+async function runSchedulerCliAction(
+  input: { json?: boolean },
+  action: (outputMode: SchedulerOutputMode) => Promise<void>
+): Promise<void> {
+  const outputMode = resolveSchedulerOutputMode(input, Boolean(stdout.isTTY));
+
+  try {
+    await action(outputMode);
+  } catch (error) {
+    if (outputMode === "json") {
+      throw error;
+    }
+
+    process.stderr.write(
+      `${formatSchedulerError(
+        toLinkedInAssistantErrorPayload(error, cliPrivacyConfig)
+      )}\n`
+    );
+    process.exitCode = 1;
+  }
+}
+
 async function runSchedulerRunOnce(
   profileName: string,
+  outputMode: SchedulerOutputMode,
   cdpUrl?: string
 ): Promise<void> {
+  const normalizedProfileName = coerceProfileName(profileName);
+  writeSchedulerProgressNotice(
+    outputMode,
+    `Running one scheduler tick for profile ${normalizedProfileName}; this may take a moment.`
+  );
   const runtime = createRuntime(cdpUrl);
   const schedulerConfig = resolveSchedulerConfig();
 
@@ -1493,15 +1821,19 @@ async function runSchedulerRunOnce(
       schedulerConfig
     });
     const result = await scheduler.runTick({
-      profileName,
+      profileName: normalizedProfileName,
       workerId: `cli:${runtime.runId}`
     });
 
-    printJson({
+    if (result.failedJobs > 0) {
+      process.exitCode = 1;
+    }
+
+    emitSchedulerRunOnceReport({
       run_id: runtime.runId,
       scheduler_config: schedulerConfig,
       ...result
-    });
+    }, outputMode);
   } finally {
     runtime.close();
   }
@@ -1509,27 +1841,37 @@ async function runSchedulerRunOnce(
 
 async function runSchedulerStart(
   profileName: string,
+  outputMode: SchedulerOutputMode,
   cdpUrl?: string
 ): Promise<void> {
-  const existingPid = await readSchedulerPid(profileName);
+  const normalizedProfileName = coerceProfileName(profileName);
+  const files = getSchedulerFiles(normalizedProfileName);
+  const existingPid = await readSchedulerPid(normalizedProfileName);
   if (existingPid && isProcessRunning(existingPid)) {
-    const currentState = await readSchedulerState(profileName);
-    printJson({
+    const currentState = await readSchedulerState(normalizedProfileName);
+    emitSchedulerStartReport({
       started: false,
       reason: "Scheduler daemon is already running for this profile.",
-      profile_name: profileName,
+      profile_name: normalizedProfileName,
       pid: existingPid,
-      state: currentState
-    });
+      state: currentState,
+      state_path: files.statePath,
+      log_path: files.logPath,
+      ...resolveSchedulerStatusConfig()
+    }, outputMode);
     return;
   }
 
   if (existingPid && !isProcessRunning(existingPid)) {
-    await removeSchedulerPid(profileName);
+    await removeSchedulerPid(normalizedProfileName);
   }
 
   maybeWarnAboutSelectorLocaleConfig(cliSelectorLocale);
 
+  writeSchedulerProgressNotice(
+    outputMode,
+    `Starting scheduler daemon for profile ${normalizedProfileName}.`
+  );
   const schedulerConfig = resolveSchedulerConfig();
   const cliEntrypoint = resolveKeepAliveCliEntrypoint();
   if (!cliEntrypoint) {
@@ -1546,7 +1888,7 @@ async function runSchedulerStart(
   if (cliSelectorLocale) {
     daemonArgs.push("--selector-locale", cliSelectorLocale);
   }
-  daemonArgs.push("scheduler", "__run", "--profile", profileName);
+  daemonArgs.push("scheduler", "__run", "--profile", normalizedProfileName);
 
   const daemon = spawn(process.execPath, daemonArgs, {
     detached: true,
@@ -1565,7 +1907,7 @@ async function runSchedulerStart(
   const now = new Date().toISOString();
   const initialState: SchedulerState = {
     pid: daemon.pid,
-    profileName,
+    profileName: normalizedProfileName,
     startedAt: now,
     updatedAt: now,
     status: "starting",
@@ -1578,50 +1920,54 @@ async function runSchedulerStart(
     ...(cdpUrl ? { cdpUrl } : {})
   };
 
-  await writeSchedulerPid(profileName, daemon.pid);
-  await writeSchedulerState(profileName, initialState);
+  await writeSchedulerPid(normalizedProfileName, daemon.pid);
+  await writeSchedulerState(normalizedProfileName, initialState);
 
-  printJson({
+  emitSchedulerStartReport({
     started: true,
-    profile_name: profileName,
+    profile_name: normalizedProfileName,
     pid: daemon.pid,
-    state_path: getSchedulerFiles(profileName).statePath,
+    state_path: files.statePath,
+    log_path: files.logPath,
     scheduler_config: schedulerConfig
-  });
+  }, outputMode);
 }
 
-async function runSchedulerStatus(profileName: string): Promise<void> {
-  const pid = await readSchedulerPid(profileName);
-  const state = await readSchedulerState(profileName);
-  const running = typeof pid === "number" ? isProcessRunning(pid) : false;
-
-  printJson({
-    profile_name: profileName,
-    running,
-    pid,
-    state,
-    stale_pid_file: Boolean(pid && !running)
-  });
+async function runSchedulerStatus(
+  profileName: string,
+  outputMode: SchedulerOutputMode,
+  jobLimit: number
+): Promise<void> {
+  const normalizedProfileName = coerceProfileName(profileName);
+  const report = await buildSchedulerStatusReport(normalizedProfileName, jobLimit);
+  emitSchedulerStatusReport(report, outputMode);
 }
 
-async function runSchedulerStop(profileName: string): Promise<void> {
-  const pid = await readSchedulerPid(profileName);
-  const previousState = await readSchedulerState(profileName);
+async function runSchedulerStop(
+  profileName: string,
+  outputMode: SchedulerOutputMode
+): Promise<void> {
+  const normalizedProfileName = coerceProfileName(profileName);
+  const files = getSchedulerFiles(normalizedProfileName);
+  const pid = await readSchedulerPid(normalizedProfileName);
+  const previousState = await readSchedulerState(normalizedProfileName);
 
   if (!pid) {
-    printJson({
+    emitSchedulerStopReport({
       stopped: false,
-      profile_name: profileName,
-      reason: "No scheduler daemon pid file found."
-    });
+      profile_name: normalizedProfileName,
+      reason: "No scheduler daemon is currently running for this profile.",
+      state_path: files.statePath,
+      log_path: files.logPath
+    }, outputMode);
     return;
   }
 
   if (!isProcessRunning(pid)) {
-    await removeSchedulerPid(profileName);
+    await removeSchedulerPid(normalizedProfileName);
     const now = new Date().toISOString();
     if (previousState) {
-      await writeSchedulerState(profileName, {
+      await writeSchedulerState(normalizedProfileName, {
         ...previousState,
         status: "stopped",
         updatedAt: now,
@@ -1629,14 +1975,21 @@ async function runSchedulerStop(profileName: string): Promise<void> {
         lastError: "Recovered from stale pid file."
       });
     }
-    printJson({
+    emitSchedulerStopReport({
       stopped: true,
-      profile_name: profileName,
+      profile_name: normalizedProfileName,
       pid,
-      reason: "Recovered stale scheduler pid file."
-    });
+      reason: "Removed a stale scheduler PID file for this profile.",
+      state_path: files.statePath,
+      log_path: files.logPath
+    }, outputMode);
     return;
   }
+
+  writeSchedulerProgressNotice(
+    outputMode,
+    `Stopping scheduler daemon for profile ${normalizedProfileName}.`
+  );
 
   try {
     process.kill(pid, "SIGTERM");
@@ -1645,7 +1998,7 @@ async function runSchedulerStop(profileName: string): Promise<void> {
       "UNKNOWN",
       "Failed to send SIGTERM to scheduler daemon.",
       {
-        profile_name: profileName,
+        profile_name: normalizedProfileName,
         pid,
         cause: error instanceof Error ? error.message : String(error)
       }
@@ -1666,10 +2019,10 @@ async function runSchedulerStop(profileName: string): Promise<void> {
     process.kill(pid, "SIGKILL");
   }
 
-  await removeSchedulerPid(profileName);
+  await removeSchedulerPid(normalizedProfileName);
   const now = new Date().toISOString();
   if (previousState) {
-    await writeSchedulerState(profileName, {
+    await writeSchedulerState(normalizedProfileName, {
       ...previousState,
       status: "stopped",
       updatedAt: now,
@@ -1680,12 +2033,17 @@ async function runSchedulerStop(profileName: string): Promise<void> {
     });
   }
 
-  printJson({
+  emitSchedulerStopReport({
     stopped: true,
-    profile_name: profileName,
+    profile_name: normalizedProfileName,
     pid,
-    forced: running
-  });
+    forced: running,
+    reason: running
+      ? "Scheduler daemon did not exit after SIGTERM, so it was force-stopped."
+      : "Scheduler daemon exited cleanly.",
+    state_path: files.statePath,
+    log_path: files.logPath
+  }, outputMode);
 }
 
 async function runSchedulerDaemon(
@@ -1769,6 +2127,7 @@ async function runSchedulerDaemon(
             maxConsecutiveFailures: SCHEDULER_DAEMON_MAX_CONSECUTIVE_FAILURES,
             lastTickAt: tickAt,
             lastSuccessfulTickAt: tickAt,
+            nextWindowStartAt: result.nextWindowStartAt,
             lastSummary: summarizeSchedulerTick(result)
           };
           if (result.preparedJobs > 0) {
@@ -3137,38 +3496,94 @@ export function createCliProgram(): Command {
 
   const schedulerCommand = program
     .command("scheduler")
-    .description("Run and manage the local follow-up scheduler daemon");
+    .description(
+      "Manage the local follow-up scheduler daemon. The scheduler only prepares follow-ups near their due time, and prepared actions still require manual confirmation."
+    )
+    .addHelpText(
+      "afterAll",
+      [
+        "",
+        "Interactive terminals default to human-readable scheduler summaries.",
+        "Use --json for automation, piping, or to inspect the full structured payload.",
+        "The scheduler only prepares follow-ups; confirmation always remains manual.",
+        "",
+        "Examples:",
+        "  linkedin scheduler start --profile default",
+        "  linkedin scheduler status --profile default --jobs 10",
+        "  linkedin scheduler run-once --profile default --json",
+        "  linkedin scheduler stop --profile default"
+      ].join("\n")
+    );
 
   schedulerCommand
     .command("start")
-    .description("Start the scheduler daemon for a profile")
+    .description("Start the local scheduler daemon for a profile")
     .option("-p, --profile <profile>", "Profile name", "default")
-    .action(async (options: { profile: string }) => {
-      await runSchedulerStart(options.profile, readCdpUrl());
+    .option("--json", "Print the structured scheduler payload", false)
+    .action(async (options: { profile: string; json: boolean }) => {
+      await runSchedulerCliAction(options, async (outputMode) => {
+        await runSchedulerStart(options.profile, outputMode, readCdpUrl());
+      });
     });
 
   schedulerCommand
     .command("status")
-    .description("Show scheduler daemon status for a profile")
+    .description("Show daemon health, queue summary, and recent scheduler history")
     .option("-p, --profile <profile>", "Profile name", "default")
-    .action(async (options: { profile: string }) => {
-      await runSchedulerStatus(options.profile);
+    .option(
+      "--jobs <count>",
+      "Show up to this many queued and recent jobs in the status output",
+      String(DEFAULT_SCHEDULER_STATUS_JOB_LIMIT)
+    )
+    .option("--json", "Print the structured scheduler payload", false)
+    .addHelpText(
+      "after",
+      [
+        "",
+        "Status output previews queued jobs and recent history for the selected profile.",
+        "Use --jobs <count> to control how many queued and recent jobs are shown.",
+        "Use --json for automation or to inspect the full structured scheduler payload."
+      ].join("\n")
+    )
+    .action(async (options: { profile: string; jobs: string; json: boolean }) => {
+      await runSchedulerCliAction(options, async (outputMode) => {
+        await runSchedulerStatus(
+          options.profile,
+          outputMode,
+          coercePositiveInt(options.jobs, "jobs")
+        );
+      });
     });
 
   schedulerCommand
     .command("stop")
-    .description("Stop the scheduler daemon for a profile")
+    .description("Stop the local scheduler daemon and clean up stale state")
     .option("-p, --profile <profile>", "Profile name", "default")
-    .action(async (options: { profile: string }) => {
-      await runSchedulerStop(options.profile);
+    .option("--json", "Print the structured scheduler payload", false)
+    .action(async (options: { profile: string; json: boolean }) => {
+      await runSchedulerCliAction(options, async (outputMode) => {
+        await runSchedulerStop(options.profile, outputMode);
+      });
     });
 
   schedulerCommand
     .command("run-once")
-    .description("Run one scheduler tick immediately")
+    .alias("tick")
+    .description("Run one scheduler tick immediately and summarize the result")
     .option("-p, --profile <profile>", "Profile name", "default")
-    .action(async (options: { profile: string }) => {
-      await runSchedulerRunOnce(options.profile, readCdpUrl());
+    .option("--json", "Print the structured scheduler payload", false)
+    .addHelpText(
+      "after",
+      [
+        "",
+        "Prepared actions still require manual confirmation after a successful tick.",
+        "Use this command when you want an immediate scheduler pass without starting the daemon."
+      ].join("\n")
+    )
+    .action(async (options: { profile: string; json: boolean }) => {
+      await runSchedulerCliAction(options, async (outputMode) => {
+        await runSchedulerRunOnce(options.profile, outputMode, readCdpUrl());
+      });
     });
 
   schedulerCommand

--- a/packages/cli/src/schedulerOutput.ts
+++ b/packages/cli/src/schedulerOutput.ts
@@ -1,0 +1,728 @@
+import type {
+  LinkedInAssistantErrorPayload,
+  SchedulerConfig,
+  SchedulerLane,
+  SchedulerTickJobResult,
+  SchedulerTickResult
+} from "@linkedin-assistant/core";
+
+export type SchedulerOutputMode = "human" | "json";
+
+export interface SchedulerStateSummaryView {
+  skippedReason: SchedulerTickResult["skippedReason"];
+  discoveredAcceptedConnections: number;
+  queuedJobs: number;
+  updatedJobs: number;
+  reopenedJobs: number;
+  cancelledJobs: number;
+  claimedJobs: number;
+  preparedJobs: number;
+  rescheduledJobs: number;
+  failedJobs: number;
+}
+
+export interface SchedulerStateView {
+  pid: number;
+  profileName: string;
+  startedAt: string;
+  updatedAt: string;
+  status: "starting" | "running" | "idle" | "degraded" | "stopped";
+  pollIntervalMs: number;
+  businessHours: SchedulerConfig["businessHours"];
+  maxJobsPerTick: number;
+  maxActiveJobsPerProfile: number;
+  consecutiveFailures: number;
+  maxConsecutiveFailures: number;
+  lastTickAt?: string;
+  lastSuccessfulTickAt?: string;
+  lastPreparedAt?: string;
+  nextWindowStartAt?: string | null;
+  lastSummary?: SchedulerStateSummaryView;
+  lastError?: string;
+  cdpUrl?: string;
+  stoppedAt?: string;
+}
+
+export interface SchedulerJobPreview {
+  id: string;
+  lane: SchedulerLane;
+  status: "pending" | "leased" | "prepared" | "failed" | "cancelled";
+  targetLabel?: string;
+  scheduledAt: string;
+  updatedAt: string;
+  attemptCount: number;
+  maxAttempts: number;
+  preparedActionId?: string | null;
+  lastErrorCode?: string | null;
+  lastErrorMessage?: string | null;
+}
+
+export interface SchedulerJobCounts {
+  total: number;
+  pending: number;
+  pendingDueNow: number;
+  pendingLater: number;
+  leased: number;
+  prepared: number;
+  failed: number;
+  cancelled: number;
+}
+
+export interface SchedulerStatusReport {
+  profile_name: string;
+  running: boolean;
+  pid: number | null;
+  state: SchedulerStateView | null;
+  stale_pid_file: boolean;
+  state_path: string;
+  log_path: string;
+  scheduler_config?: SchedulerConfig;
+  scheduler_config_error?: LinkedInAssistantErrorPayload;
+  job_counts: SchedulerJobCounts;
+  next_jobs: SchedulerJobPreview[];
+  recent_jobs: SchedulerJobPreview[];
+}
+
+export interface SchedulerStartReport {
+  started: boolean;
+  reason?: string;
+  profile_name: string;
+  pid?: number;
+  state?: SchedulerStateView | null;
+  state_path: string;
+  log_path: string;
+  scheduler_config?: SchedulerConfig;
+  scheduler_config_error?: LinkedInAssistantErrorPayload;
+}
+
+export interface SchedulerStopReport {
+  stopped: boolean;
+  profile_name: string;
+  pid?: number;
+  forced?: boolean;
+  reason?: string;
+  state_path: string;
+  log_path: string;
+}
+
+export interface SchedulerRunOnceReport extends SchedulerTickResult {
+  run_id: string;
+  scheduler_config: SchedulerConfig;
+}
+
+const CONTROL_CHARACTER_PATTERN = new RegExp(
+  `[${String.fromCharCode(0)}-${String.fromCharCode(31)}${String.fromCharCode(127)}-${String.fromCharCode(159)}]+`,
+  "g"
+);
+const ANSI_ESCAPE_PATTERN = new RegExp(
+  `${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`,
+  "g"
+);
+
+function sanitizeConsoleText(value: string): string {
+  const sanitized = value
+    .replace(ANSI_ESCAPE_PATTERN, " ")
+    .replace(CONTROL_CHARACTER_PATTERN, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return sanitized.length > 0 ? sanitized : "[sanitized]";
+}
+
+function appendSection(lines: string[], title: string, entries: string[]): void {
+  if (entries.length === 0) {
+    return;
+  }
+
+  lines.push("");
+  lines.push(title);
+  lines.push(...entries);
+}
+
+function formatDurationMs(value: number): string {
+  if (!Number.isFinite(value) || value < 1_000) {
+    return `${Math.max(0, Math.round(value))}ms`;
+  }
+
+  const seconds = Math.round(value / 1_000);
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+
+  const hours = Math.round((minutes / 60) * 10) / 10;
+  return `${hours}h`;
+}
+
+function formatStatusLabel(status: string): string {
+  return sanitizeConsoleText(status.replace(/_/g, " ").toUpperCase());
+}
+
+function formatCountLabel(
+  count: number,
+  singular: string,
+  plural: string = `${singular}s`
+): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function formatBusinessHours(config: SchedulerConfig["businessHours"]): string {
+  return `${sanitizeConsoleText(config.startTime)}-${sanitizeConsoleText(config.endTime)} ${sanitizeConsoleText(config.timeZone)}`;
+}
+
+function formatLaneList(lanes: SchedulerConfig["enabledLanes"]): string {
+  if (lanes.length === 0) {
+    return "none";
+  }
+
+  return lanes.map((lane) => sanitizeConsoleText(lane)).join(", ");
+}
+
+function formatSchedulerSkipReason(
+  reason: SchedulerTickResult["skippedReason"]
+): string | null {
+  if (reason === null) {
+    return null;
+  }
+
+  switch (reason) {
+    case "disabled":
+      return "Scheduler work is disabled by the current scheduler configuration.";
+    case "outside_business_hours":
+      return "The scheduler is waiting for the next configured business-hours window.";
+    case "profile_busy":
+      return "The profile is currently busy with another CLI, MCP, or daemon task.";
+    default:
+      return sanitizeConsoleText(reason);
+  }
+}
+
+function formatJobDescriptor(job: {
+  lane: SchedulerLane;
+  targetLabel?: string;
+}): string {
+  const lane = sanitizeConsoleText(job.lane);
+  const target =
+    typeof job.targetLabel === "string" && job.targetLabel.trim().length > 0
+      ? ` / ${sanitizeConsoleText(job.targetLabel)}`
+      : "";
+
+  return `${lane}${target}`;
+}
+
+function formatJobPreviewLine(job: SchedulerJobPreview): string {
+  const suffixes = [
+    `${formatStatusLabel(job.status).toLowerCase()}, due ${sanitizeConsoleText(job.scheduledAt)}`,
+    `attempt ${job.attemptCount}/${job.maxAttempts}`
+  ];
+
+  if (job.preparedActionId) {
+    suffixes.push(`prepared action ${sanitizeConsoleText(job.preparedActionId)}`);
+  }
+  if (job.lastErrorCode) {
+    suffixes.push(`code=${sanitizeConsoleText(job.lastErrorCode)}`);
+  }
+  if (job.lastErrorMessage) {
+    suffixes.push(sanitizeConsoleText(job.lastErrorMessage));
+  }
+
+  return `- ${formatJobDescriptor(job)} — ${suffixes.join(" | ")}`;
+}
+
+function formatRecentJobLine(job: SchedulerJobPreview): string {
+  const suffixes = [`updated ${sanitizeConsoleText(job.updatedAt)}`];
+  if (job.preparedActionId) {
+    suffixes.push(`prepared action ${sanitizeConsoleText(job.preparedActionId)}`);
+  }
+  if (job.lastErrorCode) {
+    suffixes.push(`code=${sanitizeConsoleText(job.lastErrorCode)}`);
+  }
+  if (job.lastErrorMessage) {
+    suffixes.push(sanitizeConsoleText(job.lastErrorMessage));
+  }
+
+  return `- ${formatStatusLabel(job.status)} ${formatJobDescriptor(job)} — ${suffixes.join(" | ")}`;
+}
+
+function formatProcessedJobLine(job: SchedulerTickJobResult): string {
+  const parts = [`${sanitizeConsoleText(job.lane)} / ${sanitizeConsoleText(job.jobId)}`];
+
+  if (job.preparedActionId) {
+    parts.push(`prepared action ${sanitizeConsoleText(job.preparedActionId)}`);
+  }
+  if (job.scheduledAtMs) {
+    parts.push(`next attempt ${sanitizeConsoleText(new Date(job.scheduledAtMs).toISOString())}`);
+  }
+  if (job.errorCode) {
+    parts.push(`code=${sanitizeConsoleText(job.errorCode)}`);
+  }
+  if (job.errorMessage) {
+    parts.push(sanitizeConsoleText(job.errorMessage));
+  }
+
+  return `- ${formatStatusLabel(job.outcome)} ${parts.join(" | ")}`;
+}
+
+function formatConfigSummary(config: SchedulerConfig): string[] {
+  return [
+    `- Poll interval: every ${formatDurationMs(config.pollIntervalMs)}`,
+    `- Business hours: ${formatBusinessHours(config.businessHours)}`,
+    `- Enabled lanes: ${formatLaneList(config.enabledLanes)}`,
+    `- Max jobs per tick: ${config.maxJobsPerTick} | Active job cap: ${config.maxActiveJobsPerProfile}`
+  ];
+}
+
+function formatStateSummary(summary: SchedulerStateSummaryView): string {
+  const parts = [
+    `${formatCountLabel(summary.discoveredAcceptedConnections, "accepted connection")} discovered`,
+    `${summary.queuedJobs} queued`,
+    `${summary.updatedJobs} updated`,
+    `${summary.reopenedJobs} reopened`,
+    `${summary.cancelledJobs} cancelled`,
+    `${summary.claimedJobs} claimed`,
+    `${summary.preparedJobs} prepared`,
+    `${summary.rescheduledJobs} rescheduled`,
+    `${summary.failedJobs} failed`
+  ];
+
+  if (summary.skippedReason !== null) {
+    parts.push(`skipped=${sanitizeConsoleText(summary.skippedReason)}`);
+  }
+
+  return parts.join(" | ");
+}
+
+function formatStatusHeadline(report: SchedulerStatusReport): string {
+  if (report.stale_pid_file) {
+    return "STALE PID FILE";
+  }
+
+  if (report.running) {
+    return report.state ? formatStatusLabel(report.state.status) : "RUNNING";
+  }
+
+  if (report.state) {
+    return formatStatusLabel(report.state.status);
+  }
+
+  return "STOPPED";
+}
+
+function formatStatusNextSteps(report: SchedulerStatusReport): string[] {
+  const profile = sanitizeConsoleText(report.profile_name);
+  const steps: string[] = [];
+
+  if (report.stale_pid_file) {
+    steps.push(
+      `Run \`linkedin scheduler stop --profile ${profile}\` to clear the stale PID file safely.`
+    );
+  } else if (report.running) {
+    steps.push(
+      `Run \`linkedin scheduler run-once --profile ${profile}\` to force an immediate tick.`
+    );
+    steps.push(
+      `Run \`linkedin scheduler stop --profile ${profile}\` to stop the daemon.`
+    );
+  } else {
+    steps.push(
+      `Run \`linkedin scheduler start --profile ${profile}\` to start the daemon.`
+    );
+  }
+
+  if (report.scheduler_config_error) {
+    steps.push(
+      "Fix the scheduler environment variable listed above, or unset it to fall back to the default scheduler setting."
+    );
+  } else if (report.scheduler_config && report.scheduler_config.enabledLanes.length === 0) {
+    steps.push(
+      "Re-enable at least one scheduler lane before expecting queued follow-ups to prepare automatically."
+    );
+  }
+
+  if (report.job_counts.total === 0) {
+    steps.push(
+      "Accepted invitations create follow-up jobs when they are discovered; an empty queue is normal on a fresh profile."
+    );
+  }
+
+  steps.push("Use `--json` if you need the structured scheduler payload for automation.");
+  return steps;
+}
+
+function formatRunOnceNextSteps(report: SchedulerRunOnceReport): string[] {
+  const profile = sanitizeConsoleText(report.profileName);
+  const steps: string[] = [];
+
+  if (report.preparedJobs > 0) {
+    steps.push(
+      "Review and manually confirm any prepared follow-up actions; the scheduler never auto-confirms them."
+    );
+  }
+
+  if (report.skippedReason === "outside_business_hours" && report.nextWindowStartAt) {
+    steps.push(
+      `Rerun after ${sanitizeConsoleText(report.nextWindowStartAt)} or wait for the daemon to resume inside business hours.`
+    );
+  } else if (report.skippedReason === "profile_busy") {
+    steps.push(
+      `Wait for the current profile activity to finish, then rerun \`linkedin scheduler run-once --profile ${profile}\`.`
+    );
+  } else if (report.processedJobs.length === 0) {
+    steps.push(
+      `Run \`linkedin scheduler status --profile ${profile}\` to inspect the queue and recent job history.`
+    );
+  }
+
+  steps.push(
+    `Run \`linkedin scheduler start --profile ${profile}\` if you want the scheduler to keep polling in the background.`
+  );
+  return steps;
+}
+
+function formatStartNextSteps(report: SchedulerStartReport): string[] {
+  const profile = sanitizeConsoleText(report.profile_name);
+
+  if (!report.started) {
+    return [
+      `Run \`linkedin scheduler status --profile ${profile}\` to inspect the existing daemon.`,
+      `Run \`linkedin scheduler stop --profile ${profile}\` if you need to restart it cleanly.`,
+      "Use `--json` if you need the structured scheduler payload for automation."
+    ];
+  }
+
+  return [
+    `Run \`linkedin scheduler status --profile ${profile}\` to inspect daemon health, queue state, and recent job history.`,
+    "Prepared follow-up actions still require manual confirmation; nothing is sent automatically.",
+    "Use `--json` if you need the structured scheduler payload for automation."
+  ];
+}
+
+function formatStopNextSteps(report: SchedulerStopReport): string[] {
+  const profile = sanitizeConsoleText(report.profile_name);
+
+  if (report.stopped) {
+    return [
+      `Run \`linkedin scheduler status --profile ${profile}\` to confirm the daemon is idle.`,
+      `Run \`linkedin scheduler start --profile ${profile}\` when you want background scheduling again.`,
+      "Use `--json` if you need the structured scheduler payload for automation."
+    ];
+  }
+
+  return [
+    `Run \`linkedin scheduler start --profile ${profile}\` to launch the daemon.`,
+    "Use `--json` if you need the structured scheduler payload for automation."
+  ];
+}
+
+export function resolveSchedulerOutputMode(
+  input: { json?: boolean },
+  interactiveTerminal: boolean
+): SchedulerOutputMode {
+  if (input.json) {
+    return "json";
+  }
+
+  return interactiveTerminal ? "human" : "json";
+}
+
+export function formatSchedulerStatusReport(report: SchedulerStatusReport): string {
+  const lines = [`Scheduler Status: ${formatStatusHeadline(report)}`];
+
+  lines.push(`Profile: ${sanitizeConsoleText(report.profile_name)}`);
+  lines.push(`PID: ${report.pid === null ? "none" : report.pid}`);
+  lines.push(`State file: ${sanitizeConsoleText(report.state_path)}`);
+  lines.push(`Event log: ${sanitizeConsoleText(report.log_path)}`);
+
+  if (report.scheduler_config_error) {
+    appendSection(lines, "Config Warning", [
+      `- ${sanitizeConsoleText(report.scheduler_config_error.message)}`
+    ]);
+  } else if (report.scheduler_config) {
+    appendSection(lines, "Config", formatConfigSummary(report.scheduler_config));
+  }
+
+  if (report.state) {
+    const daemonEntries = [
+      `- State: ${formatStatusLabel(report.state.status)} | Updated: ${sanitizeConsoleText(report.state.updatedAt)}`,
+      `- Started: ${sanitizeConsoleText(report.state.startedAt)}`,
+      `- Consecutive failures: ${report.state.consecutiveFailures}/${report.state.maxConsecutiveFailures}`
+    ];
+
+    if (report.state.lastTickAt) {
+      daemonEntries.push(`- Last tick: ${sanitizeConsoleText(report.state.lastTickAt)}`);
+    }
+    if (report.state.lastSuccessfulTickAt) {
+      daemonEntries.push(
+        `- Last successful tick: ${sanitizeConsoleText(report.state.lastSuccessfulTickAt)}`
+      );
+    }
+    if (report.state.lastPreparedAt) {
+      daemonEntries.push(
+        `- Last prepared action: ${sanitizeConsoleText(report.state.lastPreparedAt)}`
+      );
+    }
+    if (report.state.nextWindowStartAt) {
+      daemonEntries.push(
+        `- Next business window: ${sanitizeConsoleText(report.state.nextWindowStartAt)}`
+      );
+    }
+    if (report.state.lastSummary) {
+      daemonEntries.push(`- Last summary: ${formatStateSummary(report.state.lastSummary)}`);
+      const skippedMessage = formatSchedulerSkipReason(report.state.lastSummary.skippedReason);
+      if (skippedMessage) {
+        daemonEntries.push(`- Last skip reason: ${skippedMessage}`);
+      }
+    }
+    if (report.state.lastError) {
+      daemonEntries.push(`- Last error: ${sanitizeConsoleText(report.state.lastError)}`);
+    }
+    if (report.state.stoppedAt) {
+      daemonEntries.push(`- Stopped: ${sanitizeConsoleText(report.state.stoppedAt)}`);
+    }
+
+    appendSection(lines, "Daemon", daemonEntries);
+  }
+
+  const queueEntries = [
+    `- Jobs: ${report.job_counts.total} total | ${report.job_counts.pending} pending (${report.job_counts.pendingDueNow} due now, ${report.job_counts.pendingLater} later) | ${report.job_counts.leased} leased | ${report.job_counts.prepared} prepared | ${report.job_counts.failed} failed | ${report.job_counts.cancelled} cancelled`
+  ];
+
+  if (report.job_counts.total === 0) {
+    queueEntries.push(
+      "- No scheduler jobs are recorded for this profile yet."
+    );
+  }
+
+  appendSection(lines, "Queue", queueEntries);
+  appendSection(
+    lines,
+    "Next Jobs",
+    report.next_jobs.length > 0
+      ? report.next_jobs.map((job) => formatJobPreviewLine(job))
+      : ["- No pending or leased jobs are currently queued."]
+  );
+  appendSection(
+    lines,
+    "Recent History",
+    report.recent_jobs.length > 0
+      ? report.recent_jobs.map((job) => formatRecentJobLine(job))
+      : ["- No prepared, failed, or cancelled jobs have been recorded yet."]
+  );
+  appendSection(
+    lines,
+    "Next Steps",
+    formatStatusNextSteps(report).map((step) => `- ${step}`)
+  );
+
+  return lines.join("\n");
+}
+
+export function formatSchedulerStartReport(report: SchedulerStartReport): string {
+  const title = report.started ? "Scheduler Start: STARTED" : "Scheduler Start: ALREADY RUNNING";
+  const lines = [title];
+
+  lines.push(`Profile: ${sanitizeConsoleText(report.profile_name)}`);
+  if (typeof report.pid === "number") {
+    lines.push(`PID: ${report.pid}`);
+  }
+  lines.push(`State file: ${sanitizeConsoleText(report.state_path)}`);
+  lines.push(`Event log: ${sanitizeConsoleText(report.log_path)}`);
+
+  if (report.scheduler_config_error) {
+    appendSection(lines, "Config Warning", [
+      `- ${sanitizeConsoleText(report.scheduler_config_error.message)}`
+    ]);
+  } else if (report.scheduler_config) {
+    appendSection(lines, "Config", formatConfigSummary(report.scheduler_config));
+  }
+
+  if (report.reason) {
+    appendSection(lines, "Status", [`- ${sanitizeConsoleText(report.reason)}`]);
+  }
+
+  if (report.state?.lastSummary) {
+    appendSection(lines, "Current State", [
+      `- Daemon state: ${formatStatusLabel(report.state.status)}`,
+      `- Last summary: ${formatStateSummary(report.state.lastSummary)}`
+    ]);
+  }
+
+  appendSection(
+    lines,
+    "Notes",
+    [
+      "- The scheduler prepares follow-ups near their due time and only during configured business hours.",
+      "- Prepared follow-up actions still require manual confirmation."
+    ]
+  );
+  appendSection(
+    lines,
+    "Next Steps",
+    formatStartNextSteps(report).map((step) => `- ${step}`)
+  );
+
+  return lines.join("\n");
+}
+
+export function formatSchedulerStopReport(report: SchedulerStopReport): string {
+  const title = report.stopped ? "Scheduler Stop: STOPPED" : "Scheduler Stop: NOT RUNNING";
+  const lines = [title];
+
+  lines.push(`Profile: ${sanitizeConsoleText(report.profile_name)}`);
+  if (typeof report.pid === "number") {
+    lines.push(`PID: ${report.pid}`);
+  }
+  lines.push(`State file: ${sanitizeConsoleText(report.state_path)}`);
+  lines.push(`Event log: ${sanitizeConsoleText(report.log_path)}`);
+
+  const statusEntries: string[] = [];
+  if (report.reason) {
+    statusEntries.push(`- ${sanitizeConsoleText(report.reason)}`);
+  }
+  if (report.forced) {
+    statusEntries.push("- Stop required SIGKILL after the daemon ignored SIGTERM for 5 seconds.");
+  }
+  appendSection(lines, "Status", statusEntries);
+  appendSection(
+    lines,
+    "Next Steps",
+    formatStopNextSteps(report).map((step) => `- ${step}`)
+  );
+
+  return lines.join("\n");
+}
+
+export function formatSchedulerRunOnceReport(report: SchedulerRunOnceReport): string {
+  const headline = report.skippedReason === null ? "Scheduler Tick: COMPLETED" : "Scheduler Tick: SKIPPED";
+  const lines = [headline];
+
+  lines.push(`Profile: ${sanitizeConsoleText(report.profileName)}`);
+  lines.push(`Run: ${sanitizeConsoleText(report.run_id)}`);
+
+  appendSection(lines, "Config", formatConfigSummary(report.scheduler_config));
+
+  const summaryEntries = [
+    `- Window open: ${report.windowOpen ? "yes" : "no"}`,
+    `- Accepted connections discovered: ${report.discoveredAcceptedConnections}`,
+    `- Queue sync: ${report.queuedJobs} queued | ${report.updatedJobs} updated | ${report.reopenedJobs} reopened | ${report.cancelledJobs} cancelled`,
+    `- Execution: ${report.claimedJobs} claimed | ${report.preparedJobs} prepared | ${report.rescheduledJobs} rescheduled | ${report.failedJobs} failed`
+  ];
+
+  if (report.skippedReason !== null) {
+    const skippedMessage = formatSchedulerSkipReason(report.skippedReason);
+    if (skippedMessage) {
+      summaryEntries.push(`- Result: ${skippedMessage}`);
+    }
+  }
+  if (report.nextWindowStartAt) {
+    summaryEntries.push(
+      `- Next business window: ${sanitizeConsoleText(report.nextWindowStartAt)}`
+    );
+  }
+  appendSection(lines, "Summary", summaryEntries);
+
+  appendSection(
+    lines,
+    "Processed Jobs",
+    report.processedJobs.length > 0
+      ? report.processedJobs.map((job) => formatProcessedJobLine(job))
+      : ["- No scheduler jobs were processed in this tick."]
+  );
+  appendSection(
+    lines,
+    "Next Steps",
+    formatRunOnceNextSteps(report).map((step) => `- ${step}`)
+  );
+
+  return lines.join("\n");
+}
+
+function readString(payload: Record<string, unknown>, key: string): string | null {
+  const value = payload[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function readNumber(payload: Record<string, unknown>, key: string): number | null {
+  const value = payload[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function readStringArray(
+  payload: Record<string, unknown>,
+  key: string
+): string[] | null {
+  const value = payload[key];
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const strings = value
+    .filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+    .map((entry) => entry.trim());
+
+  return strings.length > 0 ? strings : null;
+}
+
+export function formatSchedulerError(error: LinkedInAssistantErrorPayload): string {
+  const lines = [`Scheduler command failed [${sanitizeConsoleText(error.code)}]`, sanitizeConsoleText(error.message)];
+  const env = readString(error.details, "env");
+  const value = readString(error.details, "value");
+  const path = readString(error.details, "path");
+  const cause = readString(error.details, "cause");
+  const invalidLanes = readStringArray(error.details, "invalid_lanes");
+  const supportedLanes = readStringArray(error.details, "supported_lanes");
+  const startTime = readString(error.details, "start_time");
+  const endTime = readString(error.details, "end_time");
+  const timeZone = readString(error.details, "time_zone");
+  const maxJobsPerTick = readNumber(error.details, "max_jobs_per_tick");
+  const maxActiveJobsPerProfile = readNumber(
+    error.details,
+    "max_active_jobs_per_profile"
+  );
+
+  if (env) {
+    lines.push(`Setting: ${sanitizeConsoleText(env)}`);
+  }
+  if (path) {
+    lines.push(`Path: ${sanitizeConsoleText(path)}`);
+  }
+  if (value) {
+    lines.push(`Provided value: ${sanitizeConsoleText(value)}`);
+  }
+  if (invalidLanes) {
+    lines.push(`Invalid lanes: ${invalidLanes.map(sanitizeConsoleText).join(", ")}`);
+  }
+  if (supportedLanes) {
+    lines.push(`Supported lanes: ${supportedLanes.map(sanitizeConsoleText).join(", ")}`);
+  }
+  if (startTime && endTime) {
+    lines.push(
+      `Business hours: ${sanitizeConsoleText(startTime)} → ${sanitizeConsoleText(endTime)}${timeZone ? ` (${sanitizeConsoleText(timeZone)})` : ""}`
+    );
+  }
+  if (
+    typeof maxJobsPerTick === "number" &&
+    typeof maxActiveJobsPerProfile === "number"
+  ) {
+    lines.push(
+      `Constraint: max jobs per tick (${maxJobsPerTick}) must be less than or equal to max active jobs per profile (${maxActiveJobsPerProfile}).`
+    );
+  }
+  if (cause) {
+    lines.push(`Cause: ${sanitizeConsoleText(cause)}`);
+  }
+
+  if (env?.startsWith("LINKEDIN_ASSISTANT_SCHEDULER_")) {
+    lines.push(
+      "Tip: fix the scheduler setting above, or unset it to use the default scheduler value."
+    );
+  }
+
+  lines.push("Tip: run `linkedin scheduler --help` for scheduler command examples.");
+  lines.push("Tip: rerun with --json if you need the structured error payload.");
+  return lines.join("\n");
+}

--- a/packages/cli/test/schedulerCli.test.ts
+++ b/packages/cli/test/schedulerCli.test.ts
@@ -1,0 +1,351 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { stdin, stdout } from "node:process";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const schedulerCliMocks = vi.hoisted(() => ({
+  close: vi.fn(),
+  createCoreRuntime: vi.fn(),
+  loggerLog: vi.fn(),
+  schedulerRunTick: vi.fn(),
+  spawn: vi.fn()
+}));
+
+vi.mock("@linkedin-assistant/core", async () => {
+  const actual = await import("../../core/src/index.js");
+
+  class MockSchedulerService {
+    constructor() {}
+
+    async runTick(input: { profileName?: string; workerId?: string }) {
+      return await schedulerCliMocks.schedulerRunTick(input);
+    }
+  }
+
+  return {
+    ...actual,
+    createCoreRuntime: schedulerCliMocks.createCoreRuntime,
+    LinkedInSchedulerService: MockSchedulerService
+  };
+});
+
+vi.mock("node:child_process", () => ({
+  spawn: schedulerCliMocks.spawn
+}));
+
+import { AssistantDatabase, resolveConfigPaths } from "@linkedin-assistant/core";
+import { createCliProgram, runCli } from "../src/bin/linkedin.js";
+
+const SCHEDULER_ENV_KEYS = [
+  "LINKEDIN_ASSISTANT_HOME",
+  "LINKEDIN_ASSISTANT_SCHEDULER_TIMEZONE"
+] as const;
+
+function setInteractiveMode(inputIsTty: boolean, outputIsTty: boolean): void {
+  Object.defineProperty(stdin, "isTTY", {
+    configurable: true,
+    value: inputIsTty
+  });
+  Object.defineProperty(stdout, "isTTY", {
+    configurable: true,
+    value: outputIsTty
+  });
+  Object.defineProperty(process.stderr, "isTTY", {
+    configurable: true,
+    value: outputIsTty
+  });
+}
+
+function createTickResult(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    profileName: "default",
+    workerId: "cli:run-scheduler-cli",
+    windowOpen: true,
+    nextWindowStartAt: null,
+    skippedReason: null,
+    discoveredAcceptedConnections: 0,
+    queuedJobs: 0,
+    updatedJobs: 0,
+    reopenedJobs: 0,
+    cancelledJobs: 0,
+    claimedJobs: 0,
+    preparedJobs: 0,
+    rescheduledJobs: 0,
+    failedJobs: 0,
+    processedJobs: [],
+    ...overrides
+  };
+}
+
+describe("linkedin scheduler CLI UX", () => {
+  let tempDir = "";
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let previousEnv = new Map<string, string | undefined>();
+  let stderrChunks: string[] = [];
+  let stderrWriteSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-cli-scheduler-"));
+    previousEnv = new Map<string, string | undefined>();
+    for (const key of SCHEDULER_ENV_KEYS) {
+      previousEnv.set(key, process.env[key]);
+      delete process.env[key];
+    }
+
+    process.env.LINKEDIN_ASSISTANT_HOME = path.join(tempDir, "assistant-home");
+    process.exitCode = undefined;
+    setInteractiveMode(true, true);
+    stderrChunks = [];
+    vi.clearAllMocks();
+    schedulerCliMocks.spawn.mockImplementation(() => ({
+      pid: 12_345,
+      unref: vi.fn()
+    }));
+    schedulerCliMocks.createCoreRuntime.mockImplementation(() => ({
+      runId: "run-scheduler-cli",
+      db: {},
+      logger: { log: schedulerCliMocks.loggerLog },
+      followups: {},
+      close: schedulerCliMocks.close
+    }));
+    schedulerCliMocks.schedulerRunTick.mockResolvedValue(createTickResult());
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    stderrWriteSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((...args: Parameters<typeof process.stderr.write>) => {
+        const [chunk] = args;
+        stderrChunks.push(String(chunk));
+        return true;
+      });
+  });
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore();
+    stderrWriteSpy.mockRestore();
+    process.exitCode = undefined;
+    for (const key of SCHEDULER_ENV_KEYS) {
+      const previousValue = previousEnv.get(key);
+      if (typeof previousValue === "string") {
+        process.env[key] = previousValue;
+      } else {
+        delete process.env[key];
+      }
+    }
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function seedSchedulerState(): Promise<void> {
+    const schedulerDir = path.join(resolveConfigPaths().baseDir, "scheduler");
+    await mkdir(schedulerDir, { recursive: true });
+    await writeFile(
+      path.join(schedulerDir, "default.state.json"),
+      `${JSON.stringify(
+        {
+          pid: 12_345,
+          profileName: "default",
+          startedAt: "2026-03-09T08:00:00.000Z",
+          updatedAt: "2026-03-09T08:05:00.000Z",
+          status: "idle",
+          pollIntervalMs: 300_000,
+          businessHours: {
+            timeZone: "UTC",
+            startTime: "09:00",
+            endTime: "17:00"
+          },
+          maxJobsPerTick: 2,
+          maxActiveJobsPerProfile: 100,
+          consecutiveFailures: 0,
+          maxConsecutiveFailures: 5,
+          lastTickAt: "2026-03-09T08:05:00.000Z"
+        },
+        null,
+        2
+      )}\n`,
+      "utf8"
+    );
+  }
+
+  async function seedSchedulerJobs(): Promise<void> {
+    const db = new AssistantDatabase(resolveConfigPaths().dbPath);
+    try {
+      db.insertSchedulerJob({
+        id: "job_pending_1",
+        profileName: "default",
+        lane: "followup_preparation",
+        actionType: "network.followup_after_accept",
+        targetJson: JSON.stringify({
+          profile_name: "default",
+          profile_url_key: "https://www.linkedin.com/in/alice-smith/"
+        }),
+        dedupeKey: "followup_preparation:default:alice-smith",
+        scheduledAtMs: Date.parse("2026-03-09T09:00:00.000Z"),
+        maxAttempts: 5,
+        createdAtMs: Date.parse("2026-03-09T08:00:00.000Z"),
+        updatedAtMs: Date.parse("2026-03-09T08:00:00.000Z")
+      });
+      db.insertSchedulerJob({
+        id: "job_prepared_1",
+        profileName: "default",
+        lane: "followup_preparation",
+        actionType: "network.followup_after_accept",
+        targetJson: JSON.stringify({
+          profile_name: "default",
+          profile_url_key: "https://www.linkedin.com/in/bob-jones/"
+        }),
+        dedupeKey: "followup_preparation:default:bob-jones",
+        scheduledAtMs: Date.parse("2026-03-09T07:30:00.000Z"),
+        status: "prepared",
+        attemptCount: 1,
+        maxAttempts: 5,
+        preparedActionId: "pa_123",
+        createdAtMs: Date.parse("2026-03-09T07:00:00.000Z"),
+        updatedAtMs: Date.parse("2026-03-09T08:10:00.000Z")
+      });
+      db.insertSchedulerJob({
+        id: "job_failed_1",
+        profileName: "default",
+        lane: "followup_preparation",
+        actionType: "network.followup_after_accept",
+        targetJson: JSON.stringify({
+          profile_name: "default",
+          profile_url_key: "https://www.linkedin.com/in/charlie-lee/"
+        }),
+        dedupeKey: "followup_preparation:default:charlie-lee",
+        scheduledAtMs: Date.parse("2026-03-09T07:00:00.000Z"),
+        status: "failed",
+        attemptCount: 2,
+        maxAttempts: 5,
+        lastErrorCode: "NETWORK_ERROR",
+        lastErrorMessage: "Temporary network issue.",
+        createdAtMs: Date.parse("2026-03-09T06:00:00.000Z"),
+        updatedAtMs: Date.parse("2026-03-09T08:15:00.000Z")
+      });
+    } finally {
+      db.close();
+    }
+  }
+
+  it("prints a human-readable scheduler status summary by default on TTYs", async () => {
+    await seedSchedulerState();
+    await seedSchedulerJobs();
+
+    await runCli(["node", "linkedin", "scheduler", "status", "--jobs", "2"]);
+
+    const output = String(consoleLogSpy.mock.calls.at(-1)?.[0] ?? "");
+
+    expect(output).toContain("Scheduler Status:");
+    expect(output).toContain("Queue");
+    expect(output).toContain("Next Jobs");
+    expect(output).toContain("Recent History");
+    expect(output).toContain("followup_preparation");
+    expect(output).toContain("Use `--json`");
+  });
+
+  it("returns structured status JSON even when scheduler config is invalid", async () => {
+    setInteractiveMode(false, false);
+    process.env.LINKEDIN_ASSISTANT_SCHEDULER_TIMEZONE = "Mars/Olympus";
+    await seedSchedulerJobs();
+
+    await runCli(["node", "linkedin", "scheduler", "status", "--json"]);
+
+    const payload = JSON.parse(
+      String(consoleLogSpy.mock.calls.at(-1)?.[0] ?? "{}")
+    ) as Record<string, unknown>;
+
+    expect(payload.profile_name).toBe("default");
+    expect(payload.scheduler_config).toBeUndefined();
+    expect(payload.scheduler_config_error).toMatchObject({
+      code: "ACTION_PRECONDITION_FAILED",
+      message: expect.stringMatching(/valid IANA timezone/i)
+    });
+    expect(payload.job_counts).toMatchObject({
+      total: 3,
+      prepared: 1,
+      failed: 1
+    });
+    expect(Array.isArray(payload.recent_jobs)).toBe(true);
+  });
+
+  it("formats scheduler config failures in human mode", async () => {
+    process.env.LINKEDIN_ASSISTANT_SCHEDULER_TIMEZONE = "Mars/Olympus";
+
+    await runCli(["node", "linkedin", "scheduler", "run-once"]);
+
+    const stderrOutput = stderrChunks.join("");
+
+    expect(process.exitCode).toBe(1);
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+    expect(stderrOutput).toContain(
+      "Scheduler command failed [ACTION_PRECONDITION_FAILED]"
+    );
+    expect(stderrOutput).toContain(
+      "Setting: LINKEDIN_ASSISTANT_SCHEDULER_TIMEZONE"
+    );
+    expect(stderrOutput).toContain("Tip: run `linkedin scheduler --help`");
+  });
+
+  it("prints a human-readable start summary and progress notice", async () => {
+    await runCli(["node", "linkedin", "scheduler", "start"]);
+
+    const output = String(consoleLogSpy.mock.calls.at(-1)?.[0] ?? "");
+
+    expect(output).toContain("Scheduler Start: STARTED");
+    expect(output).toContain("Event log:");
+    expect(output).toContain("Prepared follow-up actions still require manual confirmation.");
+    expect(stderrChunks.join("")).toContain(
+      "[linkedin] Starting scheduler daemon for profile default."
+    );
+    expect(schedulerCliMocks.spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports the tick alias and surfaces failed job summaries", async () => {
+    schedulerCliMocks.schedulerRunTick.mockResolvedValue(
+      createTickResult({
+        discoveredAcceptedConnections: 1,
+        queuedJobs: 1,
+        claimedJobs: 1,
+        failedJobs: 1,
+        processedJobs: [
+          {
+            jobId: "job_failed_1",
+            lane: "followup_preparation",
+            outcome: "failed",
+            errorCode: "NETWORK_ERROR",
+            errorMessage: "Temporary network issue."
+          }
+        ]
+      })
+    );
+
+    await runCli(["node", "linkedin", "scheduler", "tick"]);
+
+    const output = String(consoleLogSpy.mock.calls.at(-1)?.[0] ?? "");
+
+    expect(output).toContain("Scheduler Tick: COMPLETED");
+    expect(output).toContain("Processed Jobs");
+    expect(output).toContain("NETWORK_ERROR");
+    expect(process.exitCode).toBe(1);
+    expect(schedulerCliMocks.createCoreRuntime).toHaveBeenCalledTimes(1);
+    expect(schedulerCliMocks.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("documents human and JSON scheduler usage in help output", () => {
+    const program = createCliProgram();
+    const schedulerCommand = program.commands.find(
+      (command) => command.name() === "scheduler"
+    );
+    const statusCommand = schedulerCommand?.commands.find(
+      (command) => command.name() === "status"
+    );
+
+    expect(schedulerCommand?.description()).toContain(
+      "The scheduler only prepares follow-ups near their due time"
+    );
+    expect(schedulerCommand?.description()).toContain(
+      "prepared actions still require manual confirmation"
+    );
+    expect(statusCommand?.helpInformation() ?? "").toContain("--json");
+    expect(statusCommand?.helpInformation() ?? "").toContain("--jobs");
+  });
+});

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -182,10 +182,11 @@ function parseStrictBoolean(
   }
 
   throw invalidSchedulerConfig(
-    `${envName} must be one of: 1, 0, true, false, yes, no, on, off.`,
+    `${envName} must use a scheduler boolean value: 1, 0, true, false, yes, no, on, or off. Unset it to use the default value.`,
     {
       env: envName,
-      value
+      value,
+      allowed_values: ["1", "0", "true", "false", "yes", "no", "on", "off"]
     }
   );
 }
@@ -204,7 +205,7 @@ function parseStrictPositiveInteger(input: {
   const trimmed = rawValue.trim();
   if (!/^\d+$/.test(trimmed)) {
     throw invalidSchedulerConfig(
-      `${input.envName} must be a positive integer.`,
+      `${input.envName} must be a whole number greater than 0. Unset it to use the default value.`,
       {
         env: input.envName,
         value: rawValue
@@ -215,7 +216,7 @@ function parseStrictPositiveInteger(input: {
   const parsed = Number.parseInt(trimmed, 10);
   if (!Number.isSafeInteger(parsed) || parsed <= 0) {
     throw invalidSchedulerConfig(
-      `${input.envName} must be a positive integer.`,
+      `${input.envName} must be a whole number greater than 0. Unset it to use the default value.`,
       {
         env: input.envName,
         value: rawValue
@@ -225,7 +226,7 @@ function parseStrictPositiveInteger(input: {
 
   if (typeof input.min === "number" && parsed < input.min) {
     throw invalidSchedulerConfig(
-      `${input.envName} must be at least ${input.min}.`,
+      `${input.envName} must be at least ${input.min}. Unset it to use the default value.`,
       {
         env: input.envName,
         min: input.min,
@@ -236,7 +237,7 @@ function parseStrictPositiveInteger(input: {
 
   if (typeof input.max === "number" && parsed > input.max) {
     throw invalidSchedulerConfig(
-      `${input.envName} must be at most ${input.max}.`,
+      `${input.envName} must be at most ${input.max}. Unset it to use the default value.`,
       {
         env: input.envName,
         max: input.max,
@@ -260,7 +261,7 @@ function parseStrictClockTime(
   const normalized = normalizeClockTime(value, "");
   if (!normalized) {
     throw invalidSchedulerConfig(
-      `${envName} must use HH:MM 24-hour clock formatting.`,
+      `${envName} must use HH:MM 24-hour time, for example 09:00 or 17:30.`,
       {
         env: envName,
         value
@@ -289,7 +290,7 @@ function parseSchedulerEnabledLanes(value: string | undefined): SchedulerLane[] 
   const invalidEntries = rawEntries.filter((entry) => !supported.has(entry));
   if (invalidEntries.length > 0) {
     throw invalidSchedulerConfig(
-      "LINKEDIN_ASSISTANT_SCHEDULER_ENABLED_LANES contains unsupported scheduler lanes.",
+      "LINKEDIN_ASSISTANT_SCHEDULER_ENABLED_LANES must be a comma-separated list of supported scheduler lanes. Set it to an empty string to disable all lanes.",
       {
         env: "LINKEDIN_ASSISTANT_SCHEDULER_ENABLED_LANES",
         invalid_lanes: invalidEntries,
@@ -318,7 +319,7 @@ function resolveSchedulerBusinessHours(): SchedulerBusinessHoursConfig {
 
   if (!timeZone || !isValidTimeZone(timeZone)) {
     throw invalidSchedulerConfig(
-      "LINKEDIN_ASSISTANT_SCHEDULER_TIMEZONE must be a valid IANA timezone, such as UTC or Europe/Copenhagen.",
+      "LINKEDIN_ASSISTANT_SCHEDULER_TIMEZONE must be a valid IANA timezone, such as UTC or Europe/Copenhagen. Unset it to use the local system timezone.",
       {
         env: "LINKEDIN_ASSISTANT_SCHEDULER_TIMEZONE",
         value: rawTimeZone
@@ -328,7 +329,7 @@ function resolveSchedulerBusinessHours(): SchedulerBusinessHoursConfig {
 
   if (compareClockTimes(startTime, endTime) >= 0) {
     throw invalidSchedulerConfig(
-      "Scheduler business hours must end after they start on the same local day.",
+      "Scheduler business hours must end after they start on the same local day, for example 09:00 to 17:00.",
       {
         start_time: startTime,
         end_time: endTime,
@@ -503,8 +504,9 @@ export function resolveSchedulerConfig(): SchedulerConfig {
 
   if (maxJobsPerTick > maxActiveJobsPerProfile) {
     throw invalidSchedulerConfig(
-      "Scheduler max jobs per tick must not exceed the per-profile active job limit.",
+      "LINKEDIN_ASSISTANT_SCHEDULER_MAX_JOBS_PER_TICK must be less than or equal to LINKEDIN_ASSISTANT_SCHEDULER_MAX_ACTIVE_JOBS_PER_PROFILE.",
       {
+        env: "LINKEDIN_ASSISTANT_SCHEDULER_MAX_JOBS_PER_TICK",
         max_jobs_per_tick: maxJobsPerTick,
         max_active_jobs_per_profile: maxActiveJobsPerProfile
       }
@@ -513,8 +515,9 @@ export function resolveSchedulerConfig(): SchedulerConfig {
 
   if (retry.maxBackoffMs < retry.initialBackoffMs) {
     throw invalidSchedulerConfig(
-      "Scheduler max backoff must be greater than or equal to the initial backoff.",
+      "LINKEDIN_ASSISTANT_SCHEDULER_MAX_BACKOFF_SECONDS must be greater than or equal to LINKEDIN_ASSISTANT_SCHEDULER_INITIAL_BACKOFF_SECONDS.",
       {
+        env: "LINKEDIN_ASSISTANT_SCHEDULER_MAX_BACKOFF_SECONDS",
         initial_backoff_ms: retry.initialBackoffMs,
         max_backoff_ms: retry.maxBackoffMs
       }

--- a/packages/core/test/schedulerConfig.test.ts
+++ b/packages/core/test/schedulerConfig.test.ts
@@ -3,6 +3,7 @@ import { resolveSchedulerConfig } from "../src/index.js";
 
 const SCHEDULER_ENV_KEYS = [
   "LINKEDIN_ASSISTANT_SCHEDULER_TIMEZONE",
+  "LINKEDIN_ASSISTANT_SCHEDULER_ENABLED_LANES",
   "LINKEDIN_ASSISTANT_SCHEDULER_MAX_JOBS_PER_TICK",
   "LINKEDIN_ASSISTANT_SCHEDULER_MAX_ACTIVE_JOBS_PER_PROFILE"
 ] as const;
@@ -42,7 +43,16 @@ describe("resolveSchedulerConfig", () => {
     process.env.LINKEDIN_ASSISTANT_SCHEDULER_MAX_ACTIVE_JOBS_PER_PROFILE = "4";
 
     expect(() => resolveSchedulerConfig()).toThrowError(
-      /must not exceed the per-profile active job limit/i
+      /MAX_JOBS_PER_TICK.*MAX_ACTIVE_JOBS_PER_PROFILE/i
+    );
+  });
+
+  it("rejects unsupported scheduler lanes with supported lane guidance", () => {
+    process.env.LINKEDIN_ASSISTANT_SCHEDULER_ENABLED_LANES =
+      "followup_preparation,coffee_break";
+
+    expect(() => resolveSchedulerConfig()).toThrowError(
+      /comma-separated list of supported scheduler lanes/i
     );
   });
 


### PR DESCRIPTION
## Summary
- add human-readable scheduler CLI output for interactive terminals while preserving \ for automation
- enrich \ with daemon health, queue state, and recent job history, plus a \ alias for \
- make scheduler config validation and human-facing error output more actionable

## Testing
- \
> linkedin-owa-agentools@0.1.0 typecheck
> tsc -b --pretty false --force
- \
> linkedin-owa-agentools@0.1.0 lint
> eslint .
- \
> linkedin-owa-agentools@0.1.0 test
> vitest run


 RUN  v3.2.4 /Users/user/.worktrees/linkedin-owa-agentools/loa-1

 ✓ packages/core/test/localDataDefaultPaths.test.ts (2 tests) 59ms
 ✓ packages/core/src/__tests__/selectorAudit.test.ts (25 tests) 121ms
 ✓ packages/core/src/__tests__/scheduler.test.ts (35 tests) 65ms
 ✓ packages/core/test/runtimeSelectorLocale.test.ts (3 tests) 19ms
 ✓ packages/core/test/rateLimitState.test.ts (13 tests) 25ms
 ✓ packages/core/test/localData.test.ts (8 tests) 40ms
 ✓ packages/core/test/localDataHardening.test.ts (5 tests) 110ms
 ✓ packages/cli/test/selectorLocaleCli.test.ts (3 tests) 41ms
 ✓ packages/cli/test/schedulerCli.test.ts (6 tests) 80ms
 ✓ packages/core/test/rateLimiter.test.ts (4 tests) 9ms
stdout | packages/core/src/__tests__/e2eConfirmContracts.test.ts > CLI confirm contract hardening > rejects non-interactive confirmations without mutating the prepared action
Preview summary: Echo action for default
{
  "prepared_action_id": "pa_5d77fd5ad5644df6ad0b52013f088576",
  "action_type": "test.echo",
  "status": "prepared",
  "expires_at_ms": 1773017229575,
  "preview": {
    "summary": "Echo action for default",
    "target": {
      "profile_name": "default"
    },
    "outbound": {
      "text": "echo-1773015429575"
    }
  }
}

 ✓ packages/cli/test/dataDelete.test.ts (12 tests) 285ms
 ✓ packages/core/src/__tests__/e2eConfirmContracts.test.ts (6 tests) 75ms
 ✓ packages/core/src/__tests__/linkedinPosts.test.ts (16 tests) 16ms
 ✓ packages/core/test/draftQualityEval.metrics.test.ts (31 tests) 75ms
 ✓ packages/core/src/__tests__/linkedinFollowups.test.ts (8 tests) 16ms
 ✓ packages/core/src/__tests__/healthCheck.test.ts (5 tests) 4ms
 ✓ packages/core/src/__tests__/confirmArtifacts.test.ts (2 tests) 16ms
 ✓ packages/core/test/draftQualityEval.test.ts (11 tests) 23ms
 ✓ packages/core/src/__tests__/e2eSetup.test.ts (9 tests) 10ms
 ✓ packages/cli/test/draftQualityCommand.test.ts (6 tests) 77ms
 ✓ packages/core/test/schedulerConfig.test.ts (4 tests) 28ms
 ✓ packages/cli/test/draftQualityOutput.test.ts (6 tests) 3ms
 ✓ packages/core/test/privacy.test.ts (4 tests) 18ms
 ✓ packages/core/src/__tests__/keepAlive.test.ts (12 tests) 44ms
 ✓ packages/core/src/__tests__/selectorLocale.test.ts (22 tests) 7ms
 ✓ packages/core/src/__tests__/e2eHelpers.test.ts (9 tests) 18ms
 ✓ packages/cli/test/selectorAuditOutput.test.ts (5 tests) 16ms
 ✓ packages/core/src/__tests__/headlessLogin.test.ts (29 tests) 6ms
 ✓ packages/core/src/__tests__/profileManager.test.ts (3 tests) 3ms
 ✓ packages/core/src/__tests__/sessionAuth.test.ts (3 tests) 7ms
 ✓ packages/core/src/__tests__/linkedinFeed.test.ts (7 tests) 3ms
 ✓ packages/core/src/__tests__/sessionInspection.test.ts (3 tests) 3ms
 ✓ packages/core/src/__tests__/linkedinConnections.test.ts (9 tests) 3ms
 ✓ packages/core/src/__tests__/runtimeClose.test.ts (1 test) 14ms
 ✓ packages/core/test/twoPhaseCommit.test.ts (4 tests) 8ms
 ✓ packages/core/src/__tests__/e2eRunner.test.ts (6 tests) 3ms
 ✓ packages/core/src/__tests__/connectionPool.test.ts (4 tests) 4ms
 ✓ packages/core/src/__tests__/humanize.test.ts (5 tests) 4ms
 ✓ packages/core/test/followupsState.test.ts (2 tests) 14ms
 ✓ packages/core/src/__tests__/linkedinJobs.test.ts (14 tests) 3ms
 ✓ packages/core/src/__tests__/linkedinNotifications.test.ts (4 tests) 3ms
 ✓ packages/core/src/__tests__/linkedinProfile.test.ts (7 tests) 2ms
 ✓ packages/core/src/__tests__/linkedinSearch.test.ts (5 tests) 4ms
 ✓ packages/core/test/selectorLocaleConfig.test.ts (3 tests) 2ms

 Test Files  44 passed (44)
      Tests  381 passed (381)
   Start at  01:17:08
   Duration  2.50s (transform 1.32s, setup 0ms, collect 13.03s, tests 1.38s, environment 4ms, prepare 2.06s)
- \
> linkedin-owa-agentools@0.1.0 build
> tsc -b --pretty false

Closes #105