### PR TITLE
feat: add fixture replay e2e harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install deps
         run: npm ci
 
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
       - name: Lint
         run: npm run lint
 
@@ -31,3 +34,9 @@ jobs:
 
       - name: Test
         run: npm test
+
+      - name: Fixture-backed E2E
+        run: npm run test:e2e:fixtures
+
+      - name: Build
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,11 @@ dist
 *.tsbuildinfo
 
 .linkedin-assistant
+
+test/fixtures/*
+!test/fixtures/manifest.json
+!test/fixtures/ci/
+!test/fixtures/ci/**
+test/fixtures/*/responses/
+test/fixtures/*/responses/**
+test/fixtures/*/session.har

--- a/README.md
+++ b/README.md
@@ -404,47 +404,69 @@ npm run typecheck
 npm run build
 ```
 
-## E2E Testing (Real Browser)
+## E2E Testing
 
 Unit tests use mocks. The E2E suite validates the CLI, MCP tools, and selected
-two-phase commit flows against a real authenticated LinkedIn session.
+two-phase commit flows in two modes:
 
-Run the default E2E runner:
+- a live-session lane for authenticated LinkedIn coverage via CDP
+- a fixture-backed lane that replays recorded LinkedIn HTML/HTTP fixtures locally
+
+### Commands
 
 ```bash
+# Live authenticated lane
 npm run test:e2e
+
+# Deterministic headless replay lane used by CI
+npm run test:e2e:fixtures
+
+# Show live-runner help and overrides
+npm run test:e2e -- --help
 ```
 
-The runner now skips cleanly when no authenticated CDP session is available,
-which makes it safe to invoke in CI.
+The live runner skips cleanly when no authenticated CDP session is available.
+The replay runner does not need credentials and uses `test/fixtures/manifest.json`
+plus the committed `ci` fixture set.
 
-See `docs/e2e-testing.md` for the full workflow, safe targets, and opt-in write
-flags. Run `npm run test:e2e -- --help` for the runner's built-in flag and
-environment reference.
+### Fixture workflow
 
-Pass `npm run test:e2e -- --require-session` when a missing session should fail
-instead of skip, and use `--fixtures <file>` to capture or replay the shared
-CLI/MCP coverage fixtures while iterating on E2E failures. Saved fixtures are
-profile-specific, so refresh them when `LINKEDIN_E2E_PROFILE` changes.
+Record or refresh replay fixtures manually:
+
+```bash
+linkedin fixtures record --page feed --page messaging
+owa fixtures:record --set da-dk --page profile,notifications --no-har
+```
+
+Check fixture freshness:
+
+```bash
+linkedin fixtures check
+owa fixtures:check --set ci --max-age-days 14
+```
+
+Replay fixtures are stored under `test/fixtures/`. The manifest and committed
+`ci` set stay in git for deterministic CI coverage; other local fixture sets,
+HAR files, and bulky response captures stay ignored by default.
 
 ### Coverage lanes
 
-- Default lane: read-only runtime coverage, prepare-only mutation previews, and
-  safe `test.echo` confirms for the generic confirm entrypoints
-- Contract lanes: thin CLI and MCP suites that reuse the same live fixtures
-  instead of rediscovering targets on every run
-- Opt-in write lanes: real message, connection, like, comment, and post
+- Live and replayed runtime coverage for auth, health, feed, inbox,
+  connections, profile, search, jobs, and notifications
+- CLI and MCP contract suites that verify output shape, exit codes, and confirm
+  entrypoints end-to-end
+- Opt-in write lanes for real message, connection, like, comment, and post
   confirms guarded behind explicit environment flags
-- Non-live guard rails: helper and runner unit tests that cover option parsing,
-  fixture replay, skip semantics, and confirm contract hardening
+- Non-live guard rails that cover runner parsing, fixture replay, skip
+  semantics, and confirm contract hardening
 
-### Prerequisites
+### Live prerequisites
 
 - Node.js 22+
 - `npm install`
-- Authenticated LinkedIn session in a dedicated Chromium instance exposed via
-  CDP (default: `http://localhost:18800`)
-- Optional: `LINKEDIN_CDP_URL` to point at a different CDP endpoint
+- `npx playwright install chromium`
+- For the live lane only: an authenticated Chromium session exposed via CDP
+  (default: `http://localhost:18800`)
 
 ### Safe defaults
 
@@ -452,36 +474,5 @@ By default, the E2E suite only performs read-only operations, prepare-only
 two-phase commit steps, or safe `test.echo` confirmations for the generic
 confirm entrypoints. Real outbound confirms remain opt-in.
 
-```bash
-# Default run: safe coverage only
-npm run test:e2e
-
-# Show the runner help, flags, and env overrides
-npm run test:e2e -- --help
-
-# Focus a specific E2E file while keeping the runner checks
-npm run test:e2e -- packages/core/src/__tests__/e2e/cli.e2e.test.ts
-
-# Capture or refresh the shared CLI/MCP fixtures while debugging contract bugs
-npm run test:e2e -- --fixtures .tmp/e2e-fixtures.json --refresh-fixtures \
-  packages/core/src/__tests__/e2e/cli.e2e.test.ts
-
-# Raw Vitest E2E run when you already know the session is available
-npm run test:e2e:raw
-```
-
-### Opt-in writes
-
-Use the flags documented in `docs/e2e-testing.md` for:
-
-- `LINKEDIN_E2E_ENABLE_MESSAGE_CONFIRM=1`
-- `LINKEDIN_E2E_ENABLE_CONNECTION_CONFIRM=1`
-- `LINKEDIN_E2E_ENABLE_LIKE_CONFIRM=1`
-- `LINKEDIN_E2E_ENABLE_COMMENT_CONFIRM=1`
-- `LINKEDIN_ENABLE_POST_WRITE_E2E=1`
-
-### Safe targets
-
-- Safe message target: Simon Miller (`linkedin.com/in/realsimonmiller`)
-- Safe connection target: Simon Miller unless an explicitly approved alternative is provided
-- Public actions like likes, comments, and posts require explicit approval before enabling write confirms
+See `docs/e2e-testing.md` for the full workflow, the replay manifest format,
+safe targets, and opt-in write flags.

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -1,17 +1,23 @@
 # E2E Testing
 
-The E2E suite exercises the CLI, the MCP tool surface, and the core two-phase
-commit flows against a real authenticated LinkedIn browser session.
+The E2E suite now has two complementary lanes:
 
-## Runner behavior
+- a live-session runner for validating behavior against an authenticated LinkedIn browser
+- a fixture-backed replay runner that serves recorded LinkedIn HTML/HTTP responses locally
 
-Use the default runner from the repo root:
+The replay lane gives CI and local development deterministic end-to-end coverage
+without touching live LinkedIn.
+
+## Live runner
+
+Use the default runner from the repo root when you want to exercise a real
+LinkedIn session over CDP:
 
 ```bash
 npm run test:e2e
 ```
 
-The runner:
+The live runner:
 
 1. Prints the effective E2E configuration.
 2. Checks that a CDP endpoint is reachable.
@@ -19,11 +25,8 @@ The runner:
 4. Runs the Vitest E2E suite.
 
 If no authenticated session is available, the runner prints a skip reason and
-exits successfully. This makes it safe for CI environments that do not have a
-LinkedIn browser session.
-
-Pass `--require-session` when a missing CDP/authenticated session should fail
-instead of skip:
+exits successfully. Pass `--require-session` when a missing CDP/authenticated
+session should fail instead of skip:
 
 ```bash
 npm run test:e2e -- --require-session
@@ -38,6 +41,7 @@ simple:
 ```bash
 npm run test:e2e -- packages/core/src/__tests__/e2e/cli.e2e.test.ts
 npm run test:e2e -- --reporter=verbose packages/core/src/__tests__/e2e/error-paths.e2e.test.ts
+npm run test:e2e -- --help
 ```
 
 To force the raw Vitest suite directly, use:
@@ -46,18 +50,37 @@ To force the raw Vitest suite directly, use:
 npm run test:e2e:raw
 ```
 
-The runner itself also has built-in help:
+## Fixture-backed replay runner
+
+Use the replay lane when you want deterministic Playwright coverage without
+credentials or live LinkedIn traffic:
 
 ```bash
-npm run test:e2e -- --help
+npm run test:e2e:fixtures
 ```
+
+This script enables `LINKEDIN_E2E_REPLAY=1`, loads
+`test/fixtures/manifest.json`, starts the local replay server, and runs the same
+Vitest E2E suites headlessly against recorded fixtures.
+
+Focused reruns work the same way:
+
+```bash
+npm run test:e2e:fixtures -- packages/core/src/__tests__/e2e/inbox.e2e.test.ts
+```
+
+CI uses this lane so E2E coverage runs without a real LinkedIn account.
+Unrecorded LinkedIn routes fail closed with fixture-miss errors, and non-
+LinkedIn network requests are aborted instead of silently passing through.
 
 ## Coverage lanes
 
-The E2E matrix now has four layers:
+The E2E matrix now has five layers:
 
 - Live runtime suites in `packages/core/src/__tests__/e2e/*.e2e.test.ts`
   validate the LinkedIn interaction logic directly.
+- Fixture-backed runtime suites reuse the same files but run against the local
+  replay server in CI and local headless runs.
 - Thin CLI contract coverage in
   `packages/core/src/__tests__/e2e/cli.e2e.test.ts` validates parsing, JSON
   output, exit codes, keepalive behavior, selector audit, and confirm
@@ -72,24 +95,29 @@ The E2E matrix now has four layers:
   parsing, skip semantics, fixture replay, retry behavior, and confirm
   contracts without needing LinkedIn access.
 
-The default `npm run test:e2e` path only executes tests that are read-only,
-preview-only, or use the `test.echo` executor for the generic confirm
-entrypoints. Real outbound confirms remain opt-in.
+The default live lane only executes tests that are read-only, preview-only, or
+use the `test.echo` executor for the generic confirm entrypoints. Real outbound
+confirms remain opt-in.
 
 ## Prerequisites
 
 - Node.js 22+
 - Installed dependencies via `npm install`
-- Playwright Chromium dependencies available for the existing toolchain
-- A dedicated Chromium session exposed over CDP and already logged into LinkedIn
+- Playwright Chromium available via `npx playwright install chromium`
+- For the live lane only: a dedicated Chromium session exposed over CDP and
+  already logged into LinkedIn
 
 Environment variables:
 
-- `LINKEDIN_CDP_URL` — optional, defaults to `http://localhost:18800`
+- `LINKEDIN_CDP_URL` — live lane only, defaults to `http://localhost:18800`
 - `LINKEDIN_E2E_PROFILE` — optional logical profile name, defaults to `default`
 - `LINKEDIN_E2E_REQUIRE_SESSION` — optional, set to `1` or `true` to fail instead of skip
-- `LINKEDIN_E2E_FIXTURE_FILE` — optional JSON file used to record or replay shared CLI/MCP fixtures
-- `LINKEDIN_E2E_REFRESH_FIXTURES` — optional, set to `1` or `true` to overwrite the fixture file
+- `LINKEDIN_E2E_REPLAY` — optional, set to `1` or `true` to enable replay mode
+- `LINKEDIN_E2E_FIXTURE_MANIFEST` — optional manifest path for replay mode, defaults to `test/fixtures/manifest.json`
+- `LINKEDIN_E2E_FIXTURE_SET` — optional fixture set name override, defaults to the manifest default set
+- `LINKEDIN_E2E_FIXTURE_SERVER_URL` — optional externally managed replay server base URL
+- `LINKEDIN_E2E_FIXTURE_FILE` — optional JSON file used to record or replay shared CLI/MCP discovery fixtures in the live lane
+- `LINKEDIN_E2E_REFRESH_FIXTURES` — optional, set to `1` or `true` to overwrite the live discovery fixture file
 - `LINKEDIN_E2E_JOB_QUERY` — optional job query override for live fixture discovery, defaults to `software engineer`
 - `LINKEDIN_E2E_JOB_LOCATION` — optional job location override for live fixture discovery, defaults to `Copenhagen`
 - `LINKEDIN_E2E_MESSAGE_TARGET_PATTERN` — optional regex source used when live-discovering the approved inbox thread, defaults to `Simon Miller`
@@ -103,12 +131,60 @@ Environment variables:
 - `LINKEDIN_E2E_COMMENT_POST_URL` — required only when `LINKEDIN_E2E_ENABLE_COMMENT_CONFIRM=1`
 - `LINKEDIN_ENABLE_POST_WRITE_E2E` — optional, enables real post publishing after explicit approval
 
-## Fixture replay workflow
+## Recorded fixture workflow
 
-The CLI and MCP contract suites only need a few stable identifiers: a message
-thread id, a feed post URL, a job id, and a connection target. The runner can
-capture those into a small JSON file so you can replay the same targets while
-iterating on contract or output bugs.
+Replay fixtures live under `test/fixtures/`. The committed manifest points to a
+small `ci` fixture set that is safe for headless CI. Local recordings can add
+more sets without overwriting others.
+
+Record or refresh pages manually:
+
+```bash
+linkedin fixtures record --page feed --page messaging
+owa fixtures:record --set da-dk --page profile,notifications --no-har
+```
+
+Supported page types:
+
+- `feed`
+- `profile`
+- `messaging`
+- `notifications`
+- `composer`
+- `search`
+- `connections`
+- `jobs`
+
+The recorder:
+
+- launches a persistent Playwright browser for manual LinkedIn navigation
+- records LinkedIn/Licdn responses into a fixture set plus optional HAR output
+- stores per-page metadata including capture date, locale, viewport, and URL
+- preserves untouched pages and routes so you can re-record one page at a time
+
+Validate fixture freshness:
+
+```bash
+linkedin fixtures check
+owa fixtures:check --set ci --max-age-days 14
+```
+
+`fixtures check` warns when a set or page is older than the configured age.
+
+Storage rules:
+
+- `test/fixtures/manifest.json` is committed
+- `test/fixtures/ci/**` is committed for deterministic CI coverage
+- other local fixture sets under `test/fixtures/<set>/` stay ignored by default
+- large captured HAR files and raw response bodies stay ignored unless you
+  intentionally promote them
+
+## Contract discovery fixtures
+
+The CLI and MCP contract suites also use a separate lightweight JSON fixture
+file for live discovery. Those files only store a message thread id, a feed
+post URL, a job id, and a connection target so contract-focused reruns do not
+need to rediscover live targets every time.
 
 Fixture files are intentionally small and profile-aware. The helper records the
 fixture format version, capture timestamp, `LINKEDIN_E2E_PROFILE`, and the
@@ -116,30 +192,25 @@ stable identifiers needed by the CLI/MCP suites. Replays fail fast when the
 saved format is unsupported or when the saved profile name does not match the
 current `LINKEDIN_E2E_PROFILE`.
 
-Capture or refresh the fixtures:
+Capture or refresh the live discovery fixtures:
 
 ```bash
-npm run test:e2e -- \
-  --fixtures .tmp/e2e-fixtures.json \
-  --refresh-fixtures \
-  packages/core/src/__tests__/e2e/cli.e2e.test.ts
+npm run test:e2e --   --fixtures .tmp/e2e-fixtures.json   --refresh-fixtures   packages/core/src/__tests__/e2e/cli.e2e.test.ts
 ```
 
-Replay the saved fixtures on later runs:
+Replay the saved discovery fixtures on later live runs:
 
 ```bash
-npm run test:e2e -- \
-  --fixtures .tmp/e2e-fixtures.json \
-  packages/core/src/__tests__/e2e/mcp.e2e.test.ts
+npm run test:e2e --   --fixtures .tmp/e2e-fixtures.json   packages/core/src/__tests__/e2e/mcp.e2e.test.ts
 ```
 
