### PR TITLE
test: harden fixture replay harness coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node": "^22.13.8",
         "@typescript-eslint/eslint-plugin": "^8.24.1",
         "@typescript-eslint/parser": "^8.24.1",
+        "@vitest/coverage-v8": "^3.2.4",
         "eslint": "^9.21.0",
         "globals": "^16.0.0",
         "typescript": "^5.8.2",
@@ -22,6 +23,80 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -746,12 +821,72 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@linkedin-assistant/cli": {
       "resolved": "packages/cli",
@@ -826,6 +961,17 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -1479,6 +1625,40 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -1686,6 +1866,19 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1718,6 +1911,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "4.0.3",
@@ -2146,10 +2358,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -2747,6 +2973,36 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -2838,6 +3094,28 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2924,6 +3202,13 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -3058,6 +3343,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3082,6 +3377,76 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jose": {
       "version": "6.1.3",
@@ -3193,6 +3558,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3201,6 +3573,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -3293,6 +3693,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -3452,6 +3862,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3491,6 +3908,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
@@ -4119,6 +4553,110 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4184,6 +4722,37 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/tinybench": {
@@ -4576,6 +5145,101 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -4621,7 +5285,8 @@
         "commander": "^13.1.0"
       },
       "bin": {
-        "linkedin": "dist/bin/linkedin.js"
+        "linkedin": "dist/bin/linkedin.js",
+        "owa": "dist/bin/linkedin.js"
       }
     },
     "packages/core": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/node": "^22.13.8",
     "@typescript-eslint/eslint-plugin": "^8.24.1",
     "@typescript-eslint/parser": "^8.24.1",
+    "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.21.0",
     "globals": "^16.0.0",
     "typescript": "^5.8.2",

--- a/packages/cli/test/fixturesCli.test.ts
+++ b/packages/cli/test/fixturesCli.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { stdin, stdout } from "node:process";
+import type { LinkedInReplayPageType } from "@linkedin-assistant/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@linkedin-assistant/core", async () =>
@@ -9,6 +10,14 @@ vi.mock("@linkedin-assistant/core", async () =>
 );
 
 import { runCli } from "../src/bin/linkedin.js";
