### PR TITLE
docs: add research brief for issue #88 live smoke CLI

### DIFF
--- a/docs/.research-brief-issue-88.md
+++ b/docs/.research-brief-issue-88.md
@@ -1,469 +1,607 @@
 # Research brief — issue #88 E2E live smoke tests: read-only validation CLI (Tier 2)
 
+Related issues: #88, #90, #124, #87, #11, #8
+
 ## Executive summary
 
-Issue #88 is a good fit for the current codebase. The repo already has most of
-the primitives needed for a safe live read-only validation flow:
+Issue #88 is very feasible in the current codebase, but it should be framed as
+an **orchestration + policy layer** on top of the existing runtime, not as a
+brand-new Playwright harness.
 
-- authenticated-session probing and health checks in
-  `packages/core/src/auth/session.ts:102`,
-  `packages/core/src/auth/sessionInspection.ts:62`, and
+The repo already has most of the building blocks Tier 2 needs:
+
+- a persistent-session login flow plus session/auth health checks in
+  `packages/core/src/auth/session.ts:102` and
   `packages/core/src/healthCheck.ts:84`
-- a broad set of existing read-only LinkedIn service methods wired into the
-  shared runtime in `packages/core/src/runtime.ts:105`
-- direct CLI coverage infrastructure from Tier 1 in
-  `scripts/run-e2e.js:73`, `packages/core/src/__tests__/e2e/setup.ts:474`, and
-  `packages/core/src/__tests__/e2e/helpers.ts:562`
-- existing operator-safety patterns for interactive confirmation, structured
-  logging, artifact capture, privacy redaction, and write gating in
-  `packages/cli/src/bin/linkedin.ts:1081`,
-  `packages/core/src/logging.ts:21`, `packages/core/src/artifacts.ts:21`,
-  `packages/core/src/privacy.ts:442`, and `docs/e2e-testing.md:109`
+- a broad set of read-only LinkedIn service methods exposed from one runtime in
+  `packages/core/src/runtime.ts:139` and `packages/core/src/runtime.ts:233`
+- a proven live CLI transport layer with command-level E2E coverage in
+  `packages/core/src/__tests__/e2e/cli.e2e.test.ts:12`
+- a live E2E runner that already knows how to probe auth/CDP, skip safely, or
+  fail explicitly in `scripts/run-e2e.js:73` and `scripts/run-e2e.js:162`
+- a read-only selector audit that already produces a structured report, exit
+  status, and failure artifacts in `packages/core/src/selectorAudit.ts:1193`
+  and `packages/cli/src/bin/linkedin.ts:3479`
+- existing operator-safety patterns for interactive confirmation and `--yes`
+  bypasses in `packages/cli/src/bin/linkedin.ts:1081` and
+  `packages/cli/src/bin/linkedin.ts:3658`
 
-The main gaps are policy and composition, not browser plumbing:
+The main gaps are not basic automation. They are **execution policy gaps**:
 
-- there is no dedicated `owa test:live --read-only` orchestration command yet
-- there is no true read-only runtime mode that omits write executors or blocks
-  mutation requests
-- the current auth model is persistent-profile/CDP based, not an encrypted
-  exported session bundle as described in issue #88
-- the current rate-limit primitives do not enforce issue #88’s session policy
-  of 1 request every 5 seconds with a maximum of 20 requests per run
-- selector-audit reporting exists, but there is no single validation report that
-  combines step timings, selector results, regressions, and pass/fail exit code
+1. there is no dedicated `owa test:live --read-only` command yet
+2. there is no global live-mode guard that enforces “GET-only LinkedIn traffic”
+   or blocks mutation routes/selectors
+3. there is no global Tier-2 pacing/session-budget policy equivalent to “1
+   request every 5 seconds, max 20 requests per run”
+4. there is no dedicated Tier-2 report/diff format yet, even though selector
+   audit and artifact/log plumbing already exist
+5. current read-only services are split between `runWithContext()` and direct
+   `runWithPersistentContext()` usage, which makes attached-browser/CDP behavior
+   uneven
 
-My conclusion: Tier 2 is feasible with relatively low implementation risk if it
-is built as a thin live-validation layer over the existing runtime and CLI
-helpers. The biggest design decision is whether to treat “stored session” as the
-current persistent Playwright profile model, or to add a new encrypted
-session-capture/export mechanism first.
+My main conclusion is:
 
-## What already exists
+- **Tier 2 should reuse the existing runtime and CLI surfaces.**
+- **Selector audit is the closest architectural template**, because it is
+  already read-only, multi-step, report-oriented, and uses one authenticated
+  context for several checks.
+- The first implementation should add a **shared live validation policy**
+  object/context that can later be reused by issue #90 as the foundation for
+  stricter write-validation rules.
 
-### 1) Auth and session handling are already centralized
+## What issue #88 asks for, compared to current reality
 
