### PR TITLE
fix: tighten fixture replay harness DX

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,9 @@ The live runner skips cleanly when no authenticated CDP session is available.
 The replay runner does not need credentials and uses `test/fixtures/manifest.json`
 plus the committed `ci` fixture set.
 
+Set `LINKEDIN_E2E_FIXTURE_SET=<name>` when you want `npm run test:e2e:fixtures`
+to replay a non-default recorded set.
+
 ### Fixture workflow
 
 Record or refresh replay fixtures manually:
@@ -448,6 +451,17 @@ owa fixtures:check --set ci --max-age-days 14
 Replay fixtures are stored under `test/fixtures/`. The manifest and committed
 `ci` set stay in git for deterministic CI coverage; other local fixture sets,
 HAR files, and bulky response captures stay ignored by default.
+
+The typical loop is:
+
+```bash
+linkedin fixtures record --set manual --page feed --page messaging
+linkedin fixtures check --set manual
+LINKEDIN_E2E_FIXTURE_SET=manual npm run test:e2e:fixtures -- packages/core/src/__tests__/e2e/inbox.e2e.test.ts
+```
+
+The live runner's `--fixtures` flag is separate: it stores the small CLI/MCP
+discovery target file used for live contract reruns, not the replay manifest.
 
 ### Coverage lanes
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -50,6 +50,10 @@ To force the raw Vitest suite directly, use:
 npm run test:e2e:raw
 ```
 
+`--fixtures` and `LINKEDIN_E2E_FIXTURE_FILE` only cache the small live
+discovery target file used by the CLI and MCP contract suites. They do **not**
+select the replay manifest used by `npm run test:e2e:fixtures`.
+
 ## Fixture-backed replay runner
 
 Use the replay lane when you want deterministic Playwright coverage without
@@ -66,6 +70,13 @@ Vitest E2E suites headlessly against recorded fixtures.
 Focused reruns work the same way:
 
 ```bash