+
+interface ReplayManifestPageEntry {
+  htmlPath: string;
+  pageType: LinkedInReplayPageType;
+  recordedAt: string;
+  title?: string;
+  url: string;
+}
 
 function setInteractiveMode(inputIsTty: boolean, outputIsTty: boolean): void {
   Object.defineProperty(stdin, "isTTY", {
@@ -29,7 +38,19 @@ async function writeJsonFixture(filePath: string, value: unknown): Promise<void>
   await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
 }
 
-function createReplayManifest(recordedAt: string, setName: string = "ci"): Record<string, unknown> {
+function createReplayManifest(
+  recordedAt: string,
+  setName: string = "ci",
+  pages: Partial<Record<LinkedInReplayPageType, ReplayManifestPageEntry>> = {
+    feed: {
+      pageType: "feed",
+      url: "https://www.linkedin.com/feed/",
+      htmlPath: "pages/app.html",
+      recordedAt,
+      title: "Feed"
+    }
+  }
+): Record<string, unknown> {
   return {
     format: 1,
     updatedAt: recordedAt,
@@ -45,15 +66,7 @@ function createReplayManifest(recordedAt: string, setName: string = "ci"): Recor
           height: 900
         },
         routesPath: "routes.json",
-        pages: {
-          feed: {
-            pageType: "feed",
-            url: "https://www.linkedin.com/feed/",
-            htmlPath: "pages/app.html",
-            recordedAt,
-            title: "Feed"
-          }
-        }
+        pages
       }
     }
   };
@@ -114,6 +127,33 @@ describe("linkedin fixtures commands", () => {
     expect(stderrChunks.join("\n")).toContain("Fixture page ci/feed was recorded");
   });
 
+  it("warns when a stale fixture set has no captured page entries", async () => {
+    const manifestPath = path.join(tempDir, "manifest.json");
+    await writeJsonFixture(
+      manifestPath,
+      createReplayManifest("2025-01-01T00:00:00.000Z", "manual", {})
+    );
+
+    await runCli([
+      "node",
+      "linkedin",
+      "fixtures",
+      "check",
+      "--manifest",
+      manifestPath,
+      "--set",
+      "manual"
+    ]);
+
+    expect(getLastJsonOutput()).toMatchObject({
+      manifest_path: path.resolve(manifestPath),
+      stale: true,
+      warning_count: 1,
+      set_name: "manual"
+    });
+    expect(stderrChunks.join("\n")).toContain("Fixture set manual was captured");
+  });
+
   it("supports the fixtures:check alias and scoped set validation", async () => {
     const manifestPath = path.join(tempDir, "manifest.json");
     await writeJsonFixture(manifestPath, createReplayManifest("2026-03-08T00:00:00.000Z", "manual"));
@@ -136,6 +176,24 @@ describe("linkedin fixtures commands", () => {
       warning_count: 0,
       set_name: "manual"
     });
+  });
+
+  it("fails fast when fixtures check targets an unknown set", async () => {
+    const manifestPath = path.join(tempDir, "manifest.json");
+    await writeJsonFixture(manifestPath, createReplayManifest("2026-03-08T00:00:00.000Z", "manual"));
+
+    await expect(
+      runCli([
+        "node",
+        "linkedin",
+        "fixtures",
+        "check",
+        "--manifest",
+        manifestPath,
+        "--set",
+        "missing"
+      ])
+    ).rejects.toThrow(`Fixture set missing is not defined in ${path.resolve(manifestPath)}.`);
   });
 
   it("requires an interactive terminal for fixture recording", async () => {

--- a/packages/cli/test/fixturesRecordCli.test.ts
+++ b/packages/cli/test/fixturesRecordCli.test.ts
@@ -27,6 +27,7 @@ import { runCli } from "../src/bin/linkedin.js";
 
 interface Deferred<T> {
   promise: Promise<T>;
+  reject: (error: Error) => void;
   resolve: (value: T) => void;
 }
 
@@ -47,31 +48,44 @@ interface TestFixtureCaptureResponse {
   url(): string;
 }
 
+const originalReplayEnabled = process.env.LINKEDIN_E2E_REPLAY;
+const originalFixtureManifest = process.env.LINKEDIN_E2E_FIXTURE_MANIFEST;
+const originalFixtureSet = process.env.LINKEDIN_E2E_FIXTURE_SET;
+const originalFixtureServerUrl = process.env.LINKEDIN_E2E_FIXTURE_SERVER_URL;
+
 function createDeferred<T>(): Deferred<T> {
   let resolveFn: ((value: T) => void) | undefined;
-  const promise = new Promise<T>((resolve) => {
+  let rejectFn: ((error: Error) => void) | undefined;
+  const promise = new Promise<T>((resolve, reject) => {
     resolveFn = resolve;
+    rejectFn = (error: Error) => {
+      reject(error);
+    };
   });
 
-  if (!resolveFn) {
-    throw new Error("Deferred promise did not initialize its resolver.");
+  promise.catch(() => undefined);
+
+  if (!resolveFn || !rejectFn) {
+    throw new Error("Deferred promise did not initialize its resolvers.");
   }
 
   return {
     promise,
+    reject: rejectFn,
     resolve: resolveFn
   };
 }
 
 function createFixtureResponse(
   url: string,
-  body: Promise<Buffer>
+  body: Promise<Buffer>,
+  contentType: string = "application/json; charset=utf-8"
 ): TestFixtureCaptureResponse {
   return {
     body: async () => await body,
     headers: () => ({
       "Content-Length": "15",
-      "Content-Type": "application/json; charset=utf-8"
+      "Content-Type": contentType
     }),
     request: () => ({
       method: () => "GET"
@@ -96,6 +110,32 @@ function setInteractiveMode(inputIsTty: boolean, outputIsTty: boolean): void {
   });
 }
 
+function restoreFixtureReplayEnvironment(): void {
+  if (originalReplayEnabled === undefined) {
+    delete process.env.LINKEDIN_E2E_REPLAY;
+  } else {
+    process.env.LINKEDIN_E2E_REPLAY = originalReplayEnabled;
+  }
+
+  if (originalFixtureManifest === undefined) {
+    delete process.env.LINKEDIN_E2E_FIXTURE_MANIFEST;
+  } else {
+    process.env.LINKEDIN_E2E_FIXTURE_MANIFEST = originalFixtureManifest;
+  }
+
+  if (originalFixtureSet === undefined) {
+    delete process.env.LINKEDIN_E2E_FIXTURE_SET;
+  } else {
+    process.env.LINKEDIN_E2E_FIXTURE_SET = originalFixtureSet;
+  }
+
+  if (originalFixtureServerUrl === undefined) {
+    delete process.env.LINKEDIN_E2E_FIXTURE_SERVER_URL;
+  } else {
+    process.env.LINKEDIN_E2E_FIXTURE_SERVER_URL = originalFixtureServerUrl;
+  }
+}
+
 describe("linkedin fixtures record", () => {
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
   let tempDir = "";
@@ -115,6 +155,8 @@ describe("linkedin fixtures record", () => {
   afterEach(async () => {
     consoleLogSpy.mockRestore();
     process.exitCode = undefined;
+    restoreFixtureReplayEnvironment();
+    core.shutdownSharedFixtureReplayServer();
     await rm(tempDir, { recursive: true, force: true });
   });
 
@@ -201,5 +243,219 @@ describe("linkedin fixtures record", () => {
       "responses/0001-www.linkedin.com-voyager-api-graphql.json",
       "responses/0002-www.linkedin.com-voyager-api-graphql.json"
     ]);
+  });
+
+  it("restores replay environment variables when manual capture fails", async () => {
+    const manifestPath = path.join(tempDir, "manifest.json");
+    process.env.LINKEDIN_E2E_REPLAY = "1";
+    process.env.LINKEDIN_E2E_FIXTURE_MANIFEST = "/tmp/original-manifest.json";
+    process.env.LINKEDIN_E2E_FIXTURE_SET = "original-set";
+    process.env.LINKEDIN_E2E_FIXTURE_SERVER_URL = "http://127.0.0.1:45555";
+
+    const runWithPersistentContextSpy = vi
+      .spyOn(core.ProfileManager.prototype, "runWithPersistentContext")
+      .mockImplementation(async () => {
+        expect(process.env.LINKEDIN_E2E_REPLAY).toBeUndefined();
+        expect(process.env.LINKEDIN_E2E_FIXTURE_MANIFEST).toBeUndefined();
+        expect(process.env.LINKEDIN_E2E_FIXTURE_SET).toBeUndefined();
+        expect(process.env.LINKEDIN_E2E_FIXTURE_SERVER_URL).toBeUndefined();
+        throw new Error("capture failed");
+      });
+
+    try {
+      await expect(
+        runCli([
+          "node",
+          "linkedin",
+          "fixtures",
+          "record",
+          "--manifest",
+          manifestPath,
+          "--set",
+          "manual",
+          "--page",
+          "feed",
+          "--no-har"
+        ])
+      ).rejects.toThrow("capture failed");
+    } finally {
+      runWithPersistentContextSpy.mockRestore();
+    }
+
+    expect(process.env.LINKEDIN_E2E_REPLAY).toBe("1");
+    expect(process.env.LINKEDIN_E2E_FIXTURE_MANIFEST).toBe("/tmp/original-manifest.json");
+    expect(process.env.LINKEDIN_E2E_FIXTURE_SET).toBe("original-set");
+    expect(process.env.LINKEDIN_E2E_FIXTURE_SERVER_URL).toBe("http://127.0.0.1:45555");
+  });
+
+  it("writes empty fallback bodies and ignores non-linkedin responses", async () => {
+    const manifestPath = path.join(tempDir, "manifest.json");
+    let responseHandler:
+      | ((response: TestFixtureCaptureResponse) => void)
+      | undefined;
+
+    const failingBody = createDeferred<Buffer>();
+    const fakePage = {
+      content: vi.fn(async () => "<html><body>Fixture</body></html>"),
+      evaluate: vi.fn(async () => "en-US"),
+      goto: vi.fn(async () => {
+        responseHandler?.(
+          createFixtureResponse(
+            "https://example.com/not-captured.json",
+            Promise.resolve(Buffer.from('{"ignore":true}', "utf8"))
+          )
+        );
+        responseHandler?.(
+          createFixtureResponse(
+            "https://www.linkedin.com/voyager/api/graphql?queryId=feed.partial&variables=%7B%22start%22%3A0%7D",
+            failingBody.promise
+          )
+        );
+        failingBody.reject(new Error("socket hang up"));
+      }),
+      title: vi.fn(async () => "Feed"),
+      url: vi.fn(() => "https://www.linkedin.com/feed/"),
+      viewportSize: vi.fn(() => ({
+        height: 900,
+        width: 1440
+      })),
+      waitForTimeout: vi.fn(async () => undefined)
+    };
+    const fakeContext = {
+      addInitScript: vi.fn(),
+      newPage: vi.fn(async () => fakePage),
+      on: vi.fn((event: string, handler: (response: TestFixtureCaptureResponse) => void) => {
+        if (event === "response") {
+          responseHandler = handler;
+        }
+      }),
+      pages: vi.fn(() => [fakePage]),
+      route: vi.fn()
+    };
+    const runWithPersistentContextSpy = vi
+      .spyOn(core.ProfileManager.prototype, "runWithPersistentContext")
+      .mockImplementation(async (_profileName, _options, callback) => {
+        return await callback(fakeContext as unknown as BrowserContext);
+      });
+
+    try {
+      await runCli([
+        "node",
+        "linkedin",
+        "fixtures",
+        "record",
+        "--manifest",
+        manifestPath,
+        "--set",
+        "manual",
+        "--page",
+        "feed",
+        "--no-har"
+      ]);
+    } finally {
+      runWithPersistentContextSpy.mockRestore();
+    }
+
+    const routeFile = JSON.parse(
+      await readFile(path.join(tempDir, "manual", "routes.json"), "utf8")
+    ) as FixtureRecordRouteFile;
+    const savedBodyPath = routeFile.routes[0]?.bodyPath;
+
+    expect(routeFile.routes).toHaveLength(1);
+    expect(routeFile.routes[0]?.url).toBe(
+      "https://www.linkedin.com/voyager/api/graphql?queryId=feed.partial&variables=%7B%22start%22%3A0%7D"
+    );
+    if (!savedBodyPath) {
+      throw new Error("Expected a recorded response body path.");
+    }
+
+    const savedBody = await readFile(path.join(tempDir, "manual", savedBodyPath));
+    expect(savedBody).toHaveLength(0);
+  });
+
+  it("records fixtures that can be replayed end-to-end", async () => {
+    const manifestPath = path.join(tempDir, "manifest.json");
+    const setName = "manual ø";
+    const feedHtml = "<html><body>Recorded feed</body></html>";
+    let responseHandler:
+      | ((response: TestFixtureCaptureResponse) => void)
+      | undefined;
+
+    const fakePage = {
+      content: vi.fn(async () => feedHtml),
+      evaluate: vi.fn(async () => "da-DK"),
+      goto: vi.fn(async () => {
+        responseHandler?.(
+          createFixtureResponse(
+            "https://www.linkedin.com/feed/",
+            Promise.resolve(Buffer.from(feedHtml, "utf8")),
+            "text/html; charset=utf-8"
+          )
+        );
+      }),
+      title: vi.fn(async () => "Feed"),
+      url: vi.fn(() => "https://www.linkedin.com/feed/"),
+      viewportSize: vi.fn(() => ({
+        height: 900,
+        width: 1440
+      })),
+      waitForTimeout: vi.fn(async () => undefined)
+    };
+    const fakeContext = {
+      addInitScript: vi.fn(),
+      newPage: vi.fn(async () => fakePage),
+      on: vi.fn((event: string, handler: (response: TestFixtureCaptureResponse) => void) => {
+        if (event === "response") {
+          responseHandler = handler;
+        }
+      }),
+      pages: vi.fn(() => [fakePage]),
+      route: vi.fn()
+    };
+    const runWithPersistentContextSpy = vi
+      .spyOn(core.ProfileManager.prototype, "runWithPersistentContext")
+      .mockImplementation(async (_profileName, _options, callback) => {
+        return await callback(fakeContext as unknown as BrowserContext);
+      });
+
+    try {
+      await runCli([
+        "node",
+        "linkedin",
+        "fixtures",
+        "record",
+        "--manifest",
+        manifestPath,
+        "--set",
+        setName,
+        "--page",
+        "feed",
+        "--no-har"
+      ]);
+    } finally {
+      runWithPersistentContextSpy.mockRestore();
+    }
+
+    process.env.LINKEDIN_E2E_REPLAY = "1";
+    process.env.LINKEDIN_E2E_FIXTURE_MANIFEST = manifestPath;
+    process.env.LINKEDIN_E2E_FIXTURE_SET = setName;
+
+    const replayServer = await core.ensureSharedFixtureReplayServer();
+    const response = await fetch(`${replayServer?.baseUrl}${core.REPLAY_ROUTE_PATH}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        method: "GET",
+        url: "https://www.linkedin.com/feed/"
+      })
+    });
+
+    expect(replayServer).toMatchObject({
+      setName
+    });
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("Recorded feed");
   });
 });

--- a/packages/core/src/__tests__/fixtureReplay.test.ts
+++ b/packages/core/src/__tests__/fixtureReplay.test.ts
@@ -1,9 +1,204 @@
-import { describe, expect, it } from "vitest";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { BrowserContext } from "playwright-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  REPLAY_ROUTE_PATH,
+  attachFixtureReplayToContext,
   buildFixtureRouteKey,
+  checkLinkedInFixtureStaleness,
+  createEmptyFixtureManifest,
+  ensureSharedFixtureReplayServer,
+  getFixtureReplayEnvironment,
   isLinkedInFixtureReplayUrl,
-  normalizeFixtureRouteHeaders
+  loadLinkedInFixtureSet,
+  normalizeFixtureRouteHeaders,
+  readLinkedInFixtureManifest,
+  resolveFixtureManifestPath,
+  shutdownSharedFixtureReplayServer,
+  type LinkedInFixtureManifest,
+  type LinkedInFixtureRoute,
+  type LinkedInReplayPageType
 } from "../fixtureReplay.js";
+
+interface TestFixturePageEntry {
+  htmlPath: string;
+  pageType: LinkedInReplayPageType;
+  recordedAt: string;
+  title?: string;
+  url: string;
+}
+
+interface CreateFixtureSetInput {
+  capturedAt?: string;
+  locale?: string;
+  manifestFormat?: number;
+  pages?: Partial<Record<LinkedInReplayPageType, TestFixturePageEntry>>;
+  responseFiles?: Record<string, Buffer | string>;
+  rootDir?: string;
+  routeFormat?: number;
+  routes?: LinkedInFixtureRoute[];
+  routesPath?: string;
+  setName?: string;
+}
+
+interface CreatedFixtureSet {
+  manifestPath: string;
+  setName: string;
+  setRootDir: string;
+  tempDir: string;
+}
+
+interface TestReplayRoute {
+  abort: ReturnType<typeof vi.fn>;
+  continue: ReturnType<typeof vi.fn>;
+  fulfill: ReturnType<typeof vi.fn>;
+  request(): {
+    method(): string;
+    url(): string;
+  };
+}
+
+const originalReplayEnabled = process.env.LINKEDIN_E2E_REPLAY;
+const originalFixtureManifest = process.env.LINKEDIN_E2E_FIXTURE_MANIFEST;
+const originalFixtureSet = process.env.LINKEDIN_E2E_FIXTURE_SET;
+const originalFixtureServerUrl = process.env.LINKEDIN_E2E_FIXTURE_SERVER_URL;
+
+let tempDirs: string[] = [];
+
+async function createTempDir(prefix: string): Promise<string> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(tempDir);
+  return tempDir;
+}
+
+async function writeJsonFixture(filePath: string, value: unknown): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+async function createFixtureSet(input: CreateFixtureSetInput = {}): Promise<CreatedFixtureSet> {
+  const tempDir = await createTempDir("linkedin-fixture-replay-");
+  const setName = input.setName ?? "ci";
+  const rootDir = input.rootDir ?? setName;
+  const routesPath = input.routesPath ?? "routes.json";
+  const capturedAt = input.capturedAt ?? "2026-03-09T10:00:00.000Z";
+  const manifestPath = path.join(tempDir, "manifest.json");
+  const setRootDir = path.join(tempDir, rootDir);
+  const pages = input.pages ?? {
+    feed: {
+      pageType: "feed",
+      url: "https://www.linkedin.com/feed/",
+      htmlPath: "pages/feed.html",
+      recordedAt: capturedAt,
+      title: "Feed"
+    }
+  };
+
+  const manifest: LinkedInFixtureManifest = {
+    format: input.manifestFormat ?? 1,
+    updatedAt: capturedAt,
+    defaultSetName: setName,
+    sets: {
+      [setName]: {
+        setName,
+        rootDir,
+        locale: input.locale ?? "en-US",
+        capturedAt,
+        viewport: {
+          width: 1440,
+          height: 900
+        },
+        routesPath,
+        pages
+      }
+    }
+  };
+
+  await writeJsonFixture(manifestPath, manifest);
+  await writeJsonFixture(path.join(setRootDir, routesPath), {
+    format: input.routeFormat ?? 1,
+    setName,
+    routes: input.routes ?? []
+  });
+
+  for (const [relativePath, body] of Object.entries(input.responseFiles ?? {})) {
+    const absolutePath = path.join(setRootDir, relativePath);
+    await mkdir(path.dirname(absolutePath), { recursive: true });
+    await writeFile(absolutePath, body);
+  }
+
+  return {
+    manifestPath,
+    setName,
+    setRootDir,
+    tempDir
+  };
+}
+
+function enableReplay(manifestPath: string, setName?: string): void {
+  process.env.LINKEDIN_E2E_REPLAY = "1";
+  process.env.LINKEDIN_E2E_FIXTURE_MANIFEST = manifestPath;
+  if (setName === undefined) {
+    delete process.env.LINKEDIN_E2E_FIXTURE_SET;
+  } else {
+    process.env.LINKEDIN_E2E_FIXTURE_SET = setName;
+  }
+  delete process.env.LINKEDIN_E2E_FIXTURE_SERVER_URL;
+}
+
+function restoreFixtureReplayEnvironment(): void {
+  if (originalReplayEnabled === undefined) {
+    delete process.env.LINKEDIN_E2E_REPLAY;
+  } else {
+    process.env.LINKEDIN_E2E_REPLAY = originalReplayEnabled;
+  }
+
+  if (originalFixtureManifest === undefined) {
+    delete process.env.LINKEDIN_E2E_FIXTURE_MANIFEST;
+  } else {
+    process.env.LINKEDIN_E2E_FIXTURE_MANIFEST = originalFixtureManifest;
+  }
+
+  if (originalFixtureSet === undefined) {
+    delete process.env.LINKEDIN_E2E_FIXTURE_SET;
+  } else {
+    process.env.LINKEDIN_E2E_FIXTURE_SET = originalFixtureSet;
+  }
+
+  if (originalFixtureServerUrl === undefined) {
+    delete process.env.LINKEDIN_E2E_FIXTURE_SERVER_URL;
+  } else {
+    process.env.LINKEDIN_E2E_FIXTURE_SERVER_URL = originalFixtureServerUrl;
+  }
+}
+
+function createRouteMock(url: string, method: string = "GET"): TestReplayRoute {
+  return {
+    abort: vi.fn(async () => undefined),
+    continue: vi.fn(async () => undefined),
+    fulfill: vi.fn(async () => undefined),
+    request: () => ({
+      method: () => method,
+      url: () => url
+    })
+  };
+}
+
+afterEach(async () => {
+  shutdownSharedFixtureReplayServer();
+  restoreFixtureReplayEnvironment();
+  vi.restoreAllMocks();
+  vi.resetModules();
+
+  await Promise.all(
+    tempDirs.map(async (tempDir) => {
+      await rm(tempDir, { recursive: true, force: true });
+    })
+  );
+  tempDirs = [];
+});
 
 describe("fixtureReplay helpers", () => {
   it("normalizes route keys before replay lookup", () => {
@@ -35,10 +230,492 @@ describe("fixtureReplay helpers", () => {
     });
   });
 
-  it("matches only linkedin and licdn replay targets", () => {
+  it("matches only real linkedin and licdn replay targets", () => {
     expect(isLinkedInFixtureReplayUrl("https://www.linkedin.com/feed/")).toBe(true);
     expect(isLinkedInFixtureReplayUrl("https://media.licdn.com/dms/image/foo")).toBe(true);
+    expect(isLinkedInFixtureReplayUrl("https://static.linkedin.com/sc/h/app.js")).toBe(true);
+    expect(isLinkedInFixtureReplayUrl("https://evil-linkedin.com/feed/")).toBe(false);
+    expect(isLinkedInFixtureReplayUrl("https://examplelicdn.com/media/image")).toBe(false);
     expect(isLinkedInFixtureReplayUrl("https://example.com/feed/")).toBe(false);
     expect(isLinkedInFixtureReplayUrl("data:text/html,fixture")).toBe(false);
+  });
+});
+
+describe("fixtureReplay manifests and staleness", () => {
+  it("loads fixture sets from env-resolved manifests and special-character paths", async () => {
+    const fixtureSet = await createFixtureSet({
+      setName: "manual ø",
+      rootDir: "fixture set/ø-zone",
+      routes: [
+        {
+          method: "GET",
+          url: "https://www.linkedin.com/feed/",
+          status: 200,
+          headers: {
+            "Content-Type": "text/html; charset=utf-8"
+          },
+          bodyPath: "responses/feed snapshot.html"
+        },
+        {
+          method: "POST",
+          url: "https://www.linkedin.com/voyager/api/graphql?b=2&a=1",
+          status: 201,
+          headers: {
+            "Content-Type": "application/json; charset=utf-8"
+          },
+          bodyText: '{"ok":true}'
+        }
+      ],
+      responseFiles: {
+        "responses/feed snapshot.html": "<html><body>fixture</body></html>"
+      }
+    });
+
+    process.env.LINKEDIN_E2E_FIXTURE_MANIFEST = fixtureSet.manifestPath;
+
+    expect(resolveFixtureManifestPath()).toBe(path.resolve(fixtureSet.manifestPath));
+    expect(createEmptyFixtureManifest({ defaultSetName: fixtureSet.setName })).toMatchObject({
+      defaultSetName: fixtureSet.setName,
+      sets: {}
+    });
+    expect(getFixtureReplayEnvironment()).toMatchObject({
+      enabled: false,
+      manifestPath: path.resolve(fixtureSet.manifestPath)
+    });
+
+    const manifest = await readLinkedInFixtureManifest(fixtureSet.manifestPath);
+    const loadedSet = await loadLinkedInFixtureSet(
+      fixtureSet.manifestPath,
+      fixtureSet.setName
+    );
+
+    expect(manifest.defaultSetName).toBe(fixtureSet.setName);
+    expect(loadedSet.baseDir).toBe(path.resolve(fixtureSet.setRootDir));
+    expect(loadedSet.routes).toHaveLength(2);
+    expect(loadedSet.routes[0]?.bodyPath).toBe("responses/feed snapshot.html");
+    expect(loadedSet.routes[1]?.bodyText).toBe('{"ok":true}');
+  });
+
+  it("rejects empty and corrupt fixture manifests", async () => {
+    const tempDir = await createTempDir("linkedin-fixture-empty-");
+    const emptyManifestPath = path.join(tempDir, "empty-manifest.json");
+    const corruptManifestPath = path.join(tempDir, "corrupt-manifest.json");
+
+    await writeJsonFixture(emptyManifestPath, createEmptyFixtureManifest());
+    await writeFile(corruptManifestPath, "{\n  not-json\n", "utf8");
+
+    await expect(loadLinkedInFixtureSet(emptyManifestPath)).rejects.toThrow(
+      "does not define any sets"
+    );
+    await expect(readLinkedInFixtureManifest(corruptManifestPath)).rejects.toThrow();
+  });
+
+  it("rejects malformed route files and missing response bodies", async () => {
+    const malformedFixtureSet = await createFixtureSet();
+    await writeJsonFixture(path.join(malformedFixtureSet.setRootDir, "routes.json"), {
+      format: 1,
+      setName: malformedFixtureSet.setName,
+      routes: {
+        invalid: true
+      }
+    });
+
+    await expect(
+      loadLinkedInFixtureSet(malformedFixtureSet.manifestPath, malformedFixtureSet.setName)
+    ).rejects.toThrow("routes must be an array");
+
+    const missingBodyFixtureSet = await createFixtureSet({
+      routes: [
+        {
+          method: "GET",
+          url: "https://www.linkedin.com/feed/",
+          status: 200,
+          headers: {
+            "Content-Type": "text/html; charset=utf-8"
+          },
+          bodyPath: "responses/missing.html"
+        }
+      ]
+    });
+
+    enableReplay(missingBodyFixtureSet.manifestPath, missingBodyFixtureSet.setName);
+
+    await expect(ensureSharedFixtureReplayServer()).rejects.toThrow("ENOENT");
+  });
+
+  it("rejects replay route body paths that escape the fixture set directory", async () => {
+    const fixtureSet = await createFixtureSet({
+      routes: [
+        {
+          method: "GET",
+          url: "https://www.linkedin.com/feed/",
+          status: 200,
+          headers: {
+            "Content-Type": "text/html; charset=utf-8"
+          },
+          bodyPath: "../outside.html"
+        }
+      ]
+    });
+
+    enableReplay(fixtureSet.manifestPath, fixtureSet.setName);
+
+    await expect(ensureSharedFixtureReplayServer()).rejects.toThrow(
+      "must stay within"
+    );
+  });
+
+  it("warns on stale empty sets and invalid recorded timestamps", async () => {
+    const emptyFixtureSet = await createFixtureSet({
+      capturedAt: "2025-01-01T00:00:00.000Z",
+      pages: {}
+    });
+    const invalidTimestampFixtureSet = await createFixtureSet({
+      pages: {
+        feed: {
+          pageType: "feed",
+          url: "https://www.linkedin.com/feed/",
+          htmlPath: "pages/feed.html",
+          recordedAt: "not-a-date",
+          title: "Feed"
+        }
+      }
+    });
+
+    const emptyWarnings = await checkLinkedInFixtureStaleness(emptyFixtureSet.manifestPath, {
+      maxAgeDays: 30
+    });
+    const invalidWarnings = await checkLinkedInFixtureStaleness(
+      invalidTimestampFixtureSet.manifestPath,
+      {
+        maxAgeDays: 1
+      }
+    );
+
+    expect(emptyWarnings).toHaveLength(1);
+    expect(emptyWarnings[0]).toMatchObject({
+      setName: emptyFixtureSet.setName
+    });
+    expect(emptyWarnings[0]).not.toHaveProperty("pageType");
+    await expect(
+      checkLinkedInFixtureStaleness(emptyFixtureSet.manifestPath, {
+        setName: "missing",
+        maxAgeDays: 30
+      })
+    ).rejects.toThrow(`Fixture set missing is not defined in ${emptyFixtureSet.manifestPath}.`);
+    expect(invalidWarnings).toHaveLength(1);
+    expect(invalidWarnings[0]?.ageDays).toBe(Number.POSITIVE_INFINITY);
+  });
+});
+
+describe("fixtureReplay server", () => {
+  it("starts one shared server for concurrent callers and serves concurrent lookups", async () => {
+    const largeBody = JSON.stringify({
+      payload: "x".repeat(256 * 1024)
+    });
+    const fixtureSet = await createFixtureSet({
+      routes: [
+        {
+          method: "GET",
+          url: "https://www.linkedin.com/feed/",
+          status: 200,
+          headers: {
+            "Content-Type": "text/html; charset=utf-8"
+          },
+          bodyText: "<html><body>feed fixture</body></html>"
+        },
+        {
+          method: "GET",
+          url: "https://www.linkedin.com/voyager/api/graphql?queryId=fixture.large&variables=%7B%22start%22%3A0%7D",
+          status: 200,
+          headers: {
+            "Content-Type": "application/json; charset=utf-8"
+          },
+          bodyPath: "responses/large payload.json"
+        }
+      ],
+      responseFiles: {
+        "responses/large payload.json": largeBody
+      }
+    });
+
+    enableReplay(fixtureSet.manifestPath, fixtureSet.setName);
+
+    const [firstServer, secondServer, thirdServer] = await Promise.all([
+      ensureSharedFixtureReplayServer(),
+      ensureSharedFixtureReplayServer(),
+      ensureSharedFixtureReplayServer()
+    ]);
+    const reusedServer = await ensureSharedFixtureReplayServer();
+
+    expect(firstServer?.baseUrl).toBe(secondServer?.baseUrl);
+    expect(firstServer?.baseUrl).toBe(thirdServer?.baseUrl);
+    expect(reusedServer).toBe(firstServer);
+
+    const postResponse = await fetch(`${firstServer?.baseUrl}${REPLAY_ROUTE_PATH}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        method: "GET",
+        url: "https://www.linkedin.com/feed/"
+      })
+    });
+
+    expect(postResponse.status).toBe(200);
+    expect(await postResponse.text()).toContain("feed fixture");
+
+    const replayLookupUrl =
+      `${firstServer?.baseUrl}${REPLAY_ROUTE_PATH}` +
+      "?method=GET&url=" +
+      encodeURIComponent(
+        "https://www.linkedin.com/voyager/api/graphql?queryId=fixture.large&variables=%7B%22start%22%3A0%7D"
+      );
+
+    const concurrentBodies = await Promise.all(
+      Array.from({ length: 8 }, async () => {
+        const response = await fetch(replayLookupUrl);
+        return {
+          body: await response.text(),
+          status: response.status
+        };
+      })
+    );
+
+    expect(concurrentBodies.every((entry) => entry.status === 200)).toBe(true);
+    expect(concurrentBodies.every((entry) => entry.body === largeBody)).toBe(true);
+  });
+
+  it("returns structured fixture misses and request parsing failures", async () => {
+    const fixtureSet = await createFixtureSet();
+    enableReplay(fixtureSet.manifestPath, fixtureSet.setName);
+
+    const replayServer = await ensureSharedFixtureReplayServer();
+    const missingRouteResponse = await fetch(`${replayServer?.baseUrl}${REPLAY_ROUTE_PATH}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        method: "GET",
+        url: "https://www.linkedin.com/does-not-exist/"
+      })
+    });
+    const malformedPayloadResponse = await fetch(
+      `${replayServer?.baseUrl}${REPLAY_ROUTE_PATH}`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json"
+        },
+        body: "{"
+      }
+    );
+    const unknownPathResponse = await fetch(`${replayServer?.baseUrl}/not-found`);
+
+    expect(missingRouteResponse.status).toBe(404);
+    expect(await missingRouteResponse.json()).toMatchObject({
+      error: "fixture_not_found",
+      method: "GET",
+      url: "https://www.linkedin.com/does-not-exist/"
+    });
+
+    expect(malformedPayloadResponse.status).toBe(500);
+    expect(await malformedPayloadResponse.json()).toMatchObject({
+      error: "fixture_replay_error"
+    });
+
+    expect(unknownPathResponse.status).toBe(404);
+    expect(await unknownPathResponse.json()).toEqual({
+      error: "not_found"
+    });
+  });
+
+  it("uses an externally managed replay server when configured", async () => {
+    const fixtureSet = await createFixtureSet({
+      setName: "external"
+    });
+
+    process.env.LINKEDIN_E2E_FIXTURE_MANIFEST = fixtureSet.manifestPath;
+    process.env.LINKEDIN_E2E_FIXTURE_SET = fixtureSet.setName;
+    process.env.LINKEDIN_E2E_FIXTURE_SERVER_URL = " http://127.0.0.1:45555 ";
+    delete process.env.LINKEDIN_E2E_REPLAY;
+
+    expect(getFixtureReplayEnvironment()).toMatchObject({
+      enabled: true,
+      manifestPath: path.resolve(fixtureSet.manifestPath),
+      serverUrl: "http://127.0.0.1:45555",
+      setName: fixtureSet.setName
+    });
+
+    const replayServer = await ensureSharedFixtureReplayServer();
+
+    expect(replayServer).toMatchObject({
+      baseUrl: "http://127.0.0.1:45555",
+      manifestPath: fixtureSet.manifestPath,
+      setName: fixtureSet.setName
+    });
+  });
+
+  it("surfaces replay server startup failures such as port conflicts", async () => {
+    const fixtureSet = await createFixtureSet();
+    enableReplay(fixtureSet.manifestPath, fixtureSet.setName);
+
+    let errorHandler: ((error: Error) => void) | undefined;
+    const fakeServer = {
+      address: vi.fn(() => null),
+      close: vi.fn(),
+      listen: vi.fn(() => {
+        errorHandler?.(
+          Object.assign(
+            new Error("listen EADDRINUSE: address already in use 127.0.0.1"),
+            {
+              code: "EADDRINUSE"
+            }
+          )
+        );
+        return fakeServer;
+      }),
+      once: vi.fn((event: string, handler: (error: Error) => void) => {
+        if (event === "error") {
+          errorHandler = handler;
+        }
+        return fakeServer;
+      }),
+      removeListener: vi.fn(() => fakeServer),
+      unref: vi.fn()
+    };
+
+    vi.doMock("node:http", async () => {
+      const actual = await vi.importActual<typeof import("node:http")>("node:http");
+      return {
+        ...actual,
+        createServer: vi.fn(() => fakeServer)
+      };
+    });
+
+    const fixtureReplayModule = await import("../fixtureReplay.js");
+
+    await expect(fixtureReplayModule.ensureSharedFixtureReplayServer()).rejects.toThrow(
+      "EADDRINUSE"
+    );
+
+    fixtureReplayModule.shutdownSharedFixtureReplayServer();
+    vi.doUnmock("node:http");
+  });
+});
+
+describe("fixtureReplay browser routing", () => {
+  it("returns undefined without mutating browser contexts when replay is disabled", async () => {
+    delete process.env.LINKEDIN_E2E_REPLAY;
+    delete process.env.LINKEDIN_E2E_FIXTURE_MANIFEST;
+    delete process.env.LINKEDIN_E2E_FIXTURE_SET;
+    delete process.env.LINKEDIN_E2E_FIXTURE_SERVER_URL;
+
+    const context = {
+      addInitScript: vi.fn(async () => undefined),
+      route: vi.fn(async () => undefined)
+    };
+
+    const replayServer = await attachFixtureReplayToContext(
+      context as unknown as BrowserContext
+    );
+
+    expect(replayServer).toBeUndefined();
+    expect(context.addInitScript).not.toHaveBeenCalled();
+    expect(context.route).not.toHaveBeenCalled();
+  });
+
+  it("attaches replay routing to browser contexts and fails closed for third-party traffic", async () => {
+    const fixtureSet = await createFixtureSet({
+      routes: [
+        {
+          method: "GET",
+          url: "https://www.linkedin.com/feed/",
+          status: 200,
+          headers: {
+            "Content-Type": "text/html; charset=utf-8",
+            "X-Fixture": "feed"
+          },
+          bodyText: "<html><body>feed fixture</body></html>"
+        }
+      ]
+    });
+    enableReplay(fixtureSet.manifestPath, fixtureSet.setName);
+
+    let routeHandler: ((route: TestReplayRoute) => Promise<void>) | undefined;
+    const context = {
+      addInitScript: vi.fn(async () => undefined),
+      route: vi.fn(async (_matcher: string, handler: (route: TestReplayRoute) => Promise<void>) => {
+        routeHandler = handler;
+      })
+    };
+
+    const replayServer = await attachFixtureReplayToContext(
+      context as unknown as BrowserContext
+    );
+    if (!routeHandler || !replayServer) {
+      throw new Error("Fixture replay route handler was not attached.");
+    }
+
+    expect(context.addInitScript).toHaveBeenCalledTimes(1);
+    expect(context.route).toHaveBeenCalledWith("**/*", expect.any(Function));
+
+    const dataRoute = createRouteMock("data:text/html,fixture");
+    const replayOriginRoute = createRouteMock(`${replayServer.baseUrl}${REPLAY_ROUTE_PATH}`);
+    const thirdPartyRoute = createRouteMock("https://example.com/app.js");
+    const linkedInRoute = createRouteMock("https://www.linkedin.com/feed/");
+
+    await routeHandler(dataRoute);
+    await routeHandler(replayOriginRoute);
+    await routeHandler(thirdPartyRoute);
+    await routeHandler(linkedInRoute);
+
+    expect(dataRoute.continue).toHaveBeenCalledTimes(1);
+    expect(replayOriginRoute.continue).toHaveBeenCalledTimes(1);
+    expect(thirdPartyRoute.abort).toHaveBeenCalledTimes(1);
+    expect(linkedInRoute.fulfill).toHaveBeenCalledTimes(1);
+    expect(linkedInRoute.fulfill).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 200,
+        headers: expect.objectContaining({
+          "content-type": "text/html; charset=utf-8",
+          "x-fixture": "feed"
+        })
+      })
+    );
+
+    const fulfilledBody = linkedInRoute.fulfill.mock.calls[0]?.[0]?.body;
+    expect(fulfilledBody).toEqual(Buffer.from("<html><body>feed fixture</body></html>"));
+  });
+
+  it("surfaces network failures when the configured replay server is unreachable", async () => {
+    const fixtureSet = await createFixtureSet({
+      setName: "remote"
+    });
+
+    process.env.LINKEDIN_E2E_FIXTURE_MANIFEST = fixtureSet.manifestPath;
+    process.env.LINKEDIN_E2E_FIXTURE_SET = fixtureSet.setName;
+    process.env.LINKEDIN_E2E_FIXTURE_SERVER_URL = "http://127.0.0.1:1";
+    delete process.env.LINKEDIN_E2E_REPLAY;
+
+    let routeHandler: ((route: TestReplayRoute) => Promise<void>) | undefined;
+    const context = {
+      addInitScript: vi.fn(async () => undefined),
+      route: vi.fn(async (_matcher: string, handler: (route: TestReplayRoute) => Promise<void>) => {
+        routeHandler = handler;
+      })
+    };
+
+    await attachFixtureReplayToContext(context as unknown as BrowserContext);
+    if (!routeHandler) {
+      throw new Error("Fixture replay route handler was not attached.");
+    }
+
+    const linkedInRoute = createRouteMock("https://www.linkedin.com/feed/");
+
+    await expect(routeHandler(linkedInRoute)).rejects.toThrow();
+    expect(linkedInRoute.fulfill).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/fixtureReplay.ts
+++ b/packages/core/src/fixtureReplay.ts
@@ -346,9 +346,12 @@ export function isLinkedInFixtureReplayUrl(url: string): boolean {
       return false;
     }
 
+    const hostname = parsed.hostname.toLowerCase();
     return (
-      parsed.hostname.endsWith("linkedin.com") ||
-      parsed.hostname.endsWith("licdn.com")
+      hostname === "linkedin.com" ||
+      hostname.endsWith(".linkedin.com") ||
+      hostname === "licdn.com" ||
+      hostname.endsWith(".licdn.com")
     );
   } catch {
     return false;
@@ -444,6 +447,24 @@ function writeServerResponse(
   response.end(body);
 }
 
+function resolveFixtureBodyPath(baseDir: string, bodyPath: string): string {
+  const normalizedBaseDir = path.resolve(baseDir);
+  const resolvedPath = path.resolve(normalizedBaseDir, bodyPath);
+  const relativePath = path.relative(normalizedBaseDir, resolvedPath);
+
+  if (
+    path.isAbsolute(bodyPath) ||
+    relativePath.startsWith("..") ||
+    path.isAbsolute(relativePath)
+  ) {
+    throw new Error(
+      `Fixture route bodyPath ${bodyPath} must stay within ${normalizedBaseDir}.`
+    );
+  }
+
+  return resolvedPath;
+}
+
 async function buildReplayLookup(
   baseDir: string,
   routes: LinkedInFixtureRoute[]
@@ -452,7 +473,7 @@ async function buildReplayLookup(
 
   for (const route of routes) {
     const body = route.bodyPath
-      ? await readFile(path.resolve(baseDir, route.bodyPath))
+      ? await readFile(resolveFixtureBodyPath(baseDir, route.bodyPath))
       : Buffer.from(route.bodyText ?? "", "utf8");
     lookup.set(buildFixtureRouteKey(route), {
       body,
@@ -636,6 +657,11 @@ export async function checkLinkedInFixtureStaleness(
 ): Promise<FixtureStalenessWarning[]> {
   const manifest = await readLinkedInFixtureManifest(manifestPath);
   const maxAgeDays = options.maxAgeDays ?? DEFAULT_FIXTURE_STALENESS_DAYS;
+
+  if (options.setName && manifest.sets[options.setName] === undefined) {
+    throw new Error(`Fixture set ${options.setName} is not defined in ${manifestPath}.`);
+  }
+
   const entries = options.setName
     ? [[options.setName, manifest.sets[options.setName]] as const]
     : (Object.entries(manifest.sets) as Array<[string, LinkedInFixtureSetSummary]>);


### PR DESCRIPTION
## Summary
- expand fixture replay unit coverage across manifest parsing, staleness checks, server startup, routing, and replay error paths
- add CLI fixture check and record regressions, including record-to-replay integration and replay env restoration
- harden the harness by blocking unsafe replay body paths, tightening LinkedIn domain matching, and failing unknown fixture-set checks fast

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run test:e2e:fixtures
- npx vitest run packages/core/src/__tests__/fixtureReplay.test.ts packages/cli/test/fixturesCli.test.ts packages/cli/test/fixturesRecordCli.test.ts --coverage

Closes #116