-The current session model is built around `ProfileManager` plus
-`LinkedInAuthService`:
+| Requirement from #88 | What already exists | Gap / implication |
+| --- | --- | --- |
+| Stored session/cookie, no email+password login flow | The repo already has a persistent Playwright profile login flow via `login` / `openLogin()` in `packages/cli/src/bin/linkedin.ts:4101` and `packages/core/src/auth/session.ts:491`. The `owa` alias already exists in `packages/cli/package.json:7`. | Partial. The current implementation stores session state in a Playwright profile directory, not in a dedicated app-managed session blob. The CLI also still exposes headless email/password login in `packages/core/src/auth/session.ts:171` and `packages/cli/src/bin/linkedin.ts:4101`, so Tier 2 should explicitly avoid depending on that path. |
+| Read-only validations against live LinkedIn | Read-only service methods already exist for feed, profile, notifications, inbox, connections, search, jobs, and selector audit. See `packages/core/src/linkedinFeed.ts:1706`, `packages/core/src/linkedinProfile.ts:533`, `packages/core/src/linkedinNotifications.ts:379`, `packages/core/src/linkedinInbox.ts:1141`, `packages/core/src/linkedinConnections.ts:1125`, `packages/core/src/linkedinSearch.ts:131`, `packages/core/src/linkedinJobs.ts:519`, and `packages/core/src/selectorAudit.ts:1200`. | Mostly done at the service level. What is missing is one operator command that runs a curated safe subset and emits a single pass/fail report. |
+| Confirm each action interactively, with `--yes` batch mode | The CLI already has reusable confirmation patterns via `promptYesNo()` and `runConfirmAction()` in `packages/cli/src/bin/linkedin.ts:1081` and `packages/cli/src/bin/linkedin.ts:3658`. | Partial. Those patterns are currently used for destructive or confirm flows, not for a read-only multi-step validation command. |
+| Rate-limited run policy | There is a persisted cooldown system for LinkedIn challenges in `packages/core/src/auth/rateLimitState.ts:148`, plus write-action token-bucket rate limiting in `packages/core/src/rateLimiter.ts:20`. | Missing for Tier 2. The existing rate limiter is action-specific and mostly mutation-oriented, not a shared “5 seconds between checks, max 20 requests per live validation run” policy. |
+| Stop immediately on challenge/captcha/unexpected redirect | Session inspection already detects login pages, checkpoints, and rate-limit challenge URLs in `packages/core/src/auth/sessionInspection.ts:62`. `ensureAuthenticated()` turns those into structured errors in `packages/core/src/auth/session.ts:141`. | Partial. This is strong at auth/health boundaries, but not yet a shared per-operation live-run abort policy. |
+| Hard block on write operations | All write operations are already isolated behind `prepare*()` + `confirmByToken()` two-phase commit flows. See `packages/core/src/twoPhaseCommit.ts:337`, `packages/core/src/linkedinInbox.ts:1222`, `packages/core/src/linkedinConnections.ts:1246`, `packages/core/src/linkedinFeed.ts:1791`, and `packages/core/src/linkedinPosts.ts:1808`. | Partial. The current safety boundary is API/command-level. There is no live-mode browser/network sandbox that would fail closed if a new mutation path were accidentally invoked. |
+| No mutation selectors loaded during read-only mode | Read-only services and mutation services are separate classes/methods. | Missing as an explicit policy. Nothing today prevents a future read-only flow from importing or calling a mutation helper by mistake. |
+| Network allowlist: only GET requests to LinkedIn domains | Fixture replay already has fail-closed request interception in `packages/core/src/fixtureReplay.ts:1289`. | Missing in live mode. I did not find an equivalent live-network allowlist in the runtime or CLI. |
+| Local validation report + diff vs last run | Selector audit already writes a JSON report with `report_path`, `fail_count`, failure detail, and artifacts in `packages/core/src/selectorAudit.ts:1200`. Generic artifact/log plumbing also exists in `packages/core/src/artifacts.ts:21` and `packages/core/src/logging.ts:21`. | Partial. The repo has the storage/reporting primitives, but not a Tier-2-specific summary schema or last-run diff yet. |
+| Exit code for CI-adjacent use | `health` already exits non-zero when browser/session health fails in `packages/cli/src/bin/linkedin.ts:4823`. Selector audit also maps failures to exit code `1` in CLI E2E coverage at `packages/core/src/__tests__/e2e/cli.e2e.test.ts:65`. | Mostly available. Tier 2 should follow the same convention. |
 
-- `ProfileManager` already supports two execution modes:
-  - isolated persistent Playwright profiles with file locking in
-    `packages/core/src/profileManager.ts:41` and
-    `packages/core/src/profileManager.ts:91`
-  - attached live Chrome sessions over CDP in
-    `packages/core/src/profileManager.ts:123` and
-    `packages/core/src/profileManager.ts:179`
-- `LinkedInAuthService.status()` opens the feed, inspects the current browser
-  state, clears stale auth cooldown when the session is healthy, and surfaces
-  structured status output in `packages/core/src/auth/session.ts:102`
-- `ensureAuthenticated()` already maps unauthenticated outcomes into structured
-  error codes (`AUTH_REQUIRED`, `RATE_LIMITED`, `CAPTCHA_OR_CHALLENGE`) in
-  `packages/core/src/auth/session.ts:141`
-- `inspectLinkedInSession()` detects login pages, checkpoints/challenges,
-  session cookies, and authenticated chrome in
-  `packages/core/src/auth/sessionInspection.ts:28` and
-  `packages/core/src/auth/sessionInspection.ts:62`
-- `healthCheck()` already returns a combined browser/session view suitable for
-  smoke-test preflight in `packages/core/src/healthCheck.ts:32` and
-  `packages/core/src/healthCheck.ts:84`
+## Existing auth and session patterns
 
-This is a strong base for issue #88’s “fail fast on expired session,
-challenge/captcha, or unexpected redirect” requirement.
+### 1) The runtime already has a single auth gate
 
-Important gap: there is currently no `auth:session` command, no cookie export
-or import flow, and no encrypted-at-rest session bundle. Session persistence is
-currently the browser profile itself (`packages/core/src/profileManager.ts:41`),
-not a separate secure session artifact.
+`createCoreRuntime()` wires one `LinkedInAuthService` plus all read-only and
+write-capable feature services into the same service graph in
+`packages/core/src/runtime.ts:139` and `packages/core/src/runtime.ts:233`.
 
-### 2) The runtime already exposes the read-only surfaces that issue #88 wants
+That matters because Tier 2 does **not** need a separate authentication stack.
+It can use the same runtime construction path as the normal CLI and the live
+E2E harness.
 
-`createCoreRuntime()` wires all major read flows into one service graph in
-`packages/core/src/runtime.ts:139` and `packages/core/src/runtime.ts:221`.
+### 2) `status()` and `ensureAuthenticated()` are already good smoke-test primitives
 
-The specific read-only operations from issue #88 already exist in core:
+`LinkedInAuthService.status()`:
 