-If the replay file becomes stale or malformed, rerun with `--refresh-fixtures`
-to overwrite it with fresh live-discovery output.
+If the discovery file becomes stale or malformed, rerun with
+`--refresh-fixtures` to overwrite it with fresh live-discovery output.
 
 Live discovery uses `LINKEDIN_E2E_MESSAGE_TARGET_PATTERN`,
 `LINKEDIN_E2E_JOB_QUERY`, `LINKEDIN_E2E_JOB_LOCATION`, and
-`LINKEDIN_E2E_CONNECTION_TARGET`. Once a fixture file exists, the CLI and MCP
-contract suites can replay it without rediscovering those targets.
+`LINKEDIN_E2E_CONNECTION_TARGET`. Once a discovery fixture file exists, the CLI
+and MCP contract suites can replay it without rediscovering those targets.
 
 ## Safe defaults
 
@@ -237,8 +308,9 @@ LINKEDIN_ENABLE_POST_WRITE_E2E=1 npm run test:e2e
 
 The E2E suite now covers:
 
-- Live runtime suites for auth, health, profile, search, jobs, inbox,
-  connections, feed, notifications, and preview coverage for outbound actions
+- Live and fixture-backed runtime suites for auth, health, profile, search,
+  jobs, inbox, connections, feed, notifications, and preview coverage for
+  outbound actions
 - CLI command groups: session, rate-limit, keepalive, inbox, connections,
   followups, feed, post, notifications, jobs, profile, selector audit,
   health, and both confirm entrypoints
@@ -255,9 +327,12 @@ The E2E suite now covers:
 
 ### Architecture
 
-- `scripts/run-e2e.js` is the single entrypoint that probes CDP/authentication,
-  chooses skip versus fail behavior, prints configuration, and forwards the
-  remaining args to Vitest.
+- `scripts/run-e2e.js` is the live-session entrypoint that probes
+  CDP/authentication, chooses skip versus fail behavior, prints configuration,
+  and forwards the remaining args to Vitest.
+- `packages/core/src/fixtureReplay.ts` owns the replay manifest format, local
+  mock server, route matching, and Playwright request interception used by the
+  fixture-backed lane.
 - `packages/core/src/__tests__/e2e/setup.ts` owns the shared runtime,
   temporary assistant home, stale-directory cleanup, and explicit skip helpers.
   Use `setupE2ESuite()` plus `skipIfE2EUnavailable()` instead of re-implementing
@@ -277,7 +352,10 @@ The E2E suite now covers:
    truly needs a new live identifier.
 6. Update the runner `--help`, `README.md`, and this guide whenever you add a
    new E2E environment variable, fixture field, or safety rule.
-7. Add or update non-live unit tests when changing `scripts/run-e2e.js`,
+7. Update `test/fixtures/manifest.json`, the committed `test/fixtures/ci/`
+   set, and this guide together whenever replay selectors or routes change.
+8. Add or update non-live unit tests when changing `scripts/run-e2e.js`,
+   `packages/core/src/fixtureReplay.ts`,
    `packages/core/src/__tests__/e2e/setup.ts`, or
    `packages/core/src/__tests__/e2e/helpers.ts`.
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,5 +27,13 @@ export default [
       ...tsPlugin.configs.recommended.rules,
       "@typescript-eslint/no-explicit-any": "error"
     }
+  },
+  {
+    files: ["test/fixtures/**/*.js"],
+    languageOptions: {
+      globals: {
+        ...globals.browser
+      }
+    }
   }
 ];

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc -b --pretty false --force",
     "test": "vitest run",
     "test:e2e": "node ./scripts/run-e2e.js",
+    "test:e2e:fixtures": "LINKEDIN_E2E=1 LINKEDIN_E2E_REPLAY=1 LINKEDIN_E2E_FIXTURE_MANIFEST=test/fixtures/manifest.json vitest run -c vitest.config.e2e.ts",
     "test:e2e:raw": "LINKEDIN_E2E=1 vitest run -c vitest.config.e2e.ts",
     "build": "tsc -b --pretty false"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "linkedin": "dist/bin/linkedin.js"
