### PR TITLE
docs: document scheduled follow-up scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ Default tool-owned state home (profiles, DB, artifacts):
 - Confirm-failure trace size cap: `LINKEDIN_ASSISTANT_CONFIRM_TRACE_MAX_BYTES` (defaults to `26214400`)
 - Selector locale for UI-text fallbacks: `LINKEDIN_ASSISTANT_SELECTOR_LOCALE` (defaults to `en`; supports `en`, `da`; region tags like `da-DK` normalize to `da`; unsupported values fall back to `en` with a warning; see `docs/selector-locale.md`)
 
+Scheduler / scheduled follow-up configuration:
+
+- `LINKEDIN_ASSISTANT_SCHEDULER_ENABLED=true|false` toggles local scheduler work (defaults to `true`)
+- `LINKEDIN_ASSISTANT_SCHEDULER_ENABLED_LANES=followup_preparation` controls enabled lanes; set it to an empty string to disable all lanes
+- `LINKEDIN_ASSISTANT_SCHEDULER_POLL_INTERVAL_SECONDS=300` controls daemon polling cadence
+- `LINKEDIN_ASSISTANT_SCHEDULER_BUSINESS_START=09:00`, `LINKEDIN_ASSISTANT_SCHEDULER_BUSINESS_END=17:00`, and `LINKEDIN_ASSISTANT_SCHEDULER_TIMEZONE=<IANA zone>` define the business-hours review window
+- `LINKEDIN_ASSISTANT_SCHEDULER_FOLLOWUP_DELAY_MINUTES=15` delays follow-up preparation after acceptance is detected
+- See `docs/scheduler.md` for the full scheduler guide, architecture notes, and every scheduler env var
+
 Privacy / redaction controls:
 
 - `LINKEDIN_ASSISTANT_REDACTION_MODE=off|partial|full`
@@ -121,6 +130,21 @@ npm exec -w @linkedin-assistant/cli -- linkedin keepalive stop --profile default
 ```
 
 - Keepalive state/log files are stored under `~/.linkedin-assistant/linkedin-owa-agentools/keepalive/`.
+
+Scheduled follow-up daemon:
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin scheduler start --profile default
+npm exec -w @linkedin-assistant/cli -- linkedin scheduler status --profile default --jobs 10
+npm exec -w @linkedin-assistant/cli -- linkedin scheduler run-once --profile default
+npm exec -w @linkedin-assistant/cli -- linkedin scheduler stop --profile default
+```
+
+- The scheduler is a local CLI daemon; there is no dedicated MCP scheduler tool.
+- It detects newly accepted sent invitations, queues due follow-up preparation jobs, and never auto-confirms prepared actions.
+- Default behavior is to poll every 5 minutes, wait 15 minutes after acceptance, and only prepare follow-ups during local 09:00-17:00 business hours.
+- Scheduler state/log files are stored under `~/.linkedin-assistant/linkedin-owa-agentools/scheduler/`.
+- See `docs/scheduler.md` for quickstart steps, config details, and subsystem architecture.
 
 Delete local tool state:
 
@@ -270,7 +294,12 @@ Follow-up flow after accepted invitations:
 ```bash
 npm exec -w @linkedin-assistant/cli -- linkedin followups list --profile default --since 7d
 npm exec -w @linkedin-assistant/cli -- linkedin followups prepare --profile default --since 7d
+npm exec -w @linkedin-assistant/cli -- linkedin scheduler run-once --profile default --json
 ```
+
+- `followups prepare` is the manual, operator-invoked batch workflow.
+- `scheduler run-once` and `scheduler start` reuse the same prepare-only safety model, but queue work near its due time instead of preparing everything immediately.
+- Successful scheduler ticks still leave follow-up work in the prepared state; nothing is sent automatically.
 
 Confirm prepared actions by token:
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -1,0 +1,223 @@
+# Scheduled follow-ups
+
+The scheduler is a **local, operator-visible daemon** for accepted-connection
+follow-ups.
+
+It does three things:
+
+- refreshes accepted sent-invitation state
+- queues one local scheduler job per accepted connection that still needs a
+  follow-up
+- prepares due follow-ups near the configured review window
+
+It does **not** send messages automatically. Every prepared action still goes
+through `linkedin actions confirm`.
+
+Use this guide when you need to:
+
+- start or inspect the local follow-up scheduler from the CLI
+- tune scheduler timing, business hours, or retry behavior
+- embed the scheduler service from `@linkedin-assistant/core`
+- understand how the scheduler queue relates to follow-up state and two-phase
+  confirmation
+
+## Quickstart
+
+Run a one-off scheduler tick:
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin scheduler run-once --profile default
+```
+
+Start the background daemon and inspect the queue:
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin scheduler start --profile default
+npm exec -w @linkedin-assistant/cli -- linkedin scheduler status --profile default --jobs 10
+```
+
+Stop the daemon when you are done:
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin scheduler stop --profile default
+```
+
+Notes:
+
+- interactive terminals default to human-readable scheduler summaries
+- use `--json` on `start`, `status`, `run-once`, or `stop` for automation
+- `run-once` has a `tick` alias: `linkedin scheduler tick --profile default`
+- prepared work keeps the same confirm-time safety model; the scheduler itself
+  never sends messages automatically
+- the scheduler is CLI-only today; there is no dedicated MCP scheduler daemon
+  tool
+
+## Timing model
+
+Follow-up preparation stays tied to the existing accepted-connection flow.
+
+For each accepted sent invitation that still needs a follow-up:
+
+1. the scheduler discovers or refreshes acceptance state
+2. it creates or updates one `scheduler_job` row for that connection
+3. the job becomes due at `accepted_at + followupDelayMs`
+4. the due time is snapped forward into the configured business-hours window
+5. when the job is claimed, the scheduler prepares the follow-up and stores the
+   prepared action id
+
+If the runtime is busy, the profile is locked, or a transient failure happens,
+the job is rescheduled with backoff instead of being sent automatically.
+
+## Configuration
+
+Scheduler config is environment-driven and resolved in
+`packages/core/src/config.ts`.
+
+| Environment variable | Default | Purpose |
+| --- | --- | --- |
+| `LINKEDIN_ASSISTANT_SCHEDULER_ENABLED` | `true` | Master on/off switch for scheduler work |
+| `LINKEDIN_ASSISTANT_SCHEDULER_ENABLED_LANES` | `followup_preparation` | Comma-separated enabled lanes; set to an empty string to disable all lanes |
+| `LINKEDIN_ASSISTANT_SCHEDULER_POLL_INTERVAL_SECONDS` | `300` | Background daemon poll interval |
+| `LINKEDIN_ASSISTANT_SCHEDULER_MAX_JOBS_PER_TICK` | `2` | Maximum due jobs leased and processed in one tick |
+| `LINKEDIN_ASSISTANT_SCHEDULER_MAX_ACTIVE_JOBS_PER_PROFILE` | `100` | Cap on pending + leased + prepared scheduler jobs for one profile |
+| `LINKEDIN_ASSISTANT_SCHEDULER_LEASE_SECONDS` | `120` | Lease TTL for claimed jobs before another worker may reclaim them |
+| `LINKEDIN_ASSISTANT_SCHEDULER_FOLLOWUP_DELAY_MINUTES` | `15` | Delay after acceptance before a follow-up job becomes due |
+| `LINKEDIN_ASSISTANT_SCHEDULER_FOLLOWUP_LOOKBACK_DAYS` | `30` | Accepted-connection discovery window used during refresh |
+| `LINKEDIN_ASSISTANT_SCHEDULER_BUSINESS_START` | `09:00` | Inclusive local business-hours start time (`HH:MM`) |
+| `LINKEDIN_ASSISTANT_SCHEDULER_BUSINESS_END` | `17:00` | Exclusive local business-hours end time (`HH:MM`) |
+| `LINKEDIN_ASSISTANT_SCHEDULER_TIMEZONE` | local system timezone | IANA timezone used for business-hours evaluation; falls back to `UTC` only if the local timezone cannot be resolved |
+| `LINKEDIN_ASSISTANT_SCHEDULER_MAX_ATTEMPTS` | `5` | Maximum attempts before a job is marked failed |
+| `LINKEDIN_ASSISTANT_SCHEDULER_INITIAL_BACKOFF_SECONDS` | `300` | Initial retry backoff for retryable failures |
+| `LINKEDIN_ASSISTANT_SCHEDULER_MAX_BACKOFF_SECONDS` | `21600` | Maximum retry backoff cap |
+
+Current lane guidance:
+
+- keep `followup_preparation` enabled for the shipped scheduler flow
+- other supported lane names are reserved for future scheduler queues and do
+  not add useful work in the current build
+
+Example shell configuration:
+
+```bash
+export LINKEDIN_ASSISTANT_SCHEDULER_TIMEZONE=Europe/Copenhagen
+export LINKEDIN_ASSISTANT_SCHEDULER_BUSINESS_START=08:30
+export LINKEDIN_ASSISTANT_SCHEDULER_BUSINESS_END=16:30
+export LINKEDIN_ASSISTANT_SCHEDULER_POLL_INTERVAL_SECONDS=180
+export LINKEDIN_ASSISTANT_SCHEDULER_FOLLOWUP_DELAY_MINUTES=30
+
+npm exec -w @linkedin-assistant/cli -- linkedin scheduler start --profile default
+```
+
+## CLI workflow
+
+### `linkedin scheduler start`
+
+Starts a detached daemon for one profile. The daemon wakes up on the configured
+poll interval, creates a fresh core runtime for each tick, and writes state and
+event logs under the scheduler directory inside `LINKEDIN_ASSISTANT_HOME`.
+
+### `linkedin scheduler status`
+
+Shows:
+
+- daemon state and health
+- resolved scheduler config or config validation errors
+- queue counts grouped by status
+- upcoming jobs and recent history for the selected profile
+
+Use `--jobs <count>` to control how many queued and recent jobs are shown.
+
+### `linkedin scheduler run-once`
+
+Runs one immediate scheduler pass without starting the daemon. This is the
+fastest way to validate config, discover accepted invitations, or prepare any
+due follow-ups on demand.
+
+### `linkedin scheduler stop`
+
+Stops the daemon, cleans up stale PID state when safe, and leaves already
+prepared follow-up actions untouched.
+
+## Core API
+
+Programmatic integrations can run one scheduler tick directly from
+`@linkedin-assistant/core`:
+
+```ts
+import {
+  LinkedInSchedulerService,
+  createCoreRuntime,
+  resolveSchedulerConfig
+} from "@linkedin-assistant/core";
+
+const runtime = createCoreRuntime();
+
+try {
+  const scheduler = new LinkedInSchedulerService({
+    db: runtime.db,
+    logger: runtime.logger,
+    followups: runtime.followups,
+    schedulerConfig: resolveSchedulerConfig()
+  });
+
+  const result = await scheduler.runTick({ profileName: "default" });
+  console.log(result);
+} finally {
+  runtime.close();
+}
+```
+
+Important behavior:
+
+- `LinkedInSchedulerService` runs a single tick; the CLI owns the daemon loop
+- `resolveSchedulerConfig()` reads the environment and validates scheduler-only
+  settings before work starts
+- the scheduler prepares actions through the same two-phase commit flow used by
+  `linkedin followups prepare`
+
+## Architecture
+
+The scheduler subsystem is deliberately narrow in phase 1.
+
+### Safety model
+
+- `packages/core/src/linkedinFollowups.ts` remains the source of truth for
+  accepted-connection follow-up preparation
+- `packages/core/src/scheduler.ts` only decides **when** to prepare work, not
+  how to confirm or execute it
+- `linkedin actions confirm` remains the only way to send the prepared message
+
+### Storage model
+
+- `sent_invitation_state` keeps invitation discovery, acceptance detection, and
+  follow-up lifecycle state
+- `scheduler_job` stores due times, leasing, retries, prepared action ids, and
+  queue status
+- dedupe keys ensure one active scheduler job per profile + accepted connection
+
+### Runtime model
+
+- the scheduler daemon is local-only and CLI-owned
+- each daemon tick creates a fresh core runtime instead of keeping one long-
+  lived runtime open forever
+- profile lock contention is treated as a retryable, expected scheduler
+  condition
+
+### Business-hours and retries
+
+- due follow-up jobs are aligned into the configured local business-hours window
+- retryable failures use exponential backoff capped by
+  `LINKEDIN_ASSISTANT_SCHEDULER_MAX_BACKOFF_SECONDS`
+- invalid scheduler env vars fail fast with structured config errors that are
+  surfaced in both human and JSON CLI output
+
+## Files and observability
+
+By default, scheduler state lives under:
+
+- `~/.linkedin-assistant/linkedin-owa-agentools/scheduler/*.pid`
+- `~/.linkedin-assistant/linkedin-owa-agentools/scheduler/*.state.json`
+- `~/.linkedin-assistant/linkedin-owa-agentools/scheduler/*.events.jsonl`
+
+The CLI `status` command also reports the exact state and event-log paths for
+the selected profile.

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -3517,9 +3517,20 @@ export function createCliProgram(): Command {
 
   schedulerCommand
     .command("start")
-    .description("Start the local scheduler daemon for a profile")
+    .description(
+      "Start the local scheduler daemon for a profile using the current poll interval and business-hours settings"
+    )
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("--json", "Print the structured scheduler payload", false)
+    .addHelpText(
+      "after",
+      [
+        "",
+        "The daemon wakes up on the configured poll interval and respects scheduler business hours.",
+        "It only prepares due follow-ups; confirmation always remains manual.",
+        "Use `linkedin scheduler status` to inspect queue counts, recent history, and state/log paths."
+      ].join("\n")
+    )
     .action(async (options: { profile: string; json: boolean }) => {
       await runSchedulerCliAction(options, async (outputMode) => {
         await runSchedulerStart(options.profile, outputMode, readCdpUrl());
@@ -3557,9 +3568,19 @@ export function createCliProgram(): Command {
 
   schedulerCommand
     .command("stop")
-    .description("Stop the local scheduler daemon and clean up stale state")
+    .description(
+      "Stop the local scheduler daemon and clean up stale state without deleting queued jobs"
+    )
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("--json", "Print the structured scheduler payload", false)
+    .addHelpText(
+      "after",
+      [
+        "",
+        "Stopping the daemon does not delete queued jobs or prepared follow-up actions.",
+        "Use `linkedin scheduler status` after stopping if you want to confirm the daemon is idle."
+      ].join("\n")
+    )
     .action(async (options: { profile: string; json: boolean }) => {
       await runSchedulerCliAction(options, async (outputMode) => {
         await runSchedulerStop(options.profile, outputMode);
@@ -3569,13 +3590,16 @@ export function createCliProgram(): Command {
   schedulerCommand
     .command("run-once")
     .alias("tick")
-    .description("Run one scheduler tick immediately and summarize the result")
+    .description(
+      "Run one scheduler tick immediately, refresh queue state, and summarize the result"
+    )
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("--json", "Print the structured scheduler payload", false)
     .addHelpText(
       "after",
       [
         "",
+        "A tick refreshes accepted invitations, syncs queue state, and prepares any due follow-ups.",
         "Prepared actions still require manual confirmation after a successful tick.",
         "Use this command when you want an immediate scheduler pass without starting the daemon."
       ].join("\n")

--- a/packages/cli/test/schedulerCli.test.ts
+++ b/packages/cli/test/schedulerCli.test.ts
@@ -335,8 +335,17 @@ describe("linkedin scheduler CLI UX", () => {
     const schedulerCommand = program.commands.find(
       (command) => command.name() === "scheduler"
     );
+    const startCommand = schedulerCommand?.commands.find(
+      (command) => command.name() === "start"
+    );
     const statusCommand = schedulerCommand?.commands.find(
       (command) => command.name() === "status"
+    );
+    const stopCommand = schedulerCommand?.commands.find(
+      (command) => command.name() === "stop"
+    );
+    const runOnceCommand = schedulerCommand?.commands.find(
+      (command) => command.name() === "run-once"
     );
 
     expect(schedulerCommand?.description()).toContain(
@@ -345,7 +354,16 @@ describe("linkedin scheduler CLI UX", () => {
     expect(schedulerCommand?.description()).toContain(
       "prepared actions still require manual confirmation"
     );
+    expect(startCommand?.helpInformation() ?? "").toContain(
+      "current poll interval"
+    );
     expect(statusCommand?.helpInformation() ?? "").toContain("--json");
     expect(statusCommand?.helpInformation() ?? "").toContain("--jobs");
+    expect(stopCommand?.helpInformation() ?? "").toMatch(
+      /without deleting queued\s+jobs/
+    );
+    expect(runOnceCommand?.helpInformation() ?? "").toContain(
+      "refresh queue state"
+    );
   });
 });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -42,6 +42,13 @@ export interface ConfirmFailureArtifactConfig {
   traceMaxBytes: number;
 }
 
+/**
+ * Scheduler lane names accepted by config validation.
+ *
+ * @remarks
+ * Only `followup_preparation` performs useful work in the current build. The
+ * remaining names reserve stable config values for future scheduler queues.
+ */
 export const SCHEDULER_LANES = [
   "inbox_triage",
   "pending_invite_checks",
@@ -49,47 +56,89 @@ export const SCHEDULER_LANES = [
   "feed_engagement"
 ] as const;
 
+/**
+ * Union of supported scheduler lane identifiers.
+ */
 export type SchedulerLane = (typeof SCHEDULER_LANES)[number];
 
+/**
+ * Scheduler lanes enabled by default when no explicit env override is set.
+ */
 export const DEFAULT_SCHEDULER_ENABLED_LANES: SchedulerLane[] = [
   "followup_preparation"
 ];
 
+/** Default background poll interval for the local scheduler daemon. */
 export const DEFAULT_SCHEDULER_POLL_INTERVAL_MS = 5 * 60 * 1000;
+/** Default number of due jobs claimed and processed in one tick. */
 export const DEFAULT_SCHEDULER_MAX_JOBS_PER_TICK = 2;
+/** Default cap on active scheduler jobs tracked for one profile. */
 export const DEFAULT_SCHEDULER_MAX_ACTIVE_JOBS_PER_PROFILE = 100;
+/** Default lease TTL applied when a worker claims scheduler jobs. */
 export const DEFAULT_SCHEDULER_LEASE_TTL_MS = 2 * 60 * 1000;
+/** Default delay between acceptance detection and follow-up preparation. */
 export const DEFAULT_SCHEDULER_FOLLOWUP_DELAY_MS = 15 * 60 * 1000;
+/** Default lookback window used when refreshing accepted connections. */
 export const DEFAULT_SCHEDULER_FOLLOWUP_LOOKBACK_MS =
   30 * 24 * 60 * 60 * 1000;
+/** Default maximum retry attempts for a scheduler job. */
 export const DEFAULT_SCHEDULER_MAX_ATTEMPTS = 5;
+/** Default initial retry backoff for retryable scheduler failures. */
 export const DEFAULT_SCHEDULER_INITIAL_BACKOFF_MS = 5 * 60 * 1000;
+/** Default cap for exponential scheduler retry backoff. */
 export const DEFAULT_SCHEDULER_MAX_BACKOFF_MS = 6 * 60 * 60 * 1000;
+/** Default local business-hours start used by the scheduler. */
 export const DEFAULT_SCHEDULER_BUSINESS_START = "09:00";
+/** Default local business-hours end used by the scheduler. */
 export const DEFAULT_SCHEDULER_BUSINESS_END = "17:00";
 
+/**
+ * Business-hours window applied before the scheduler may prepare due work.
+ */
 export interface SchedulerBusinessHoursConfig {
+  /** IANA timezone used to interpret the local business-hours window. */
   timeZone: string;
+  /** Inclusive local start time in `HH:MM` 24-hour format. */
   startTime: string;
+  /** Exclusive local end time in `HH:MM` 24-hour format. */
   endTime: string;
 }
 
+/**
+ * Retry policy applied when scheduler jobs fail with retryable errors.
+ */
 export interface SchedulerRetryConfig {
+  /** Maximum attempts before a job is marked failed. */
   maxAttempts: number;
+  /** Initial retry delay used for the first retryable failure. */
   initialBackoffMs: number;
+  /** Upper bound for exponential backoff growth. */
   maxBackoffMs: number;
 }
 
+/**
+ * Resolved scheduler configuration shared by the CLI daemon and core service.
+ */
 export interface SchedulerConfig {
+  /** Master on/off switch for scheduler work. */
   enabled: boolean;
+  /** Delay between background daemon ticks. */
   pollIntervalMs: number;
+  /** Maximum number of due jobs processed in one tick. */
   maxJobsPerTick: number;
+  /** Maximum number of active jobs tracked for one profile. */
   maxActiveJobsPerProfile: number;
+  /** Lease TTL used when a worker claims scheduler jobs. */
   leaseTtlMs: number;
+  /** Enabled scheduler lanes after config validation and normalization. */
   enabledLanes: SchedulerLane[];
+  /** Local business-hours window used for due-time alignment. */
   businessHours: SchedulerBusinessHoursConfig;
+  /** Delay between acceptance detection and follow-up job due time. */
   followupDelayMs: number;
+  /** Accepted-connection lookback window used during refresh. */
   followupLookbackMs: number;
+  /** Retry policy for retryable scheduler failures. */
   retry: SchedulerRetryConfig;
 }
 
@@ -437,6 +486,14 @@ export function resolveConfirmFailureArtifactConfig(): ConfirmFailureArtifactCon
   };
 }
 
+/**
+ * Resolves scheduler settings from environment variables.
+ *
+ * @remarks
+ * This function validates business hours, lane names, and retry bounds up
+ * front so the CLI can fail fast with actionable guidance before any work is
+ * queued or prepared.
+ */
 export function resolveSchedulerConfig(): SchedulerConfig {
   const pollIntervalMs =
     parseStrictPositiveInteger({

--- a/packages/core/src/linkedinFollowups.ts
+++ b/packages/core/src/linkedinFollowups.ts
@@ -66,6 +66,9 @@ interface AcceptanceProbeResult {
   acceptedDetection: string;
 }
 
+/**
+ * Accepted sent invitation enriched with follow-up preparation status.
+ */
 export interface LinkedInAcceptedConnection {
   profile_url_key: string;
   profile_url: string;
@@ -83,12 +86,18 @@ export interface LinkedInAcceptedConnection {
   followup_expires_at_ms: number | null;
 }
 
+/**
+ * Input for listing accepted connections that may need follow-up work.
+ */
 export interface ListAcceptedConnectionsInput {
   profileName?: string;
   since?: string;
   sinceMs?: number;
 }
 
+/**
+ * Input for the manual batch prepare workflow after acceptance detection.
+ */
 export interface PrepareFollowupsAfterAcceptInput {
   profileName?: string;
   since?: string;
@@ -96,6 +105,10 @@ export interface PrepareFollowupsAfterAcceptInput {
   operatorNote?: string;
 }
 
+/**
+ * Input for preparing a follow-up for one accepted connection by stable
+ * profile identity.
+ */
 export interface PrepareAcceptedConnectionFollowupInput {
   profileName?: string;
   profileUrlKey: string;
@@ -103,6 +116,10 @@ export interface PrepareAcceptedConnectionFollowupInput {
   refreshState?: boolean;
 }
 
+/**
+ * Prepared follow-up action details returned from the accepted-connection
+ * follow-up flow.
+ */
 export interface PreparedAcceptedConnectionFollowup {
   connection: LinkedInAcceptedConnection;
   preparedActionId: string;
@@ -111,12 +128,18 @@ export interface PreparedAcceptedConnectionFollowup {
   preview: Record<string, unknown>;
 }
 
+/**
+ * Result returned from the manual batch follow-up prepare command.
+ */
 export interface PrepareFollowupsAfterAcceptResult {
   since: string;
   acceptedConnections: LinkedInAcceptedConnection[];
   preparedFollowups: PreparedAcceptedConnectionFollowup[];
 }
 
+/**
+ * Runtime dependencies used by the confirm-time follow-up executor.
+ */
 export interface LinkedInFollowupsExecutorRuntime {
   db: AssistantDatabase;
   auth: LinkedInAuthService;
@@ -128,6 +151,9 @@ export interface LinkedInFollowupsExecutorRuntime {
   logger: JsonEventLogger;
 }
 
+/**
+ * Runtime dependencies used by the accepted-connection follow-up service.
+ */
 export interface LinkedInFollowupsRuntime extends LinkedInFollowupsExecutorRuntime {
   connections: {
     listPendingInvitations(input: {
@@ -159,6 +185,9 @@ function extractFirstName(fullName: string): string {
   return normalizeText(fullName).split(" ")[0] ?? "";
 }
 
+/**
+ * Builds the default accepted-connection follow-up message.
+ */
 export function buildDefaultFollowupText(fullName: string): string {
   const firstName = extractFirstName(fullName);
   if (firstName) {
@@ -168,6 +197,10 @@ export function buildDefaultFollowupText(fullName: string): string {
   return "Hi, thanks for accepting my invitation. Great to connect.";
 }
 
+/**
+ * Resolves the accepted-connection follow-up lookback window from a relative
+ * duration or absolute timestamp.
+ */
 export function resolveFollowupSinceWindow(
   since: string | undefined,
   nowMs = Date.now()
@@ -822,6 +855,9 @@ function mapAcceptedConnections(
   );
 }
 
+/**
+ * Confirm-time executor for accepted-connection follow-up actions.
+ */
 export class FollowupAfterAcceptActionExecutor
   implements ActionExecutor<LinkedInFollowupsExecutorRuntime>
 {
@@ -1099,6 +1135,10 @@ export class FollowupAfterAcceptActionExecutor
   }
 }
 
+/**
+ * Builds the follow-up action executor registry used by the shared two-phase
+ * commit runtime.
+ */
 export function createFollowupActionExecutors(): Record<
   string,
   ActionExecutor<LinkedInFollowupsExecutorRuntime>
@@ -1108,6 +1148,14 @@ export function createFollowupActionExecutors(): Record<
   };
 }
 
+/**
+ * Lists accepted sent invitations and prepares follow-up actions on demand.
+ *
+ * @remarks
+ * This service never auto-confirms prepared actions. It produces prepared
+ * actions that must still be confirmed through the shared two-phase commit
+ * flow.
+ */
 export class LinkedInFollowupsService {
   constructor(private readonly runtime: LinkedInFollowupsRuntime) {}
 
@@ -1135,6 +1183,10 @@ export class LinkedInFollowupsService {
     };
   }
 
+  /**
+   * Refreshes accepted invitation state and returns accepted connections within
+   * the requested lookback window.
+   */
   async listAcceptedConnections(
     input: ListAcceptedConnectionsInput = {}
   ): Promise<LinkedInAcceptedConnection[]> {
@@ -1149,6 +1201,10 @@ export class LinkedInFollowupsService {
     }).acceptedConnections;
   }
 
+  /**
+   * Refreshes accepted invitation state and prepares follow-ups for every
+   * accepted connection that still needs one.
+   */
   async prepareFollowupsAfterAccept(
     input: PrepareFollowupsAfterAcceptInput = {}
   ): Promise<PrepareFollowupsAfterAcceptResult> {
@@ -1195,6 +1251,13 @@ export class LinkedInFollowupsService {
     };
   }
 
+  /**
+   * Prepares a follow-up for one accepted connection identified by
+   * `profileUrlKey`.
+   *
+   * @returns The prepared action when the connection still needs a follow-up;
+   * otherwise `null`.
+   */
   async prepareFollowupForAcceptedConnection(
     input: PrepareAcceptedConnectionFollowupInput
   ): Promise<PreparedAcceptedConnectionFollowup | null> {

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -50,6 +50,9 @@ interface SchedulerFollowupService {
   ): Promise<PreparedAcceptedConnectionFollowup | null>;
 }
 
+/**
+ * Minimal runtime contract required by {@link LinkedInSchedulerService}.
+ */
 export interface LinkedInSchedulerRuntime {
   db: AssistantDatabase;
   logger: JsonEventLogger;
@@ -57,6 +60,9 @@ export interface LinkedInSchedulerRuntime {
   schedulerConfig?: SchedulerConfig;
 }
 
+/**
+ * Outcome recorded for one claimed job processed during a scheduler tick.
+ */
 export interface SchedulerTickJobResult {
   jobId: string;
   lane: SchedulerLane;
@@ -67,12 +73,18 @@ export interface SchedulerTickJobResult {
   scheduledAtMs?: number;
 }
 
+/**
+ * Reason a scheduler tick returned before claiming any jobs.
+ */
 export type SchedulerTickSkippedReason =
   | "disabled"
   | "outside_business_hours"
   | "profile_busy"
   | null;
 
+/**
+ * High-level summary returned from a single scheduler tick.
+ */
 export interface SchedulerTickResult {
   profileName: string;
   workerId: string;
@@ -203,6 +215,10 @@ function getLocalMinutesSinceMidnight(
   return parts.hour * 60 + parts.minute;
 }
 
+/**
+ * Returns whether a UTC timestamp falls inside the configured local business
+ * hours window.
+ */
 export function isWithinBusinessHours(
   utcMs: number,
   businessHours: SchedulerBusinessHoursConfig
@@ -214,6 +230,12 @@ export function isWithinBusinessHours(
   return currentMinutes >= startMinutes && currentMinutes < endMinutes;
 }
 
+/**
+ * Moves a UTC timestamp forward to the next valid business-hours window.
+ *
+ * @remarks
+ * Values that are already inside the configured window are returned unchanged.
+ */
 export function alignToBusinessHours(
   utcMs: number,
   businessHours: SchedulerBusinessHoursConfig
@@ -243,6 +265,9 @@ export function alignToBusinessHours(
   );
 }
 
+/**
+ * Calculates capped exponential backoff for retryable scheduler failures.
+ */
 export function calculateSchedulerBackoffMs(
   failureCount: number,
   retry: SchedulerConfig["retry"]
@@ -251,6 +276,10 @@ export function calculateSchedulerBackoffMs(
   return Math.min(retry.maxBackoffMs, retry.initialBackoffMs * 2 ** exponent);
 }
 
+/**
+ * Computes the due time for an accepted-connection follow-up job and aligns it
+ * to business hours.
+ */
 export function scheduleAcceptedConnectionFollowupAtMs(input: {
   connection: LinkedInAcceptedConnection;
   nowMs: number;
@@ -437,6 +466,10 @@ function toIsoStringOrNull(utcMs: number | null): string | null {
   return utcMs === null ? null : new Date(utcMs).toISOString();
 }
 
+/**
+ * Local scheduler that discovers accepted invitations, syncs queue state, and
+ * prepares due follow-ups without auto-confirming them.
+ */
 export class LinkedInSchedulerService {
   private readonly config: SchedulerConfig;
 
@@ -444,6 +477,9 @@ export class LinkedInSchedulerService {
     this.config = runtime.schedulerConfig ?? resolveSchedulerConfig();
   }
 
+  /**
+   * Runs one discovery, queue-sync, lease, and prepare cycle for a profile.
+   */
   async runTick(input: {
     profileName?: string;
     nowMs?: number;


### PR DESCRIPTION
## Summary
- document the local scheduler workflow, configuration, and usage in `README.md`
- add `docs/scheduler.md` with quickstart steps, architecture notes, and the full scheduler env-var surface
- add JSDoc for the public scheduler and follow-up APIs, and tighten scheduler CLI help coverage

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #107