-- feed listing and post viewing in `packages/core/src/linkedinFeed.ts:1706` and
+- checks persisted rate-limit cooldown state first
+- opens a browser context through `ProfileManager.runWithContext()`
+- navigates to `https://www.linkedin.com/feed/`
+- delegates the actual auth/challenge decision to
+  `inspectLinkedInSession()`
+
+See `packages/core/src/auth/session.ts:102`.
+
+`ensureAuthenticated()` wraps that and throws structured errors with operator
+guidance for:
+
+- `AUTH_REQUIRED`
+- `CAPTCHA_OR_CHALLENGE`
+- `RATE_LIMITED`
+
+See `packages/core/src/auth/session.ts:141`.
+
+This is already close to what Tier 2 needs for “fail fast on challenge/captcha
+or expired session.”
+
+### 3) Session detection is heuristic, but good enough for Tier 2
+
+`inspectLinkedInSession()` currently treats these as positive/negative signals:
+
+- negative: login form visible, `/login`, `/authwall`, `/checkpoint`, known
+  challenge URLs
+- positive: global nav visible, profile-menu visible, or a non-empty `li_at`
+  cookie
+
+See `packages/core/src/auth/sessionInspection.ts:15`,
+`packages/core/src/auth/sessionInspection.ts:36`, and
+`packages/core/src/auth/sessionInspection.ts:62`.
+
+That is a good fit for a smoke CLI because it answers the practical question:
+“can this session act like an authenticated LinkedIn session right now?”
+
+### 4) The strongest existing smoke endpoint is `health`, not `status`
+
+`checkFullHealth()` combines browser responsiveness with session
+authentication in `packages/core/src/healthCheck.ts:84`, and the CLI `health`
+command already exits with code `1` when browser or session health is not good
+in `packages/cli/src/bin/linkedin.ts:4823`.
+
+That is a stronger precedent for Tier 2 pass/fail behavior than `status`, which
+is more informational.
+
+### 5) Session storage is profile-based, not `auth:session`-style
+
+The project explicitly creates and owns a Playwright persistent context stored
+under the assistant home directory in `PROJECT.md:50`. `ProfileManager` then
+reopens that profile through `runWithPersistentContext()` in
+`packages/core/src/profileManager.ts:91`.
+
+This means issue #88’s session-storage requirement is only **partially** met:
+
+- **met**: the operator can store and reuse a session without typing email and
+  password every run
+- **not met**: there is no explicit `owa auth:session` capture/import/export
+  surface yet, and the repo does not implement its own encrypted-at-rest
+  session blob
+
+The repo does have strong privacy controls for logs, artifacts, and sealed
+prepared-action payloads in `packages/core/src/privacy.ts:364`,
+`packages/core/src/logging.ts:39`, `packages/core/src/artifacts.ts:44`, and
+`packages/core/src/twoPhaseCommit.ts:377`, but that is not the same thing as
+application-managed encrypted cookie storage.
+
+## Existing read-only surfaces that Tier 2 can reuse
+
+### Runtime service inventory
+
+The following methods are the most relevant Tier-2 candidates:
+
+- feed: `packages/core/src/linkedinFeed.ts:1706` and
   `packages/core/src/linkedinFeed.ts:1742`
-- inbox thread listing and thread inspection in
-  `packages/core/src/linkedinInbox.ts:1141` and
+- profile: `packages/core/src/linkedinProfile.ts:533`
+- notifications: `packages/core/src/linkedinNotifications.ts:379`
+- inbox: `packages/core/src/linkedinInbox.ts:1141` and
   `packages/core/src/linkedinInbox.ts:1190`
-- connection listing and pending invitation listing in
-  `packages/core/src/linkedinConnections.ts:1125` and
+- connections: `packages/core/src/linkedinConnections.ts:1125` and
   `packages/core/src/linkedinConnections.ts:1162`
-- notifications listing in `packages/core/src/linkedinNotifications.ts:379`
-- profile viewing in `packages/core/src/linkedinProfile.ts:533`
-- search and jobs lookup in `packages/core/src/linkedinSearch.ts:131`,
+- search/jobs if desired later: `packages/core/src/linkedinSearch.ts:131`,
   `packages/core/src/linkedinJobs.ts:519`, and
   `packages/core/src/linkedinJobs.ts:569`
+- selector audit: `packages/core/src/selectorAudit.ts:1200`
 
-The CLI already exposes these as operator commands:
+The common pattern is:
 
-- `status` and `health` in `packages/cli/src/bin/linkedin.ts:3796` and
-  `packages/cli/src/bin/linkedin.ts:4822`
-- `search` in `packages/cli/src/bin/linkedin.ts:4316`
-- `inbox list` / `inbox show` in `packages/cli/src/bin/linkedin.ts:4345` and
-  `packages/cli/src/bin/linkedin.ts:4361`
-- `connections list` / `connections pending` in
-  `packages/cli/src/bin/linkedin.ts:4397` and
-  `packages/cli/src/bin/linkedin.ts:4411`
-- `feed list` / `feed view` in `packages/cli/src/bin/linkedin.ts:4518` and
-  `packages/cli/src/bin/linkedin.ts:4532`
-- `notifications list` in `packages/cli/src/bin/linkedin.ts:4639`
-- `jobs search` / `jobs view` in `packages/cli/src/bin/linkedin.ts:4657` and
-  `packages/cli/src/bin/linkedin.ts:4682`
-- `profile view` in `packages/cli/src/bin/linkedin.ts:4694`
-- `audit selectors` in `packages/cli/src/bin/linkedin.ts:4714`
+1. normalize input
+2. call `auth.ensureAuthenticated()`
+3. open a browser context/page
+4. navigate to a LinkedIn page
+5. scrape structured data
 
-This means the raw building blocks for a “read-only validation CLI” are already
-present. The missing piece is an opinionated command that runs them as one
-scripted validation session with shared policy and reporting.
+That is exactly the kind of work a Tier-2 smoke runner needs to coordinate.
 
-### 3) Tier 1 already added the right live-test scaffolding
+### CLI surface inventory
 
-Tier 1’s live E2E lane is a useful template for issue #88.
+The CLI already exposes the operator-facing read-only commands that Tier 2
+would likely aggregate:
 
-The runner already provides:
+- `status` in `packages/cli/src/bin/linkedin.ts:3796`
+- `login` in `packages/cli/src/bin/linkedin.ts:4101`
+- `search` in `packages/cli/src/bin/linkedin.ts:4317`
+- `inbox` in `packages/cli/src/bin/linkedin.ts:4342`
+- `connections` in `packages/cli/src/bin/linkedin.ts:4394`
+- `feed` in `packages/cli/src/bin/linkedin.ts:4515`
+- `notifications` in `packages/cli/src/bin/linkedin.ts:4639`
+- `jobs` in `packages/cli/src/bin/linkedin.ts:4657`
+- `profile` in `packages/cli/src/bin/linkedin.ts:4694`
+- `audit` in `packages/cli/src/bin/linkedin.ts:4714`
+- `actions` in `packages/cli/src/bin/linkedin.ts:4803`
+- `health` in `packages/cli/src/bin/linkedin.ts:4823`
 