+npm run test:e2e:fixtures -- packages/core/src/__tests__/e2e/inbox.e2e.test.ts
+```
+
+Replay a non-default recorded set by overriding `LINKEDIN_E2E_FIXTURE_SET`:
+
+```bash
+LINKEDIN_E2E_FIXTURE_SET=da-dk \
 npm run test:e2e:fixtures -- packages/core/src/__tests__/e2e/inbox.e2e.test.ts
 ```
 
@@ -171,6 +182,14 @@ owa fixtures:check --set ci --max-age-days 14
 
 `fixtures check` warns when a set or page is older than the configured age.
 
+Typical record → validate → replay loop:
+
+```bash
+linkedin fixtures record --set manual --page feed --page messaging
+linkedin fixtures check --set manual
+LINKEDIN_E2E_FIXTURE_SET=manual npm run test:e2e:fixtures -- packages/core/src/__tests__/e2e/inbox.e2e.test.ts
+```
+
 Storage rules:
 
 - `test/fixtures/manifest.json` is committed
@@ -179,12 +198,61 @@ Storage rules:
 - large captured HAR files and raw response bodies stay ignored unless you
   intentionally promote them
 
+### Replay manifest format
+
+The replay manifest stays intentionally small. Each manifest entry points at one
+fixture set root, one route file, and a per-page HTML snapshot map:
+
+```json
+{
+  "format": 1,
+  "updatedAt": "2026-03-09T10:00:00.000Z",
+  "defaultSetName": "ci",
+  "sets": {
+    "ci": {
+      "setName": "ci",
+      "rootDir": "ci",
+      "locale": "en-US",
+      "capturedAt": "2026-03-09T10:00:00.000Z",
+      "viewport": {
+        "width": 1440,
+        "height": 900
+      },
+      "routesPath": "routes.json",
+      "pages": {
+        "feed": {
+          "pageType": "feed",
+          "url": "https://www.linkedin.com/feed/",
+          "htmlPath": "pages/app.html",
+          "recordedAt": "2026-03-09T10:00:00.000Z"
+        }
+      }
+    }
+  }
+}
+```
+
+Key path rules:
+
+- `rootDir` stays relative to the manifest directory
+- `routesPath`, `harPath`, every page `htmlPath`, and each route `bodyPath`
+  stay relative to the fixture set root
+- `defaultSetName` must reference a defined manifest key
+- the route file `setName` must match the manifest set name, and duplicate
+  `METHOD + URL` replay keys are rejected
+- unknown set errors list the available set names so you can quickly rerun with
+  `--set <name>` or `LINKEDIN_E2E_FIXTURE_SET=<name>`
+
 ## Contract discovery fixtures
 
 The CLI and MCP contract suites also use a separate lightweight JSON fixture
 file for live discovery. Those files only store a message thread id, a feed
 post URL, a job id, and a connection target so contract-focused reruns do not
 need to rediscover live targets every time.
+
+These discovery files are separate from the replay manifest above: they speed up
+live CLI/MCP reruns, while the replay manifest controls `npm run
+test:e2e:fixtures`.
 
 Fixture files are intentionally small and profile-aware. The helper records the
 fixture format version, capture timestamp, `LINKEDIN_E2E_PROFILE`, and the

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -155,8 +155,9 @@ interface LocalDataDeletionPreview {
 }
 
 function coercePositiveInt(value: string, label: string): number {
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+  const normalized = value.trim();
+  const parsed = Number.parseInt(normalized, 10);
+  if (!/^\d+$/u.test(normalized) || !Number.isFinite(parsed) || parsed <= 0) {
     throw new LinkedInAssistantError(
       "ACTION_PRECONDITION_FAILED",
       `${label} must be a positive integer.`
@@ -166,8 +167,9 @@ function coercePositiveInt(value: string, label: string): number {
 }
 
 function coerceNonNegativeInt(value: string, label: string): number {
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed < 0) {
+  const normalized = value.trim();
+  const parsed = Number.parseInt(normalized, 10);
+  if (!/^\d+$/u.test(normalized) || !Number.isFinite(parsed) || parsed < 0) {
     throw new LinkedInAssistantError(
       "ACTION_PRECONDITION_FAILED",
       `${label} must be a non-negative integer.`
@@ -294,6 +296,13 @@ function collectFixtureReplayPageTypes(
     .map((item) => item.trim())
     .filter((item) => item.length > 0)
     .map((item) => coerceFixtureReplayPageType(item));
+
+  if (nextValues.length === 0) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "page must include at least one page type when --page is provided."
+    );
+  }
 
   return [...previous, ...nextValues];
 }
@@ -4246,7 +4255,11 @@ export function createCliProgram(): Command {
           "",
           "Examples:",
           "  linkedin fixtures record --page feed --page messaging",
-          "  owa fixtures:record --set da-dk --page feed,notifications --no-har"
+          "  owa fixtures:record --set da-dk --page feed,notifications --no-har",
+          "",
+          "Next steps:",
+          "  linkedin fixtures check --set <name>",
+          "  LINKEDIN_E2E_FIXTURE_SET=<name> npm run test:e2e:fixtures -- packages/core/src/__tests__/e2e/inbox.e2e.test.ts"
         ].join("\n")
       )
       .action(runFixtureRecordCommand);
@@ -4273,7 +4286,11 @@ export function createCliProgram(): Command {
           "",
           "Examples:",
           "  linkedin fixtures check",
-          "  owa fixtures:check --set ci --max-age-days 14"
+          "  owa fixtures:check --set ci --max-age-days 14",
+          "",
+          "Follow-up:",
+          "  Re-record stale pages with linkedin fixtures record --set <name> --page <type>",
+          "  Replay a checked set with LINKEDIN_E2E_FIXTURE_SET=<name> npm run test:e2e:fixtures"
         ].join("\n")
       )
       .action(runFixtureCheckCommand);

--- a/packages/cli/test/fixturesCli.test.ts
+++ b/packages/cli/test/fixturesCli.test.ts
@@ -193,7 +193,22 @@ describe("linkedin fixtures commands", () => {
         "--set",
         "missing"
       ])
-    ).rejects.toThrow(`Fixture set missing is not defined in ${path.resolve(manifestPath)}.`);
+    ).rejects.toThrow(
+      `Fixture set missing is not defined in ${path.resolve(manifestPath)}. Available fixture sets: manual.`
+    );
+  });
+
+  it("rejects non-numeric --max-age-days values", async () => {
+    await expect(
+      runCli([
+        "node",
+        "linkedin",
+        "fixtures",
+        "check",
+        "--max-age-days",
+        "30days"
+      ])
+    ).rejects.toThrow("max-age-days must be a positive integer.");
   });
 
   it("requires an interactive terminal for fixture recording", async () => {

--- a/packages/cli/test/fixturesRecordCli.test.ts
+++ b/packages/cli/test/fixturesRecordCli.test.ts
@@ -288,6 +288,47 @@ describe("linkedin fixtures record", () => {
     expect(process.env.LINKEDIN_E2E_FIXTURE_SERVER_URL).toBe("http://127.0.0.1:45555");
   });
 
+  it("rejects non-numeric viewport flags before recording starts", async () => {
+    await expect(
+      runCli([
+        "node",
+        "linkedin",
+        "fixtures",
+        "record",
+        "--page",
+        "feed",
+        "--width",
+        "1440px"
+      ])
+    ).rejects.toThrow("width must be a positive integer.");
+
+    await expect(
+      runCli([
+        "node",
+        "linkedin",
+        "fixtures",
+        "record",
+        "--page",
+        "feed",
+        "--height",
+        "900px"
+      ])
+    ).rejects.toThrow("height must be a positive integer.");
+  });
+
+  it("fails fast when --page resolves to an empty selection", async () => {
+    await expect(
+      runCli([
+        "node",
+        "linkedin",
+        "fixtures",
+        "record",
+        "--page",
+        ","
+      ])
+    ).rejects.toThrow("page must include at least one page type when --page is provided.");
+  });
+
   it("writes empty fallback bodies and ignores non-linkedin responses", async () => {
     const manifestPath = path.join(tempDir, "manifest.json");
     let responseHandler:

--- a/packages/core/src/__tests__/e2e/helpers.ts
+++ b/packages/core/src/__tests__/e2e/helpers.ts
@@ -91,6 +91,19 @@ const TRANSIENT_E2E_ERROR_PATTERN =
 const DEFAULT_REPLAY_POST_URL =
   "https://www.linkedin.com/feed/update/urn:li:activity:fixture-post-1/";
 
+/**
+ * On-disk JSON contract stored in `LINKEDIN_E2E_FIXTURE_FILE`.
+ *
+ * These saved discovery targets are distinct from the replay manifest under
+ * `test/fixtures/manifest.json`: they only cache a few live identifiers needed
+ * by the thin CLI and MCP E2E suites.
+ */
+interface CliCoverageFixtureFile extends CliCoverageFixtures {
+  capturedAt: string;
+  format: number;
+  profileName: string;
+}
+
 function readTrimmedEnv(name: string): string | undefined {
   const value = process.env[name];
   if (typeof value !== "string") {
@@ -272,11 +285,11 @@ function parseCliCoverageFixtures(
 function readCliCoverageFixturesFromFile(filePath: string): CliCoverageFixtures {
   try {
     const raw = readFileSync(filePath, "utf8");
-    return parseCliCoverageFixtures(JSON.parse(raw) as unknown, `Fixture file ${filePath}`);
+    return parseCliCoverageFixtures(JSON.parse(raw) as unknown, `Discovery fixture file ${filePath}`);
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     throw new Error(
-      `Could not load coverage fixtures from ${filePath}. ${reason} ` +
+      `Could not load discovery fixtures from ${filePath}. ${reason} ` +
         "Delete the file or rerun with --refresh-fixtures (LINKEDIN_E2E_REFRESH_FIXTURES=1)."
     );
   }
@@ -286,19 +299,17 @@ function writeCliCoverageFixturesToFile(
   filePath: string,
   fixtures: CliCoverageFixtures
 ): void {
+  const payload: CliCoverageFixtureFile = {
+    format: E2E_FIXTURE_FORMAT_VERSION,
+    capturedAt: new Date().toISOString(),
+    profileName: getDefaultProfileName(),
+    ...fixtures
+  };
+
   mkdirSync(path.dirname(filePath), { recursive: true });
   writeFileSync(
     filePath,
-    `${JSON.stringify(
-      {
-        format: E2E_FIXTURE_FORMAT_VERSION,
-        capturedAt: new Date().toISOString(),
-        profileName: getDefaultProfileName(),
-        ...fixtures
-      },
-      null,
-      2
-    )}\n`,
+    `${JSON.stringify(payload, null, 2)}\n`,
     "utf8"
   );
 }

--- a/packages/core/src/__tests__/e2e/setup.ts
+++ b/packages/core/src/__tests__/e2e/setup.ts
@@ -262,10 +262,7 @@ async function probeFixtureReplay(): Promise<{
         `(${replayServer.summary.locale}, ${replayServer.summary.viewport.width}x${replayServer.summary.viewport.height}).`
     };
   } catch (error) {
-    return {
-      available: false,
-      reason: `Fixture replay could not start. ${summarizeUnknownError(error)}`
-    };
+    throw new Error(`Fixture replay could not start. ${summarizeUnknownError(error)}`);
   }
 }
 

--- a/packages/core/src/__tests__/e2eRunner.test.ts
+++ b/packages/core/src/__tests__/e2eRunner.test.ts
@@ -51,6 +51,15 @@ describe("run-e2e runner options", () => {
     expect(() => parseRunnerOptions(["--fixtures="]))
       .toThrow("--fixtures requires a non-empty file path");
   });
+
+  it("rejects option-like values after --fixtures", () => {
+    expect(() => parseRunnerOptions(["--fixtures", "--refresh-fixtures"]))
+      .toThrow("--fixtures requires a file path argument, not another flag (--refresh-fixtures)");
+    expect(() => parseRunnerOptions(["--fixtures", "--"]))
+      .toThrow("--fixtures requires a file path argument, not another flag (--)");
+    expect(() => parseRunnerOptions(["--fixtures", "-h"]))
+      .toThrow("--fixtures requires a file path argument, not another flag (-h)");
+  });
 });
 
 describe("run-e2e runner messaging", () => {
@@ -75,7 +84,7 @@ describe("run-e2e runner messaging", () => {
         "CDP endpoint: http://127.0.0.1:18800",
         "Profile: review-profile",
         "Session policy: required",
-        expect.stringContaining("Coverage fixtures:"),
+        expect.stringContaining("Discovery fixtures:"),
         "Opt-in confirms: message",
         "Vitest args: packages/core/src/__tests__/e2e/error-paths.e2e.test.ts"
       ])
@@ -114,12 +123,14 @@ describe("run-e2e runner messaging", () => {
     );
   });
 
-  it("documents fixture replay and strict mode in the help text", () => {
+  it("documents discovery fixtures, replay lane, and strict mode in the help text", () => {
     const helpText = getRunnerHelpText();
 
     expect(helpText).toContain("--require-session");
     expect(helpText).toContain("--fixtures <file>");
     expect(helpText).toContain("--refresh-fixtures");
+    expect(helpText).toContain("saved CLI/MCP discovery targets");
+    expect(helpText).toContain("npm run test:e2e:fixtures");
     expect(helpText).toContain("LINKEDIN_E2E_REQUIRE_SESSION");
     expect(helpText).toContain("docs/e2e-testing.md");
   });

--- a/packages/core/src/__tests__/e2eSetup.test.ts
+++ b/packages/core/src/__tests__/e2eSetup.test.ts
@@ -122,6 +122,16 @@ describe("E2E setup helpers", () => {
     expect(availability.reason).toContain("Fixture replay is active for set ci");
   });
 
+  it("fails fast when replay mode is enabled but the replay harness is misconfigured", async () => {
+    process.env.LINKEDIN_E2E_REPLAY = "1";
+    process.env.LINKEDIN_E2E_FIXTURE_MANIFEST = path.resolve("test/fixtures/missing-manifest.json");
+    delete process.env.LINKEDIN_CDP_URL;
+
+    await expect(getE2EAvailability()).rejects.toThrow(
+      `Fixture replay could not start. Fixture manifest ${path.resolve("test/fixtures/missing-manifest.json")} does not exist.`
+    );
+  });
+
   it("reports malformed CDP URLs as unavailable", async () => {
     process.env.LINKEDIN_CDP_URL = "not-a-url";
 

--- a/packages/core/src/__tests__/fixtureReplay.test.ts
+++ b/packages/core/src/__tests__/fixtureReplay.test.ts
@@ -320,6 +320,14 @@ describe("fixtureReplay manifests and staleness", () => {
     expect(loadedSet.routes[1]?.bodyText).toBe('{"ok":true}');
   });
 
+  it("validates externally managed replay server URLs before startup", async () => {
+    process.env.LINKEDIN_E2E_FIXTURE_SERVER_URL = "not-a-url";
+
+    expect(() => getFixtureReplayEnvironment()).toThrow(
+      "LINKEDIN_E2E_FIXTURE_SERVER_URL must be an absolute http(s) URL."
+    );
+  });
+
   it("rejects empty and corrupt fixture manifests", async () => {
     const tempDir = await createTempDir("linkedin-fixture-empty-");
     const emptyManifestPath = path.join(tempDir, "empty-manifest.json");
@@ -563,7 +571,9 @@ describe("fixtureReplay manifests and staleness", () => {
         setName: "missing",
         maxAgeDays: 30
       })
-    ).rejects.toThrow(`Fixture set missing is not defined in ${emptyFixtureSet.manifestPath}.`);
+    ).rejects.toThrow(
+      `Fixture set missing is not defined in ${emptyFixtureSet.manifestPath}. Available fixture sets: ${emptyFixtureSet.setName}.`
+    );
   });
 });
 

--- a/packages/core/src/fixtureReplay.ts
+++ b/packages/core/src/fixtureReplay.ts
@@ -3,19 +3,24 @@ import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { BrowserContext } from "playwright-core";
 
+/** Current on-disk schema version for replay manifests and route files. */
 export const LINKEDIN_FIXTURE_MANIFEST_FORMAT_VERSION = 1;
 export const DEFAULT_FIXTURE_STALENESS_DAYS = 30;
+/** Default replay manifest loaded by `npm run test:e2e:fixtures`. */
 export const DEFAULT_FIXTURE_MANIFEST_PATH = path.resolve(
   process.cwd(),
   "test/fixtures/manifest.json"
 );
+/** Internal HTTP endpoint exposed by the local replay server. */
 export const REPLAY_ROUTE_PATH = "/__linkedin_fixture__/replay";
+/** Environment variables that toggle or configure the replay lane. */
 export const FIXTURE_REPLAY_ENV_KEYS = [
   "LINKEDIN_E2E_REPLAY",
   "LINKEDIN_E2E_FIXTURE_SERVER_URL",
   "LINKEDIN_E2E_FIXTURE_SET",
   "LINKEDIN_E2E_FIXTURE_MANIFEST"
 ] as const;
+/** Supported LinkedIn surfaces that can be recorded into a fixture set. */
 export const LINKEDIN_REPLAY_PAGE_TYPES = [
   "feed",
   "profile",
@@ -36,31 +41,44 @@ const FIXTURE_REPLAY_SERVER_TIMEOUT_MS = 30_000;
 
 export type LinkedInReplayPageType = (typeof LINKEDIN_REPLAY_PAGE_TYPES)[number];
 
+/** Browser viewport recorded alongside each fixture set. */
 export interface LinkedInFixtureViewport {
   width: number;
   height: number;
 }
 
+/** Metadata for one replayable LinkedIn page snapshot inside a fixture set. */
 export interface LinkedInFixturePageEntry {
   pageType: LinkedInReplayPageType;
   url: string;
+  /** Path relative to the fixture set root directory. */
   htmlPath: string;
   recordedAt: string;
   title?: string;
 }
 
+/**
+ * Summary metadata stored under one manifest entry.
+ *
+ * `rootDir`, `routesPath`, `harPath`, and each page `htmlPath` stay relative to
+ * the manifest or set root so fixture sets remain relocatable inside the repo.
+ */
 export interface LinkedInFixtureSetSummary {
   setName: string;
+  /** Path relative to the manifest directory. */
   rootDir: string;
   locale: string;
   capturedAt: string;
   viewport: LinkedInFixtureViewport;
+  /** Path relative to `rootDir`. */
   routesPath: string;
   description?: string;
+  /** Optional HAR file path relative to `rootDir`. */
   harPath?: string;
   pages: Partial<Record<LinkedInReplayPageType, LinkedInFixturePageEntry>>;
 }
 
+/** Top-level JSON document that declares the available replay fixture sets. */
 export interface LinkedInFixtureManifest {
   format: number;
   updatedAt: string;
@@ -68,22 +86,31 @@ export interface LinkedInFixtureManifest {
   sets: Record<string, LinkedInFixtureSetSummary>;
 }
 
+/**
+ * Replayable HTTP response metadata.
+ *
+ * Routes may inline `bodyText` for small text payloads or point `bodyPath` at a
+ * response body file relative to the fixture set root.
+ */
 export interface LinkedInFixtureRoute {
   method: string;
   url: string;
   status: number;
   headers: Record<string, string>;
+  /** Path relative to the fixture set root. Mutually exclusive with `bodyText`. */
   bodyPath?: string;
   bodyText?: string;
   pageType?: LinkedInReplayPageType;
 }
 
+/** JSON file stored under each fixture set that lists its replayable routes. */
 export interface LinkedInFixtureRouteFile {
   format: number;
   setName: string;
   routes: LinkedInFixtureRoute[];
 }
 
+/** Fully resolved replay fixture set loaded from disk. */
 export interface LinkedInFixtureSet {
   manifestPath: string;
   setName: string;
@@ -92,6 +119,7 @@ export interface LinkedInFixtureSet {
   routes: LinkedInFixtureRoute[];
 }
 
+/** Staleness warning returned by `checkLinkedInFixtureStaleness()`. */
 export interface FixtureStalenessWarning {
   ageDays: number;
   maxAgeDays: number;
@@ -108,6 +136,7 @@ export interface FixtureReplayEnvironment {
   setName?: string;
 }
 
+/** Running replay server metadata returned by the shared replay bootstrap. */
 export interface StartedFixtureReplayServer {
   baseUrl: string;
   close: () => void;
@@ -149,6 +178,25 @@ const sharedServerState: MutableSharedServerState = {
 };
 
 const linkedInReplayPageTypes = new Set<string>(LINKEDIN_REPLAY_PAGE_TYPES);
+
+function formatAvailableFixtureSets(setNames: string[]): string {
+  if (setNames.length === 0) {
+    return "No fixture sets are defined in this manifest.";
+  }
+
+  return `Available fixture sets: ${[...setNames].sort((left, right) => left.localeCompare(right)).join(", ")}.`;
+}
+
+function createUnknownFixtureSetError(
+  requestedSetName: string,
+  manifestPath: string,
+  setNames: string[]
+): Error {
+  return new Error(
+    `Fixture set ${requestedSetName} is not defined in ${manifestPath}. ` +
+      formatAvailableFixtureSets(setNames)
+  );
+}
 
 function readTrimmedEnv(name: string): string | undefined {
   const value = process.env[name];
@@ -359,7 +407,8 @@ function parseManifest(value: unknown, manifestPath: string): LinkedInFixtureMan
   const defaultSetName = asOptionalString(record.defaultSetName);
   if (defaultSetName && Object.keys(sets).length > 0 && sets[defaultSetName] === undefined) {
     throw new Error(
-      `Fixture manifest ${manifestPath}.defaultSetName must reference a defined fixture set.`
+      `Fixture manifest ${manifestPath}.defaultSetName must reference a defined fixture set. ` +
+        formatAvailableFixtureSets(Object.keys(sets))
     );
   }
 
@@ -980,11 +1029,14 @@ export function resolveFixtureManifestPath(manifestPath?: string): string {
 export function getFixtureReplayEnvironment(): FixtureReplayEnvironment {
   const serverUrl = readTrimmedEnv("LINKEDIN_E2E_FIXTURE_SERVER_URL");
   const setName = readTrimmedEnv("LINKEDIN_E2E_FIXTURE_SET");
+  const validatedServerUrl = serverUrl
+    ? asHttpUrl(serverUrl, "LINKEDIN_E2E_FIXTURE_SERVER_URL")
+    : undefined;
 
   return {
-    enabled: readEnabledFlag("LINKEDIN_E2E_REPLAY") || serverUrl !== undefined,
+    enabled: readEnabledFlag("LINKEDIN_E2E_REPLAY") || validatedServerUrl !== undefined,
     manifestPath: resolveFixtureManifestPath(),
-    ...(serverUrl ? { serverUrl } : {}),
+    ...(validatedServerUrl ? { serverUrl: validatedServerUrl } : {}),
     ...(setName ? { setName } : {})
   };
 }
@@ -1027,14 +1079,18 @@ export async function loadLinkedInFixtureSet(
   requestedSetName?: string
 ): Promise<LinkedInFixtureSet> {
   const manifest = await readLinkedInFixtureManifest(manifestPath);
+  const availableSetNames = Object.keys(manifest.sets);
   const setName = requestedSetName ?? manifest.defaultSetName ?? Object.keys(manifest.sets)[0];
   if (!setName) {
-    throw new Error(`Fixture manifest ${manifestPath} does not define any sets.`);
+    throw new Error(
+      `Fixture manifest ${manifestPath} does not define any sets. ` +
+        'Record one with "linkedin fixtures record --set <name> --page feed" or point the replay lane at a populated manifest.'
+    );
   }
 
   const summary = manifest.sets[setName];
   if (!summary) {
-    throw new Error(`Fixture set ${setName} is not defined in ${manifestPath}.`);
+    throw createUnknownFixtureSetError(setName, manifestPath, availableSetNames);
   }
 
   const routeFilePath = getResolvedRouteFilePath(manifestPath, summary);
@@ -1068,7 +1124,7 @@ export async function checkLinkedInFixtureStaleness(
   const maxAgeDays = options.maxAgeDays ?? DEFAULT_FIXTURE_STALENESS_DAYS;
 
   if (options.setName && manifest.sets[options.setName] === undefined) {
-    throw new Error(`Fixture set ${options.setName} is not defined in ${manifestPath}.`);
+    throw createUnknownFixtureSetError(options.setName, manifestPath, Object.keys(manifest.sets));
   }
 
   const entries = options.setName

--- a/scripts/run-e2e.js
+++ b/scripts/run-e2e.js
@@ -62,6 +62,10 @@ function parseFixtureFlag(argument) {
   return value;
 }
 
+function isOptionLikeArgument(value) {
+  return value === "--" || /^-/.test(value);
+}
+
 /**
  * Parses runner-specific flags while preserving any remaining arguments for
  * direct Vitest forwarding.
@@ -103,6 +107,12 @@ export function parseRunnerOptions(argv, env = process.env) {
         typeof nextArgument === "string" ? nextArgument.trim() : "";
       if (resolvedPath.length === 0) {
         throw new Error("--fixtures requires a file path argument.");
+      }
+      if (isOptionLikeArgument(resolvedPath)) {
+        throw new Error(
+          `--fixtures requires a file path argument, not another flag (${resolvedPath}). ` +
+            "If the path really starts with '-', pass --fixtures=<file>."
+        );
       }
 
       fixtureFile = resolvedPath;
@@ -161,8 +171,8 @@ export function formatRunnerConfiguration(options, env = process.env) {
     `Profile: ${profileName}`,
     `Session policy: ${options.requireSession ? "required" : "skip when unavailable"}`,
     options.fixtureFile === undefined
-      ? `Coverage fixtures: ${fixtureFile}`
-      : `Coverage fixtures: ${fixtureFile}${
+      ? `Discovery fixtures: ${fixtureFile}`
+      : `Discovery fixtures: ${fixtureFile}${
           options.refreshFixtures ? " (refresh enabled)" : ""
         }`,
     `Opt-in confirms: ${enabledWrites.length > 0 ? enabledWrites.join(", ") : "none"}`,
@@ -185,18 +195,21 @@ export function getRunnerHelpText() {
     "Runner options:",
     "  --help                 Show this help text.",
     "  --require-session      Fail instead of skipping when CDP/auth is unavailable.",
-    "  --fixtures <file>      Read or record CLI/MCP coverage fixtures at <file>.",
-    "  --refresh-fixtures     Re-discover fixtures and overwrite the fixture file.",
+    "  --fixtures <file>      Read or record saved CLI/MCP discovery targets at <file>.",
+    "  --refresh-fixtures     Re-discover live CLI/MCP targets and overwrite that file.",
     "",
     "Safe defaults:",
     "  Default runs stay read-only, preview-only, or use test.echo confirms.",
     "  Real outbound confirms stay opt-in behind dedicated environment flags.",
     "",
+    "Replay lane:",
+    "  Use npm run test:e2e:fixtures for the full replay-manifest lane backed by test/fixtures/manifest.json.",
+    "",
     "Vitest examples:",
     "  npm run test:e2e -- packages/core/src/__tests__/e2e/cli.e2e.test.ts",
     "  npm run test:e2e -- --reporter=verbose packages/core/src/__tests__/e2e/error-paths.e2e.test.ts",
     "",
-    "Fixture replay examples:",
+    "Discovery fixture examples:",
     "  npm run test:e2e -- --fixtures .tmp/e2e-fixtures.json packages/core/src/__tests__/e2e/cli.e2e.test.ts",
     "  npm run test:e2e -- --fixtures .tmp/e2e-fixtures.json --refresh-fixtures packages/core/src/__tests__/e2e/mcp.e2e.test.ts",
     "",
@@ -204,7 +217,7 @@ export function getRunnerHelpText() {
     "  LINKEDIN_CDP_URL              CDP endpoint to probe (default: http://localhost:18800)",
     "  LINKEDIN_E2E_PROFILE          Logical profile name used by the E2E helpers",
     "  LINKEDIN_E2E_REQUIRE_SESSION  Same as --require-session when set to 1/true",
-    "  LINKEDIN_E2E_FIXTURE_FILE     Same as --fixtures <file>",
+    "  LINKEDIN_E2E_FIXTURE_FILE     Same as --fixtures <file> for saved CLI/MCP discovery targets",
     "  LINKEDIN_E2E_REFRESH_FIXTURES Same as --refresh-fixtures when set to 1/true",
     "  LINKEDIN_E2E_JOB_QUERY        Job query used for live fixture discovery",
     "  LINKEDIN_E2E_JOB_LOCATION     Job location used for live fixture discovery",


### PR DESCRIPTION
## Summary
- clarify discovery-vs-replay fixture terminology across the runner, docs, and README
- fail fast when replay mode is explicitly enabled but the replay harness cannot start
- tighten fixture-related CLI validation and add regression coverage for common setup mistakes

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #120