### PR TITLE
refactor: simplify fixture replay harness for #114

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -26,11 +26,15 @@ import {
   clearRateLimitState,
   createLocalDataDeletionPlan,
   createEmptyFixtureManifest,
+  buildFixtureRouteKey,
   evaluateDraftQuality,
   getLinkedInSelectorLocaleConfigWarning,
   isInRateLimitCooldown,
+  isLinkedInFixtureReplayUrl,
   LINKEDIN_REPLAY_PAGE_TYPES,
+  FIXTURE_REPLAY_ENV_KEYS,
   LINKEDIN_FEED_REACTION_TYPES,
+  LINKEDIN_FIXTURE_MANIFEST_FORMAT_VERSION,
   LINKEDIN_POST_VISIBILITY_TYPES,
   LINKEDIN_SELECTOR_LOCALES,
   LinkedInAssistantError,
@@ -41,6 +45,7 @@ import {
   deleteLocalData,
   loadLinkedInFixtureSet,
   normalizeLinkedInFeedReaction,
+  normalizeFixtureRouteHeaders,
   normalizeLinkedInPostVisibility,
   parseDraftQualityCandidateSet,
   parseDraftQualityDataset,
@@ -243,12 +248,6 @@ const DEFAULT_FIXTURE_VIEWPORT = {
 const FIXTURE_ROUTE_FILE_NAME = "routes.json";
 const FIXTURE_RESPONSE_DIR_NAME = "responses";
 const FIXTURE_PAGES_DIR_NAME = "pages";
-const FIXTURE_REPLAY_ENV_KEYS = [
-  "LINKEDIN_E2E_REPLAY",
-  "LINKEDIN_E2E_FIXTURE_SERVER_URL",
-  "LINKEDIN_E2E_FIXTURE_SET",
-  "LINKEDIN_E2E_FIXTURE_MANIFEST"
-] as const;
 const FIXTURE_CAPTURE_URLS: Record<LinkedInReplayPageType, string> = {
   composer: "https://www.linkedin.com/feed/",
   connections: "https://www.linkedin.com/mynetwork/invite-connect/connections/",
@@ -305,24 +304,6 @@ function uniqueFixtureReplayPageTypes(
   return Array.from(new Set(pageTypes));
 }
 
-function normalizeFixtureRouteHeaders(
-  headers: Record<string, string>
-): Record<string, string> {
-  const normalized: Record<string, string> = {};
-  for (const [key, value] of Object.entries(headers)) {
-    normalized[key.toLowerCase()] = value;
-  }
-
-  delete normalized["content-length"];
-  delete normalized["content-encoding"];
-  delete normalized["transfer-encoding"];
-  return normalized;
-}
-
-function createFixtureRouteKey(route: Pick<LinkedInFixtureRoute, "method" | "url">): string {
-  return `${route.method.toUpperCase()} ${route.url}`;
-}
-
 function sanitizeFixtureFileStem(value: string): string {
   return value.replace(/[^a-z0-9._-]+/giu, "-").replace(/-{2,}/gu, "-");
 }
@@ -363,17 +344,6 @@ function guessFixtureResponseExtension(
   }
 }
 
-function shouldCaptureFixtureResponse(url: string): boolean {
-  try {
-    const parsed = new URL(url);
-    return (
-      parsed.protocol === "http:" || parsed.protocol === "https:"
-    ) && (parsed.hostname.endsWith("linkedin.com") || parsed.hostname.endsWith("licdn.com"));
-  } catch {
-    return false;
-  }
-}
-
 async function loadFixtureManifestOrCreate(
   manifestPath: string
 ): Promise<LinkedInFixtureManifest> {
@@ -386,14 +356,9 @@ async function loadFixtureManifestOrCreate(
 
 async function loadExistingFixtureRoutes(
   manifestPath: string,
-  setName: string
+  setName: string,
+  setSummary: LinkedInFixtureSetSummary | undefined
 ): Promise<LinkedInFixtureRoute[]> {
-  if (!existsSync(manifestPath)) {
-    return [];
-  }
-
-  const manifest = await readLinkedInFixtureManifest(manifestPath);
-  const setSummary = manifest.sets[setName];
   if (!setSummary) {
     return [];
   }
@@ -416,14 +381,14 @@ function mergeFixtureRoutes(
 ): LinkedInFixtureRoute[] {
   const merged = new Map<string, LinkedInFixtureRoute>();
   for (const route of existingRoutes) {
-    merged.set(createFixtureRouteKey(route), route);
+    merged.set(buildFixtureRouteKey(route), route);
   }
   for (const route of nextRoutes) {
-    merged.set(createFixtureRouteKey(route), route);
+    merged.set(buildFixtureRouteKey(route), route);
   }
 
   return Array.from(merged.values()).sort((left, right) =>
-    createFixtureRouteKey(left).localeCompare(createFixtureRouteKey(right))
+    buildFixtureRouteKey(left).localeCompare(buildFixtureRouteKey(right))
   );
 }
 
@@ -463,7 +428,7 @@ async function captureFixtureResponse(
   index: number
 ): Promise<LinkedInFixtureRoute | null> {
   const url = response.url();
-  if (!shouldCaptureFixtureResponse(url)) {
+  if (!isLinkedInFixtureReplayUrl(url)) {
     return null;
   }
 
@@ -534,12 +499,19 @@ async function runFixturesRecord(input: FixtureRecordInput): Promise<void> {
   const manifestPath = resolveFixtureManifestPath(input.manifestPath);
   const manifest = await loadFixtureManifestOrCreate(manifestPath);
   const setName = input.setName;
-  const setRootDir = path.resolve(path.dirname(manifestPath), setName);
+  const previousSetSummary = manifest.sets[setName];
+  const setRootDir = path.resolve(
+    path.dirname(manifestPath),
+    previousSetSummary?.rootDir ?? setName
+  );
   const pagesDir = path.join(setRootDir, FIXTURE_PAGES_DIR_NAME);
   const harRelativePath = input.har ? "session.har" : undefined;
   const harAbsolutePath = harRelativePath ? path.join(setRootDir, harRelativePath) : undefined;
-  const previousSetSummary = manifest.sets[setName];
-  const existingRoutes = await loadExistingFixtureRoutes(manifestPath, setName);
+  const existingRoutes = await loadExistingFixtureRoutes(
+    manifestPath,
+    setName,
+    previousSetSummary
+  );
   const capturedRoutes = new Map<string, LinkedInFixtureRoute>();
   const captureJobs: Array<Promise<void>> = [];
   const pageEntries: Partial<Record<LinkedInReplayPageType, LinkedInFixturePageEntry>> = {
@@ -578,70 +550,70 @@ async function runFixturesRecord(input: FixtureRecordInput): Promise<void> {
       },
       async (context) => {
         let responseIndex = existingRoutes.length;
-      context.on("response", (response) => {
-        const captureJob = captureFixtureResponse(response, setRootDir, responseIndex + 1)
-          .then((capturedRoute) => {
-            responseIndex += 1;
-            if (!capturedRoute) {
-              return;
+        context.on("response", (response) => {
+          responseIndex += 1;
+          const captureJob = captureFixtureResponse(response, setRootDir, responseIndex)
+            .then((capturedRoute) => {
+              if (!capturedRoute) {
+                return;
+              }
+
+              capturedRoutes.set(buildFixtureRouteKey(capturedRoute), capturedRoute);
+            })
+            .catch(() => undefined);
+          captureJobs.push(captureJob);
+        });
+
+        const page = context.pages()[0] ?? (await context.newPage());
+        const prompt = createInterface({
+          input: stdin,
+          output: stdout
+        });
+
+        try {
+          for (const pageType of input.pageTypes) {
+            const suggestedUrl = FIXTURE_CAPTURE_URLS[pageType];
+            if (suggestedUrl) {
+              await page.goto(suggestedUrl, { waitUntil: "domcontentloaded" }).catch(() => undefined);
             }
 
-            capturedRoutes.set(createFixtureRouteKey(capturedRoute), capturedRoute);
-          })
-          .catch(() => undefined);
-        captureJobs.push(captureJob);
-      });
+            writeCliNotice(
+              `Navigate the browser to the LinkedIn ${pageType} page you want to capture.`
+            );
+            await prompt.question(
+              `Press Enter to capture ${pageType} (current page: ${page.url() || suggestedUrl}). `
+            );
 
-      const page = context.pages()[0] ?? (await context.newPage());
-      const prompt = createInterface({
-        input: stdin,
-        output: stdout
-      });
+            const htmlRelativePath = path.join(FIXTURE_PAGES_DIR_NAME, `${pageType}.html`);
+            const htmlAbsolutePath = path.join(setRootDir, htmlRelativePath);
+            await writeFile(htmlAbsolutePath, `${await page.content()}\n`, "utf8");
 
-      try {
-        for (const pageType of input.pageTypes) {
-          const suggestedUrl = FIXTURE_CAPTURE_URLS[pageType];
-          if (suggestedUrl) {
-            await page.goto(suggestedUrl, { waitUntil: "domcontentloaded" }).catch(() => undefined);
+            const currentUrl = page.url();
+            const pageTitle = await page.title().catch(() => undefined);
+            const pageLocale = await page.evaluate(() => navigator.language).catch(() => undefined);
+            const viewport = page.viewportSize();
+            captureLocale = typeof pageLocale === "string" && pageLocale.trim().length > 0
+              ? pageLocale.trim()
+              : captureLocale;
+            if (viewport) {
+              captureViewport = viewport;
+            }
+
+            pageEntries[pageType] = {
+              pageType,
+              url: currentUrl || suggestedUrl,
+              htmlPath: htmlRelativePath,
+              recordedAt: new Date().toISOString(),
+              ...(typeof pageTitle === "string" && pageTitle.trim().length > 0
+                ? { title: pageTitle.trim() }
+                : {})
+            };
           }
 
-          writeCliNotice(
-            `Navigate the browser to the LinkedIn ${pageType} page you want to capture.`
-          );
-          await prompt.question(
-            `Press Enter to capture ${pageType} (current page: ${page.url() || suggestedUrl}). `
-          );
-
-          const htmlRelativePath = path.join(FIXTURE_PAGES_DIR_NAME, `${pageType}.html`);
-          const htmlAbsolutePath = path.join(setRootDir, htmlRelativePath);
-          await writeFile(htmlAbsolutePath, `${await page.content()}\n`, "utf8");
-
-          const currentUrl = page.url();
-          const pageTitle = await page.title().catch(() => undefined);
-          const pageLocale = await page.evaluate(() => navigator.language).catch(() => undefined);
-          const viewport = page.viewportSize();
-          captureLocale = typeof pageLocale === "string" && pageLocale.trim().length > 0
-            ? pageLocale.trim()
-            : captureLocale;
-          if (viewport) {
-            captureViewport = viewport;
-          }
-
-          pageEntries[pageType] = {
-            pageType,
-            url: currentUrl || suggestedUrl,
-            htmlPath: htmlRelativePath,
-            recordedAt: new Date().toISOString(),
-            ...(typeof pageTitle === "string" && pageTitle.trim().length > 0
-              ? { title: pageTitle.trim() }
-              : {})
-          };
+          await page.waitForTimeout(750);
+        } finally {
+          prompt.close();
         }
-
-        await page.waitForTimeout(750);
-      } finally {
-        prompt.close();
-      }
       }
     );
   });
@@ -653,7 +625,7 @@ async function runFixturesRecord(input: FixtureRecordInput): Promise<void> {
     path.join(setRootDir, FIXTURE_ROUTE_FILE_NAME),
     `${JSON.stringify(
       {
-        format: 1,
+        format: LINKEDIN_FIXTURE_MANIFEST_FORMAT_VERSION,
         setName,
         routes: mergedRoutes
       },

--- a/packages/cli/test/fixturesRecordCli.test.ts
+++ b/packages/cli/test/fixturesRecordCli.test.ts
@@ -1,0 +1,205 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { stdin, stdout } from "node:process";
+import type { BrowserContext } from "playwright-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const readlineMocks = vi.hoisted(() => ({
+  close: vi.fn(),
+  createInterface: vi.fn(),
+  question: vi.fn(async () => "")
+}));
+
+vi.mock("@linkedin-assistant/core", async () =>
+  await import("../../core/src/index.js")
+);
+
+vi.mock("node:readline/promises", () => ({
+  createInterface: readlineMocks.createInterface.mockImplementation(() => ({
+    close: readlineMocks.close,
+    question: readlineMocks.question
+  }))
+}));
+
+import * as core from "@linkedin-assistant/core";
+import { runCli } from "../src/bin/linkedin.js";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+interface FixtureRecordRouteFile {
+  routes: Array<{
+    bodyPath?: string;
+    url: string;
+  }>;
+}
+
+interface TestFixtureCaptureResponse {
+  body(): Promise<Buffer>;
+  headers(): Record<string, string>;
+  request(): {
+    method(): string;
+  };
+  status(): number;
+  url(): string;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolveFn: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolveFn = resolve;
+  });
+
+  if (!resolveFn) {
+    throw new Error("Deferred promise did not initialize its resolver.");
+  }
+
+  return {
+    promise,
+    resolve: resolveFn
+  };
+}
+
+function createFixtureResponse(
+  url: string,
+  body: Promise<Buffer>
+): TestFixtureCaptureResponse {
+  return {
+    body: async () => await body,
+    headers: () => ({
+      "Content-Length": "15",
+      "Content-Type": "application/json; charset=utf-8"
+    }),
+    request: () => ({
+      method: () => "GET"
+    }),
+    status: () => 200,
+    url: () => url
+  };
+}
+
+function setInteractiveMode(inputIsTty: boolean, outputIsTty: boolean): void {
+  Object.defineProperty(stdin, "isTTY", {
+    configurable: true,
+    value: inputIsTty
+  });
+  Object.defineProperty(stdout, "isTTY", {
+    configurable: true,
+    value: outputIsTty
+  });
+  Object.defineProperty(process.stderr, "isTTY", {
+    configurable: true,
+    value: outputIsTty
+  });
+}
+
+describe("linkedin fixtures record", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let tempDir = "";
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-cli-fixture-record-"));
+    process.exitCode = undefined;
+    setInteractiveMode(true, true);
+    vi.clearAllMocks();
+    readlineMocks.createInterface.mockImplementation(() => ({
+      close: readlineMocks.close,
+      question: readlineMocks.question
+    }));
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore();
+    process.exitCode = undefined;
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("assigns unique response files when fixture captures resolve out of order", async () => {
+    const firstBody = createDeferred<Buffer>();
+    const secondBody = createDeferred<Buffer>();
+    const manifestPath = path.join(tempDir, "manifest.json");
+    let responseHandler:
+      | ((response: TestFixtureCaptureResponse) => void)
+      | undefined;
+
+    const fakePage = {
+      content: vi.fn(async () => "<html><body>Fixture</body></html>"),
+      evaluate: vi.fn(async () => "en-US"),
+      goto: vi.fn(async () => {
+        responseHandler?.(
+          createFixtureResponse(
+            "https://www.linkedin.com/voyager/api/graphql?queryId=feed.fixture&variables=%7B%22start%22%3A0%7D",
+            firstBody.promise
+          )
+        );
+        responseHandler?.(
+          createFixtureResponse(
+            "https://www.linkedin.com/voyager/api/graphql?queryId=profile.fixture&variables=%7B%22start%22%3A0%7D",
+            secondBody.promise
+          )
+        );
+        secondBody.resolve(Buffer.from('{"fixture":"second"}', "utf8"));
+        firstBody.resolve(Buffer.from('{"fixture":"first"}', "utf8"));
+      }),
+      title: vi.fn(async () => "Feed"),
+      url: vi.fn(() => "https://www.linkedin.com/feed/"),
+      viewportSize: vi.fn(() => ({
+        height: 900,
+        width: 1440
+      })),
+      waitForTimeout: vi.fn(async () => undefined)
+    };
+    const fakeContext = {
+      addInitScript: vi.fn(),
+      newPage: vi.fn(async () => fakePage),
+      on: vi.fn((event: string, handler: (response: TestFixtureCaptureResponse) => void) => {
+        if (event === "response") {
+          responseHandler = handler;
+        }
+      }),
+      pages: vi.fn(() => [fakePage]),
+      route: vi.fn()
+    };
+    const runWithPersistentContextSpy = vi
+      .spyOn(core.ProfileManager.prototype, "runWithPersistentContext")
+      .mockImplementation(async (_profileName, _options, callback) => {
+        return await callback(fakeContext as unknown as BrowserContext);
+      });
+
+    try {
+      await runCli([
+        "node",
+        "linkedin",
+        "fixtures",
+        "record",
+        "--manifest",
+        manifestPath,
+        "--set",
+        "manual",
+        "--page",
+        "feed",
+        "--no-har"
+      ]);
+    } finally {
+      runWithPersistentContextSpy.mockRestore();
+    }
+
+    const routeFile = JSON.parse(
+      await readFile(path.join(tempDir, "manual", "routes.json"), "utf8")
+    ) as FixtureRecordRouteFile;
+
+    expect(routeFile.routes).toHaveLength(2);
+    expect(routeFile.routes.map((route) => route.url)).toEqual([
+      "https://www.linkedin.com/voyager/api/graphql?queryId=feed.fixture&variables=%7B%22start%22%3A0%7D",
+      "https://www.linkedin.com/voyager/api/graphql?queryId=profile.fixture&variables=%7B%22start%22%3A0%7D"
+    ]);
+    expect(routeFile.routes.map((route) => route.bodyPath)).toEqual([
+      "responses/0001-www.linkedin.com-voyager-api-graphql.json",
+      "responses/0002-www.linkedin.com-voyager-api-graphql.json"
+    ]);
+  });
+});

--- a/packages/core/src/__tests__/fixtureReplay.test.ts
+++ b/packages/core/src/__tests__/fixtureReplay.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFixtureRouteKey,
+  isLinkedInFixtureReplayUrl,
+  normalizeFixtureRouteHeaders
+} from "../fixtureReplay.js";
+
+describe("fixtureReplay helpers", () => {
+  it("normalizes route keys before replay lookup", () => {
+    expect(
+      buildFixtureRouteKey({
+        method: "get",
+        url: "https://www.linkedin.com/jobs/search/?location=Copenhagen&keywords=software%20engineer#results"
+      })
+    ).toBe(
+      buildFixtureRouteKey({
+        method: "GET",
+        url: "https://www.linkedin.com/jobs/search/?keywords=software%20engineer&location=Copenhagen"
+      })
+    );
+  });
+
+  it("normalizes response headers and strips unsafe transfer metadata", () => {
+    expect(
+      normalizeFixtureRouteHeaders({
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "123",
+        "Content-Encoding": "gzip",
+        "Transfer-Encoding": "chunked",
+        "X-Trace-Id": "fixture-1"
+      })
+    ).toEqual({
+      "content-type": "application/json; charset=utf-8",
+      "x-trace-id": "fixture-1"
+    });
+  });
+
+  it("matches only linkedin and licdn replay targets", () => {
+    expect(isLinkedInFixtureReplayUrl("https://www.linkedin.com/feed/")).toBe(true);
+    expect(isLinkedInFixtureReplayUrl("https://media.licdn.com/dms/image/foo")).toBe(true);
+    expect(isLinkedInFixtureReplayUrl("https://example.com/feed/")).toBe(false);
+    expect(isLinkedInFixtureReplayUrl("data:text/html,fixture")).toBe(false);
+  });
+});

--- a/packages/core/src/fixtureReplay.ts
+++ b/packages/core/src/fixtureReplay.ts
@@ -1,4 +1,4 @@
-import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { BrowserContext } from "playwright-core";
@@ -10,6 +10,12 @@ export const DEFAULT_FIXTURE_MANIFEST_PATH = path.resolve(
   "test/fixtures/manifest.json"
 );
 export const REPLAY_ROUTE_PATH = "/__linkedin_fixture__/replay";
+export const FIXTURE_REPLAY_ENV_KEYS = [
+  "LINKEDIN_E2E_REPLAY",
+  "LINKEDIN_E2E_FIXTURE_SERVER_URL",
+  "LINKEDIN_E2E_FIXTURE_SET",
+  "LINKEDIN_E2E_FIXTURE_MANIFEST"
+] as const;
 export const LINKEDIN_REPLAY_PAGE_TYPES = [
   "feed",
   "profile",
@@ -106,7 +112,6 @@ export interface StartedFixtureReplayServer {
 interface ReplayLookupEntry {
   body: Buffer;
   headers: Record<string, string>;
-  route: LinkedInFixtureRoute;
   status: number;
 }
 
@@ -116,16 +121,16 @@ interface ReplayRequestPayload {
 }
 
 interface MutableSharedServerState {
-  server: Server | undefined;
   promise: Promise<StartedFixtureReplayServer> | undefined;
   started: StartedFixtureReplayServer | undefined;
 }
 
 const sharedServerState: MutableSharedServerState = {
-  server: undefined,
   promise: undefined,
   started: undefined
 };
+
+const linkedInReplayPageTypes = new Set<string>(LINKEDIN_REPLAY_PAGE_TYPES);
 
 function readTrimmedEnv(name: string): string | undefined {
   const value = process.env[name];
@@ -173,7 +178,7 @@ function asFiniteNumber(value: unknown, label: string): number {
 
 function asPageType(value: unknown, label: string): LinkedInReplayPageType {
   const resolved = asString(value, label);
-  if ((LINKEDIN_REPLAY_PAGE_TYPES as readonly string[]).includes(resolved)) {
+  if (linkedInReplayPageTypes.has(resolved)) {
     return resolved as LinkedInReplayPageType;
   }
 
@@ -235,7 +240,7 @@ function parseRoute(value: unknown, label: string): LinkedInFixtureRoute {
   const headersRecord = asRecord(record.headers ?? {}, `${label}.headers`);
   const headers: Record<string, string> = {};
   for (const [headerKey, headerValue] of Object.entries(headersRecord)) {
-    headers[headerKey.toLowerCase()] = String(headerValue);
+    headers[headerKey] = String(headerValue);
   }
 
   const pageTypeValue = record.pageType;
@@ -243,7 +248,7 @@ function parseRoute(value: unknown, label: string): LinkedInFixtureRoute {
     method: asString(record.method, `${label}.method`).toUpperCase(),
     url: asString(record.url, `${label}.url`),
     status: asFiniteNumber(record.status, `${label}.status`),
-    headers,
+    headers: normalizeFixtureRouteHeaders(headers),
     ...(asOptionalString(record.bodyPath)
       ? { bodyPath: asString(record.bodyPath, `${label}.bodyPath`) }
       : {}),
@@ -310,8 +315,10 @@ function normalizeRouteUrl(url: string): string {
   return parsed.toString();
 }
 
-function buildRouteKey(method: string, url: string): string {
-  return `${method.toUpperCase()} ${normalizeRouteUrl(url)}`;
+export function buildFixtureRouteKey(
+  route: Pick<LinkedInFixtureRoute, "method" | "url">
+): string {
+  return `${route.method.toUpperCase()} ${normalizeRouteUrl(route.url)}`;
 }
 
 function resolveFixtureSetBaseDir(
@@ -332,7 +339,7 @@ async function readJsonFile(filePath: string): Promise<unknown> {
   return JSON.parse(await readFile(filePath, "utf8")) as unknown;
 }
 
-function isLinkedInReplayLikeUrl(url: string): boolean {
+export function isLinkedInFixtureReplayUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
     if (!(parsed.protocol === "http:" || parsed.protocol === "https:")) {
@@ -357,12 +364,33 @@ function getAgeDays(recordedAt: string): number {
   return Math.floor((Date.now() - recordedMs) / (24 * 60 * 60 * 1000));
 }
 
-function removeUnsafeHeaders(headers: Record<string, string>): Record<string, string> {
-  const safeHeaders = { ...headers };
-  delete safeHeaders["content-length"];
-  delete safeHeaders["content-encoding"];
-  delete safeHeaders["transfer-encoding"];
-  return safeHeaders;
+export function normalizeFixtureRouteHeaders(
+  headers: Record<string, string>
+): Record<string, string> {
+  const normalizedHeaders: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    normalizedHeaders[key.toLowerCase()] = value;
+  }
+
+  delete normalizedHeaders["content-length"];
+  delete normalizedHeaders["content-encoding"];
+  delete normalizedHeaders["transfer-encoding"];
+  return normalizedHeaders;
+}
+
+function assertFixtureFileFormat(
+  fileLabel: string,
+  filePath: string,
+  format: number
+): void {
+  if (format === LINKEDIN_FIXTURE_MANIFEST_FORMAT_VERSION) {
+    return;
+  }
+
+  throw new Error(
+    `${fileLabel} ${filePath} uses unsupported format ${format}. ` +
+      `Expected ${LINKEDIN_FIXTURE_MANIFEST_FORMAT_VERSION}.`
+  );
 }
 
 function createReplayMissBody(payload: ReplayRequestPayload): Buffer {
@@ -417,21 +445,18 @@ function writeServerResponse(
 }
 
 async function buildReplayLookup(
-  manifestPath: string,
-  summary: LinkedInFixtureSetSummary,
+  baseDir: string,
   routes: LinkedInFixtureRoute[]
 ): Promise<Map<string, ReplayLookupEntry>> {
-  const baseDir = resolveFixtureSetBaseDir(manifestPath, summary);
   const lookup = new Map<string, ReplayLookupEntry>();
 
   for (const route of routes) {
     const body = route.bodyPath
       ? await readFile(path.resolve(baseDir, route.bodyPath))
       : Buffer.from(route.bodyText ?? "", "utf8");
-    lookup.set(buildRouteKey(route.method, route.url), {
+    lookup.set(buildFixtureRouteKey(route), {
       body,
-      headers: removeUnsafeHeaders(route.headers),
-      route,
+      headers: normalizeFixtureRouteHeaders(route.headers),
       status: route.status
     });
   }
@@ -444,7 +469,7 @@ async function startFixtureReplayServer(
   requestedSetName?: string
 ): Promise<StartedFixtureReplayServer> {
   const fixtureSet = await loadLinkedInFixtureSet(manifestPath, requestedSetName);
-  const lookup = await buildReplayLookup(manifestPath, fixtureSet.summary, fixtureSet.routes);
+  const lookup = await buildReplayLookup(fixtureSet.baseDir, fixtureSet.routes);
 
   const server = createServer(async (request, response) => {
     try {
@@ -460,7 +485,7 @@ async function startFixtureReplayServer(
       }
 
       const payload = await readReplayRequestPayload(request);
-      const lookupEntry = lookup.get(buildRouteKey(payload.method, payload.url));
+      const lookupEntry = lookup.get(buildFixtureRouteKey(payload));
       if (!lookupEntry) {
         writeServerResponse(
           response,
@@ -521,7 +546,6 @@ async function startFixtureReplayServer(
     });
   });
 
-  sharedServerState.server = server;
   sharedServerState.started = started;
   return started;
 }
@@ -543,17 +567,14 @@ export function resolveFixtureManifestPath(manifestPath?: string): string {
 }
 
 export function getFixtureReplayEnvironment(): FixtureReplayEnvironment {
+  const serverUrl = readTrimmedEnv("LINKEDIN_E2E_FIXTURE_SERVER_URL");
+  const setName = readTrimmedEnv("LINKEDIN_E2E_FIXTURE_SET");
+
   return {
-    enabled:
-      readEnabledFlag("LINKEDIN_E2E_REPLAY") ||
-      readTrimmedEnv("LINKEDIN_E2E_FIXTURE_SERVER_URL") !== undefined,
+    enabled: readEnabledFlag("LINKEDIN_E2E_REPLAY") || serverUrl !== undefined,
     manifestPath: resolveFixtureManifestPath(),
-    ...(readTrimmedEnv("LINKEDIN_E2E_FIXTURE_SERVER_URL")
-      ? { serverUrl: asString(readTrimmedEnv("LINKEDIN_E2E_FIXTURE_SERVER_URL"), "LINKEDIN_E2E_FIXTURE_SERVER_URL") }
-      : {}),
-    ...(readTrimmedEnv("LINKEDIN_E2E_FIXTURE_SET")
-      ? { setName: asString(readTrimmedEnv("LINKEDIN_E2E_FIXTURE_SET"), "LINKEDIN_E2E_FIXTURE_SET") }
-      : {})
+    ...(serverUrl ? { serverUrl } : {}),
+    ...(setName ? { setName } : {})
   };
 }
 
@@ -565,12 +586,7 @@ export async function readLinkedInFixtureManifest(
   manifestPath: string = resolveFixtureManifestPath()
 ): Promise<LinkedInFixtureManifest> {
   const parsed = parseManifest(await readJsonFile(manifestPath), manifestPath);
-  if (parsed.format !== LINKEDIN_FIXTURE_MANIFEST_FORMAT_VERSION) {
-    throw new Error(
-      `Fixture manifest ${manifestPath} uses unsupported format ${parsed.format}. ` +
-        `Expected ${LINKEDIN_FIXTURE_MANIFEST_FORMAT_VERSION}.`
-    );
-  }
+  assertFixtureFileFormat("Fixture manifest", manifestPath, parsed.format);
 
   return parsed;
 }
@@ -603,12 +619,7 @@ export async function loadLinkedInFixtureSet(
 
   const routeFilePath = getResolvedRouteFilePath(manifestPath, summary);
   const parsedRouteFile = parseRouteFile(await readJsonFile(routeFilePath), routeFilePath);
-  if (parsedRouteFile.format !== LINKEDIN_FIXTURE_MANIFEST_FORMAT_VERSION) {
-    throw new Error(
-      `Fixture route file ${routeFilePath} uses unsupported format ${parsedRouteFile.format}. ` +
-        `Expected ${LINKEDIN_FIXTURE_MANIFEST_FORMAT_VERSION}.`
-    );
-  }
+  assertFixtureFileFormat("Fixture route file", routeFilePath, parsedRouteFile.format);
 
   return {
     manifestPath,
@@ -712,7 +723,6 @@ export async function ensureSharedFixtureReplayServer(): Promise<StartedFixtureR
 
 export function shutdownSharedFixtureReplayServer(): void {
   sharedServerState.started?.close();
-  sharedServerState.server = undefined;
   sharedServerState.started = undefined;
   sharedServerState.promise = undefined;
 }
@@ -743,7 +753,7 @@ export async function attachFixtureReplayToContext(
       return;
     }
 
-    if (!isLinkedInReplayLikeUrl(requestUrl)) {
+    if (!isLinkedInFixtureReplayUrl(requestUrl)) {
       await route.abort().catch(() => undefined);
       return;
     }
@@ -760,7 +770,9 @@ export async function attachFixtureReplayToContext(
     });
 
     const body = Buffer.from(await replayResponse.arrayBuffer());
-    const headers = removeUnsafeHeaders(Object.fromEntries(replayResponse.headers.entries()));
+    const headers = normalizeFixtureRouteHeaders(
+      Object.fromEntries(replayResponse.headers.entries())
+    );
     await route.fulfill({
       status: replayResponse.status,
       headers,


### PR DESCRIPTION
## Summary\n- consolidate fixture replay route-key, URL, header, and env helpers into core\n- keep fixture recording aligned with replay lookups and preserve custom fixture set roots\n- add regression tests for helper normalization and out-of-order fixture capture writes\n\n## Validation\n- npm run typecheck\n- npm run lint\n- npm test\n- npm run test:e2e:fixtures\n- npm run build\n\nCloses #114