-- argument parsing for session requirements and lightweight discovery fixtures in
-  `scripts/run-e2e.js:73`
-- safe-default messaging that explicitly says default live runs are read-only,
-  preview-only, or `test.echo` backed in `scripts/run-e2e.js:205`
-- explicit skip-vs-fail semantics when no authenticated session is available in
-  `scripts/run-e2e.js:250` and `scripts/run-e2e.js:363`
+There is also already a hidden colon-alias pattern for fixtures:
 
-The shared E2E harness already provides:
+- `fixtures record` / `fixtures check`
+- hidden aliases `fixtures:record` / `fixtures:check`
 
-- a single temporary assistant-home directory per run in
-  `packages/core/src/__tests__/e2e/setup.ts:353`
-- shared runtime creation in `packages/core/src/__tests__/e2e/setup.ts:318`
-- cached session/CDP availability in `packages/core/src/__tests__/e2e/setup.ts:421`
-- explicit test skipping in `packages/core/src/__tests__/e2e/setup.ts:531`
+See `packages/cli/src/bin/linkedin.ts:4311`.
 
-The Tier 1 CLI/MCP helpers already provide:
+That means issue #88’s proposed `owa test:live --read-only` naming is aligned
+with an existing, if limited, CLI convention.
 
-- direct invocation of the real CLI entrypoint with timeout and retry handling
-  in `packages/core/src/__tests__/e2e/helpers.ts:562`
-- parsing of mixed CLI output into machine-readable JSON in
-  `packages/core/src/__tests__/e2e/helpers.ts:624`
-- discovery and caching of safe live identifiers for CLI and MCP contract tests
-  in `packages/core/src/__tests__/e2e/helpers.ts:871`
+### Recommended Tier-2 read-only subset
 
-Most importantly, the live CLI contract suite already exercises nearly all of
-the read-only surfaces that issue #88 wants:
+Based on what already exists, the safest first Tier-2 scope is:
 
-- session, health, rate-limit, login, and selector audit in
+- `health`
+- `audit selectors`
+- `feed list`
+- `profile view me`
+- `notifications list`
+- `inbox list`
+- `inbox show` for one discovered thread
+- `connections list`
+- optionally `connections pending`
+
+I would **not** include `followups list` in a strict first pass, because it
+refreshes acceptance state and mutates the local DB even though it does not
+write to LinkedIn. See `packages/core/src/linkedinFollowups.ts:1190` and
+`packages/core/src/linkedinFollowups.ts:1296`.
+
+I would also keep `search` and `jobs` out of the initial Tier-2 acceptance
+scope unless the issue owner explicitly wants them, because issue #88’s stated
+read-only list is narrower and those services currently use a different context
+path than some of the other read-only modules.
+
+## Tier-1 / current E2E infrastructure that is directly reusable
+
+### 1) The live runner already handles “skip vs fail” policy
+
+`scripts/run-e2e.js` already:
+
+- parses runner-specific flags like `--require-session` and `--fixtures`
+- prints the effective runtime configuration
+- probes CDP availability and LinkedIn auth
+- decides whether to skip or fail before launching Vitest
+
+See `scripts/run-e2e.js:73`, `scripts/run-e2e.js:162`, and
+`scripts/run-e2e.js:201`.
+
+That logic should heavily influence Tier 2 UX. A human-triggered smoke command
+should also be explicit about:
+
+- what profile/session it will use
+- whether it is allowed to continue when auth is degraded
+- why it failed or short-circuited
+
+### 2) Shared live-suite helpers already exist
+
+`packages/core/src/__tests__/e2e/setup.ts` provides:
+
+- CDP probing
+- auth probing
+- stale temp-dir cleanup
+- one shared runtime per suite
+- explicit `skipIfE2EUnavailable()` behavior
+
+See `packages/core/src/__tests__/e2e/setup.ts:208`,
+`packages/core/src/__tests__/e2e/setup.ts:413`,
+`packages/core/src/__tests__/e2e/setup.ts:474`, and
+`packages/core/src/__tests__/e2e/setup.ts:531`.
+
+That confirms the repo already knows how to centralize “is live validation even
+safe/possible right now?” logic.
+
+### 3) CLI command invocation is already tested end-to-end
+
+`packages/core/src/__tests__/e2e/helpers.ts` already has in-process helpers for:
+
+- running the real CLI entrypoint
+- capturing mixed stdout/stderr output
+- extracting the last JSON object from mixed output
+- handling optional timeouts and retries
+
+See `packages/core/src/__tests__/e2e/helpers.ts:562` and
+`packages/core/src/__tests__/e2e/helpers.ts:617`.
+
+The live CLI E2E suite already proves that the real binary surface can be
+driven safely:
+
+- session/health/rate-limit/login/selector audit at
   `packages/core/src/__tests__/e2e/cli.e2e.test.ts:19`
-- inbox and confirm entrypoints in
+- inbox plus both confirm entrypoints at
   `packages/core/src/__tests__/e2e/cli.e2e.test.ts:86`
-- connections and followups in
+- connections/followups/keepalive at
   `packages/core/src/__tests__/e2e/cli.e2e.test.ts:187`
-- feed, post, profile, search, jobs, and notifications in
+- feed/post/profile/search/jobs/notifications at
   `packages/core/src/__tests__/e2e/cli.e2e.test.ts:311`
 
-That makes issue #88 more of a productized CLI workflow than a net-new browser
-automation problem.
+That is a strong signal that issue #88 should be implemented as a **normal CLI
+command with normal CLI E2E coverage**, not as a separate ad hoc script.
 
-### 4) Safety and guardrail patterns already exist, but they are not yet combined into a read-only policy
+### 4) Tier 1 discovery fixtures suggest a good reuse pattern
 
-There are several useful safety primitives already in the repo:
+`getCliCoverageFixtures()` already caches a small set of live identifiers for
+CLI/MCP E2E reruns in `packages/core/src/__tests__/e2e/helpers.ts:871`, and the
+developer docs explain the separate live discovery fixture concept in
+`docs/e2e-testing.md:367`.
 
-- two-phase commit for all outbound actions, including token TTLs, preview
-  lookup, and executor dispatch in `packages/core/src/twoPhaseCommit.ts:323`
-- a generic interactive `Type "yes" to confirm` prompt and non-interactive
-  refusal behavior in `packages/cli/src/bin/linkedin.ts:1081` and
+That pattern is relevant to Tier 2 for two reasons:
+
+1. it shows how the repo already thinks about **safe reuse of live identifiers**
+2. it could be adapted later if Tier 2 needs a stable inbox thread or target
+   profile between runs without rediscovery every time
+
+## Existing safety guardrails
+
+### 1) The strongest existing safety rule is two-phase commit
+
+All outbound mutations already follow the repo-wide prepare → confirm model in
+`packages/core/src/twoPhaseCommit.ts:337` and
+`packages/core/src/twoPhaseCommit.ts:424`.
+
+That gives the codebase a strong default architecture for “don’t do real things
+by accident.”
+
+It also means a read-only Tier-2 command can stay safe simply by never touching
+these surfaces:
+
+- `inbox.prepareReply()` in `packages/core/src/linkedinInbox.ts:1222`
+- `connections.prepareSendInvitation()` / `prepareAcceptInvitation()` /
+  `prepareWithdrawInvitation()` in `packages/core/src/linkedinConnections.ts:1246`
+- `feed.prepareLikePost()` / `prepareCommentOnPost()` in
+  `packages/core/src/linkedinFeed.ts:1791`
+- `posts.prepareCreate()` in `packages/core/src/linkedinPosts.ts:1808`
+
+### 2) Interactive confirmation and `--yes` already exist
+
+The CLI already has the operator-confirmation mechanics that issue #88 asks for:
+
+- `promptYesNo()` prompts for a literal `yes` in
+  `packages/cli/src/bin/linkedin.ts:1081`
+- non-interactive refusal helpers exist in
   `packages/cli/src/bin/linkedin.ts:1095`
-- hardened confirm behavior that refuses non-interactive confirms without
-  `--yes` and preserves prepared-action state in
-  `packages/cli/src/bin/linkedin.ts:3658` and
-  `packages/core/src/__tests__/e2eConfirmContracts.test.ts:102`
-- structured JSON event logging with privacy redaction in
-  `packages/core/src/logging.ts:21`
-- per-run artifact writing and indexing in `packages/core/src/artifacts.ts:21`
-- privacy redaction across CLI, log, storage, and artifact surfaces in
-  `packages/core/src/privacy.ts:442`
-- failure-time screenshot/trace capture for confirms in
+- `actions confirm` already shows a preview and requires either an interactive
+  confirmation or `--yes` in `packages/cli/src/bin/linkedin.ts:3658`
+
+Tier 2 should reuse this pattern for each live validation step or for a grouped
+run plan.
+
+### 3) Live E2E already defaults to read-only / preview-only
+
+`docs/e2e-testing.md` explicitly documents:
+
+- “Safe defaults” in `docs/e2e-testing.md:474`
+- “Approved targets and opt-in writes” in `docs/e2e-testing.md:492`
+- explicit opt-in flags for message, connection, like, comment, and post
+  confirms in `docs/e2e-testing.md:507`, `docs/e2e-testing.md:520`,
+  `docs/e2e-testing.md:540`, and `docs/e2e-testing.md:553`
+
+This matters because issue #88 is not introducing a brand-new safety posture.
+It is extending an existing one.
+
+### 4) Privacy, artifact, and structured-error plumbing are already strong
+
+The repo already has useful safety/diagnostic infrastructure for Tier 2:
+
+- structured JSON logs in `packages/core/src/logging.ts:21`
+- structured artifacts and report writing in `packages/core/src/artifacts.ts:21`
+- privacy redaction for logs/artifacts/errors in
+  `packages/core/src/privacy.ts:442` and `packages/core/src/errors.ts:41`
+- confirm-failure screenshots/traces in
   `packages/core/src/confirmArtifacts.ts:437`
-- a generic per-counter rate limiter in `packages/core/src/rateLimiter.ts:20`
-- persistent auth cooldown state surfaced through `linkedin rate-limit` in
-  `packages/core/src/auth/session.ts:102` and
-  `packages/cli/src/bin/linkedin.ts:3803`
 
-There are also existing live-test guardrails around real outbound behavior:
+This means issue #88 does **not** need a new storage/reporting subsystem.
 
-- the E2E docs explicitly say the default live lane stays read-only,
-  preview-only, or `test.echo` backed in `docs/e2e-testing.md:109`
-- real outbound confirms are opt-in via dedicated environment flags in
-  `docs/e2e-testing.md:137`
-- safe live discovery targets are constrained by
-  `LINKEDIN_E2E_MESSAGE_TARGET_PATTERN` and
-  `LINKEDIN_E2E_CONNECTION_TARGET` in `docs/e2e-testing.md:134` and
-  `docs/e2e-testing.md:135`, with matching helper code in
-  `packages/core/src/__tests__/e2e/helpers.ts:523` and
-  `packages/core/src/__tests__/e2e/helpers.ts:528`
+### 5) The biggest guardrail gaps are policy-level, not plumbing-level
 
-These patterns are the right foundation for a live read-only smoke CLI.
+I did **not** find these protections in live mode today:
 
-## Gaps against issue #88
+- a global GET-only request allowlist for LinkedIn domains
+- a shared “no mutation selectors/helpers may load in read-only mode” policy
+- a single per-run request counter / request budget
+- a shared “sleep/pacing between read-only operations” policy
+- a centralized 30-second operation timeout wrapper for the proposed Tier-2
+  command
 
-### 1) There is no true read-only execution mode yet
+The closest existing mechanism is **fixture replay** request interception, not
+live-mode interception. Under replay, the repo routes all requests through a
+local replay service and aborts non-LinkedIn traffic in
+`packages/core/src/fixtureReplay.ts:1289`.
 
-The runtime currently registers all read and write services plus all action
-executors by default in `packages/core/src/runtime.ts:189` and
-`packages/core/src/runtime.ts:208`.
+That is exactly the kind of fail-closed behavior issue #88 wants, but it does
+not currently exist for live LinkedIn runs.
 
