### PR TITLE
docs: add issue #87 fixture replay research brief

### DIFF
--- a/docs/.research-brief-issue-87.md
+++ b/docs/.research-brief-issue-87.md
@@ -1,0 +1,666 @@
+# Research brief — issue #87 E2E test harness: recorded fixture replay (Tier 1)
+
+## Executive summary
+
+Issue #87 asks for a deterministic, CI-safe E2E harness that replays recorded
+LinkedIn fixtures instead of depending on a live authenticated browser session.
+The repo already has a surprisingly strong foundation for that work:
+
+- a dedicated live E2E lane via `npm run test:e2e` (`package.json:13`,
+  `vitest.config.e2e.ts:8`)
+- a shared suite/runtime wrapper for E2E tests in
+  `packages/core/src/__tests__/e2e/setup.ts:385`
+- broad live coverage across read flows, preview-only two-phase commit flows,
+  thin CLI coverage, thin MCP coverage, and error-path coverage in
+  `packages/core/src/__tests__/e2e/*.e2e.test.ts`
+- existing fixture replay, but only for a **small JSON file of stable IDs** used
+  by the CLI/MCP contract suites (`scripts/run-e2e.js:69`,
+  `docs/e2e-testing.md:106`, `packages/core/src/__tests__/e2e/helpers.ts:830`)
+
+The main gap is that there is **no recorded page/HTTP fixture system yet**.
+Everything still assumes real LinkedIn URLs, a real browser context, and a real
+session. That matters because the current codebase is far more naturally
+compatible with **Playwright HAR replay at the LinkedIn origin** than with a
+localhost mock server: service modules hardcode `https://www.linkedin.com/...`
+URLs throughout `auth`, `feed`, `inbox`, `profile`, `jobs`, `search`,
+`notifications`, `connections`, and `selectorAudit`
+(`packages/core/src/auth/session.ts:116`,
+`packages/core/src/linkedinFeed.ts:81`,
+`packages/core/src/linkedinInbox.ts:36`,
+`packages/core/src/linkedinProfile.ts:61`,
+`packages/core/src/linkedinJobs.ts:88`,
+`packages/core/src/linkedinSearch.ts:119`,
+`packages/core/src/linkedinNotifications.ts:41`,
+`packages/core/src/linkedinConnections.ts:102`,
+`packages/core/src/selectorAudit.ts:255`).
+
+My main conclusion is:
+
+- **Tier 1 is very feasible** without rewriting feature modules.
+- The lowest-risk design is **Vitest + Playwright browser contexts +
+  `browserContext.routeFromHAR()`**, not a localhost-origin mirror.
+- The biggest implementation constraints are **auth gating**, **service worker
+  bypass**, **inbox network replay**, **locale/account-state fixture sets**, and
+  **CI browser provisioning**.
+
+## Current test infrastructure
+
+### Test lanes and entry points
+
+The root repo has a clean split between unit and E2E lanes:
+
+- `npm test` runs `vitest run` (`package.json:13`)
+- `npm run test:e2e` runs the custom runner `node ./scripts/run-e2e.js`
+  (`package.json:14`)
+- `npm run test:e2e:raw` runs Vitest directly against
+  `vitest.config.e2e.ts` (`package.json:15`)
+- `npm run build`, `npm run lint`, and `npm run typecheck` are the normal repo
+  quality gates (`package.json:11`)
+
+`vitest.config.ts:11` includes normal test files and excludes `*.e2e.test.ts`,
+while `vitest.config.e2e.ts:8` includes only
+`packages/core/src/__tests__/e2e/**/*.e2e.test.ts`.
+
+### The current E2E runner is live-session-first
+
+`scripts/run-e2e.js` is not a Playwright test runner; it is a **preflight +
+Vitest launcher** that:
+
+1. parses `--require-session`, `--fixtures`, and `--refresh-fixtures`
+   (`scripts/run-e2e.js:69`)
+2. prints the effective runtime configuration (`scripts/run-e2e.js:150`)
+3. probes the CDP endpoint and LinkedIn authentication by opening
+   `https://www.linkedin.com/feed/` over CDP (`scripts/run-e2e.js:247`)
+4. launches Vitest with `vitest.config.e2e.ts` only when the live session is
+   available (`scripts/run-e2e.js:329`)
+
+That is important context for Tier 1: the existing E2E entry point is designed
+for **live session discovery and safe skipping**, not for replaying captured
+browser traffic.
+
+### Shared E2E setup
+
+The live suite shares one runtime and one temporary assistant-home directory per
+Vitest process:
+
+- CDP availability/authentication is cached in
+  `packages/core/src/__tests__/e2e/setup.ts:353`
+- the shared runtime comes from `createCoreRuntime()` in
+  `packages/core/src/__tests__/e2e/setup.ts:267`
+- suite fixtures are resolved once in `setupE2ESuite()` in
+  `packages/core/src/__tests__/e2e/setup.ts:385`
+- tests skip explicitly through `skipIfE2EUnavailable()` in
+  `packages/core/src/__tests__/e2e/setup.ts:442`
+
+This helper is reusable, but today it assumes the runtime should still be backed
+by CDP or persistent profiles.
+
+### Current E2E coverage inventory
+
+The repo already has broad live E2E coverage:
+
+- auth: `packages/core/src/__tests__/e2e/auth.e2e.test.ts:4`
+- health + keepalive: `packages/core/src/__tests__/e2e/health.e2e.test.ts:9`
+- profile: `packages/core/src/__tests__/e2e/profile.e2e.test.ts:4`
+- search: `packages/core/src/__tests__/e2e/search.e2e.test.ts:4`
+- jobs: `packages/core/src/__tests__/e2e/jobs.e2e.test.ts:4`
+- notifications: `packages/core/src/__tests__/e2e/notifications.e2e.test.ts:4`
+- inbox read: `packages/core/src/__tests__/e2e/inbox.e2e.test.ts:4`
+- inbox write preview/confirm lane: `packages/core/src/__tests__/e2e/inbox-write.e2e.test.ts:25`
+- connections read: `packages/core/src/__tests__/e2e/connections.e2e.test.ts:4`
+- connections write preview lane: `packages/core/src/__tests__/e2e/connections-write.e2e.test.ts:16`
+- feed read: `packages/core/src/__tests__/e2e/feed.e2e.test.ts:4`
+- feed like preview lane: `packages/core/src/__tests__/e2e/feed-like.e2e.test.ts:19`
+- feed comment preview lane: `packages/core/src/__tests__/e2e/feed-write.e2e.test.ts:30`
+- post composer preview lane: `packages/core/src/__tests__/e2e/post-write.e2e.test.ts:20`
+- CLI contract coverage: `packages/core/src/__tests__/e2e/cli.e2e.test.ts:12`
+- MCP contract coverage: `packages/core/src/__tests__/e2e/mcp.e2e.test.ts:12`
+- failure-path coverage: `packages/core/src/__tests__/e2e/error-paths.e2e.test.ts:54`
+
+The docs summarize the same coverage matrix in `docs/e2e-testing.md:55`.
+
+### Non-live tests around the E2E harness already exist
+
+The repo also has unit tests specifically for the E2E infrastructure:
+
+- runner parsing and launch behavior:
+  `packages/core/src/__tests__/e2eRunner.test.ts`
+- setup/skip semantics:
+  `packages/core/src/__tests__/e2eSetup.test.ts:40`
+- helper + fixture-file behavior:
+  `packages/core/src/__tests__/e2eHelpers.test.ts:7`
+- confirm-contract assertions:
+  `packages/core/src/__tests__/e2eConfirmContracts.test.ts`
+
+That means Tier 1 can add new harness logic without forcing all validation into
+full browser tests.
+
+### CI does not run E2E today
+
+`.github/workflows/ci.yml:8` runs `lint`, `typecheck`, and `npm test`, but it
+**does not** run `npm run test:e2e`. It also sets
+`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` (`.github/workflows/ci.yml:11`).
+
+That is the clearest signal that issue #87 should add a **new CI-safe replay
+lane**, not overload the current live-session runner.
+
+## Existing Playwright usage patterns
+
+### The repo uses Playwright as a browser automation library, not as a test framework
+
+The monorepo depends on `playwright-core`, not `@playwright/test` or the full
+`playwright` package (`packages/core/package.json:19`). There is no
+`playwright.config.*` file. Test orchestration is done by Vitest.
+
+That is actually fine for Tier 1: `routeFromHAR()` and `recordHar` are browser
+APIs, not Playwright-test-only APIs. A replay harness can stay inside the
+current Vitest architecture.
+
+### Runtime browser/session layer
+
+`packages/core/src/profileManager.ts` is the key abstraction today:
+
+- `runWithPersistentContext()` launches a persistent Chromium context against a
+  profile directory (`packages/core/src/profileManager.ts:87`)
+- `runWithCDP()` attaches to a live browser via `chromium.connectOverCDP()`
+  (`packages/core/src/profileManager.ts:117`)
+- `runWithContext()` chooses between CDP and persistent context
+  (`packages/core/src/profileManager.ts:173`)
+
+There is also a pooled CDP connection helper in
+`packages/core/src/connectionPool.ts:31`, but the main feature services still
+route through `ProfileManager`.
+
+### Artifacts and tracing are already part of mutation flows
+
+The repo already has a structured artifact system in
+`packages/core/src/artifacts.ts:21`.
+
+Mutation-heavy flows already capture trace/screenshot artifacts, for example:
+
+- post create prepare starts Playwright tracing in
+  `packages/core/src/linkedinPosts.ts:1837`
+- post create confirm also traces and captures pre-publish screenshots in
+  `packages/core/src/linkedinPosts.ts:2001`
+- selector audit captures screenshot / DOM / accessibility failure artifacts via
+  `packages/core/src/selectorAudit.ts`
+
+This is useful for Tier 1: the replay harness should preserve this debugging
+story instead of replacing it with opaque mocks.
+
+### Standalone live-browser scripts exist
+
+There are two other browser-facing scripts worth noting:
+
+- `scripts/integration-test.ts:1` is a read-only CDP smoke script
+- `scripts/keep-alive.sh:33` uses `connectOverCDP()` and
+  `launchPersistentContext()` to transplant cookies between browsers
+
+These are not directly reusable as Tier 1 harness code, but they reinforce the
+repo’s assumption that “LinkedIn == real Chromium session attached over CDP or
+persistent profile.”
+
+## Existing fixture and mock patterns
+
+### 1) There is already fixture replay for CLI/MCP target IDs
+
+The most relevant existing pattern is **not HAR replay**. It is the shared
+`CliCoverageFixtures` file used by the CLI and MCP E2E suites:
+
+- fixture file schema: `packages/core/src/__tests__/e2e/helpers.ts:58`
+- format versioning + profile-name validation:
+  `packages/core/src/__tests__/e2e/helpers.ts:224`
+- read/write helpers: `packages/core/src/__tests__/e2e/helpers.ts:265`
+- live discovery: `packages/core/src/__tests__/e2e/helpers.ts:813`
+- replay entry point: `packages/core/src/__tests__/e2e/helpers.ts:830`
+- runner flags: `scripts/run-e2e.js:69`
+- docs: `docs/e2e-testing.md:106`
+
+This fixture file stores only:
+
+- `threadId`
+- `postUrl`
+- `jobId`
+- `connectionTarget`
+
+That is useful precedent for manifest design, but it is **not** a page fixture
+system.
+
+### 2) Unit tests already mock Playwright objects heavily
+
+Non-live tests rely on manual page/locator/browser mocks and `vi.mock()`:
+
+- `packages/core/src/__tests__/profileManager.test.ts:11`
+- `packages/core/src/__tests__/connectionPool.test.ts:9`
+- `packages/core/src/__tests__/selectorAudit.test.ts:45`
+- `packages/core/src/__tests__/sessionAuth.test.ts:22`
+
+This gives the repo good unit coverage around browser abstraction boundaries,
+but it does not exercise real DOM structure, real rendered LinkedIn HTML, or
+real response timing.
+
+### 3) There are no LinkedIn HAR/HTML/network fixtures today
+
+The repo has no `recordHar`, `routeFromHAR`, or HAR files. The only fixture
+directory currently checked in is unrelated draft-quality data under
+`packages/core/test/fixtures/draft-quality/*`.
+
+There is also no `.gitignore` entry for replay fixtures yet (`.gitignore:1`).
+
+## Feature modules and what they cover
+
+The runtime wiring in `packages/core/src/runtime.ts:221` shows the core service
+surface that Tier 1 would need to cover:
+
+| Module | Key user flows | Current live coverage | Replay priority | Notes |
+| --- | --- | --- | --- | --- |
+| `LinkedInAuthService` | session status, ensure-authenticated, login flows (`packages/core/src/auth/session.ts:102`, `packages/core/src/auth/session.ts:141`, `packages/core/src/auth/session.ts:171`, `packages/core/src/auth/session.ts:491`) | auth E2E + CLI/MCP | Medium | `status()`/`ensureAuthenticated()` are replayable; real login is not a Tier 1 target. |
+| `LinkedInProfileService` | view own/other profile (`packages/core/src/linkedinProfile.ts:533`) | profile E2E + CLI/MCP | High | Pure DOM extraction. Good first replay target. |
+| `LinkedInSearchService` | people, company, and jobs search (`packages/core/src/linkedinSearch.ts:131`) | search E2E + CLI/MCP | High | Structural DOM scraping. Good first replay target. |
+| `LinkedInJobsService` | dedicated jobs search and view (`packages/core/src/linkedinJobs.ts:519`, `packages/core/src/linkedinJobs.ts:569`) | jobs E2E + CLI/MCP | High | Good fit for page + API replay. |
+| `LinkedInNotificationsService` | list notifications (`packages/core/src/linkedinNotifications.ts:379`) | notifications E2E + CLI/MCP | High | Good fixture-backed read suite candidate. |
+| `LinkedInInboxService` | list threads, get thread, prepare reply, confirm send (`packages/core/src/linkedinInbox.ts:1141`, `packages/core/src/linkedinInbox.ts:1190`, `packages/core/src/linkedinInbox.ts:1222`, `packages/core/src/linkedinInbox.ts:1323`) | inbox E2E + CLI/MCP + preview/confirm lane | Very high | Most important network-aware module. |
+| `LinkedInConnectionsService` | list connections, pending invites, prepare invite/accept/withdraw (`packages/core/src/linkedinConnections.ts:1125`, `packages/core/src/linkedinConnections.ts:1162`, `packages/core/src/linkedinConnections.ts:1246`, `packages/core/src/linkedinConnections.ts:1285`, `packages/core/src/linkedinConnections.ts:1321`) | connections E2E + CLI/MCP + preview lane | Very high | Requires account-state fixtures. |
+| `LinkedInFollowupsService` | list accepted connections, prepare followups after accept (`packages/core/src/linkedinFollowups.ts:1190`, `packages/core/src/linkedinFollowups.ts:1208`, `packages/core/src/linkedinFollowups.ts:1261`) | covered indirectly by CLI/MCP | High | Depends on profile + messaging surfaces. |
+| `LinkedInFeedService` | view feed, view post, prepare like/comment (`packages/core/src/linkedinFeed.ts:1706`, `packages/core/src/linkedinFeed.ts:1742`, `packages/core/src/linkedinFeed.ts:1791`, `packages/core/src/linkedinFeed.ts:1830`) | feed E2E + CLI/MCP + preview lanes | Very high | Core read/write selector coverage target. |
+| `LinkedInPostsService` | open composer, prepare create, confirm publish (`packages/core/src/linkedinPosts.ts:1808`, `packages/core/src/linkedinPosts.ts:1972`) | post preview lane + CLI/MCP | Very high | Highest-value selector exercise after feed/inbox. |
+| `LinkedInSelectorAuditService` | page-level selector regression audit (`packages/core/src/selectorAudit.ts:1159`) | CLI + error-path E2E | High | Excellent replay candidate for drift detection. |
+
+### Coverage gaps worth calling out
+
+Two gaps stand out:
+
+1. `followups` has CLI/MCP coverage, but no standalone fixture-friendly browser
+   suite yet.
+2. `selectorAudit` only covers **feed, inbox, profile, connections, and
+   notifications** via the built-in registry
+   (`packages/core/src/selectorAudit.ts:365`). It does **not** currently audit
+   jobs, search, post composer, or followups.
+
+## Selector layer and data extraction pipeline
+
+### Broad architecture
+
+The repo has two different selector/data-extraction shapes:
+
+1. **Read flows** mostly navigate, wait for a surface, then run `page.evaluate()`
+   to scrape rendered DOM.
+2. **Mutation flows** build ordered candidate arrays and probe them until one is
+   visible, then click/fill/confirm.
+
+That means Tier 1 needs to validate both:
+
+- HTML structure + rendered text for read scraping
+- selector fallback order + click/fill behavior for write flows
+
+### Read extraction is DOM-heavy, with one notable network-aware exception
+
+Representative read pipelines:
+
+- search waits for search result cards and scrapes them via `page.evaluate()` in
+  `packages/core/src/linkedinSearch.ts:163`
+- profile scraping is almost entirely DOM-evaluate based in
+  `packages/core/src/linkedinProfile.ts:124`
+- jobs uses explicit surface waiters plus `page.evaluate()` extractors in
+  `packages/core/src/linkedinJobs.ts:99` and
+  `packages/core/src/linkedinJobs.ts:188`
+- notifications waits for a card surface and scrapes notifications in
+  `packages/core/src/linkedinNotifications.ts:63` and
+  `packages/core/src/linkedinNotifications.ts:95`
+- feed waits for feed/post surfaces and extracts posts in
+  `packages/core/src/linkedinFeed.ts:427` and
+  `packages/core/src/linkedinFeed.ts:488`
+
+The biggest special case is **inbox**:
+
+- it waits for messaging network responses via `page.waitForResponse()` in
+  `packages/core/src/linkedinInbox.ts:753`
+- it parses network payloads in `packages/core/src/linkedinInbox.ts:781`
+- it also scrapes thread DOM in `packages/core/src/linkedinInbox.ts:806`
+- it merges DOM and network detail in
+  `packages/core/src/linkedinInbox.ts:997`
+
+That makes inbox the most important proof point for HAR replay, because a simple
+HTML snapshot alone would miss the `waitForResponse()` path.
+
+### Mutation selectors are already structured for fallback probing
+
+The dominant mutation pattern is an ordered selector-candidate array.
+Representative shapes:
+
+- inbox `SelectorCandidate` and resolver:
+  `packages/core/src/linkedinInbox.ts:78`,
+  `packages/core/src/linkedinInbox.ts:1069`
+- feed `SelectorCandidate` and resolver:
+  `packages/core/src/linkedinFeed.ts:184`,
+  `packages/core/src/linkedinFeed.ts:742`
+- posts `SelectorCandidate` / `ScopedSelectorCandidate` and resolvers:
+  `packages/core/src/linkedinPosts.ts:118`,
+  `packages/core/src/linkedinPosts.ts:1039`
+- connections visible-locator probing:
+  `packages/core/src/linkedinConnections.ts:120`
+
+The resolver pattern is consistent:
+
+- each candidate has a stable `key`
+- each candidate exposes a human-readable `selectorHint`
+- each candidate builds a `Locator` through `locatorFactory`
+- the module loops candidates in order until one becomes visible
+- on total failure it throws `UI_CHANGED_SELECTOR_FAILED` with the selector key
+  and all attempted hints
+
+This is great news for Tier 1: fixture-backed E2Es do not need a new selector
+model. They mainly need realistic DOM and response replay.
+
+### Candidate ordering already reflects the repo’s selector philosophy
+
+The concrete candidate groups follow the same pattern across modules:
+
+1. semantic role/name selectors
+2. aria-label-derived selectors
+3. stable-ish CSS hooks or data attributes
+4. broader text-based fallbacks
+5. page-wide emergency fallbacks when scoped lookup fails
+
+Examples:
+
+- inbox message composer probes role/textbox → placeholder →
+  `.msg-form__contenteditable` → generic `.msg-form [contenteditable='true']`
+  (`packages/core/src/linkedinInbox.ts:1422`)
+- feed comment flow probes social-action button → aria-label → role/button →
+  fallback comment toolbar, then contenteditable/textbox/textarea composer
+  fallbacks (`packages/core/src/linkedinFeed.ts:1478`)
+- post composer probes start-post button by role → aria-label → share-box
+  trigger → text fallback; then dialog root → textbox → contenteditable →
+  textarea (`packages/core/src/linkedinPosts.ts:1176`,
+  `packages/core/src/linkedinPosts.ts:1227`,
+  `packages/core/src/linkedinPosts.ts:1273`)
+- feed post targeting prefers `data-urn` and permalink identities before falling
+  back to the first `article` (`packages/core/src/linkedinFeed.ts:964`)
+
+### Locale handling already exists and should shape fixture sets
+
+The repo already has locale-aware selector infrastructure in
+`packages/core/src/selectorLocale.ts:106`.
+
+Important facts for Tier 1:
+
+- supported selector locales are currently `en` and `da`
+  (`packages/core/src/selectorLocale.ts:109`)
+- phrase dictionaries already exist for keys such as `send`, `connect`,
+  `comment`, `post`, `visibility`, `notifications`, etc.
+  (`packages/core/src/selectorLocale.ts:118`)
+- selector audit already builds locale-aware regex and aria selectors from this
+  dictionary (`packages/core/src/selectorAudit.ts:15`)
+
+A replay fixture manifest should therefore record **locale explicitly** and
+probably group fixtures by locale. Otherwise Tier 1 will end up replaying only a
+single English-shaped DOM snapshot against modules that are explicitly trying to
+support locale variation.
+
+## Playwright HAR capabilities relevant to issue #87
+
+I reviewed the current Playwright documentation for HAR recording/replay.
+The important capabilities for this repo are:
+
+- `browserContext.routeFromHAR()` / `page.routeFromHAR()` can replay matching
+  requests directly from a HAR file.
+- `notFound: "abort"` fails closed on missing requests, which aligns well with
+  issue #87’s “no silent pass-through” requirement.
+- `update: true` can create or refresh HAR files while running against real
+  LinkedIn.
+- `updateContent: "embed" | "attach"` and `updateMode: "minimal" | "full"`
+  let us trade off file size vs debug richness during capture.
+- `recordHar` on context creation can capture all requests for all pages in that
+  context, optionally filtered by URL.
+- Playwright explicitly warns that Service Worker-intercepted requests are not
+  served from HAR; the docs recommend `serviceWorkers: "block"` when using HAR
+  replay.
+
+### Why this matters for this repo
+
+HAR replay is a strong fit because the codebase already navigates to real
+LinkedIn URLs. With `browserContext.routeFromHAR()` the service code can keep
+calling `page.goto("https://www.linkedin.com/..." )` and still stay offline.
+
+A localhost mock server is less natural here because the service layer would
+need one of these refactors first:
+
+- replace hardcoded LinkedIn URLs with a shared base-URL resolver
+- introduce a proxy/rewrite layer that preserves LinkedIn-origin assumptions
+- or wrap every navigation entry point in test-only URL translation
+
+So, from a codebase-fit perspective:
+
+- **HAR replay is the low-refactor path**
+- **a localhost-origin mock server is the higher-refactor path**
+
+If issue #87’s local server requirement is non-negotiable, budget explicit work
+for a LinkedIn base-URL abstraction before building the server.
+
+## Feature modules that need fixture-backed E2E coverage
+
+These are the core modules that should be considered in-scope for Tier 1,
+ordered roughly by implementation value:
+
+1. **Feed** — home feed rendering, post extraction, post targeting, like/comment
+   selector flows (`packages/core/src/linkedinFeed.ts:1706`)
+2. **Inbox** — thread list/detail, network-backed message parsing, composer/send
+   selectors (`packages/core/src/linkedinInbox.ts:1141`)
+3. **Post composer** — composer open/root/input/visibility/submit selectors
+   (`packages/core/src/linkedinPosts.ts:1808`)
+4. **Connections** — list/pending, invite/accept/withdraw UI states
+   (`packages/core/src/linkedinConnections.ts:1125`)
+5. **Profile** — profile header + about/experience/education extraction
+   (`packages/core/src/linkedinProfile.ts:533`)
+6. **Search** — people/companies/jobs result extraction
+   (`packages/core/src/linkedinSearch.ts:131`)
+7. **Jobs** — dedicated jobs search + job detail extraction
+   (`packages/core/src/linkedinJobs.ts:519`)
+8. **Notifications** — notification list extraction and type inference
+   (`packages/core/src/linkedinNotifications.ts:379`)
+9. **Followups** — accepted-connection probing + message trigger reuse
+   (`packages/core/src/linkedinFollowups.ts:1190`)
+10. **Selector audit** — a fixture-backed drift detector for five high-value
+    pages (`packages/core/src/selectorAudit.ts:365`)
+
+### What is probably out of scope for pure fixture replay
+
+These flows are less suitable as Tier 1 primary targets:
+
+- `headlessLogin()` and `openLogin()` in `auth/session.ts` because they are
+  inherently about real authentication state and checkpoint handling
+  (`packages/core/src/auth/session.ts:171`,
+  `packages/core/src/auth/session.ts:491`)
+- keepalive/cookie-transplant scripts, which are operational live-session tools
+  (`scripts/keep-alive.sh:23`)
+
+Tier 1 can still cover `auth.status()` and `ensureAuthenticated()` if the replay
+context provides deterministic feed/login pages or if the fixture runtime uses a
+test-only authenticated auth adapter.
+
+## Open issue overlaps and dependencies
+
+### Direct downstream issues
+
+- **#88 — Tier 2 live read-only validation**
+  This is downstream of #87 conceptually, but not blocked on HAR replay. Tier 1
+  gives deterministic CI-safe regression coverage; Tier 2 still provides live
+  drift detection against the real site.
+- **#90 — Tier 3 write-action validation**
+  This remains necessary even after #87. HAR replay can validate selector
+  matching, action execution code paths, and error handling, but it cannot prove
+  that LinkedIn truly accepted a write in production.
+
+### Cross-cutting overlap
+
+- **#8 — Internationalization/locale support for selectors**
+  This is the most important cross-cutting dependency. Fixture manifests should
+  record locale now, and any page-type fixture taxonomy should assume multiple
+  locale variants eventually.
+
+### Current open issue landscape
+
+The currently open issues most relevant to Tier 1 are:
+
+- `#87` — recorded fixture replay
+- `#88` — live read-only validation
+- `#90` — live write validation
+- `#8` — selector locale support
+
+I did not find another open issue that already introduces HAR/mock-server
+plumbing.
+
+## Recent commits relevant to this work
+
+Recent history shows that the E2E harness has been actively hardened already:
+
+- `801ec01` — introduced the original live E2E lane and Vitest config
+- `252fabe` — added CLI/MCP E2E contract coverage, shared helpers, docs, and
+  the custom E2E runner
+- `b2cd4b1` — simplified the shared E2E scaffolding
+- `270d2cf` — hardened E2E coverage contracts and setup semantics
+- `ad888c0` — hardened E2E helper/setup infrastructure and added dedicated unit
+  tests
+- `d5c83d2` — improved developer workflow and extended fixture-file support in
+  the runner/helpers
+- `e6f1403` — documented the current E2E hardening workflow
+
+The strong implication is that Tier 1 should be built as the **next layer on top
+of this harness**, not as a clean-room replacement.
+
+## Main regression risks if a replay harness is added
+
+### 1) Auth gating is wired into every service
+
+Most services call `runtime.auth.ensureAuthenticated()` before doing anything.
+That is great for live safety, but it means a replay harness must either:
+
+- make `auth.status()` deterministic under replay, or
+- inject a test-only authenticated auth service/runtime
+
+If this is not addressed early, every replay test will fail before the feature
+module even gets to its selectors.
+
+### 2) The codebase is hardcoded to the LinkedIn origin
+
+All major modules navigate directly to `https://www.linkedin.com/...` URLs. That
+makes `routeFromHAR()` easy, but it makes a localhost mock server awkward. A
+server-first design without URL abstraction risks a large, noisy refactor across
+many modules.
+
+### 3) Inbox depends on real response replay, not just HTML snapshots
+
+`LinkedInInboxService` waits for LinkedIn messaging responses and merges them
+with DOM extraction (`packages/core/src/linkedinInbox.ts:753`,
+`packages/core/src/linkedinInbox.ts:997`). A replay harness that only serves
+saved HTML will under-test the most important inbox code paths.
+
+### 4) Some features need multiple account-state fixtures
+
+Connections, composer, and feed mutations are state-sensitive. One fixture set
+will not be enough. At minimum, expect distinct capture states for:
+
+- feed loaded
+- post composer closed/open
+- comment composer expanded
+- message thread loaded
+- pending sent invitation
+- pending received invitation
+- connected profile with message entry point
+
+### 5) Locale-sensitive selectors can create false regressions
+
+The repo already has locale-aware selector dictionaries. If the first fixture set
+is English-only, replay tests may accidentally encode “English DOM == correct”
+as the default assumption and mask future issue #8 work.
+
+### 6) Service workers can bypass HAR replay
+
+Playwright’s HAR replay does not serve Service Worker-intercepted requests. If
+Tier 1 uses HAR without `serviceWorkers: "block"`, the suite can fail in ways
+that look flaky or can silently reach the network.
+
+### 7) CI is not currently provisioned for browser-backed E2E
+
+CI uses `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` and never runs E2E today.
+A fixture lane therefore needs explicit browser provisioning and should probably
+be introduced as a new script/job instead of piggybacking on the existing live
+runner.
+
+### 8) Replay fixtures can capture sensitive LinkedIn data
+
+HAR files and HTML snapshots can include profile data, message content, cookies,
+and request headers. The issue already hints that large fixtures should be
+`gitignore`d with only a manifest committed. That is the right default. The
+capture pipeline should also include sanitization/redaction rules before any
+fixture corpus is shared.
+
+### 9) Tier 1 will not replace Tier 2/Tier 3
+
+A replay harness can validate selector matching, DOM extraction, prepared-action
+previews, and even replayed “confirm” code paths. It still cannot prove live
+LinkedIn behavior. Keeping #88 and #90 separate is the correct design.
+
+## Recommended implementation direction
+
+### Short version
+
+The safest path is:
+
+1. add a **new fixture-backed E2E lane** instead of changing `npm run test:e2e`
+2. keep **Vitest** as the test runner
+3. add a **fixture runtime/context adapter** that launches an ephemeral browser
+   context for replay
+4. capture/replay with **`browserContext.routeFromHAR()` first**
+5. record **locale + page-type + account-state metadata** in a manifest
+6. start with **read flows + selector audit + prepare flows**, then add replayed
+   confirm paths
+
+### Why this fits the repo best
+
+This approach preserves:
+
+- the existing `createCoreRuntime()` feature-service graph
+- the current test structure and Vitest tooling
+- the current artifact and selector-audit debugging story
+- the separation between Tier 1 replay and Tier 2/Tier 3 live validation
+
+### If localhost mock server is a hard requirement
+
+If the final implementation must literally serve fixtures from `localhost`, I
+recommend treating this as a two-part effort:
+
+1. introduce a shared LinkedIn base-URL resolver across service modules
+2. build the mock server on top of that abstraction
+
+Trying to build the server before that URL abstraction will fight the current
+service design.
+
+## Suggested first implementation slice
+
+If issue #87 is implemented incrementally, the first slice should probably be:
+
+1. **new replay runtime/context**
+2. **feed/profile/notifications fixture set**
+3. **selector audit replay suite**
+4. **inbox replay proof-of-concept using HAR-backed response events**
+5. **new CI job for fixture-backed E2E**
+
+That would validate the core architecture before tackling composer,
+connections-state permutations, and replayed confirm flows.
+
+## Bottom line
+
+The codebase is ready for Tier 1, but the winning design is dictated by the
+existing architecture:
+
+- current E2Es are live-session Vitest tests
+- current fixtures only replay stable target IDs
+- service modules assume real LinkedIn URLs
+- selector logic is already structured for replay-friendly DOM validation
+- inbox specifically needs network replay, not just saved HTML
+
+So the most practical implementation target is **HAR-backed browser-context
+replay with a new fixture E2E lane**, plus a manifest that tracks locale,
+account state, capture date, and fixture freshness.


### PR DESCRIPTION
## Summary
- add docs/.research-brief-issue-87.md for the Tier 1 fixture replay research phase
- map the current Vitest and Playwright E2E infrastructure, selector/data-extraction paths, and existing fixture patterns
- document related issues, recent test-infrastructure commits, regression risks, and a recommended implementation slice

## Why
Issue #109 asks for a research brief before implementing the recorded fixture replay harness in issue #87.

Parent: #87

Closes #109