+    "linkedin": "dist/bin/linkedin.js",
+    "owa": "dist/bin/linkedin.js"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -25,20 +25,28 @@ import {
   asLinkedInAssistantError,
   clearRateLimitState,
   createLocalDataDeletionPlan,
+  createEmptyFixtureManifest,
   evaluateDraftQuality,
   getLinkedInSelectorLocaleConfigWarning,
   isInRateLimitCooldown,
+  LINKEDIN_REPLAY_PAGE_TYPES,
   LINKEDIN_FEED_REACTION_TYPES,
   LINKEDIN_POST_VISIBILITY_TYPES,
   LINKEDIN_SELECTOR_LOCALES,
   LinkedInAssistantError,
   LinkedInSchedulerService,
+  DEFAULT_FIXTURE_STALENESS_DAYS,
   createCoreRuntime,
+  checkLinkedInFixtureStaleness,
   deleteLocalData,
+  loadLinkedInFixtureSet,
   normalizeLinkedInFeedReaction,
   normalizeLinkedInPostVisibility,
   parseDraftQualityCandidateSet,
   parseDraftQualityDataset,
+  ProfileManager,
+  readLinkedInFixtureManifest,
+  resolveFixtureManifestPath,
   resolveConfigPaths,
   resolveFollowupSinceWindow,
   resolveLinkedInSelectorLocaleConfigResolution,
@@ -48,7 +56,13 @@ import {
   resolvePrivacyConfig,
   resolveSchedulerConfig,
   toLinkedInAssistantErrorPayload,
+  writeLinkedInFixtureManifest,
   type DraftQualityReport,
+  type LinkedInFixtureManifest,
+  type LinkedInFixturePageEntry,
+  type LinkedInFixtureRoute,
+  type LinkedInFixtureSetSummary,
+  type LinkedInReplayPageType,
   type LocalDataDeletionFailure,
   type SchedulerConfig,
   type SchedulerJobRow,
@@ -146,6 +160,17 @@ function coercePositiveInt(value: string, label: string): number {
   return parsed;
 }
 
+function coerceNonNegativeInt(value: string, label: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must be a non-negative integer.`
+    );
+  }
+  return parsed;
+}
+
 function coerceSearchCategory(value: string): SearchCategory {
   if (value === "people" || value === "companies" || value === "jobs") {
     return value;
@@ -207,6 +232,470 @@ function createRuntime(cdpUrl?: string) {
           ...(cliSelectorLocale ? { selectorLocale: cliSelectorLocale } : {})
         }
   );
+}
+
+const DEFAULT_FIXTURE_RECORD_PROFILE = "fixtures";
+const DEFAULT_FIXTURE_RECORD_SET = "manual";
+const DEFAULT_FIXTURE_VIEWPORT = {
+  width: 1440,
+  height: 900
+} as const;
+const FIXTURE_ROUTE_FILE_NAME = "routes.json";
+const FIXTURE_RESPONSE_DIR_NAME = "responses";
+const FIXTURE_PAGES_DIR_NAME = "pages";
+const FIXTURE_REPLAY_ENV_KEYS = [
+  "LINKEDIN_E2E_REPLAY",
+  "LINKEDIN_E2E_FIXTURE_SERVER_URL",
+  "LINKEDIN_E2E_FIXTURE_SET",
+  "LINKEDIN_E2E_FIXTURE_MANIFEST"
+] as const;
+const FIXTURE_CAPTURE_URLS: Record<LinkedInReplayPageType, string> = {
+  composer: "https://www.linkedin.com/feed/",
+  connections: "https://www.linkedin.com/mynetwork/invite-connect/connections/",
+  feed: "https://www.linkedin.com/feed/",
+  jobs: "https://www.linkedin.com/jobs/search/?keywords=software%20engineer",
+  messaging: "https://www.linkedin.com/messaging/",
+  notifications: "https://www.linkedin.com/notifications/",
+  profile: "https://www.linkedin.com/in/me/",
+  search: "https://www.linkedin.com/search/results/people/?keywords=Simon%20Miller"
+};
+
+interface FixtureRecordInput {
+  har: boolean;
+  height: number;
+  manifestPath?: string;
+  pageTypes: LinkedInReplayPageType[];
+  profileName: string;
+  setName: string;
+  width: number;
+}
+
+function isFixtureReplayPageType(value: string): value is LinkedInReplayPageType {
+  return (LINKEDIN_REPLAY_PAGE_TYPES as readonly string[]).includes(value);
+}
+
+function coerceFixtureReplayPageType(value: string): LinkedInReplayPageType {
+  const normalized = value.trim().toLowerCase();
+  if (isFixtureReplayPageType(normalized)) {
+    return normalized;
+  }
+
+  throw new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    `page must be one of: ${LINKEDIN_REPLAY_PAGE_TYPES.join(", ")}.`
+  );
+}
+
+function collectFixtureReplayPageTypes(
+  value: string,
+  previous: LinkedInReplayPageType[]
+): LinkedInReplayPageType[] {
+  const nextValues = value
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+    .map((item) => coerceFixtureReplayPageType(item));
+
+  return [...previous, ...nextValues];
+}
+
+function uniqueFixtureReplayPageTypes(
+  pageTypes: LinkedInReplayPageType[]
+): LinkedInReplayPageType[] {
+  return Array.from(new Set(pageTypes));
+}
+
+function normalizeFixtureRouteHeaders(
+  headers: Record<string, string>
+): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    normalized[key.toLowerCase()] = value;
+  }
+
+  delete normalized["content-length"];
+  delete normalized["content-encoding"];
+  delete normalized["transfer-encoding"];
+  return normalized;
+}
+
+function createFixtureRouteKey(route: Pick<LinkedInFixtureRoute, "method" | "url">): string {
+  return `${route.method.toUpperCase()} ${route.url}`;
+}
+
+function sanitizeFixtureFileStem(value: string): string {
+  return value.replace(/[^a-z0-9._-]+/giu, "-").replace(/-{2,}/gu, "-");
+}
+
+function guessFixtureResponseExtension(
+  contentType: string | undefined,
+  url: string
+): string {
+  const normalizedType = (contentType ?? "").toLowerCase();
+  if (normalizedType.includes("text/html")) {
+    return ".html";
+  }
+  if (normalizedType.includes("application/json")) {
+    return ".json";
+  }
+  if (normalizedType.includes("javascript")) {
+    return ".js";
+  }
+  if (normalizedType.includes("text/css")) {
+    return ".css";
+  }
+  if (normalizedType.includes("image/png")) {
+    return ".png";
+  }
+  if (normalizedType.includes("image/jpeg")) {
+    return ".jpg";
+  }
+  if (normalizedType.includes("image/svg")) {
+    return ".svg";
+  }
+
+  try {
+    const parsed = new URL(url);
+    const extension = path.extname(parsed.pathname);
+    return extension || ".bin";
+  } catch {
+    return ".bin";
+  }
+}
+
+function shouldCaptureFixtureResponse(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.protocol === "http:" || parsed.protocol === "https:"
+    ) && (parsed.hostname.endsWith("linkedin.com") || parsed.hostname.endsWith("licdn.com"));
+  } catch {
+    return false;
+  }
+}
+
+async function loadFixtureManifestOrCreate(
+  manifestPath: string
+): Promise<LinkedInFixtureManifest> {
+  if (!existsSync(manifestPath)) {
+    return createEmptyFixtureManifest();
+  }
+
+  return await readLinkedInFixtureManifest(manifestPath);
+}
+
+async function loadExistingFixtureRoutes(
+  manifestPath: string,
+  setName: string
+): Promise<LinkedInFixtureRoute[]> {
+  if (!existsSync(manifestPath)) {
+    return [];
+  }
+
+  const manifest = await readLinkedInFixtureManifest(manifestPath);
+  const setSummary = manifest.sets[setName];
+  if (!setSummary) {
+    return [];
+  }
+
+  const routesPath = path.resolve(
+    path.dirname(manifestPath),
+    setSummary.rootDir,
+    setSummary.routesPath
+  );
+  if (!existsSync(routesPath)) {
+    return [];
+  }
+
+  return (await loadLinkedInFixtureSet(manifestPath, setName)).routes;
+}
+
+function mergeFixtureRoutes(
+  existingRoutes: LinkedInFixtureRoute[],
+  nextRoutes: LinkedInFixtureRoute[]
+): LinkedInFixtureRoute[] {
+  const merged = new Map<string, LinkedInFixtureRoute>();
+  for (const route of existingRoutes) {
+    merged.set(createFixtureRouteKey(route), route);
+  }
+  for (const route of nextRoutes) {
+    merged.set(createFixtureRouteKey(route), route);
+  }
+
+  return Array.from(merged.values()).sort((left, right) =>
+    createFixtureRouteKey(left).localeCompare(createFixtureRouteKey(right))
+  );
+}
+
+interface FixtureCaptureResponse {
+  body(): Promise<Buffer>;
+  headers(): Record<string, string>;
+  request(): {
+    method(): string;
+  };
+  status(): number;
+  url(): string;
+}
+
+async function withFixtureReplayDisabled<T>(callback: () => Promise<T>): Promise<T> {
+  const previousValues = new Map<string, string | undefined>();
+  for (const key of FIXTURE_REPLAY_ENV_KEYS) {
+    previousValues.set(key, process.env[key]);
+    delete process.env[key];
+  }
+
+  try {
+    return await callback();
+  } finally {
+    for (const [key, value] of previousValues.entries()) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+async function captureFixtureResponse(
+  response: FixtureCaptureResponse,
+  setDir: string,
+  index: number
+): Promise<LinkedInFixtureRoute | null> {
+  const url = response.url();
+  if (!shouldCaptureFixtureResponse(url)) {
+    return null;
+  }
+
+  const method = response.request().method().toUpperCase();
+  const headers = normalizeFixtureRouteHeaders(response.headers());
+  const extension = guessFixtureResponseExtension(headers["content-type"], url);
+
+  let fileStem = `${String(index).padStart(4, "0")}`;
+  try {
+    const parsed = new URL(url);
+    const pathStem = sanitizeFixtureFileStem(
+      `${parsed.hostname}${parsed.pathname === "/" ? "/root" : parsed.pathname}`
+    );
+    fileStem = `${fileStem}-${pathStem}`;
+  } catch {
+    // Use the fallback sequence number stem.
+  }
+
+  const relativeBodyPath = path.join(FIXTURE_RESPONSE_DIR_NAME, `${fileStem}${extension}`);
+  const absoluteBodyPath = path.join(setDir, relativeBodyPath);
+  const bodyBuffer = await response.body().catch(() => Buffer.from(""));
+  await mkdir(path.dirname(absoluteBodyPath), { recursive: true });
+  await writeFile(absoluteBodyPath, bodyBuffer);
+
+  return {
+    method,
+    url,
+    status: response.status(),
+    headers,
+    bodyPath: relativeBodyPath
+  };
+}
+
+async function runFixturesCheck(input: {
+  manifestPath?: string;
+  maxAgeDays?: number;
+  setName?: string;
+}): Promise<void> {
+  const manifestPath = resolveFixtureManifestPath(input.manifestPath);
+  const maxAgeDays = input.maxAgeDays ?? DEFAULT_FIXTURE_STALENESS_DAYS;
+  const warnings = await checkLinkedInFixtureStaleness(manifestPath, {
+    maxAgeDays,
+    ...(input.setName ? { setName: input.setName } : {})
+  });
+
+  for (const warning of warnings) {
+    writeCliWarning(warning.message);
+  }
+
+  printJson({
+    manifest_path: manifestPath,
+    max_age_days: maxAgeDays,
+    set_name: input.setName ?? null,
+    stale: warnings.length > 0,
+    warning_count: warnings.length,
+    warnings
+  });
+}
+
+async function runFixturesRecord(input: FixtureRecordInput): Promise<void> {
+  if (!stdin.isTTY || !stdout.isTTY) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "fixtures:record requires an interactive terminal because it pauses for manual navigation."
+    );
+  }
+
+  const manifestPath = resolveFixtureManifestPath(input.manifestPath);
+  const manifest = await loadFixtureManifestOrCreate(manifestPath);
+  const setName = input.setName;
+  const setRootDir = path.resolve(path.dirname(manifestPath), setName);
+  const pagesDir = path.join(setRootDir, FIXTURE_PAGES_DIR_NAME);
+  const harRelativePath = input.har ? "session.har" : undefined;
+  const harAbsolutePath = harRelativePath ? path.join(setRootDir, harRelativePath) : undefined;
+  const previousSetSummary = manifest.sets[setName];
+  const existingRoutes = await loadExistingFixtureRoutes(manifestPath, setName);
+  const capturedRoutes = new Map<string, LinkedInFixtureRoute>();
+  const captureJobs: Array<Promise<void>> = [];
+  const pageEntries: Partial<Record<LinkedInReplayPageType, LinkedInFixturePageEntry>> = {
+    ...(previousSetSummary?.pages ?? {})
+  };
+
+  await mkdir(path.dirname(manifestPath), { recursive: true });
+  await mkdir(setRootDir, { recursive: true });
+  await mkdir(pagesDir, { recursive: true });
+
+  const profileManager = new ProfileManager(resolveConfigPaths());
+  let captureLocale = previousSetSummary?.locale ?? "en-US";
+  let captureViewport: { width: number; height: number } = {
+    width: input.width,
+    height: input.height
+  };
+
+  await withFixtureReplayDisabled(async () => {
+    await profileManager.runWithPersistentContext(
+      input.profileName,
+      {
+        headless: false,
+        launchOptions: {
+          viewport: {
+            width: input.width,
+            height: input.height
+          },
+          ...(harAbsolutePath
+            ? {
+                recordHar: {
+                  path: harAbsolutePath
+                }
+              }
+            : {})
+        }
+      },
+      async (context) => {
+        let responseIndex = existingRoutes.length;
+      context.on("response", (response) => {
+        const captureJob = captureFixtureResponse(response, setRootDir, responseIndex + 1)
+          .then((capturedRoute) => {
+            responseIndex += 1;
+            if (!capturedRoute) {
+              return;
+            }
+
+            capturedRoutes.set(createFixtureRouteKey(capturedRoute), capturedRoute);
+          })
+          .catch(() => undefined);
+        captureJobs.push(captureJob);
+      });
+
+      const page = context.pages()[0] ?? (await context.newPage());
+      const prompt = createInterface({
+        input: stdin,
+        output: stdout
+      });
+
+      try {
+        for (const pageType of input.pageTypes) {
+          const suggestedUrl = FIXTURE_CAPTURE_URLS[pageType];
+          if (suggestedUrl) {
+            await page.goto(suggestedUrl, { waitUntil: "domcontentloaded" }).catch(() => undefined);
+          }
+
+          writeCliNotice(
+            `Navigate the browser to the LinkedIn ${pageType} page you want to capture.`
+          );
+          await prompt.question(
+            `Press Enter to capture ${pageType} (current page: ${page.url() || suggestedUrl}). `
+          );
+
+          const htmlRelativePath = path.join(FIXTURE_PAGES_DIR_NAME, `${pageType}.html`);
+          const htmlAbsolutePath = path.join(setRootDir, htmlRelativePath);
+          await writeFile(htmlAbsolutePath, `${await page.content()}\n`, "utf8");
+
+          const currentUrl = page.url();
+          const pageTitle = await page.title().catch(() => undefined);
+          const pageLocale = await page.evaluate(() => navigator.language).catch(() => undefined);
+          const viewport = page.viewportSize();
+          captureLocale = typeof pageLocale === "string" && pageLocale.trim().length > 0
+            ? pageLocale.trim()
+            : captureLocale;
+          if (viewport) {
+            captureViewport = viewport;
+          }
+
+          pageEntries[pageType] = {
+            pageType,
+            url: currentUrl || suggestedUrl,
+            htmlPath: htmlRelativePath,
+            recordedAt: new Date().toISOString(),
+            ...(typeof pageTitle === "string" && pageTitle.trim().length > 0
+              ? { title: pageTitle.trim() }
+              : {})
+          };
+        }
+
+        await page.waitForTimeout(750);
+      } finally {
+        prompt.close();
+      }
+      }
+    );
+  });
+
+  await Promise.allSettled(captureJobs);
+
+  const mergedRoutes = mergeFixtureRoutes(existingRoutes, [...capturedRoutes.values()]);
+  await writeFile(
+    path.join(setRootDir, FIXTURE_ROUTE_FILE_NAME),
+    `${JSON.stringify(
+      {
+        format: 1,
+        setName,
+        routes: mergedRoutes
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+
+  const capturedAt = new Date().toISOString();
+  const setSummary: LinkedInFixtureSetSummary = {
+    setName,
+    rootDir: path.relative(path.dirname(manifestPath), setRootDir),
+    locale: captureLocale,
+    capturedAt,
+    viewport: captureViewport,
+    routesPath: FIXTURE_ROUTE_FILE_NAME,
+    ...(harRelativePath ? { harPath: harRelativePath } : {}),
+    description:
+      previousSetSummary?.description ??
+      "Recorded manually through the LinkedIn fixture replay workflow.",
+    pages: pageEntries
+  };
+
+  manifest.sets[setName] = setSummary;
+  if (!manifest.defaultSetName) {
+    manifest.defaultSetName = setName;
+  }
+
+  await writeLinkedInFixtureManifest(manifestPath, manifest);
+
+  printJson({
+    manifest_path: manifestPath,
+    set_name: setName,
+    captured_at: capturedAt,
+    locale: captureLocale,
+    viewport: captureViewport,
+    pages: pageEntries,
+    routes_path: path.join(setSummary.rootDir, FIXTURE_ROUTE_FILE_NAME),
+    route_count: mergedRoutes.length,
+    ...(harRelativePath ? { har_path: path.join(setSummary.rootDir, harRelativePath) } : {})
+  });
 }
 
 interface KeepAliveState {
@@ -3426,7 +3915,7 @@ export function createCliProgram(): Command {
               options.intervalSeconds,
               "interval-seconds"
             ),
-            jitterSeconds: coercePositiveInt(
+            jitterSeconds: coerceNonNegativeInt(
               options.jitterSeconds,
               "jitter-seconds"
             ),
@@ -3701,6 +4190,130 @@ export function createCliProgram(): Command {
         }
       }
     );
+
+  const runFixtureRecordCommand = async (options: {
+    har: boolean;
+    height: string;
+    manifest?: string;
+    page: LinkedInReplayPageType[];
+    profile: string;
+    set: string;
+    width: string;
+  }) => {
+    const pageTypes = uniqueFixtureReplayPageTypes(
+      options.page.length > 0 ? options.page : [...LINKEDIN_REPLAY_PAGE_TYPES]
+    );
+
+    await runFixturesRecord({
+      har: options.har,
+      height: coercePositiveInt(options.height, "height"),
+      ...(options.manifest ? { manifestPath: options.manifest } : {}),
+      pageTypes,
+      profileName: coerceProfileName(options.profile),
+      setName: coerceProfileName(options.set, "set"),
+      width: coercePositiveInt(options.width, "width")
+    });
+  };
+
+  const runFixtureCheckCommand = async (options: {
+    manifest?: string;
+    maxAgeDays: string;
+    set?: string;
+  }) => {
+    await runFixturesCheck({
+      ...(options.manifest ? { manifestPath: options.manifest } : {}),
+      maxAgeDays: coercePositiveInt(options.maxAgeDays, "max-age-days"),
+      ...(options.set ? { setName: coerceProfileName(options.set, "set") } : {})
+    });
+  };
+
+  const configureFixtureRecordCommand = (command: Command): Command =>
+    command
+      .description(
+        "Launch a manual Playwright capture flow and update a LinkedIn replay fixture set"
+      )
+      .option(
+        "-p, --profile <profile>",
+        "Profile name used for the manual LinkedIn browser session",
+        DEFAULT_FIXTURE_RECORD_PROFILE
+      )
+      .option(
+        "-s, --set <name>",
+        "Fixture set name stored under test/fixtures/",
+        DEFAULT_FIXTURE_RECORD_SET
+      )
+      .option(
+        "--page <type>",
+        `Repeat or comma-separate page types (${LINKEDIN_REPLAY_PAGE_TYPES.join(", ")})`,
+        collectFixtureReplayPageTypes,
+        [] as LinkedInReplayPageType[]
+      )
+      .option(
+        "--manifest <path>",
+        `Fixture manifest path (default: ${resolveFixtureManifestPath()})`
+      )
+      .option(
+        "--width <px>",
+        "Viewport width in pixels",
+        String(DEFAULT_FIXTURE_VIEWPORT.width)
+      )
+      .option(
+        "--height <px>",
+        "Viewport height in pixels",
+        String(DEFAULT_FIXTURE_VIEWPORT.height)
+      )
+      .option("--no-har", "Skip HAR capture and only save HTML snapshots + replay routes")
+      .addHelpText(
+        "after",
+        [
+          "",
+          "Capture flow:",
+          "  - launches a persistent Playwright browser for manual LinkedIn navigation",
+          "  - records only linkedin.com / licdn.com responses into the selected fixture set",
+          "  - rewrites the requested pages while preserving untouched page entries and routes",
+          "",
+          "Examples:",
+          "  linkedin fixtures record --page feed --page messaging",
+          "  owa fixtures:record --set da-dk --page feed,notifications --no-har"
+        ].join("\n")
+      )
+      .action(runFixtureRecordCommand);
+
+  const configureFixtureCheckCommand = (command: Command): Command =>
+    command
+      .description("Validate replay fixture freshness and print staleness warnings")
+      .option(
+        "-s, --set <name>",
+        "Only validate one fixture set from the manifest"
+      )
+      .option(
+        "--manifest <path>",
+        `Fixture manifest path (default: ${resolveFixtureManifestPath()})`
+      )
+      .option(
+        "--max-age-days <days>",
+        "Warn when captured pages are older than this many days",
+        String(DEFAULT_FIXTURE_STALENESS_DAYS)
+      )
+      .addHelpText(
+        "after",
+        [
+          "",
+          "Examples:",
+          "  linkedin fixtures check",
+          "  owa fixtures:check --set ci --max-age-days 14"
+        ].join("\n")
+      )
+      .action(runFixtureCheckCommand);
+
+  const fixturesCommand = program
+    .command("fixtures")
+    .description("Record and validate LinkedIn replay fixture sets");
+
+  configureFixtureRecordCommand(fixturesCommand.command("record"));
+  configureFixtureCheckCommand(fixturesCommand.command("check"));
+  configureFixtureRecordCommand(program.command("fixtures:record", { hidden: true }));
+  configureFixtureCheckCommand(program.command("fixtures:check", { hidden: true }));
 
   program
     .command("search")

--- a/packages/cli/test/fixturesCli.test.ts
+++ b/packages/cli/test/fixturesCli.test.ts
@@ -1,0 +1,151 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { stdin, stdout } from "node:process";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@linkedin-assistant/core", async () =>
+  await import("../../core/src/index.js")
+);
+
+import { runCli } from "../src/bin/linkedin.js";
+
+function setInteractiveMode(inputIsTty: boolean, outputIsTty: boolean): void {
+  Object.defineProperty(stdin, "isTTY", {
+    configurable: true,
+    value: inputIsTty
+  });
+  Object.defineProperty(stdout, "isTTY", {
+    configurable: true,
+    value: outputIsTty
+  });
+  Object.defineProperty(process.stderr, "isTTY", {
+    configurable: true,
+    value: outputIsTty
+  });
+}
+
+async function writeJsonFixture(filePath: string, value: unknown): Promise<void> {
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function createReplayManifest(recordedAt: string, setName: string = "ci"): Record<string, unknown> {
+  return {
+    format: 1,
+    updatedAt: recordedAt,
+    defaultSetName: setName,
+    sets: {
+      [setName]: {
+        setName,
+        rootDir: setName,
+        locale: "en-US",
+        capturedAt: recordedAt,
+        viewport: {
+          width: 1440,
+          height: 900
+        },
+        routesPath: "routes.json",
+        pages: {
+          feed: {
+            pageType: "feed",
+            url: "https://www.linkedin.com/feed/",
+            htmlPath: "pages/app.html",
+            recordedAt,
+            title: "Feed"
+          }
+        }
+      }
+    }
+  };
+}
+
+describe("linkedin fixtures commands", () => {
+  let tempDir = "";
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let stderrWriteSpy: ReturnType<typeof vi.spyOn>;
+  let stderrChunks: string[] = [];
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-cli-fixtures-"));
+    process.exitCode = undefined;
+    setInteractiveMode(false, false);
+    vi.clearAllMocks();
+    stderrChunks = [];
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    stderrWriteSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((...args: Parameters<typeof process.stderr.write>) => {
+        const [chunk] = args;
+        stderrChunks.push(String(chunk));
+        return true;
+      });
+  });
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore();
+    stderrWriteSpy.mockRestore();
+    process.exitCode = undefined;
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  function getLastJsonOutput(): Record<string, unknown> {
+    return JSON.parse(String(consoleLogSpy.mock.calls.at(-1)?.[0] ?? "")) as Record<string, unknown>;
+  }
+
+  it("warns when replay fixtures are stale", async () => {
+    const manifestPath = path.join(tempDir, "manifest.json");
+    await writeJsonFixture(manifestPath, createReplayManifest("2025-01-01T00:00:00.000Z"));
+
+    await runCli([
+      "node",
+      "linkedin",
+      "fixtures",
+      "check",
+      "--manifest",
+      manifestPath
+    ]);
+
+    expect(getLastJsonOutput()).toMatchObject({
+      manifest_path: path.resolve(manifestPath),
+      stale: true,
+      warning_count: 1,
+      set_name: null
+    });
+    expect(stderrChunks.join("\n")).toContain("Fixture page ci/feed was recorded");
+  });
+
+  it("supports the fixtures:check alias and scoped set validation", async () => {
+    const manifestPath = path.join(tempDir, "manifest.json");
+    await writeJsonFixture(manifestPath, createReplayManifest("2026-03-08T00:00:00.000Z", "manual"));
+
+    await runCli([
+      "node",
+      "linkedin",
+      "fixtures:check",
+      "--manifest",
+      manifestPath,
+      "--set",
+      "manual",
+      "--max-age-days",
+      "30"
+    ]);
+
+    expect(getLastJsonOutput()).toMatchObject({
+      manifest_path: path.resolve(manifestPath),
+      stale: false,
+      warning_count: 0,
+      set_name: "manual"
+    });
+  });
+
+  it("requires an interactive terminal for fixture recording", async () => {
+    await expect(
+      runCli([
+        "node",
+        "linkedin",
+        "fixtures",
+        "record"
+      ])
+    ).rejects.toThrow("fixtures:record requires an interactive terminal");
+  });
+});

--- a/packages/core/src/__tests__/e2e/error-paths.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/error-paths.e2e.test.ts
@@ -22,9 +22,10 @@ async function createIsolatedRuntime(): Promise<{
   dispose: () => Promise<void>;
 }> {
   const baseDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-e2e-"));
+  const cdpUrl = getCdpUrl();
   const runtime = createCoreRuntime({
     baseDir,
-    cdpUrl: getCdpUrl()
+    ...(cdpUrl ? { cdpUrl } : {})
   });
 
   return {

--- a/packages/core/src/__tests__/e2e/health.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/health.e2e.test.ts
@@ -35,9 +35,15 @@ describe("KeepAlive E2E", () => {
   it("starts, emits health-event, and stops cleanly", async (context) => {
     skipIfE2EUnavailable(e2e, context);
 
+    const cdpUrl = getCdpUrl();
+    if (!cdpUrl) {
+      context.skip("KeepAlive coverage requires a CDP endpoint; fixture replay does not expose one.");
+      return;
+    }
+
     const pool = new CDPConnectionPool({ idleTimeoutMs: 60_000 });
     const service = new SessionKeepAliveService(pool, {
-      cdpUrl: getCdpUrl(),
+      cdpUrl,
       intervalMs: 5_000,
       jitterMs: 0,
       activitySimulationEnabled: false,

--- a/packages/core/src/__tests__/e2e/helpers.ts
+++ b/packages/core/src/__tests__/e2e/helpers.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { isFixtureReplayEnabled } from "../../fixtureReplay.js";
 import type { CoreRuntime } from "../../runtime.js";
 import { toLinkedInAssistantErrorPayload } from "../../errors.js";
 import { TEST_ECHO_ACTION_TYPE } from "../../twoPhaseCommit.js";
@@ -87,6 +88,8 @@ const DEFAULT_JOB_LOCATION = "Copenhagen";
 const E2E_FIXTURE_FORMAT_VERSION = 1;
 const TRANSIENT_E2E_ERROR_PATTERN =
   /timed out|timeout|Target closed|Execution context was destroyed|page crashed|browser has been closed|context was closed|ECONNRESET|ECONNREFUSED|EPIPE/i;
+const DEFAULT_REPLAY_POST_URL =
+  "https://www.linkedin.com/feed/update/urn:li:activity:fixture-post-1/";
 
 function readTrimmedEnv(name: string): string | undefined {
   const value = process.env[name];
@@ -101,6 +104,10 @@ function readTrimmedEnv(name: string): string | undefined {
 function readEnabledFlag(name: string): boolean {
   const value = readTrimmedEnv(name);
   return value === "1" || value === "true";
+}
+
+export function isReplayModeEnabled(): boolean {
+  return isFixtureReplayEnabled();
 }
 
 function getDefaultJobQuery(): string {
@@ -397,11 +404,21 @@ async function captureCommandExecution(
   const stderrChunks: string[] = [];
   const originalStdoutWrite = process.stdout.write;
   const originalStderrWrite = process.stderr.write;
+  const originalConsoleLog = console.log;
+  const originalConsoleError = console.error;
   const originalExitCode = process.exitCode;
   let exitCode = 0;
 
   process.stdout.write = createWriteInterceptor(stdoutChunks);
   process.stderr.write = createWriteInterceptor(stderrChunks);
+  console.log = (...args: unknown[]) => {
+    stdoutChunks.push(`${args.map((value) => summarizeUnknownValue(value)).join(" ")}
+`);
+  };
+  console.error = (...args: unknown[]) => {
+    stderrChunks.push(`${args.map((value) => summarizeUnknownValue(value)).join(" ")}
+`);
+  };
   process.exitCode = 0;
 
   let error: unknown;
@@ -420,6 +437,8 @@ async function captureCommandExecution(
   } finally {
     process.stdout.write = originalStdoutWrite;
     process.stderr.write = originalStderrWrite;
+    console.log = originalConsoleLog;
+    console.error = originalConsoleError;
     exitCode = process.exitCode ?? 0;
     process.exitCode = originalExitCode;
   }
@@ -504,22 +523,25 @@ export function getDefaultMessageTargetPattern(): RegExp {
 
 /** Returns whether an opt-in E2E flag is enabled. */
 export function isOptInEnabled(name: string): boolean {
-  return readEnabledFlag(name);
+  return isReplayModeEnabled() || readEnabledFlag(name);
 }
 
 /** Returns the configured connection confirm mode for real outbound tests. */
 export function getConnectionConfirmMode(): string {
-  return readTrimmedEnv("LINKEDIN_E2E_CONNECTION_CONFIRM_MODE") ?? "";
+  return readTrimmedEnv("LINKEDIN_E2E_CONNECTION_CONFIRM_MODE") ??
+    (isReplayModeEnabled() ? "invite" : "");
 }
 
 /** Returns the approved post URL used by the real like confirm test. */
 export function getOptInLikePostUrl(): string | undefined {
-  return readTrimmedEnv("LINKEDIN_E2E_LIKE_POST_URL");
+  return readTrimmedEnv("LINKEDIN_E2E_LIKE_POST_URL") ??
+    (isReplayModeEnabled() ? DEFAULT_REPLAY_POST_URL : undefined);
 }
 
 /** Returns the approved post URL used by the real comment confirm test. */
 export function getOptInCommentPostUrl(): string | undefined {
-  return readTrimmedEnv("LINKEDIN_E2E_COMMENT_POST_URL");
+  return readTrimmedEnv("LINKEDIN_E2E_COMMENT_POST_URL") ??
+    (isReplayModeEnabled() ? DEFAULT_REPLAY_POST_URL : undefined);
 }
 
 /**
@@ -538,7 +560,13 @@ export async function runCliCommandWith(
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     const execute = async (): Promise<void> => {
-      await runner(["node", "linkedin", "--cdp-url", getCdpUrl(), ...args]);
+      const cdpUrl = getCdpUrl();
+      await runner([
+        "node",
+        "linkedin",
+        ...(cdpUrl ? ["--cdp-url", cdpUrl] : []),
+        ...args
+      ]);
     };
 
     const wrappedExecution = async (): Promise<void> => {
@@ -608,11 +636,13 @@ export async function callMcpToolWith(
   let lastError: unknown;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    const execute = async (): Promise<unknown> =>
-      caller(name, {
-        cdpUrl: getCdpUrl(),
-        ...args
+    const execute = async (): Promise<unknown> => {
+      const cdpUrl = getCdpUrl();
+      return caller(name, {
+        ...args,
+        ...(cdpUrl ? { cdpUrl } : {})
       });
+    };
 
     const wrappedExecution = async (): Promise<unknown> => {
       if (options.assistantHome) {

--- a/packages/core/src/__tests__/e2e/setup.ts
+++ b/packages/core/src/__tests__/e2e/setup.ts
@@ -10,6 +10,11 @@ import {
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, type TestContext } from "vitest";
+import {
+  ensureSharedFixtureReplayServer,
+  isFixtureReplayEnabled,
+  shutdownSharedFixtureReplayServer
+} from "../../fixtureReplay.js";
 import { createCoreRuntime, type CoreRuntime } from "../../runtime.js";
 
 /** Default CDP endpoint used by the shared real-session E2E harness. */
@@ -77,7 +82,15 @@ function summarizeUnknownError(error: unknown): string {
   return String(error);
 }
 
-function readConfiguredCdpUrl(): string {
+function isReplayE2EEnabled(): boolean {
+  return isFixtureReplayEnabled();
+}
+
+function readConfiguredCdpUrl(): string | undefined {
+  if (isReplayE2EEnabled()) {
+    return undefined;
+  }
+
   const value = process.env.LINKEDIN_CDP_URL;
   return typeof value === "string" && value.trim().length > 0
     ? value.trim()
@@ -229,11 +242,52 @@ async function probeCdpEndpoint(cdpUrl: string): Promise<{
   }
 }
 
+async function probeFixtureReplay(): Promise<{
+  available: boolean;
+  reason: string;
+}> {
+  try {
+    const replayServer = await ensureSharedFixtureReplayServer();
+    if (!replayServer) {
+      return {
+        available: false,
+        reason: "Fixture replay is disabled."
+      };
+    }
+
+    return {
+      available: true,
+      reason:
+        `Fixture replay is active for set ${replayServer.setName} ` +
+        `(${replayServer.summary.locale}, ${replayServer.summary.viewport.width}x${replayServer.summary.viewport.height}).`
+    };
+  } catch (error) {
+    return {
+      available: false,
+      reason: `Fixture replay could not start. ${summarizeUnknownError(error)}`
+    };
+  }
+}
+
 async function probeAuthentication(): Promise<{
   authenticated: boolean;
   reason: string;
 }> {
+  if (isReplayE2EEnabled()) {
+    const replay = await probeFixtureReplay();
+    return {
+      authenticated: replay.available,
+      reason: replay.reason
+    };
+  }
+
   const cdpUrl = getCdpUrl();
+  if (!cdpUrl) {
+    return {
+      authenticated: false,
+      reason: "No CDP URL is configured."
+    };
+  }
 
   try {
     const status = await getRuntime().auth.status();
@@ -267,15 +321,23 @@ async function probeAuthentication(): Promise<{
 export function getRuntime(): CoreRuntime {
   if (!sharedRuntime) {
     const cdpUrl = getCdpUrl();
-    const validationError = getCdpUrlValidationError(cdpUrl);
-    if (validationError) {
-      throw new Error(validationError);
+    if (cdpUrl) {
+      const validationError = getCdpUrlValidationError(cdpUrl);
+      if (validationError) {
+        throw new Error(validationError);
+      }
     }
 
-    sharedRuntime = createCoreRuntime({
-      baseDir: getE2EBaseDir(),
+    sharedRuntime = createCoreRuntime(
       cdpUrl
-    });
+        ? {
+            baseDir: getE2EBaseDir(),
+            cdpUrl
+          }
+        : {
+            baseDir: getE2EBaseDir()
+          }
+    );
   }
   return sharedRuntime;
 }
@@ -283,7 +345,7 @@ export function getRuntime(): CoreRuntime {
 /**
  * Resolves the effective CDP URL for the E2E harness.
  */
-export function getCdpUrl(): string {
+export function getCdpUrl(): string | undefined {
   return readConfiguredCdpUrl();
 }
 
@@ -335,7 +397,16 @@ export async function withE2EEnvironment<T>(callback: () => Promise<T>): Promise
  * Probes whether the configured CDP endpoint is reachable.
  */
 export async function checkCdpAvailable(): Promise<boolean> {
-  return (await probeCdpEndpoint(getCdpUrl())).available;
+  if (isReplayE2EEnabled()) {
+    return (await probeFixtureReplay()).available;
+  }
+
+  const cdpUrl = getCdpUrl();
+  if (!cdpUrl) {
+    return false;
+  }
+
+  return (await probeCdpEndpoint(cdpUrl)).available;
 }
 
 /**
@@ -355,7 +426,28 @@ export async function getE2EAvailability(): Promise<E2EAvailability> {
     return sharedAvailability;
   }
 
+  if (isReplayE2EEnabled()) {
+    const replay = await probeFixtureReplay();
+    sharedAvailability = {
+      cdpAvailable: replay.available,
+      authenticated: replay.available,
+      canRun: replay.available,
+      reason: replay.reason
+    };
+    return sharedAvailability;
+  }
+
   const cdpUrl = getCdpUrl();
+  if (!cdpUrl) {
+    sharedAvailability = {
+      cdpAvailable: false,
+      authenticated: false,
+      canRun: false,
+      reason: "No CDP endpoint is configured."
+    };
+    return sharedAvailability;
+  }
+
   const cdp = await probeCdpEndpoint(cdpUrl);
   if (!cdp.available) {
     sharedAvailability = {
@@ -476,6 +568,8 @@ export function cleanupRuntime(): void {
   if (runtime) {
     runtime.close();
   }
+
+  shutdownSharedFixtureReplayServer();
 
   if (baseDir && existsSync(baseDir)) {
     rmSync(baseDir, { recursive: true, force: true });

--- a/packages/core/src/__tests__/e2eSetup.test.ts
+++ b/packages/core/src/__tests__/e2eSetup.test.ts
@@ -18,6 +18,9 @@ import {
 
 const originalAssistantHome = process.env.LINKEDIN_ASSISTANT_HOME;
 const originalCdpUrl = process.env.LINKEDIN_CDP_URL;
+const originalReplayEnabled = process.env.LINKEDIN_E2E_REPLAY;
+const originalFixtureManifest = process.env.LINKEDIN_E2E_FIXTURE_MANIFEST;
+const originalFixtureSet = process.env.LINKEDIN_E2E_FIXTURE_SET;
 
 afterEach(() => {
   cleanupRuntime();
@@ -31,10 +34,27 @@ afterEach(() => {
 
   if (originalCdpUrl === undefined) {
     delete process.env.LINKEDIN_CDP_URL;
-    return;
+  } else {
+    process.env.LINKEDIN_CDP_URL = originalCdpUrl;
   }
 
-  process.env.LINKEDIN_CDP_URL = originalCdpUrl;
+  if (originalReplayEnabled === undefined) {
+    delete process.env.LINKEDIN_E2E_REPLAY;
+  } else {
+    process.env.LINKEDIN_E2E_REPLAY = originalReplayEnabled;
+  }
+
+  if (originalFixtureManifest === undefined) {
+    delete process.env.LINKEDIN_E2E_FIXTURE_MANIFEST;
+  } else {
+    process.env.LINKEDIN_E2E_FIXTURE_MANIFEST = originalFixtureManifest;
+  }
+
+  if (originalFixtureSet === undefined) {
+    delete process.env.LINKEDIN_E2E_FIXTURE_SET;
+  } else {
+    process.env.LINKEDIN_E2E_FIXTURE_SET = originalFixtureSet;
+  }
 });
 
 describe("E2E setup helpers", () => {
@@ -82,6 +102,24 @@ describe("E2E setup helpers", () => {
     delete process.env.LINKEDIN_CDP_URL;
 
     expect(getCdpUrl()).toBe(DEFAULT_E2E_CDP_URL);
+  });
+
+  it("switches to fixture replay availability when replay mode is enabled", async () => {
+    process.env.LINKEDIN_E2E_REPLAY = "1";
+    process.env.LINKEDIN_E2E_FIXTURE_MANIFEST = path.resolve("test/fixtures/manifest.json");
+    process.env.LINKEDIN_E2E_FIXTURE_SET = "ci";
+    delete process.env.LINKEDIN_CDP_URL;
+
+    expect(getCdpUrl()).toBeUndefined();
+
+    const availability = await getE2EAvailability();
+
+    expect(availability).toMatchObject({
+      cdpAvailable: true,
+      authenticated: true,
+      canRun: true
+    });
+    expect(availability.reason).toContain("Fixture replay is active for set ci");
   });
 
   it("reports malformed CDP URLs as unavailable", async () => {

--- a/packages/core/src/fixtureReplay.ts
+++ b/packages/core/src/fixtureReplay.ts
@@ -1,0 +1,772 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { BrowserContext } from "playwright-core";
+
+export const LINKEDIN_FIXTURE_MANIFEST_FORMAT_VERSION = 1;
+export const DEFAULT_FIXTURE_STALENESS_DAYS = 30;
+export const DEFAULT_FIXTURE_MANIFEST_PATH = path.resolve(
+  process.cwd(),
+  "test/fixtures/manifest.json"
+);
+export const REPLAY_ROUTE_PATH = "/__linkedin_fixture__/replay";
+export const LINKEDIN_REPLAY_PAGE_TYPES = [
+  "feed",
+  "profile",
+  "messaging",
+  "notifications",
+  "composer",
+  "search",
+  "connections",
+  "jobs"
+] as const;
+
+export type LinkedInReplayPageType = (typeof LINKEDIN_REPLAY_PAGE_TYPES)[number];
+
+export interface LinkedInFixtureViewport {
+  width: number;
+  height: number;
+}
+
+export interface LinkedInFixturePageEntry {
+  pageType: LinkedInReplayPageType;
+  url: string;
+  htmlPath: string;
+  recordedAt: string;
+  title?: string;
+}
+
+export interface LinkedInFixtureSetSummary {
+  setName: string;
+  rootDir: string;
+  locale: string;
+  capturedAt: string;
+  viewport: LinkedInFixtureViewport;
+  routesPath: string;
+  description?: string;
+  harPath?: string;
+  pages: Partial<Record<LinkedInReplayPageType, LinkedInFixturePageEntry>>;
+}
+
+export interface LinkedInFixtureManifest {
+  format: number;
+  updatedAt: string;
+  defaultSetName?: string;
+  sets: Record<string, LinkedInFixtureSetSummary>;
+}
+
+export interface LinkedInFixtureRoute {
+  method: string;
+  url: string;
+  status: number;
+  headers: Record<string, string>;
+  bodyPath?: string;
+  bodyText?: string;
+  pageType?: LinkedInReplayPageType;
+}
+
+export interface LinkedInFixtureRouteFile {
+  format: number;
+  setName: string;
+  routes: LinkedInFixtureRoute[];
+}
+
+export interface LinkedInFixtureSet {
+  manifestPath: string;
+  setName: string;
+  baseDir: string;
+  summary: LinkedInFixtureSetSummary;
+  routes: LinkedInFixtureRoute[];
+}
+
+export interface FixtureStalenessWarning {
+  ageDays: number;
+  maxAgeDays: number;
+  message: string;
+  pageType?: LinkedInReplayPageType;
+  recordedAt: string;
+  setName: string;
+}
+
+export interface FixtureReplayEnvironment {
+  enabled: boolean;
+  manifestPath: string;
+  serverUrl?: string;
+  setName?: string;
+}
+
+export interface StartedFixtureReplayServer {
+  baseUrl: string;
+  close: () => void;
+  manifestPath: string;
+  setName: string;
+  summary: LinkedInFixtureSetSummary;
+}
+
+interface ReplayLookupEntry {
+  body: Buffer;
+  headers: Record<string, string>;
+  route: LinkedInFixtureRoute;
+  status: number;
+}
+
+interface ReplayRequestPayload {
+  method: string;
+  url: string;
+}
+
+interface MutableSharedServerState {
+  server: Server | undefined;
+  promise: Promise<StartedFixtureReplayServer> | undefined;
+  started: StartedFixtureReplayServer | undefined;
+}
+
+const sharedServerState: MutableSharedServerState = {
+  server: undefined,
+  promise: undefined,
+  started: undefined
+};
+
+function readTrimmedEnv(name: string): string | undefined {
+  const value = process.env[name];
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readEnabledFlag(name: string): boolean {
+  const value = readTrimmedEnv(name);
+  return value === "1" || value === "true";
+}
+
+function asRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be a JSON object.`);
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function asOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function asString(value: unknown, label: string): string {
+  const resolved = asOptionalString(value);
+  if (!resolved) {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+
+  return resolved;
+}
+
+function asFiniteNumber(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${label} must be a finite number.`);
+  }
+
+  return value;
+}
+
+function asPageType(value: unknown, label: string): LinkedInReplayPageType {
+  const resolved = asString(value, label);
+  if ((LINKEDIN_REPLAY_PAGE_TYPES as readonly string[]).includes(resolved)) {
+    return resolved as LinkedInReplayPageType;
+  }
+
+  throw new Error(`${label} must be one of ${LINKEDIN_REPLAY_PAGE_TYPES.join(", ")}.`);
+}
+
+function parseViewport(value: unknown, label: string): LinkedInFixtureViewport {
+  const record = asRecord(value, label);
+  return {
+    width: asFiniteNumber(record.width, `${label}.width`),
+    height: asFiniteNumber(record.height, `${label}.height`)
+  };
+}
+
+function parsePageEntry(
+  key: string,
+  value: unknown,
+  label: string
+): LinkedInFixturePageEntry {
+  const record = asRecord(value, label);
+  return {
+    pageType: asPageType(record.pageType ?? key, `${label}.pageType`),
+    url: asString(record.url, `${label}.url`),
+    htmlPath: asString(record.htmlPath, `${label}.htmlPath`),
+    recordedAt: asString(record.recordedAt, `${label}.recordedAt`),
+    ...(asOptionalString(record.title) ? { title: asString(record.title, `${label}.title`) } : {})
+  };
+}
+
+function parseSetSummary(key: string, value: unknown, label: string): LinkedInFixtureSetSummary {
+  const record = asRecord(value, label);
+  const pagesRecord = asRecord(record.pages ?? {}, `${label}.pages`);
+  const pages: Partial<Record<LinkedInReplayPageType, LinkedInFixturePageEntry>> = {};
+
+  for (const [pageKey, pageValue] of Object.entries(pagesRecord)) {
+    const page = parsePageEntry(pageKey, pageValue, `${label}.pages.${pageKey}`);
+    pages[page.pageType] = page;
+  }
+
+  return {
+    setName: asString(record.setName ?? key, `${label}.setName`),
+    rootDir: asString(record.rootDir, `${label}.rootDir`),
+    locale: asString(record.locale, `${label}.locale`),
+    capturedAt: asString(record.capturedAt, `${label}.capturedAt`),
+    viewport: parseViewport(record.viewport, `${label}.viewport`),
+    routesPath: asString(record.routesPath, `${label}.routesPath`),
+    ...(asOptionalString(record.description)
+      ? { description: asString(record.description, `${label}.description`) }
+      : {}),
+    ...(asOptionalString(record.harPath)
+      ? { harPath: asString(record.harPath, `${label}.harPath`) }
+      : {}),
+    pages
+  };
+}
+
+function parseRoute(value: unknown, label: string): LinkedInFixtureRoute {
+  const record = asRecord(value, label);
+  const headersRecord = asRecord(record.headers ?? {}, `${label}.headers`);
+  const headers: Record<string, string> = {};
+  for (const [headerKey, headerValue] of Object.entries(headersRecord)) {
+    headers[headerKey.toLowerCase()] = String(headerValue);
+  }
+
+  const pageTypeValue = record.pageType;
+  return {
+    method: asString(record.method, `${label}.method`).toUpperCase(),
+    url: asString(record.url, `${label}.url`),
+    status: asFiniteNumber(record.status, `${label}.status`),
+    headers,
+    ...(asOptionalString(record.bodyPath)
+      ? { bodyPath: asString(record.bodyPath, `${label}.bodyPath`) }
+      : {}),
+    ...(typeof record.bodyText === "string" ? { bodyText: record.bodyText } : {}),
+    ...(pageTypeValue !== undefined
+      ? { pageType: asPageType(pageTypeValue, `${label}.pageType`) }
+      : {})
+  };
+}
+
+function parseManifest(value: unknown, manifestPath: string): LinkedInFixtureManifest {
+  const record = asRecord(value, `Fixture manifest ${manifestPath}`);
+  const setsRecord = asRecord(record.sets ?? {}, `Fixture manifest ${manifestPath}.sets`);
+  const sets: Record<string, LinkedInFixtureSetSummary> = {};
+
+  for (const [key, setValue] of Object.entries(setsRecord)) {
+    const parsedSet = parseSetSummary(key, setValue, `Fixture manifest ${manifestPath}.sets.${key}`);
+    sets[key] = parsedSet;
+  }
+
+  return {
+    format: asFiniteNumber(record.format, `Fixture manifest ${manifestPath}.format`),
+    updatedAt: asString(record.updatedAt, `Fixture manifest ${manifestPath}.updatedAt`),
+    ...(asOptionalString(record.defaultSetName)
+      ? { defaultSetName: asString(record.defaultSetName, `Fixture manifest ${manifestPath}.defaultSetName`) }
+      : {}),
+    sets
+  };
+}
+
+function parseRouteFile(value: unknown, routePath: string): LinkedInFixtureRouteFile {
+  const record = asRecord(value, `Fixture route file ${routePath}`);
+  const routesValue = record.routes;
+  if (!Array.isArray(routesValue)) {
+    throw new Error(`Fixture route file ${routePath}.routes must be an array.`);
+  }
+
+  return {
+    format: asFiniteNumber(record.format, `Fixture route file ${routePath}.format`),
+    setName: asString(record.setName, `Fixture route file ${routePath}.setName`),
+    routes: routesValue.map((route, index) =>
+      parseRoute(route, `Fixture route file ${routePath}.routes[${index}]`)
+    )
+  };
+}
+
+function normalizeRouteUrl(url: string): string {
+  const parsed = new URL(url);
+  parsed.hash = "";
+  parsed.hostname = parsed.hostname.toLowerCase();
+
+  const sortedSearchParams = [...parsed.searchParams.entries()].sort(([leftKey, leftValue], [rightKey, rightValue]) => {
+    if (leftKey === rightKey) {
+      return leftValue.localeCompare(rightValue);
+    }
+    return leftKey.localeCompare(rightKey);
+  });
+
+  parsed.search = "";
+  for (const [key, value] of sortedSearchParams) {
+    parsed.searchParams.append(key, value);
+  }
+
+  return parsed.toString();
+}
+
+function buildRouteKey(method: string, url: string): string {
+  return `${method.toUpperCase()} ${normalizeRouteUrl(url)}`;
+}
+
+function resolveFixtureSetBaseDir(
+  manifestPath: string,
+  summary: LinkedInFixtureSetSummary
+): string {
+  return path.resolve(path.dirname(manifestPath), summary.rootDir);
+}
+
+function getResolvedRouteFilePath(
+  manifestPath: string,
+  summary: LinkedInFixtureSetSummary
+): string {
+  return path.resolve(resolveFixtureSetBaseDir(manifestPath, summary), summary.routesPath);
+}
+
+async function readJsonFile(filePath: string): Promise<unknown> {
+  return JSON.parse(await readFile(filePath, "utf8")) as unknown;
+}
+
+function isLinkedInReplayLikeUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (!(parsed.protocol === "http:" || parsed.protocol === "https:")) {
+      return false;
+    }
+
+    return (
+      parsed.hostname.endsWith("linkedin.com") ||
+      parsed.hostname.endsWith("licdn.com")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function getAgeDays(recordedAt: string): number {
+  const recordedMs = Date.parse(recordedAt);
+  if (!Number.isFinite(recordedMs)) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  return Math.floor((Date.now() - recordedMs) / (24 * 60 * 60 * 1000));
+}
+
+function removeUnsafeHeaders(headers: Record<string, string>): Record<string, string> {
+  const safeHeaders = { ...headers };
+  delete safeHeaders["content-length"];
+  delete safeHeaders["content-encoding"];
+  delete safeHeaders["transfer-encoding"];
+  return safeHeaders;
+}
+
+function createReplayMissBody(payload: ReplayRequestPayload): Buffer {
+  return Buffer.from(
+    JSON.stringify(
+      {
+        error: "fixture_not_found",
+        message: `No replay fixture exists for ${payload.method.toUpperCase()} ${payload.url}.`,
+        method: payload.method.toUpperCase(),
+        url: payload.url
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+}
+
+async function readReplayRequestPayload(request: IncomingMessage): Promise<ReplayRequestPayload> {
+  if (request.method === "GET") {
+    const parsed = new URL(request.url ?? REPLAY_ROUTE_PATH, "http://127.0.0.1");
+    return {
+      method: asString(parsed.searchParams.get("method"), "replay request method"),
+      url: asString(parsed.searchParams.get("url"), "replay request url")
+    };
+  }
+
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  const raw = Buffer.concat(chunks).toString("utf8");
+  const record = asRecord(JSON.parse(raw) as unknown, "replay request body");
+  return {
+    method: asString(record.method, "replay request body.method"),
+    url: asString(record.url, "replay request body.url")
+  };
+}
+
+function writeServerResponse(
+  response: ServerResponse,
+  status: number,
+  headers: Record<string, string>,
+  body: Buffer
+): void {
+  response.writeHead(status, {
+    ...headers,
+    "content-length": String(body.byteLength)
+  });
+  response.end(body);
+}
+
+async function buildReplayLookup(
+  manifestPath: string,
+  summary: LinkedInFixtureSetSummary,
+  routes: LinkedInFixtureRoute[]
+): Promise<Map<string, ReplayLookupEntry>> {
+  const baseDir = resolveFixtureSetBaseDir(manifestPath, summary);
+  const lookup = new Map<string, ReplayLookupEntry>();
+
+  for (const route of routes) {
+    const body = route.bodyPath
+      ? await readFile(path.resolve(baseDir, route.bodyPath))
+      : Buffer.from(route.bodyText ?? "", "utf8");
+    lookup.set(buildRouteKey(route.method, route.url), {
+      body,
+      headers: removeUnsafeHeaders(route.headers),
+      route,
+      status: route.status
+    });
+  }
+
+  return lookup;
+}
+
+async function startFixtureReplayServer(
+  manifestPath: string,
+  requestedSetName?: string
+): Promise<StartedFixtureReplayServer> {
+  const fixtureSet = await loadLinkedInFixtureSet(manifestPath, requestedSetName);
+  const lookup = await buildReplayLookup(manifestPath, fixtureSet.summary, fixtureSet.routes);
+
+  const server = createServer(async (request, response) => {
+    try {
+      const parsedUrl = new URL(request.url ?? REPLAY_ROUTE_PATH, "http://127.0.0.1");
+      if (parsedUrl.pathname !== REPLAY_ROUTE_PATH) {
+        writeServerResponse(
+          response,
+          404,
+          { "content-type": "application/json; charset=utf-8" },
+          Buffer.from(JSON.stringify({ error: "not_found" }), "utf8")
+        );
+        return;
+      }
+
+      const payload = await readReplayRequestPayload(request);
+      const lookupEntry = lookup.get(buildRouteKey(payload.method, payload.url));
+      if (!lookupEntry) {
+        writeServerResponse(
+          response,
+          404,
+          { "content-type": "application/json; charset=utf-8" },
+          createReplayMissBody(payload)
+        );
+        return;
+      }
+
+      writeServerResponse(
+        response,
+        lookupEntry.status,
+        lookupEntry.headers,
+        lookupEntry.body
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      writeServerResponse(
+        response,
+        500,
+        { "content-type": "application/json; charset=utf-8" },
+        Buffer.from(
+          JSON.stringify(
+            {
+              error: "fixture_replay_error",
+              message
+            },
+            null,
+            2
+          ),
+          "utf8"
+        )
+      );
+    }
+  });
+
+  const started = await new Promise<StartedFixtureReplayServer>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Fixture replay server did not expose a TCP address."));
+        return;
+      }
+
+      server.removeListener("error", reject);
+      server.unref();
+      resolve({
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        close: () => {
+          server.close();
+        },
+        manifestPath,
+        setName: fixtureSet.setName,
+        summary: fixtureSet.summary
+      });
+    });
+  });
+
+  sharedServerState.server = server;
+  sharedServerState.started = started;
+  return started;
+}
+
+export function createEmptyFixtureManifest(
+  input: { defaultSetName?: string } = {}
+): LinkedInFixtureManifest {
+  return {
+    format: LINKEDIN_FIXTURE_MANIFEST_FORMAT_VERSION,
+    updatedAt: new Date().toISOString(),
+    ...(input.defaultSetName ? { defaultSetName: input.defaultSetName } : {}),
+    sets: {}
+  };
+}
+
+export function resolveFixtureManifestPath(manifestPath?: string): string {
+  const resolvedPath = manifestPath ?? readTrimmedEnv("LINKEDIN_E2E_FIXTURE_MANIFEST");
+  return resolvedPath ? path.resolve(resolvedPath) : DEFAULT_FIXTURE_MANIFEST_PATH;
+}
+
+export function getFixtureReplayEnvironment(): FixtureReplayEnvironment {
+  return {
+    enabled:
+      readEnabledFlag("LINKEDIN_E2E_REPLAY") ||
+      readTrimmedEnv("LINKEDIN_E2E_FIXTURE_SERVER_URL") !== undefined,
+    manifestPath: resolveFixtureManifestPath(),
+    ...(readTrimmedEnv("LINKEDIN_E2E_FIXTURE_SERVER_URL")
+      ? { serverUrl: asString(readTrimmedEnv("LINKEDIN_E2E_FIXTURE_SERVER_URL"), "LINKEDIN_E2E_FIXTURE_SERVER_URL") }
+      : {}),
+    ...(readTrimmedEnv("LINKEDIN_E2E_FIXTURE_SET")
+      ? { setName: asString(readTrimmedEnv("LINKEDIN_E2E_FIXTURE_SET"), "LINKEDIN_E2E_FIXTURE_SET") }
+      : {})
+  };
+}
+
+export function isFixtureReplayEnabled(): boolean {
+  return getFixtureReplayEnvironment().enabled;
+}
+
+export async function readLinkedInFixtureManifest(
+  manifestPath: string = resolveFixtureManifestPath()
+): Promise<LinkedInFixtureManifest> {
+  const parsed = parseManifest(await readJsonFile(manifestPath), manifestPath);
+  if (parsed.format !== LINKEDIN_FIXTURE_MANIFEST_FORMAT_VERSION) {
+    throw new Error(
+      `Fixture manifest ${manifestPath} uses unsupported format ${parsed.format}. ` +
+        `Expected ${LINKEDIN_FIXTURE_MANIFEST_FORMAT_VERSION}.`
+    );
+  }
+
+  return parsed;
+}
+
+export async function writeLinkedInFixtureManifest(
+  manifestPath: string,
+  manifest: LinkedInFixtureManifest
+): Promise<void> {
+  const payload = {
+    ...manifest,
+    updatedAt: new Date().toISOString()
+  } satisfies LinkedInFixtureManifest;
+  await writeFile(manifestPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+export async function loadLinkedInFixtureSet(
+  manifestPath: string = resolveFixtureManifestPath(),
+  requestedSetName?: string
+): Promise<LinkedInFixtureSet> {
+  const manifest = await readLinkedInFixtureManifest(manifestPath);
+  const setName = requestedSetName ?? manifest.defaultSetName ?? Object.keys(manifest.sets)[0];
+  if (!setName) {
+    throw new Error(`Fixture manifest ${manifestPath} does not define any sets.`);
+  }
+
+  const summary = manifest.sets[setName];
+  if (!summary) {
+    throw new Error(`Fixture set ${setName} is not defined in ${manifestPath}.`);
+  }
+
+  const routeFilePath = getResolvedRouteFilePath(manifestPath, summary);
+  const parsedRouteFile = parseRouteFile(await readJsonFile(routeFilePath), routeFilePath);
+  if (parsedRouteFile.format !== LINKEDIN_FIXTURE_MANIFEST_FORMAT_VERSION) {
+    throw new Error(
+      `Fixture route file ${routeFilePath} uses unsupported format ${parsedRouteFile.format}. ` +
+        `Expected ${LINKEDIN_FIXTURE_MANIFEST_FORMAT_VERSION}.`
+    );
+  }
+
+  return {
+    manifestPath,
+    setName,
+    baseDir: resolveFixtureSetBaseDir(manifestPath, summary),
+    summary,
+    routes: parsedRouteFile.routes
+  };
+}
+
+export async function checkLinkedInFixtureStaleness(
+  manifestPath: string = resolveFixtureManifestPath(),
+  options: { maxAgeDays?: number; setName?: string } = {}
+): Promise<FixtureStalenessWarning[]> {
+  const manifest = await readLinkedInFixtureManifest(manifestPath);
+  const maxAgeDays = options.maxAgeDays ?? DEFAULT_FIXTURE_STALENESS_DAYS;
+  const entries = options.setName
+    ? [[options.setName, manifest.sets[options.setName]] as const]
+    : (Object.entries(manifest.sets) as Array<[string, LinkedInFixtureSetSummary]>);
+  const warnings: FixtureStalenessWarning[] = [];
+
+  for (const [setName, summary] of entries) {
+    if (!summary) {
+      continue;
+    }
+
+    const pages = Object.values(summary.pages).filter(
+      (page): page is LinkedInFixturePageEntry => page !== undefined
+    );
+
+    if (pages.length === 0) {
+      const ageDays = getAgeDays(summary.capturedAt);
+      if (ageDays > maxAgeDays) {
+        warnings.push({
+          ageDays,
+          maxAgeDays,
+          recordedAt: summary.capturedAt,
+          setName,
+          message:
+            `Fixture set ${setName} was captured ${ageDays} day(s) ago ` +
+            `on ${summary.capturedAt}. Refresh it because it exceeds ${maxAgeDays} days.`
+        });
+      }
+      continue;
+    }
+
+    for (const page of pages) {
+      const ageDays = getAgeDays(page.recordedAt);
+      if (ageDays <= maxAgeDays) {
+        continue;
+      }
+
+      warnings.push({
+        ageDays,
+        maxAgeDays,
+        pageType: page.pageType,
+        recordedAt: page.recordedAt,
+        setName,
+        message:
+          `Fixture page ${setName}/${page.pageType} was recorded ${ageDays} day(s) ago ` +
+          `on ${page.recordedAt}. Refresh it because it exceeds ${maxAgeDays} days.`
+      });
+    }
+  }
+
+  return warnings;
+}
+
+export async function ensureSharedFixtureReplayServer(): Promise<StartedFixtureReplayServer | undefined> {
+  const environment = getFixtureReplayEnvironment();
+  if (!environment.enabled) {
+    return undefined;
+  }
+
+  if (environment.serverUrl) {
+    const fixtureSet = await loadLinkedInFixtureSet(environment.manifestPath, environment.setName);
+    return {
+      baseUrl: environment.serverUrl,
+      close: () => undefined,
+      manifestPath: environment.manifestPath,
+      setName: fixtureSet.setName,
+      summary: fixtureSet.summary
+    };
+  }
+
+  if (sharedServerState.started) {
+    return sharedServerState.started;
+  }
+
+  if (!sharedServerState.promise) {
+    sharedServerState.promise = startFixtureReplayServer(
+      environment.manifestPath,
+      environment.setName
+    ).finally(() => {
+      sharedServerState.promise = undefined;
+    });
+  }
+
+  return sharedServerState.promise;
+}
+
+export function shutdownSharedFixtureReplayServer(): void {
+  sharedServerState.started?.close();
+  sharedServerState.server = undefined;
+  sharedServerState.started = undefined;
+  sharedServerState.promise = undefined;
+}
+
+export async function attachFixtureReplayToContext(
+  context: BrowserContext
+): Promise<StartedFixtureReplayServer | undefined> {
+  const replayServer = await ensureSharedFixtureReplayServer();
+  if (!replayServer) {
+    return undefined;
+  }
+
+  await context.addInitScript(() => {
+    globalThis.document.cookie = "li_at=fixture-session; path=/; SameSite=Lax";
+  });
+
+  const replayOrigin = new URL(replayServer.baseUrl).origin;
+
+  await context.route("**/*", async (route) => {
+    const requestUrl = route.request().url();
+    if (!/^https?:/i.test(requestUrl)) {
+      await route.continue().catch(() => undefined);
+      return;
+    }
+
+    if (requestUrl.startsWith(replayOrigin)) {
+      await route.continue().catch(() => undefined);
+      return;
+    }
+
+    if (!isLinkedInReplayLikeUrl(requestUrl)) {
+      await route.abort().catch(() => undefined);
+      return;
+    }
+
+    const replayResponse = await fetch(`${replayServer.baseUrl}${REPLAY_ROUTE_PATH}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        method: route.request().method().toUpperCase(),
+        url: requestUrl
+      } satisfies ReplayRequestPayload)
+    });
+
+    const body = Buffer.from(await replayResponse.arrayBuffer());
+    const headers = removeUnsafeHeaders(Object.fromEntries(replayResponse.headers.entries()));
+    await route.fulfill({
+      status: replayResponse.status,
+      headers,
+      body
+    });
+  });
+
+  return replayServer;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export * from "./db/database.js";
 export * from "./draftQualityEval.js";
 export * from "./draftQualityTypes.js";
 export * from "./errors.js";
+export * from "./fixtureReplay.js";
 export * from "./healthCheck.js";
 export * from "./humanize.js";
 export * from "./keepAlive.js";

--- a/packages/core/src/profileManager.ts
+++ b/packages/core/src/profileManager.ts
@@ -7,6 +7,10 @@ import {
 } from "playwright-core";
 import type { ConfigPaths } from "./config.js";
 import { LinkedInAssistantError } from "./errors.js";
+import {
+  attachFixtureReplayToContext,
+  isFixtureReplayEnabled
+} from "./fixtureReplay.js";
 
 type PersistentLaunchOptions = NonNullable<
   Parameters<typeof chromium.launchPersistentContext>[1]
@@ -90,9 +94,10 @@ export class ProfileManager {
     callback: (context: BrowserContext) => Promise<T>
   ): Promise<T> {
     return this.withProfileLock(profileName, async (userDataDir) => {
+      const fixtureReplayEnabled = isFixtureReplayEnabled();
       const launchOptions: PersistentLaunchOptions = {
         ...(options.launchOptions ?? {}),
-        headless: options.headless ?? true
+        headless: fixtureReplayEnabled ? true : (options.headless ?? true)
       };
 
       const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
@@ -103,6 +108,7 @@ export class ProfileManager {
       let context: BrowserContext | undefined;
       try {
         context = await chromium.launchPersistentContext(userDataDir, launchOptions);
+        await attachFixtureReplayToContext(context);
         return await callback(context);
       } catch (error) {
         throw withPlaywrightInstallHint(error);

--- a/test/fixtures/ci/api/messaging-conversations.json
+++ b/test/fixtures/ci/api/messaging-conversations.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "messengerConversationsBySyncToken": {
+      "elements": [
+        {
+          "conversationUrl": "https://www.linkedin.com/messaging/thread/fixture-thread-1/",
+          "title": {
+            "text": "Simon Miller"
+          },
+          "descriptionText": {
+            "text": "Let's use fixture replay for safe coverage."
+          },
+          "unreadCount": 1,
+          "entityUrn": "urn:li:msg_conversation:(urn:li:fs_messagingProfile:viewer,fixture-thread-1)"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/ci/api/messaging-thread.json
+++ b/test/fixtures/ci/api/messaging-thread.json
@@ -1,0 +1,44 @@
+{
+  "data": {
+    "messengerMessagesBySyncToken": {
+      "elements": [
+        {
+          "body": {
+            "text": "Let's use fixture replay for safe coverage."
+          },
+          "deliveredAt": 1773018000000,
+          "actor": {
+            "participantType": {
+              "member": {
+                "firstName": {
+                  "text": "Simon"
+                },
+                "lastName": {
+                  "text": "Miller"
+                }
+              }
+            }
+          }
+        },
+        {
+          "body": {
+            "text": "Sounds good — deterministic tests are much easier to trust."
+          },
+          "deliveredAt": 1773021600000,
+          "actor": {
+            "participantType": {
+              "member": {
+                "firstName": {
+                  "text": "Fixture"
+                },
+                "lastName": {
+                  "text": "Operator"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/ci/assets/replay-state.js
+++ b/test/fixtures/ci/assets/replay-state.js
@@ -1,0 +1,699 @@
+(() => {
+  const STORAGE_KEY = "linkedin_fixture_replay_state";
+  const THREAD_ID = "fixture-thread-1";
+  const THREAD_URL = "https://www.linkedin.com/messaging/thread/fixture-thread-1/";
+  const CONVERSATIONS_URL =
+    "https://www.linkedin.com/voyagerMessagingGraphQL/graphql?queryId=messengerConversations.fixture&variables=%7B%22start%22%3A0%7D";
+  const MESSAGES_URL =
+    "https://www.linkedin.com/voyagerMessagingGraphQL/graphql?queryId=messengerMessages.fixture&variables=%7B%22threadId%22%3A%22fixture-thread-1%22%7D";
+  const PROFILE_SLUG = "realsimonmiller";
+  const PROFILE_URL = `https://www.linkedin.com/in/${PROFILE_SLUG}/`;
+  const ME_URL = "https://www.linkedin.com/in/me/";
+  const JOB_ID = "1234567890";
+  const JOB_URL = `https://www.linkedin.com/jobs/view/${JOB_ID}/`;
+  const POST_ID = "urn:li:activity:fixture-post-1";
+  const POST_URL = `https://www.linkedin.com/feed/update/${POST_ID}/`;
+  const BASE_POST = {
+    id: POST_ID,
+    url: POST_URL,
+    authorName: "Simon Miller",
+    authorHeadline: "Product Lead at Replay Labs",
+    authorProfileUrl: PROFILE_URL,
+    postedAt: "1h",
+    text: "Building safe automation with fixture replay gives us deterministic LinkedIn coverage without touching production accounts.",
+    reactionsCount: 12,
+    repostsCount: 1
+  };
+
+  function defaultState() {
+    return {
+      connections: {
+        received: {
+          [PROFILE_SLUG]: true
+        },
+        sent: {}
+      },
+      feed: {
+        comments: {
+          [POST_ID]: ["Love this direction."]
+        },
+        posts: [],
+        reactions: {}
+      },
+      messaging: {
+        [THREAD_ID]: {
+          messages: [
+            {
+              author: "Simon Miller",
+              sentAt: "2026-03-09T08:00:00.000Z",
+              text: "Let's use fixture replay for safe coverage."
+            },
+            {
+              author: "Fixture Operator",
+              sentAt: "2026-03-09T09:00:00.000Z",
+              text: "Sounds good — deterministic tests are much easier to trust."
+            }
+          ],
+          snippet: "Let's use fixture replay for safe coverage.",
+          title: "Simon Miller",
+          unreadCount: 1
+        }
+      }
+    };
+  }
+
+  function loadState() {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        const state = defaultState();
+        saveState(state);
+        return state;
+      }
+
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === "object" ? parsed : defaultState();
+    } catch {
+      return defaultState();
+    }
+  }
+
+  function saveState(state) {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  }
+
+  function escapeHtml(value) {
+    return String(value)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#39;");
+  }
+
+  function getAllPosts(state) {
+    return [BASE_POST, ...state.feed.posts];
+  }
+
+  function createPostHtml(post, state, singleView) {
+    const comments = state.feed.comments[post.id] ?? [];
+    const reaction = state.feed.reactions[post.id] ?? null;
+    const reacted = reaction !== null;
+    const commentsHidden = singleView ? "" : " hidden";
+    const safeText = escapeHtml(post.text);
+
+    return `
+      <article class="feed-shared-update-v2 occludable-update" data-urn="${escapeHtml(post.id)}">
+        <a href="${escapeHtml(post.url)}" class="post-permalink">Open post</a>
+        <div>
+          <a href="${escapeHtml(post.authorProfileUrl)}">
+            <span class="update-components-actor__name">${escapeHtml(post.authorName)}</span>
+          </a>
+        </div>
+        <div class="update-components-actor__description">${escapeHtml(post.authorHeadline)}</div>
+        <time>${escapeHtml(post.postedAt)}</time>
+        <div class="update-components-text">${safeText}</div>
+        <div class="social-details-social-counts__reactions-count">${BASE_POST.reactionsCount + (reacted ? 1 : 0)} reactions</div>
+        <div class="social-details-social-counts__comments">${comments.length} comments</div>
+        <div class="social-details-social-counts__reposts">${escapeHtml(post.repostsCount)} reposts</div>
+        <div>
+          <button
+            class="social-actions-button react-button__trigger${reacted ? " react-button--active" : ""}"
+            aria-label="${reacted ? "Remove your reaction" : "Like"}"
+            aria-pressed="${reacted ? "true" : "false"}"
+            data-post-id="${escapeHtml(post.id)}"
+          >Like</button>
+          <button class="social-actions-button comment-button" data-post-id="${escapeHtml(post.id)}">Comment</button>
+        </div>
+        <div class="comments-comment-box" data-post-id="${escapeHtml(post.id)}"${commentsHidden}>
+          <div
+            class="comments-comment-box__editor"
+            contenteditable="true"
+            role="textbox"
+            aria-label="Add a comment"
+            data-post-id="${escapeHtml(post.id)}"
+          ></div>
+          <button class="comments-comment-box__submit-button" data-post-id="${escapeHtml(post.id)}" disabled>Post</button>
+        </div>
+        <div class="comments-list" data-post-id="${escapeHtml(post.id)}">
+          ${comments
+            .map(
+              (comment) => `
+                <div class="comments-comment-item">
+                  <div class="comments-comment-item__main-content">${escapeHtml(comment)}</div>
+                </div>
+              `
+            )
+            .join("")}
+        </div>
+      </article>
+    `;
+  }
+
+  function createPublishedPost(text, index) {
+    return {
+      authorHeadline: "Fixture Operator",
+      authorName: "Fixture Operator",
+      authorProfileUrl: ME_URL,
+      id: `urn:li:activity:fixture-user-post-${index}`,
+      postedAt: "Just now",
+      reactionsCount: 0,
+      repostsCount: 0,
+      text,
+      url: `https://www.linkedin.com/feed/update/urn:li:activity:fixture-user-post-${index}/`
+    };
+  }
+
+  function renderFeed(singleView = false) {
+    const root = document.querySelector("#replay-root");
+    const state = loadState();
+    const posts = getAllPosts(state);
+    const visiblePosts = singleView
+      ? posts.filter((post) => post.url === window.location.href || post.id === POST_ID)
+      : posts;
+
+    root.innerHTML = `
+      <section class="share-box-feed-entry">
+        <button class="share-box-feed-entry__trigger" aria-label="Start a post">Start a post</button>
+      </section>
+      <section class="composer-dialog" role="dialog" hidden>
+        <button class="composer-close" aria-label="Close">Close</button>
+        <button class="composer-visibility" aria-label="Anyone">Anyone</button>
+        <div class="ql-editor" contenteditable="true" role="textbox" aria-label="What do you want to talk about?"></div>
+        <button class="share-actions__primary-action" disabled>Post</button>
+      </section>
+      ${visiblePosts.map((post) => createPostHtml(post, state, singleView)).join("")}
+    `;
+
+    const likeButtons = root.querySelectorAll(".react-button__trigger");
+    likeButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        const freshState = loadState();
+        const postId = button.getAttribute("data-post-id");
+        if (!postId) {
+          return;
+        }
+
+        if (freshState.feed.reactions[postId]) {
+          delete freshState.feed.reactions[postId];
+        } else {
+          freshState.feed.reactions[postId] = "like";
+        }
+
+        saveState(freshState);
+        renderFeed(singleView);
+      });
+    });
+
+    root.querySelectorAll(".comment-button").forEach((button) => {
+      button.addEventListener("click", () => {
+        const postId = button.getAttribute("data-post-id");
+        const editor = root.querySelector(`.comments-comment-box[data-post-id="${postId}"]`);
+        if (editor) {
+          editor.removeAttribute("hidden");
+        }
+      });
+    });
+
+    root.querySelectorAll(".comments-comment-box__editor").forEach((editor) => {
+      editor.addEventListener("input", () => {
+        const postId = editor.getAttribute("data-post-id");
+        const submit = root.querySelector(`.comments-comment-box__submit-button[data-post-id="${postId}"]`);
+        if (!(submit instanceof HTMLButtonElement)) {
+          return;
+        }
+
+        submit.disabled = editor.textContent.trim().length === 0;
+      });
+    });
+
+    root.querySelectorAll(".comments-comment-box__submit-button").forEach((button) => {
+      button.addEventListener("click", () => {
+        const freshState = loadState();
+        const postId = button.getAttribute("data-post-id");
+        const editor = root.querySelector(`.comments-comment-box__editor[data-post-id="${postId}"]`);
+        if (!(editor instanceof HTMLElement) || !postId) {
+          return;
+        }
+
+        const text = editor.textContent.trim();
+        if (!text) {
+          return;
+        }
+
+        if (!Array.isArray(freshState.feed.comments[postId])) {
+          freshState.feed.comments[postId] = [];
+        }
+        freshState.feed.comments[postId].push(text);
+        saveState(freshState);
+        renderFeed(singleView);
+      });
+    });
+
+    const trigger = root.querySelector(".share-box-feed-entry__trigger");
+    const dialog = root.querySelector(".composer-dialog");
+    const editor = root.querySelector(".ql-editor");
+    const publish = root.querySelector(".share-actions__primary-action");
+    const close = root.querySelector(".composer-close");
+    if (trigger && dialog && editor && publish && close) {
+      trigger.addEventListener("click", () => {
+        dialog.removeAttribute("hidden");
+      });
+
+      editor.addEventListener("input", () => {
+        publish.disabled = editor.textContent.trim().length === 0;
+      });
+
+      close.addEventListener("click", () => {
+        dialog.setAttribute("hidden", "");
+      });
+
+      publish.addEventListener("click", () => {
+        const text = editor.textContent.trim();
+        if (!text) {
+          return;
+        }
+
+        const freshState = loadState();
+        const nextIndex = freshState.feed.posts.length + 1;
+        freshState.feed.posts.unshift(createPublishedPost(text, nextIndex));
+        saveState(freshState);
+        dialog.setAttribute("hidden", "");
+        renderFeed(singleView);
+      });
+    }
+  }
+
+  function renderMessagingList() {
+    const root = document.querySelector("#replay-root");
+    const state = loadState();
+    const thread = state.messaging[THREAD_ID];
+    root.innerHTML = `
+      <main class="msg-conversations-container">
+        <a href="${THREAD_URL}" class="msg-conversation-card">
+          <div class="msg-conversation-card__participant-names">${escapeHtml(thread.title)}</div>
+          <div class="msg-conversation-card__message-snippet">${escapeHtml(thread.snippet)}</div>
+          <div class="msg-conversation-card__unread-count">${escapeHtml(thread.unreadCount)}</div>
+        </a>
+      </main>
+    `;
+
+    void fetch(CONVERSATIONS_URL).catch(() => undefined);
+  }
+
+  function renderMessagingThread() {
+    const root = document.querySelector("#replay-root");
+    const state = loadState();
+    const thread = state.messaging[THREAD_ID];
+    root.innerHTML = `
+      <main class="msg-s-message-list-content">
+        <h2 class="msg-thread__participant-names">${escapeHtml(thread.title)}</h2>
+        <div class="msg-s-message-list">
+          ${thread.messages
+            .map(
+              (message) => `
+                <div class="msg-s-event-listitem msg-s-message-list__event">
+                  <div class="msg-s-message-group__profile-link">${escapeHtml(message.author)}</div>
+                  <div class="msg-s-event-listitem__body">${escapeHtml(message.text)}</div>
+                  <time>${escapeHtml(message.sentAt)}</time>
+                </div>
+              `
+            )
+            .join("")}
+        </div>
+        <div class="msg-form">
+          <div class="msg-form__contenteditable" contenteditable="true" role="textbox" aria-label="Write a message"></div>
+          <button class="msg-form__send-button">Send</button>
+        </div>
+      </main>
+    `;
+
+    void fetch(MESSAGES_URL).catch(() => undefined);
+
+    const composer = root.querySelector(".msg-form__contenteditable");
+    const sendButton = root.querySelector(".msg-form__send-button");
+    if (composer && sendButton) {
+      sendButton.addEventListener("click", () => {
+        const text = composer.textContent.trim();
+        if (!text) {
+          return;
+        }
+
+        const freshState = loadState();
+        freshState.messaging[THREAD_ID].messages.push({
+          author: "Fixture Operator",
+          sentAt: new Date().toISOString(),
+          text
+        });
+        freshState.messaging[THREAD_ID].snippet = text;
+        freshState.messaging[THREAD_ID].unreadCount = 0;
+        saveState(freshState);
+        renderMessagingThread();
+      });
+    }
+  }
+
+  function profileSummary(slug) {
+    if (slug === "me") {
+      return {
+        fullName: "Fixture Operator",
+        headline: "Automation Engineer",
+        location: "Copenhagen, Denmark",
+        about: "I build safe automation workflows and deterministic browser fixtures.",
+        degree: "1st"
+      };
+    }
+
+    return {
+      fullName: "Simon Miller",
+      headline: "Product Lead at Replay Labs",
+      location: "London, United Kingdom",
+      about: "Curious about safe automation, fixture replay, and robust test harnesses.",
+      degree: "2nd"
+    };
+  }
+
+  function renderProfile(slug) {
+    const root = document.querySelector("#replay-root");
+    const state = loadState();
+    const profile = profileSummary(slug);
+    const sent = Boolean(state.connections.sent[slug]);
+
+    root.innerHTML = `
+      <section class="pv-top-card">
+        <h1 class="text-heading-xlarge">${escapeHtml(profile.fullName)}</h1>
+        <div class="text-body-medium" data-anonymize="headline">${escapeHtml(profile.headline)}</div>
+        <span class="text-body-small inline" data-anonymize="location">${escapeHtml(profile.location)}</span>
+        <div class="dist-value">${escapeHtml(profile.degree)}</div>
+        ${slug === "me" ? "" : `<button class="profile-connect ${sent ? "pending" : ""}" aria-label="${sent ? "Withdraw" : "Connect"}">${sent ? "Pending" : "Connect"}</button>`}
+        ${slug === "me" ? "" : `<div class="invitation-status">${sent ? "Invitation sent" : ""}</div>`}
+      </section>
+      ${slug === "me" ? "" : `
+        <section class="connect-dialog" hidden>
+          <button class="connect-add-note">Add a note</button>
+          <textarea name="message" aria-label="Invitation"></textarea>
+          <button class="connect-send">Send</button>
+        </section>
+      `}
+      <section id="about">
+        <h2>About</h2>
+        <div class="inline-show-more-text">${escapeHtml(profile.about)}</div>
+      </section>
+      <section id="experience">
+        <h2>Experience</h2>
+        <ul class="clean-list">
+          <li class="pvs-list__paged-list-item">
+            <div class="t-bold">Replay Labs</div>
+            <div class="t-normal">${escapeHtml(profile.headline)}</div>
+            <div class="pvs-entity__caption-wrapper">2024 – Present</div>
+            <div class="pvs-entity__description-wrapper">Owning safe automation and reliability.</div>
+          </li>
+        </ul>
+      </section>
+      <section id="education">
+        <h2>Education</h2>
+        <ul class="clean-list">
+          <li class="pvs-list__paged-list-item">
+            <div class="t-bold">Technical University</div>
+            <div class="t-normal">Computer Science</div>
+            <div class="pvs-entity__caption-wrapper">2012 – 2015</div>
+          </li>
+        </ul>
+      </section>
+    `;
+
+    const connectButton = root.querySelector(".profile-connect");
+    const dialog = root.querySelector(".connect-dialog");
+    const send = root.querySelector(".connect-send");
+    const textarea = root.querySelector("textarea[name='message']");
+    if (connectButton && dialog && send && textarea) {
+      connectButton.addEventListener("click", () => {
+        if (connectButton.textContent.trim() === "Pending") {
+          return;
+        }
+        dialog.removeAttribute("hidden");
+      });
+
+      send.addEventListener("click", () => {
+        const freshState = loadState();
+        freshState.connections.sent[slug] = {
+          note: textarea.value,
+          pending: true
+        };
+        saveState(freshState);
+        renderProfile(slug);
+      });
+    }
+  }
+
+  function renderConnectionsList() {
+    const root = document.querySelector("#replay-root");
+    root.innerHTML = `
+      <ul class="clean-list">
+        <li class="mn-connection-card">
+          <a href="${PROFILE_URL}"><span class="mn-connection-card__name">Simon Miller</span></a>
+          <div class="mn-connection-card__occupation">Product Lead at Replay Labs</div>
+          <time>Connected 2 years ago</time>
+        </li>
+      </ul>
+    `;
+  }
+
+  function renderInvitations(received) {
+    const root = document.querySelector("#replay-root");
+    const state = loadState();
+    const card = received
+      ? state.connections.received[PROFILE_SLUG]
+      : state.connections.sent[PROFILE_SLUG];
+    const listItems = [];
+
+    if (card) {
+      listItems.push(`
+        <li class="invitation-card">
+          <a href="${PROFILE_URL}"><span class="invitation-card__title">Simon Miller</span></a>
+          <div class="invitation-card__subtitle">Product Lead at Replay Labs</div>
+          ${received ? `<button class="accept">Accept</button><button>Ignore</button>` : `<button class="withdraw-trigger">Withdraw</button><div>Invitation sent</div>`}
+        </li>
+      `);
+    }
+
+    root.innerHTML = `
+      <ul class="clean-list">
+        ${listItems.join("")}
+      </ul>
+      <section class="withdraw-dialog" hidden>
+        <button class="withdraw-confirm">Withdraw</button>
+      </section>
+    `;
+
+    if (received) {
+      const accept = root.querySelector(".accept");
+      if (accept) {
+        accept.addEventListener("click", () => {
+          const freshState = loadState();
+          delete freshState.connections.received[PROFILE_SLUG];
+          saveState(freshState);
+          renderInvitations(true);
+        });
+      }
+      return;
+    }
+
+    const withdrawTrigger = root.querySelector(".withdraw-trigger");
+    const withdrawDialog = root.querySelector(".withdraw-dialog");
+    const withdrawConfirm = root.querySelector(".withdraw-confirm");
+    if (withdrawTrigger && withdrawDialog && withdrawConfirm) {
+      withdrawTrigger.addEventListener("click", () => {
+        withdrawDialog.removeAttribute("hidden");
+      });
+      withdrawConfirm.addEventListener("click", () => {
+        const freshState = loadState();
+        delete freshState.connections.sent[PROFILE_SLUG];
+        saveState(freshState);
+        renderInvitations(false);
+      });
+    }
+  }
+
+  function renderSearchPeople() {
+    const root = document.querySelector("#replay-root");
+    root.innerHTML = `
+      <div class="reusable-search__result-container">
+        <div class="entity-result__title-text">
+          <a href="${PROFILE_URL}"><span aria-hidden="true">Simon Miller</span></a>
+        </div>
+        <div class="entity-result__primary-subtitle">Product Lead at Replay Labs</div>
+        <div class="entity-result__secondary-subtitle">London, United Kingdom</div>
+        <div class="dist-value">2nd</div>
+      </div>
+    `;
+  }
+
+  function renderSearchCompanies() {
+    const root = document.querySelector("#replay-root");
+    root.innerHTML = `
+      <div class="reusable-search__result-container">
+        <img alt="Replay Labs logo" src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" />
+        <div class="entity-result__title-text">
+          <a href="https://www.linkedin.com/company/replay-labs/"><span aria-hidden="true">Power International</span></a>
+        </div>
+        <div class="entity-result__primary-subtitle">Software company</div>
+        <div class="entity-result__secondary-subtitle">Copenhagen, Denmark</div>
+        <div class="entity-result__summary">Building reliable product systems.</div>
+      </div>
+    `;
+  }
+
+  function renderSearchJobs() {
+    const root = document.querySelector("#replay-root");
+    root.innerHTML = `
+      <div class="job-card-container">
+        <a class="job-card-container__link" href="${JOB_URL}">Software Engineer</a>
+        <div class="job-card-container__company-name">Replay Labs</div>
+        <div class="job-card-container__metadata-wrapper">Copenhagen, Denmark</div>
+        <time>2 days ago</time>
+      </div>
+    `;
+  }
+
+  function renderJobsSearch() {
+    const root = document.querySelector("#replay-root");
+    root.innerHTML = `
+      <main class="jobs-search-results-list">
+        <div class="job-card-container">
+          <a class="job-card-container__link" href="${JOB_URL}">Software Engineer</a>
+          <div class="job-card-container__company-name">Replay Labs</div>
+          <div class="job-card-container__metadata-wrapper">Copenhagen, Denmark</div>
+          <time>2 days ago</time>
+          <div class="job-card-container__salary-info">€80,000 – €95,000</div>
+        </div>
+      </main>
+    `;
+  }
+
+  function renderJobView() {
+    const root = document.querySelector("#replay-root");
+    root.innerHTML = `
+      <main class="jobs-details job-view-layout">
+        <div class="job-details-jobs-unified-top-card">
+          <h1 class="job-details-jobs-unified-top-card__job-title">Software Engineer</h1>
+          <a href="https://www.linkedin.com/company/replay-labs/" class="job-details-jobs-unified-top-card__company-name">Replay Labs</a>
+          <div class="job-details-jobs-unified-top-card__bullet">Copenhagen, Denmark</div>
+          <div class="job-details-jobs-unified-top-card__posted-date">Posted 2 days ago</div>
+          <div class="job-details-jobs-unified-top-card__job-insight">Full-time</div>
+        </div>
+        <div class="jobs-description__content">Build safe automation tooling and deterministic replay systems.</div>
+      </main>
+    `;
+  }
+
+  function renderNotifications() {
+    const root = document.querySelector("#replay-root");
+    root.innerHTML = `
+      <main>
+        <h1>Notifications</h1>
+        <article class="notification-card" data-notification-id="notif-1" data-notification-type="comment" data-unread="true">
+          <div class="notification-card__message">Simon Miller commented on your post about fixture replay.</div>
+          <time class="notification-card__time">1h</time>
+          <a href="${POST_URL}">Open notification</a>
+        </article>
+        <article class="notification-card" data-notification-id="notif-2" data-notification-type="connection" data-unread="false">
+          <div class="notification-card__message">You have a new connection invitation.</div>
+          <time class="notification-card__time">2h</time>
+          <a href="https://www.linkedin.com/notifications/">Open notification</a>
+        </article>
+      </main>
+    `;
+  }
+
+  function renderUnknown() {
+    const root = document.querySelector("#replay-root");
+    root.innerHTML = `<main><h1>Unknown replay route</h1><p>${escapeHtml(window.location.href)}</p></main>`;
+  }
+
+  function renderPage() {
+    const pathName = window.location.pathname;
+    const normalizedPath = pathName.endsWith("/") ? pathName : `${pathName}/`;
+
+    if (normalizedPath === "/feed/") {
+      renderFeed(false);
+      return;
+    }
+
+    if (normalizedPath.startsWith("/feed/update/")) {
+      renderFeed(true);
+      return;
+    }
+
+    if (normalizedPath === "/messaging/") {
+      renderMessagingList();
+      return;
+    }
+
+    if (normalizedPath === "/messaging/thread/fixture-thread-1/") {
+      renderMessagingThread();
+      return;
+    }
+
+    if (normalizedPath === "/in/me/") {
+      renderProfile("me");
+      return;
+    }
+
+    if (normalizedPath === `/${`in/${PROFILE_SLUG}`}/`) {
+      renderProfile(PROFILE_SLUG);
+      return;
+    }
+
+    if (normalizedPath === "/mynetwork/invite-connect/connections/") {
+      renderConnectionsList();
+      return;
+    }
+
+    if (normalizedPath === "/mynetwork/invitation-manager/") {
+      renderInvitations(true);
+      return;
+    }
+
+    if (normalizedPath === "/mynetwork/invitation-manager/sent/") {
+      renderInvitations(false);
+      return;
+    }
+
+    if (normalizedPath === "/search/results/people/") {
+      renderSearchPeople();
+      return;
+    }
+
+    if (normalizedPath === "/search/results/companies/") {
+      renderSearchCompanies();
+      return;
+    }
+
+    if (normalizedPath === "/search/results/jobs/") {
+      renderSearchJobs();
+      return;
+    }
+
+    if (normalizedPath === "/jobs/search/") {
+      renderJobsSearch();
+      return;
+    }
+
+    if (normalizedPath === `/jobs/view/${JOB_ID}/`) {
+      renderJobView();
+      return;
+    }
+
+    if (normalizedPath === "/notifications/") {
+      renderNotifications();
+      return;
+    }
+
+    renderUnknown();
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    renderPage();
+  });
+})();

--- a/test/fixtures/ci/pages/app.html
+++ b/test/fixtures/ci/pages/app.html
@@ -1,0 +1,161 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>LinkedIn Replay Fixture</title>
+    <style>
+      body {
+        font-family: Arial, Helvetica, sans-serif;
+        margin: 0;
+        background: #f3f2ef;
+        color: #1d2226;
+      }
+
+      nav.global-nav {
+        background: #ffffff;
+        border-bottom: 1px solid #d9d9d9;
+        padding: 12px 24px;
+        font-weight: 600;
+      }
+
+      main {
+        max-width: 980px;
+        margin: 24px auto;
+        padding: 0 16px 64px;
+      }
+
+      section,
+      article,
+      .panel,
+      .notification-card,
+      .job-card-container,
+      .reusable-search__result-container,
+      .invitation-card,
+      .mn-connection-card,
+      .msg-conversation-card,
+      .feed-shared-update-v2,
+      .jobs-details,
+      .pv-top-card {
+        background: #ffffff;
+        border: 1px solid #d9d9d9;
+        border-radius: 12px;
+        padding: 16px;
+        margin-bottom: 16px;
+      }
+
+      h1,
+      h2,
+      h3,
+      p {
+        margin-top: 0;
+      }
+
+      a {
+        color: #0a66c2;
+        text-decoration: none;
+      }
+
+      button {
+        border: 1px solid #0a66c2;
+        background: #ffffff;
+        color: #0a66c2;
+        border-radius: 999px;
+        padding: 8px 14px;
+        cursor: pointer;
+        font-weight: 600;
+        margin-right: 8px;
+      }
+
+      button[disabled] {
+        opacity: 0.55;
+        cursor: not-allowed;
+      }
+
+      .share-box-feed-entry__trigger,
+      .share-actions__primary-action,
+      .msg-form__send-button,
+      .comments-comment-box__submit-button,
+      button.pending,
+      button.accept {
+        background: #0a66c2;
+        color: #ffffff;
+      }
+
+      .react-button--active {
+        background: #0a66c2;
+        color: #ffffff;
+      }
+
+      .update-components-text,
+      .jobs-description__content,
+      .inline-show-more-text,
+      .comments-comment-item__main-content,
+      .msg-s-event-listitem__body {
+        white-space: pre-wrap;
+      }
+
+      [contenteditable="true"] {
+        min-height: 44px;
+        border: 1px solid #c7c7c7;
+        border-radius: 8px;
+        padding: 10px;
+        margin-bottom: 12px;
+        background: #ffffff;
+      }
+
+      .composer-dialog[hidden],
+      .connect-dialog[hidden],
+      .withdraw-dialog[hidden],
+      .comments-comment-box[hidden] {
+        display: none;
+      }
+
+      .composer-dialog,
+      .connect-dialog,
+      .withdraw-dialog {
+        position: sticky;
+        top: 16px;
+        z-index: 10;
+        background: #ffffff;
+        border: 1px solid #0a66c2;
+        border-radius: 12px;
+        padding: 16px;
+        margin-bottom: 16px;
+      }
+
+      .social-details-social-counts__comments,
+      .social-details-social-counts__reactions-count,
+      .social-details-social-counts__reposts,
+      .text-body-small,
+      .text-body-medium,
+      .entity-result__secondary-subtitle,
+      .job-card-container__metadata-wrapper,
+      .notification-card__time,
+      .job-details-jobs-unified-top-card__bullet {
+        color: #666666;
+        font-size: 14px;
+      }
+
+      .msg-s-message-list__event,
+      .msg-s-event-listitem {
+        padding: 10px;
+        border-radius: 10px;
+        border: 1px solid #d9d9d9;
+        margin-bottom: 10px;
+        background: #fafafa;
+      }
+
+      ul.clean-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <nav class="global-nav">LinkedIn Fixture Replay</nav>
+    <main id="replay-root"></main>
+    <script src="/__replay/replay-state.js"></script>
+  </body>
+</html>

--- a/test/fixtures/ci/pages/login.html
+++ b/test/fixtures/ci/pages/login.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>LinkedIn Login Replay</title>
+  </head>
+  <body>
+    <main>
+      <p>Redirecting to the replay feed…</p>
+    </main>
+    <script>
+      document.cookie = "li_at=fixture-session; path=/; SameSite=Lax";
+      setTimeout(() => {
+        window.location.replace("https://www.linkedin.com/feed/");
+      }, 25);
+    </script>
+  </body>
+</html>

--- a/test/fixtures/ci/routes.json
+++ b/test/fixtures/ci/routes.json
@@ -1,0 +1,204 @@
+{
+  "format": 1,
+  "setName": "ci",
+  "routes": [
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/__replay/replay-state.js",
+      "status": 200,
+      "headers": {
+        "content-type": "application/javascript; charset=utf-8"
+      },
+      "bodyPath": "assets/replay-state.js"
+    },
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/login",
+      "status": 200,
+      "headers": {
+        "content-type": "text/html; charset=utf-8"
+      },
+      "bodyPath": "pages/login.html"
+    },
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/feed/",
+      "status": 200,
+      "headers": {
+        "content-type": "text/html; charset=utf-8"
+      },
+      "bodyPath": "pages/app.html",
+      "pageType": "feed"
+    },
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/feed/update/urn:li:activity:fixture-post-1/",
+      "status": 200,
+      "headers": {
+        "content-type": "text/html; charset=utf-8"
+      },
+      "bodyPath": "pages/app.html",
+      "pageType": "feed"
+    },
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/messaging/",
+      "status": 200,
+      "headers": {
+        "content-type": "text/html; charset=utf-8"
+      },
+      "bodyPath": "pages/app.html",
+      "pageType": "messaging"
+    },
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/messaging/thread/fixture-thread-1/",
+      "status": 200,
+      "headers": {
+        "content-type": "text/html; charset=utf-8"
+      },
+      "bodyPath": "pages/app.html",
+      "pageType": "messaging"
+    },
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/voyagerMessagingGraphQL/graphql?queryId=messengerConversations.fixture&variables=%7B%22start%22%3A0%7D",
+      "status": 200,
+      "headers": {
+        "content-type": "application/json; charset=utf-8"
+      },
+      "bodyPath": "api/messaging-conversations.json",
+      "pageType": "messaging"
+    },
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/voyagerMessagingGraphQL/graphql?queryId=messengerMessages.fixture&variables=%7B%22threadId%22%3A%22fixture-thread-1%22%7D",
+      "status": 200,
+      "headers": {
+        "content-type": "application/json; charset=utf-8"
+      },
+      "bodyPath": "api/messaging-thread.json",
+      "pageType": "messaging"
+    },
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/in/me/",
+      "status": 200,
+      "headers": {
+        "content-type": "text/html; charset=utf-8"
+      },
+      "bodyPath": "pages/app.html",
+      "pageType": "profile"
+    },
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/in/realsimonmiller/",
+      "status": 200,
+      "headers": {
+        "content-type": "text/html; charset=utf-8"
+      },
+      "bodyPath": "pages/app.html",
+      "pageType": "profile"
+    },
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/search/results/people/?keywords=Simon%20Miller",
+      "status": 200,
+      "headers": {
+        "content-type": "text/html; charset=utf-8"
+      },
+      "bodyPath": "pages/app.html",
+      "pageType": "search"
+    },
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/search/results/companies/?keywords=Power%20International",
+      "status": 200,
+      "headers": {
+        "content-type": "text/html; charset=utf-8"
+      },
+      "bodyPath": "pages/app.html",
+      "pageType": "search"
+    },
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/search/results/jobs/?keywords=software%20engineer%20copenhagen",
+      "status": 200,
+      "headers": {
+        "content-type": "text/html; charset=utf-8"
+      },
+      "bodyPath": "pages/app.html",
+      "pageType": "search"
+    },
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/jobs/search/?keywords=software%20engineer",
+      "status": 200,
+      "headers": {
+        "content-type": "text/html; charset=utf-8"
+      },
+      "bodyPath": "pages/app.html",
+      "pageType": "jobs"
+    },
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/jobs/search/?keywords=software%20engineer&location=Copenhagen",
+      "status": 200,
+      "headers": {
+        "content-type": "text/html; charset=utf-8"
+      },
+      "bodyPath": "pages/app.html",
+      "pageType": "jobs"
+    },
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/jobs/view/1234567890/",
+      "status": 200,
+      "headers": {
+        "content-type": "text/html; charset=utf-8"
+      },
+      "bodyPath": "pages/app.html",
+      "pageType": "jobs"
+    },
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/notifications/",
+      "status": 200,
+      "headers": {
+        "content-type": "text/html; charset=utf-8"
+      },
+      "bodyPath": "pages/app.html",
+      "pageType": "notifications"
+    },
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/mynetwork/invite-connect/connections/",
+      "status": 200,
+      "headers": {
+        "content-type": "text/html; charset=utf-8"
+      },
+      "bodyPath": "pages/app.html",
+      "pageType": "connections"
+    },
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/mynetwork/invitation-manager/",
+      "status": 200,
+      "headers": {
+        "content-type": "text/html; charset=utf-8"
+      },
+      "bodyPath": "pages/app.html",
+      "pageType": "connections"
+    },
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/mynetwork/invitation-manager/sent/",
+      "status": 200,
+      "headers": {
+        "content-type": "text/html; charset=utf-8"
+      },
+      "bodyPath": "pages/app.html",
+      "pageType": "connections"
+    }
+  ]
+}

--- a/test/fixtures/manifest.json
+++ b/test/fixtures/manifest.json
@@ -1,0 +1,77 @@
+{
+  "format": 1,
+  "updatedAt": "2026-03-09T10:00:00.000Z",
+  "defaultSetName": "ci",
+  "sets": {
+    "ci": {
+      "setName": "ci",
+      "rootDir": "ci",
+      "locale": "en-US",
+      "capturedAt": "2026-03-09T10:00:00.000Z",
+      "viewport": {
+        "width": 1440,
+        "height": 900
+      },
+      "routesPath": "routes.json",
+      "description": "Synthetic LinkedIn replay fixtures for CI-safe end-to-end coverage.",
+      "pages": {
+        "feed": {
+          "pageType": "feed",
+          "url": "https://www.linkedin.com/feed/",
+          "htmlPath": "pages/app.html",
+          "recordedAt": "2026-03-09T10:00:00.000Z",
+          "title": "Feed"
+        },
+        "profile": {
+          "pageType": "profile",
+          "url": "https://www.linkedin.com/in/realsimonmiller/",
+          "htmlPath": "pages/app.html",
+          "recordedAt": "2026-03-09T10:00:00.000Z",
+          "title": "Profile"
+        },
+        "messaging": {
+          "pageType": "messaging",
+          "url": "https://www.linkedin.com/messaging/",
+          "htmlPath": "pages/app.html",
+          "recordedAt": "2026-03-09T10:00:00.000Z",
+          "title": "Messaging"
+        },
+        "notifications": {
+          "pageType": "notifications",
+          "url": "https://www.linkedin.com/notifications/",
+          "htmlPath": "pages/app.html",
+          "recordedAt": "2026-03-09T10:00:00.000Z",
+          "title": "Notifications"
+        },
+        "composer": {
+          "pageType": "composer",
+          "url": "https://www.linkedin.com/feed/",
+          "htmlPath": "pages/app.html",
+          "recordedAt": "2026-03-09T10:00:00.000Z",
+          "title": "Composer"
+        },
+        "search": {
+          "pageType": "search",
+          "url": "https://www.linkedin.com/search/results/people/?keywords=Simon%20Miller",
+          "htmlPath": "pages/app.html",
+          "recordedAt": "2026-03-09T10:00:00.000Z",
+          "title": "Search"
+        },
+        "connections": {
+          "pageType": "connections",
+          "url": "https://www.linkedin.com/mynetwork/invite-connect/connections/",
+          "htmlPath": "pages/app.html",
+          "recordedAt": "2026-03-09T10:00:00.000Z",
+          "title": "Connections"
+        },
+        "jobs": {
+          "pageType": "jobs",
+          "url": "https://www.linkedin.com/jobs/search/?keywords=software%20engineer",
+          "htmlPath": "pages/app.html",
+          "recordedAt": "2026-03-09T10:00:00.000Z",
+          "title": "Jobs"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a LinkedIn fixture replay server, manifest format, and Playwright interception layer
- add fixture record/check CLI commands plus committed CI-safe replay fixtures and docs
- run replay-backed E2E in CI with a dedicated script and supporting tests

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build
- npm run test:e2e:fixtures

Closes #87