-The CLI likewise exposes read and write commands from the same program:
+## Important implementation risks
 
-- read-only commands such as `search`, `inbox list`, `feed list`, and
-  `profile view`
-- write or preview-write commands such as `inbox prepare-reply`,
-  `connections invite`, `feed like`, `feed comment`, `post prepare`, and
-  `actions confirm` in `packages/cli/src/bin/linkedin.ts:4377`,
-  `packages/cli/src/bin/linkedin.ts:4436`,
-  `packages/cli/src/bin/linkedin.ts:4545`,
-  `packages/cli/src/bin/linkedin.ts:4571`,
-  `packages/cli/src/bin/linkedin.ts:4592`, and
-  `packages/cli/src/bin/linkedin.ts:4803`
+### 1) CDP support is inconsistent across read-only services
 
-So the repo has safe write patterns, but it does not yet have a hard
-read-only-only policy boundary.
+Some read-only services honor `cdpUrl` through `runWithContext()`:
 
-### 2) Issue #88’s session-storage requirement is only partially covered
+- feed
+- profile
+- inbox
+- connections
 
-Issue #88 asks for a stored session/cookie flow that is encrypted at rest and
-never passed to agents. The current codebase stores session state implicitly in
-tool-owned browser profiles (`packages/core/src/profileManager.ts:41`) or uses a
-live attached browser via CDP (`packages/core/src/profileManager.ts:123`).
+Others go straight to `runWithPersistentContext()` and therefore ignore the
+runtime’s CDP pathway:
 
-That is operationally workable for a human-triggered smoke command, but it is
-not the same as a dedicated session-capture command plus encrypted cookie store.
+- search in `packages/core/src/linkedinSearch.ts:159`
+- jobs in `packages/core/src/linkedinJobs.ts:537`
+- notifications in `packages/core/src/linkedinNotifications.ts:390`
 
-### 3) The existing rate-limit pieces do not match the requested policy
+This is the biggest architectural inconsistency I found. If Tier 2 wants one
+attached-browser smoke flow, these modules either need harmonization or the
+first version should stick to services that already share the same context
+strategy.
 
-There are two useful rate-limit-related mechanisms today, but neither matches
-issue #88 directly:
+### 2) Repeated auth checks will add avoidable traffic and latency
 
-- auth cooldown state after challenge/rate limit in
-  `packages/core/src/auth/session.ts:103`
-- generic per-counter action rate limiting in `packages/core/src/rateLimiter.ts:20`
+Most services call `ensureAuthenticated()` independently before doing their own
+work. Because `status()` itself navigates to `/feed/`, a naïve Tier-2 command
+that chains many operations will trigger extra navigations and session checks.
+See `packages/core/src/auth/session.ts:102`.
 
-Issue #88 needs a live-validation session budget:
+That is why I think selector audit is the right architectural model: one auth
+check, one context, many page-level checks.
 
-- max 1 request per 5 seconds
-- max 20 requests per validation session
-- automatic stop when the budget is exhausted
+### 3) Inbox is the flakiest “read-only” candidate
 
-That policy does not exist yet as a single reusable abstraction.
+Inbox read paths are safe, but they are also the most network-sensitive. The
+inbox service prefers network-derived message data and falls back to DOM
+scraping when needed in `packages/core/src/linkedinInbox.ts:1141`.
 
-### 4) Network-level read-only enforcement does not exist yet
+Tier 2 should probably treat inbox as a later or softer-fail step than health,
+profile, notifications, or feed.
 
-The fixture replay system does have a strong host allowlist: non-LinkedIn hosts
-are blocked in `packages/core/src/fixtureReplay.ts:1289`. But that behavior is
-for replay mode, not live browsing.
+### 4) `followups list` is read-only on LinkedIn, but not locally
 
-There is currently no live-mode interception layer that:
+As noted above, `listAcceptedConnections()` refreshes state and writes acceptance
+data into the local DB through `refreshAcceptanceState()` in
+`packages/core/src/linkedinFollowups.ts:1296`.
 
-- blocks non-LinkedIn traffic
-- blocks non-GET LinkedIn requests
-- aborts the session on unexpected request shapes
+That makes it a poor fit for a first-pass “strictly read-only validation CLI.”
 
-One caution here: the exact browser traffic profile of LinkedIn’s live UI needs
-to be validated before enforcing a strict GET-only rule. The current live code
-does not assume such a rule, and the replay plumbing is method-aware rather than
-GET-only in `packages/core/src/fixtureReplay.ts:688`.
+### 5) Session storage and login semantics need careful wording
 
-### 5) Reporting is close, but not yet issue #88-complete
+Issue #88 says “CLI command: `owa auth:session` to capture a session from a
+manual login,” but the current product language and behavior are profile-based:
 
-There is already a mature selector-audit report with:
+- `owa login --profile ...`
+- persistent Playwright profile directory
+- optional headless login path still present
 
-- structured pass/fail counts
-- fallback detection
-- failure artifacts
-- a durable `report_path`
+Tier 2 implementation should either:
 
-This is exposed from `packages/core/src/selectorAudit.ts:1200` and surfaced by
-the CLI in `packages/cli/src/bin/linkedin.ts:3479`.
+1. explicitly align the issue wording to the existing `login --profile` model,
+   or
+2. treat `auth:session` as a follow-on UX layer on top of the same underlying
+   profile storage
 
-That makes selector regression reporting largely solved.
+### 6) Locale overlap is real
 
-What is still missing is a single report for the whole live validation run that
-also includes:
+Issue #8 is still open, and Tier 2’s job is to detect real-site selector drift.
+That means Tier 2 must carry selector-locale context through the report and
+avoid silently assuming English-only sessions. The current locale-aware selector
+work already exists in the runtime and selector audit, so Tier 2 should build
+on that instead of bypassing it.
 
-- per-step timings
-- pass/fail for feed/profile/notifications/inbox/connections checks
-- auth/session preflight result
-- request-budget usage
-- diff-vs-previous-run summary for CI-adjacent use
+## Open issue overlap review
 
-## Open-issue overlap scan
+All currently open issues were reviewed on 2026-03-09.
 
-Open issues checked on March 9, 2026:
+| Issue | Title | Overlap | Notes |
+| --- | --- | --- | --- |
+| #8 | Internationalization/locale support for selectors | Medium / cross-cutting | Tier 2 is partly about selector drift detection, so its reports should include selector locale and reuse the existing locale-aware selector plumbing instead of hardcoding English assumptions. |
+| #86 | LinkedIn activity webhooks (poll-based subscription system) | Low / future | Both features depend on safe read-only polling of LinkedIn state, but there is no immediate implementation conflict. A future webhook poller could reuse Tier-2 execution-policy work. |
+| #88 | E2E live smoke tests: read-only validation CLI (Tier 2) | Direct | Parent feature. |
+| #90 | E2E write-action validation harness (Tier 3) | High / downstream | Tier 3 will need the same session lifecycle, reporting, audit logging, and live-run guardrails. Tier 2 should introduce reusable live-execution policy primitives instead of baking everything into a one-off read-only command. |
+| #124 | [Research] Issue #88: E2E live smoke tests — read-only validation CLI (Tier 2) | Direct | Current task. |
 
-- `#124` — research ticket for issue #88
-- `#90` — E2E write-action validation harness (Tier 3)
-- `#88` — read-only live smoke validation CLI (Tier 2)
-- `#86` — LinkedIn activity webhooks
-- `#8` — Internationalization/locale support for selectors
+Closed but highly relevant issues:
 
-### Issue #90 is the closest neighbor and should share infrastructure
+| Issue | Title | Why it matters |
+| --- | --- | --- |
+| #11 | E2E test coverage hardening | Established the live runner, CLI/MCP E2E coverage shape, and opt-in write safety posture that Tier 2 should extend rather than replace. |
+| #87 | Recorded fixture replay (Tier 1) | Gives deterministic CI-safe regression coverage and already created the live/discovery-fixture patterns that Tier 2 can borrow for stable identifiers and report expectations. |
 
-Issue #90 is the next tier in the same testing track. The overlap is strong:
+## Recent commits relevant to this work
 
-- both issues want a human-triggered live validation harness
-- both want a stored-session mechanism
-- both need local audit/report output
-- both benefit from shared step execution, timing, and artifact plumbing
+Recent history shows that the E2E layer and its docs have been evolving quickly:
 
-The important boundary is policy, not implementation:
+- `e6d1f67` — documented the fixture replay workflow and current Tier-1 state
+- `f2f80d5` — tightened fixture replay harness DX
+- `ab24864` — added the fixture replay E2E harness
+- `e6f1403` — documented the shipped E2E hardening workflow
+- `d5c83d2` — improved the E2E developer workflow
+- `ad888c0` — hardened E2E helper infrastructure
+- `270d2cf` — hardened E2E coverage contracts
+- `b2cd4b1` — simplified E2E hardening scaffolding
+- `252fabe` — hardened real-session E2E coverage and safety
+- `801ec01` — introduced the original E2E lane and keepalive hardening
 
-- issue #88 should be batchable with `--yes` because it stays read-only
-- issue #90 explicitly forbids batch mode and requires one human confirmation
-  per real write
-- issue #90 also adds account-safety requirements that do not belong in the
-  read-only flow
+The strong implication is that issue #88 should be treated as the **next layer
+on top of the current E2E architecture**, not a clean-room test subsystem.
 
-Recommendation: build a shared “live validation runner + report model” layer,
-but keep separate read-only and write-validation policy wrappers.
+## Recommended shape for issue #88
 
-### Issue #8 is a real dependency for result quality, but not a blocker
+### 1) Add a dedicated live-validation command group
 
-Selector locale support is already partially in place:
+I would implement both:
 
-- the CLI has a global `--selector-locale` flag in
-  `packages/cli/src/bin/linkedin.ts:3750`
-- config resolution and fallback diagnostics already exist in
-  `packages/core/src/config.ts:620`
+- `owa test live --read-only`
+- hidden alias `owa test:live --read-only`
 
-That reduces risk, but issue #8 still overlaps with issue #88 in two ways:
+That matches the existing Commander style plus the existing hidden colon-alias
+pattern already used by fixtures in `packages/cli/src/bin/linkedin.ts:4311`.
 
-- live smoke runs will produce false negatives if locale-sensitive selectors lag
-  behind the operator’s LinkedIn UI
-- auth/session inspection still depends partly on UI text/labels in
-  `packages/core/src/auth/sessionInspection.ts:97`
+### 2) Model it after selector audit, not after a pile of existing commands
 
-Recommendation: Tier 2 should explicitly thread selector-locale through the new
-command and report the effective locale in the validation output.
+The selector audit service is the best existing template because it already:
 
-### Issue #86 is adjacent but not conflicting
+- authenticates once
+- uses one context across several checks
+- writes a JSON report
+- captures useful artifacts
+- has clear pass/fail semantics
 
-Issue #86 can eventually reuse the same read-only service surfaces, auth checks,
-and local report/logging patterns, but it does not conflict with issue #88’s
-scope. Nothing in the current repo suggests a direct sequencing dependency.
+See `packages/core/src/selectorAudit.ts:1193`.
 
-## Recommended implementation shape for issue #88
+Tier 2 should likely follow the same shape:
 
-### 1) Add one explicit live-validation entrypoint, not many ad hoc flags
+1. run one upfront health/auth check
+2. build a read-only run plan
+3. optionally confirm each step unless `--yes`
+4. execute the checks through one shared context where possible
+5. emit one JSON report and one terminal summary
+6. compare against the last report and exit non-zero on failure/regression
 
-The CLI binary already supports both `linkedin` and `owa` aliases in
-`packages/cli/package.json:7`, so the issue wording already fits the current
-operator surface.
+### 3) Introduce a shared live-validation policy layer
 
-Recommended surface:
+The core missing abstraction is something like:
 
-- `owa test:live --read-only`
-- `owa test:live --read-only --yes`
-- `owa test:live --read-only --profile <name>`
-- `owa test:live --read-only --selector-locale <locale>`
-- `owa test:live --read-only --timeout-ms <ms>`
+- request pacing
+- max requests / per-run budget
+- allowed domains/methods
+- challenge/redirect abort policy
+- default per-step timeout
+- explicit prohibition on write helpers
 
-### 2) Prefer a small core orchestration module plus a thin CLI wrapper
+This should live in `packages/core`, not only in the CLI, because issue #90 is
+very likely to need the same policy framework with stricter write rules.
 
-Even though the feature is CLI-first, a small core module would make the work
-more testable and more reusable for issue #90.
+### 4) Keep the first step set narrow
 
-Suggested split:
+My recommended first-pass Tier-2 checks are:
 
-- `packages/core/src/liveValidation.ts`
-  - executes an ordered list of read-only checks
-  - enforces request budget / pacing
-  - captures timings and report data
-  - uses `runtime.logger` and `runtime.artifacts` for durable output
-- `packages/cli/src/bin/linkedin.ts`
-  - parses flags
-  - handles interactive per-step confirmation unless `--yes` is passed
-  - prints the final report JSON and exit code
+- session health
+- selector audit
+- feed list
+- profile view (`me`)
+- notifications list
+- inbox list
+- inbox show (one discovered thread)
+- connections list
 
-This follows the repo’s existing architecture better than burying the entire
-workflow inside the CLI file.
+That is already enough to validate the most important read-only surfaces from
+issue #88 without pulling in every possible page type.
 
-### 3) Build the read-only policy as an allowlist, not as “please be careful”
+### 5) Reuse existing report/artifact primitives
 
-The cleanest implementation would combine three layers:
+Do not invent a second reporting/storage stack.
 
-- command-step allowlist: only run status/health/feed/profile/notifications/
-  inbox/connections/search/jobs/audit steps
-- runtime policy: no calls into `prepare*()` or `confirm*()` paths from the
-  live-validation module
-- network policy: abort unexpected hosts and validate live request behavior
-  before deciding whether strict GET-only enforcement is viable
+Use:
 
-Because `createCoreRuntime()` currently wires every executor by default in
-`packages/core/src/runtime.ts:208`, a dedicated read-only runtime factory or a
-read-only policy wrapper would be cleaner than relying on convention alone.
+- `ArtifactHelpers.writeJson()` from `packages/core/src/artifacts.ts:64`
+- `JsonEventLogger.log()` from `packages/core/src/logging.ts:39`
+- selector audit’s report path / failure detail shape as a design reference in
+  `packages/core/src/selectorAudit.ts:1283`
 
-### 4) Reuse selector audit instead of inventing a second selector-report system
+### 6) Treat session-capture UX as a follow-on concern unless the issue owner insists
 
-Issue #88 wants to know which selectors matched, which failed, and what regressed.
-The repo already has the right primitive for this in `selectorAudit`.
+If the scope stays strictly aligned to issue #88’s main value — safe live
+validation against a real LinkedIn session — the current `owa login --profile`
+model is already sufficient to get started.
 
-A good Tier 2 report should likely combine:
-
-- a `selectorAudit` report reference/path
-- step timings for `status`, `health`, `feed`, `profile`, `notifications`,
-  `inbox`, and `connections`
-- request-budget stats
-- top-level `passed` / `failed` outcome
-- previous-run comparison for regression detection
-
-That is likely lower risk than building a second selector-specific reporting
-mechanism from scratch.
-
-### 5) Reuse existing interactive-confirmation UX patterns
-
-Issue #88’s interactive mode maps well to the existing CLI prompt helper in
-`packages/cli/src/bin/linkedin.ts:1081`.
-
-Recommended behavior:
-
-- default interactive mode:
-  - print the next planned read-only step
-  - ask for confirmation before executing it
-- `--yes` mode:
-  - skip the prompts
-  - keep every other safety rule identical
-
-This mirrors the existing operator experience instead of introducing a new
-confirmation style.
-
-## Recommended test plan for the eventual implementation
-
-Tier 2 should be testable mostly with existing infrastructure:
-
-- unit tests for request-budget enforcement, report diffing, and read-only
-  policy behavior
-- CLI contract tests that call the real `linkedin`/`owa` entrypoint directly,
-  reusing `packages/core/src/__tests__/e2e/helpers.ts:562`
-- one live E2E smoke test file wired through `npm run test:e2e`, reusing the
-  Tier 1 session preflight and skip behavior from `scripts/run-e2e.js:346`
-- selector-audit assertions that verify report generation and exit-code mapping
-
-I would not recommend adding MCP work for this issue unless product scope
-changes; everything in issue #88 is explicitly CLI-oriented.
+The dedicated `owa auth:session` UX can be added later if the project wants a
+clearer operator story around session capture/import/export.
 
 ## Bottom line
 
-Issue #88 does not need a new browser foundation. It needs a new read-only
-policy layer and a new operator workflow built on top of primitives that mostly
-already exist.
+Issue #88 is a good fit for the current architecture.
 
-The highest-value implementation order looks like this:
+The repo already has:
 
-1. define a dedicated live-validation report model and read-only step list
-2. add a CLI `test:live --read-only` command that reuses existing runtime calls
-3. enforce session pacing/budget and early abort behavior
-4. reuse selector-audit output for regression reporting
-5. decide whether “stored session” means persistent profiles for now, or whether
-   issue #88 should also absorb the larger encrypted session-capture feature
+- live session/auth probing
+- broad read-only runtime surfaces
+- command-level CLI E2E coverage
+- structured reports/artifacts/logging
+- two-phase commit and opt-in write safety posture
 
-If the team wants the smallest possible first cut, Tier 2 can ship safely using
-the current persistent-profile/CDP auth model and defer secure session export to
-follow-up work. If the issue is interpreted strictly, the session-capture piece
-is the only major net-new subsystem.
+What it still needs is a **Tier-2-specific execution policy** and a **single
+operator-facing command/report surface**.
+
+If I were turning this brief into an implementation plan, I would define the
+work as:
+
+1. add a reusable live-validation policy layer in `packages/core`
+2. add a `test live` / `test:live` CLI command that orchestrates a narrow safe
+   read-only step set
+3. reuse selector-audit-style reporting and exit-code behavior
+4. add CLI E2E coverage using the existing live runner/helpers
+5. document the command in the same style as `docs/e2e-testing.md`


### PR DESCRIPTION
## Summary
- add `docs/.research-brief-issue-88.md` for the Tier 2 research phase
- document the current auth/session, read-only runtime and CLI surfaces, Tier 1 E2E infrastructure, and safety guardrails
- record overlap notes for open issues #90, #8, and #86 plus a recommended implementation shape for issue #88

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #124
