### PR TITLE
feat: add read-only live validation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,42 @@ Failures
 - Set `LINKEDIN_ASSISTANT_SELECTOR_LOCALE` to change the default selector
   locale for the current shell.
 
+### Live read-only validation
+
+Live read-only validation is a human-triggered smoke test for the production
+LinkedIn UI. It uses an encrypted stored browser session, verifies only
+read-only surfaces, blocks non-GET traffic during the run, and records a local
+report with selector matches, failures, timings, and regressions versus the
+previous run.
+
+See `docs/live-validation.md` for the full workflow.
+
+```bash
+# Capture an encrypted stored session from a manual login
+npm exec -w @linkedin-assistant/cli -- owa auth:session --session smoke
+
+# Run the read-only smoke test interactively
+npm exec -w @linkedin-assistant/cli -- owa test:live --read-only --session smoke
+
+# Skip per-step confirmations but keep every guardrail enabled
+npm exec -w @linkedin-assistant/cli -- owa test:live --read-only --session smoke --yes --json
+```
+
+- `owa auth:session` opens a dedicated browser window, waits for a manual
+  LinkedIn login, and stores Playwright session state encrypted at rest under
+  the tool-owned profile directory.
+- `owa test:live --read-only` validates the feed, profile, notifications,
+  messaging, and connections surfaces only.
+- Interactive mode pauses before every step; `--yes` keeps the run read-only
+  and only skips the confirmation prompts.
+- The live validator enforces a minimum 5-second gap between steps and a
+  maximum of 20 steps per session.
+- Any session expiry, challenge, captcha, or unexpected redirect stops the run.
+- The validator writes a run-scoped JSON report and updates a stable
+  `latest-report.json` snapshot used for regression diffing on the next run.
+- If the stored session is missing or expired in an interactive terminal, the
+  CLI prompts to refresh it via `owa auth:session` and retries once.
+
 ### Draft quality evaluation
 
 Draft quality evaluation is a read-only, offline harness for scoring reply

--- a/docs/live-validation.md
+++ b/docs/live-validation.md
@@ -1,0 +1,82 @@
+# Live read-only validation
+
+The live validation workflow is a Tier 2 smoke test for selector and page-shape
+drift on real LinkedIn pages. It is designed for a human operator, stays
+strictly read-only, and favors local safety over broad automation.
+
+## Commands
+
+Capture an encrypted stored session from a manual LinkedIn login:
+
+```bash
+npm exec -w @linkedin-assistant/cli -- owa auth:session --session smoke
+```
+
+Run the live read-only validation interactively:
+
+```bash
+npm exec -w @linkedin-assistant/cli -- owa test:live --read-only --session smoke
+```
+
+Run the same validation in batch mode while keeping every guardrail enabled:
+
+```bash
+npm exec -w @linkedin-assistant/cli -- owa test:live --read-only --session smoke --yes --json
+```
+
+## What the validator checks
+
+The validator only exercises read-only flows:
+
+- feed surface
+- signed-in profile header
+- notifications surface
+- inbox conversation list and one readable thread when available
+- connections surface
+
+Every step records selector matches, failures, warnings, and page-load timing.
+
+## Safety guardrails
+
+- `--read-only` is required; the command refuses to run without it.
+- `--cdp-url` is rejected for this workflow so the validator uses only the
+  encrypted stored session.
+- Interactive runs prompt before each step unless `--yes` is supplied.
+- The validator enforces a minimum 5-second delay between steps and a maximum
+  of 20 steps per session.
+- During the run, only `GET` requests to LinkedIn-owned domains are allowed.
+  Non-GET requests and non-LinkedIn domains are blocked and recorded in the
+  report.
+- Any challenge, captcha, login redirect, or unexpected redirect stops the run.
+- The validator never loads mutation-specific selectors or prepares outbound
+  actions.
+
+## Session capture and refresh
+
+- `owa auth:session` opens a dedicated Chromium window.
+- Sign in manually and wait for LinkedIn to land on an authenticated page.
+- The CLI captures Playwright storage state and stores it encrypted at rest.
+- Session contents are never printed to stdout/stderr.
+- If `owa test:live --read-only` detects an expired or challenged session in an
+  interactive terminal, it prompts to capture a fresh session and retries the
+  validation once.
+
+## Reports and exit codes
+
+Each run writes:
+
+- a run-scoped report under `artifacts/<run-id>/live-readonly/report.json`
+- the structured event log for that run under `artifacts/<run-id>/events.jsonl`
+- a stable snapshot at `artifacts/live-readonly/latest-report.json`
+
+The stable snapshot is compared with the next run to highlight:
+
+- new selector failures
+- selector drift toward weaker fallback candidates
+- recovered selectors
+
+Exit behavior:
+
+- `0` when every read-only operation passes
+- `1` when one or more operations fail, or when the workflow is blocked by
+  authentication / challenge / redirect guardrails

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -42,6 +42,7 @@ import {
   DEFAULT_FIXTURE_STALENESS_DAYS,
   createCoreRuntime,
   checkLinkedInFixtureStaleness,
+  captureLinkedInSession,
   deleteLocalData,
   loadLinkedInFixtureSet,
   normalizeLinkedInFeedReaction,
@@ -60,6 +61,7 @@ import {
   resolveLegacyRateLimitStateFilePath,
   resolvePrivacyConfig,
   resolveSchedulerConfig,
+  runReadOnlyLinkedInLiveValidation,
   toLinkedInAssistantErrorPayload,
   writeLinkedInFixtureManifest,
   type DraftQualityReport,
@@ -81,6 +83,11 @@ import {
   formatDraftQualityReport,
   resolveDraftQualityOutputMode
 } from "../draftQualityOutput.js";
+import {
+  formatReadOnlyValidationError,
+  formatReadOnlyValidationReport,
+  resolveReadOnlyValidationOutputMode
+} from "../liveValidationOutput.js";
 import {
   formatSelectorAuditError,
   formatSelectorAuditReport,
@@ -1582,6 +1589,199 @@ async function runStatus(profileName: string, cdpUrl?: string): Promise<void> {
     printJson({ run_id: runtime.runId, ...status });
   } finally {
     runtime.close();
+  }
+}
+
+function assertNoExternalSessionOverrideForStoredSession(cdpUrl?: string): void {
+  if (!cdpUrl) {
+    return;
+  }
+
+  throw new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    "Stored-session auth and read-only live validation do not support --cdp-url. Omit --cdp-url to use the encrypted stored session flow."
+  );
+}
+
+async function captureStoredSession(input: {
+  sessionName: string;
+  timeoutMinutes: number;
+}): Promise<Awaited<ReturnType<typeof captureLinkedInSession>>> {
+  writeCliNotice(
+    `Opening a dedicated Chromium window to capture session "${input.sessionName}".`
+  );
+  writeCliNotice(
+    "Sign in manually. The browser closes automatically after the authenticated session is stored."
+  );
+
+  return captureLinkedInSession({
+    sessionName: input.sessionName,
+    timeoutMs: input.timeoutMinutes * 60_000
+  });
+}
+
+async function runAuthSessionCapture(input: {
+  sessionName: string;
+  timeoutMinutes: number;
+}, cdpUrl?: string): Promise<void> {
+  assertNoExternalSessionOverrideForStoredSession(cdpUrl);
+  assertInteractiveTerminal("capture a stored LinkedIn session");
+
+  const result = await captureStoredSession(input);
+  printJson({
+    authenticated: result.authenticated,
+    captured_at: result.capturedAt,
+    checked_at: result.checkedAt,
+    current_url: result.currentUrl,
+    li_at_expires_at: result.liAtCookieExpiresAt,
+    session_file: result.filePath,
+    session_name: result.sessionName
+  });
+}
+
+function isStoredSessionRefreshError(error: unknown): boolean {
+  return (
+    error instanceof LinkedInAssistantError &&
+    (error.code === "AUTH_REQUIRED" || error.code === "CAPTCHA_OR_CHALLENGE")
+  );
+}
+
+async function maybeRefreshStoredSession(
+  input: {
+    sessionName: string;
+    timeoutMinutes: number;
+    yes: boolean;
+  },
+  error: unknown
+): Promise<boolean> {
+  if (input.yes || !stdin.isTTY || !stdout.isTTY || !isStoredSessionRefreshError(error)) {
+    return false;
+  }
+
+  const errorPayload = toLinkedInAssistantErrorPayload(error, cliPrivacyConfig);
+  process.stderr.write(`${formatReadOnlyValidationError(errorPayload)}\n`);
+  const confirmed = await promptYesNo(
+    `Capture a fresh stored session named "${input.sessionName}" now?`
+  );
+  if (!confirmed) {
+    return false;
+  }
+
+  await captureStoredSession({
+    sessionName: input.sessionName,
+    timeoutMinutes: input.timeoutMinutes
+  });
+  return true;
+}
+
+async function runLiveReadOnlyValidation(input: {
+  json: boolean;
+  readOnly: boolean;
+  sessionName: string;
+  timeoutSeconds: number;
+  yes: boolean;
+}, cdpUrl?: string): Promise<void> {
+  assertNoExternalSessionOverrideForStoredSession(cdpUrl);
+
+  if (!input.readOnly) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      'Live validation is currently restricted to read-only mode. Rerun the command with "--read-only".'
+    );
+  }
+
+  if (!input.yes) {
+    assertInteractiveTerminal("run interactive live validation without --yes");
+  }
+
+  const outputMode = resolveReadOnlyValidationOutputMode(
+    { json: input.json },
+    Boolean(stdout.isTTY)
+  );
+  const runValidation = async () => {
+    const onBeforeOperation = input.yes
+      ? undefined
+      : async (operation: Parameters<
+          NonNullable<
+            NonNullable<
+              Parameters<typeof runReadOnlyLinkedInLiveValidation>[0]
+            >["onBeforeOperation"]
+          >
+        >[0]) => {
+          console.log(`Read-only step: ${operation.summary}`);
+          const confirmed = await promptYesNo("Continue with this step?");
+          if (!confirmed) {
+            throw new LinkedInAssistantError(
+              "ACTION_PRECONDITION_FAILED",
+              "Read-only live validation was cancelled by the operator.",
+              {
+                operation: operation.id,
+                session_name: input.sessionName
+              }
+            );
+          }
+        };
+
+    return runReadOnlyLinkedInLiveValidation({
+      sessionName: input.sessionName,
+      ...(onBeforeOperation ? { onBeforeOperation } : {}),
+      timeoutMs: input.timeoutSeconds * 1_000
+    });
+  };
+
+  try {
+    const report = await runValidation();
+
+    if (outputMode === "json") {
+      printJson(report);
+    } else {
+      const redactedReport = redactStructuredValue(
+        report,
+        cliPrivacyConfig,
+        "cli"
+      ) as typeof report;
+      console.log(formatReadOnlyValidationReport(redactedReport));
+    }
+
+    if (report.outcome === "fail") {
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    const refreshed = await maybeRefreshStoredSession(
+      {
+        sessionName: input.sessionName,
+        timeoutMinutes: Math.max(1, Math.ceil(input.timeoutSeconds / 60)),
+        yes: input.yes
+      },
+      error
+    );
+
+    if (refreshed) {
+      const report = await runValidation();
+      if (outputMode === "json") {
+        printJson(report);
+      } else {
+        const redactedReport = redactStructuredValue(
+          report,
+          cliPrivacyConfig,
+          "cli"
+        ) as typeof report;
+        console.log(formatReadOnlyValidationReport(redactedReport));
+      }
+
+      if (report.outcome === "fail") {
+        process.exitCode = 1;
+      }
+      return;
+    }
+
+    if (outputMode === "json") {
+      throw error;
+    }
+
+    const errorPayload = toLinkedInAssistantErrorPayload(error, cliPrivacyConfig);
+    process.stderr.write(`${formatReadOnlyValidationError(errorPayload)}\n`);
+    process.exitCode = 1;
   }
 }
 
@@ -3807,6 +4007,115 @@ export function createCliProgram(): Command {
     .action(async (options: { clear: boolean }) => {
       await runRateLimitStatus(options.clear);
     });
+
+  const authCommand = program
+    .command("auth")
+    .description("Capture and manage stored encrypted LinkedIn sessions");
+
+  const configureAuthSessionCommand = (command: Command): void => {
+    command
+      .description("Capture an encrypted LinkedIn session from a manual browser login")
+      .option("-s, --session <session>", "Stored session name", "default")
+      .option(
+        "-t, --timeout-minutes <minutes>",
+        "How long to wait for the manual login to finish",
+        "10"
+      )
+      .addHelpText(
+        "after",
+        [
+          "",
+          "Safety:",
+          "  - opens a dedicated browser window for manual login only",
+          "  - stores Playwright session state encrypted at rest",
+          "  - never prints cookies or storage contents",
+          "",
+          "Examples:",
+          "  owa auth:session",
+          "  owa auth:session --session smoke --timeout-minutes 15"
+        ].join("\n")
+      )
+      .action(
+        async (options: { session: string; timeoutMinutes: string }) => {
+          await runAuthSessionCapture(
+            {
+              sessionName: coerceProfileName(options.session, "session"),
+              timeoutMinutes: coercePositiveInt(
+                options.timeoutMinutes,
+                "timeout-minutes"
+              )
+            },
+            readCdpUrl()
+          );
+        }
+      );
+  };
+
+  configureAuthSessionCommand(authCommand.command("session"));
+  configureAuthSessionCommand(program.command("auth:session", { hidden: true }));
+
+  const testCommand = program
+    .command("test")
+    .description("Run LinkedIn live validation workflows");
+
+  const configureLiveValidationCommand = (command: Command): void => {
+    command
+      .description("Run read-only live validation against LinkedIn using a stored session")
+      .option(
+        "--read-only",
+        "Confirm that the live validation should run in strictly read-only mode",
+        false
+      )
+      .option("-s, --session <session>", "Stored session name", "default")
+      .option(
+        "--timeout-seconds <seconds>",
+        "Maximum time allowed per validation step",
+        "30"
+      )
+      .option("-y, --yes", "Skip per-step confirmation prompts", false)
+      .option("--json", "Print the structured report JSON", false)
+      .addHelpText(
+        "after",
+        [
+          "",
+          "Safety guardrails:",
+          "  - requires --read-only",
+          "  - blocks non-GET requests and non-LinkedIn domains",
+          "  - prompts before every step unless --yes is set",
+          "  - stops when the stored session expires or a challenge appears",
+          "",
+          "Examples:",
+          "  owa test:live --read-only",
+          "  owa test:live --read-only --yes --session smoke --json"
+        ].join("\n")
+      )
+      .action(
+        async (options: {
+          json: boolean;
+          readOnly: boolean;
+          session: string;
+          timeoutSeconds: string;
+          yes: boolean;
+        }) => {
+          await runLiveReadOnlyValidation(
+            {
+              json: options.json,
+              readOnly: options.readOnly,
+              sessionName: coerceProfileName(options.session, "session"),
+              timeoutSeconds: coercePositiveInt(
+                options.timeoutSeconds,
+                "timeout-seconds"
+              ),
+              yes: options.yes
+            },
+            readCdpUrl()
+          );
+        }
+      );
+  };
+
+  configureLiveValidationCommand(testCommand.command("live"));
+  configureLiveValidationCommand(program.command("test:live", { hidden: true }));
 
   const dataCommand = program
     .command("data")

--- a/packages/cli/src/liveValidationOutput.ts
+++ b/packages/cli/src/liveValidationOutput.ts
@@ -1,0 +1,131 @@
+import type {
+  LinkedInAssistantErrorPayload,
+  ReadOnlyValidationDiffEntry,
+  ReadOnlyValidationOperationResult,
+  ReadOnlyValidationReport
+} from "@linkedin-assistant/core";
+
+export type ReadOnlyValidationOutputMode = "human" | "json";
+
+function appendSection(lines: string[], title: string, entries: string[]): void {
+  if (entries.length === 0) {
+    return;
+  }
+
+  lines.push("");
+  lines.push(title);
+  lines.push(...entries);
+}
+
+function formatOutcome(report: ReadOnlyValidationReport): string {
+  return report.outcome === "fail" ? "FAIL" : "PASS";
+}
+
+function formatOperationStatus(operation: ReadOnlyValidationOperationResult): string {
+  return operation.status === "fail" ? "FAIL" : "PASS";
+}
+
+function formatOperationSummary(operation: ReadOnlyValidationOperationResult): string {
+  const warningSuffix = operation.warnings.length > 0
+    ? ` | ${operation.warnings.length} warning${operation.warnings.length === 1 ? "" : "s"}`
+    : "";
+  return `- ${formatOperationStatus(operation)} ${operation.operation}: ${operation.matched_count} matched, ${operation.failed_count} failed, ${operation.page_load_ms}ms${warningSuffix}`;
+}
+
+function formatDiffEntry(entry: ReadOnlyValidationDiffEntry): string {
+  const changeLabel = entry.change === "new_failure"
+    ? "New failure"
+    : entry.change === "fallback_drift"
+      ? "Selector drift"
+      : "Recovered";
+  const previousCandidate = entry.previous_candidate_key ?? "none";
+  const currentCandidate = entry.current_candidate_key ?? "none";
+
+  return `- ${changeLabel}: ${entry.operation}/${entry.selector_key} (${previousCandidate} → ${currentCandidate})`;
+}
+
+function formatBlockedRequests(report: ReadOnlyValidationReport): string[] {
+  return report.blocked_requests.slice(0, 5).map((blockedRequest) => {
+    return `- ${blockedRequest.method} ${blockedRequest.url} [${blockedRequest.reason}]`;
+  });
+}
+
+function formatFailedSelectorBlocks(
+  report: ReadOnlyValidationReport
+): string[] {
+  return report.operations.flatMap((operation) => {
+    return operation.selector_results
+      .filter((selectorResult) => selectorResult.status === "fail")
+      .map((selectorResult) => {
+        return `- ${operation.operation}/${selectorResult.selector_key} — ${selectorResult.error ?? "No selector candidate matched."}`;
+      });
+  });
+}
+
+export function resolveReadOnlyValidationOutputMode(
+  options: { json: boolean },
+  isInteractiveOutput: boolean
+): ReadOnlyValidationOutputMode {
+  return options.json || !isInteractiveOutput ? "json" : "human";
+}
+
+export function formatReadOnlyValidationReport(
+  report: ReadOnlyValidationReport
+): string {
+  const lines = [
+    `Live Validation: ${formatOutcome(report)}`,
+    `Summary: ${report.summary}`,
+    `Session: ${report.session.session_name} (captured ${report.session.captured_at})`,
+    `Report JSON: ${report.report_path}`,
+    `Events: ${report.events_path}`
+  ];
+
+  appendSection(
+    lines,
+    "Operations",
+    report.operations.map((operation) => formatOperationSummary(operation))
+  );
+
+  appendSection(lines, "Failures", formatFailedSelectorBlocks(report));
+  appendSection(
+    lines,
+    "Regressions",
+    report.diff.regressions.map((entry) => formatDiffEntry(entry))
+  );
+  appendSection(
+    lines,
+    "Recoveries",
+    report.diff.recoveries.map((entry) => formatDiffEntry(entry))
+  );
+
+  if (report.blocked_request_count > 0) {
+    appendSection(
+      lines,
+      "Blocked Requests",
+      [
+        `- ${report.blocked_request_count} request${report.blocked_request_count === 1 ? "" : "s"} blocked by the read-only guard`,
+        ...formatBlockedRequests(report)
+      ]
+    );
+  }
+
+  appendSection(
+    lines,
+    "Next Steps",
+    report.recommended_actions.map((action) => `- ${action}`)
+  );
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function formatReadOnlyValidationError(
+  payload: LinkedInAssistantErrorPayload
+): string {
+  const lines = [`Live validation failed [${payload.code}]`, payload.message];
+
+  if (Object.keys(payload.details).length > 0) {
+    lines.push(`Details: ${JSON.stringify(payload.details)}`);
+  }
+
+  return lines.join("\n");
+}

--- a/packages/cli/test/liveValidationCli.test.ts
+++ b/packages/cli/test/liveValidationCli.test.ts
@@ -1,0 +1,249 @@
+import { stdin, stdout } from "node:process";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const liveValidationCliMocks = vi.hoisted(() => ({
+  answers: [] as string[],
+  captureLinkedInSession: vi.fn(),
+  runReadOnlyLinkedInLiveValidation: vi.fn()
+}));
+
+vi.mock("node:readline/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:readline/promises")>(
+    "node:readline/promises"
+  );
+
+  return {
+    ...actual,
+    createInterface: vi.fn(() => ({
+      close: vi.fn(),
+      question: vi.fn(async () => liveValidationCliMocks.answers.shift() ?? "yes")
+    }))
+  };
+});
+
+vi.mock("@linkedin-assistant/core", async () => {
+  const actual = await import("../../core/src/index.js");
+
+  return {
+    ...actual,
+    captureLinkedInSession: liveValidationCliMocks.captureLinkedInSession,
+    runReadOnlyLinkedInLiveValidation:
+      liveValidationCliMocks.runReadOnlyLinkedInLiveValidation
+  };
+});
+
+import { LinkedInAssistantError } from "@linkedin-assistant/core";
+import { runCli } from "../src/bin/linkedin.js";
+
+function setInteractiveMode(inputIsTty: boolean, outputIsTty: boolean): void {
+  Object.defineProperty(stdin, "isTTY", {
+    configurable: true,
+    value: inputIsTty
+  });
+  Object.defineProperty(stdout, "isTTY", {
+    configurable: true,
+    value: outputIsTty
+  });
+  Object.defineProperty(process.stderr, "isTTY", {
+    configurable: true,
+    value: outputIsTty
+  });
+}
+
+function createValidationReport(
+  outcome: "pass" | "fail" = "pass"
+): Record<string, unknown> {
+  return {
+    blocked_request_count: 0,
+    blocked_requests: [],
+    checked_at: "2026-03-09T10:00:00.000Z",
+    diff: {
+      recoveries: [],
+      regressions: [],
+      unchanged_count: 2
+    },
+    events_path: "/tmp/live-readonly/events.jsonl",
+    fail_count: outcome === "fail" ? 1 : 0,
+    latest_report_path: "/tmp/live-readonly/latest-report.json",
+    operation_count: 1,
+    operations: [
+      {
+        completed_at: "2026-03-09T10:00:05.000Z",
+        failed_count: outcome === "fail" ? 1 : 0,
+        final_url: "https://www.linkedin.com/feed/",
+        matched_count: outcome === "fail" ? 0 : 1,
+        operation: "feed",
+        page_load_ms: 1400,
+        selector_results: [
+          {
+            description: "Feed content surface",
+            ...(outcome === "fail"
+              ? {
+                  error: "No selector candidate matched feed_surface.",
+                  matched_candidate_key: null,
+                  matched_candidate_rank: null,
+                  matched_selector: null,
+                  status: "fail"
+                }
+              : {
+                  matched_candidate_key: "feed-update-card",
+                  matched_candidate_rank: 0,
+                  matched_selector: "div.feed-shared-update-v2",
+                  status: "pass"
+                }),
+            selector_key: "feed_surface"
+          }
+        ],
+        started_at: "2026-03-09T10:00:00.000Z",
+        status: outcome,
+        summary: "Load the LinkedIn feed and verify the main feed surface.",
+        url: "https://www.linkedin.com/feed/",
+        warnings: []
+      }
+    ],
+    outcome,
+    pass_count: outcome === "fail" ? 0 : 1,
+    recommended_actions: ["Open /tmp/live-readonly/report.json"],
+    report_path: "/tmp/live-readonly/report.json",
+    request_limits: {
+      max_requests: 20,
+      max_requests_reached: false,
+      min_interval_ms: 5000,
+      used_requests: 1
+    },
+    run_id: "run_live_validation_test",
+    session: {
+      captured_at: "2026-03-09T09:00:00.000Z",
+      file_path: "/tmp/session.enc.json",
+      li_at_expires_at: "2026-04-01T00:00:00.000Z",
+      session_name: "smoke"
+    },
+    summary: "Checked 1 read-only LinkedIn operation. 1 passed. 0 failed."
+  };
+}
+
+describe("linkedin live validation CLI", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    setInteractiveMode(true, true);
+    process.exitCode = undefined;
+    liveValidationCliMocks.answers = [];
+    vi.clearAllMocks();
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    process.exitCode = undefined;
+  });
+
+  it("captures a stored session through the auth:session alias", async () => {
+    liveValidationCliMocks.captureLinkedInSession.mockResolvedValue({
+      authenticated: true,
+      capturedAt: "2026-03-09T09:00:00.000Z",
+      checkedAt: "2026-03-09T09:01:00.000Z",
+      currentUrl: "https://www.linkedin.com/feed/",
+      filePath: "/tmp/stored-session.enc.json",
+      liAtCookieExpiresAt: "2026-04-01T00:00:00.000Z",
+      sessionName: "smoke"
+    });
+
+    await runCli([
+      "node",
+      "linkedin",
+      "auth:session",
+      "--session",
+      "smoke"
+    ]);
+
+    expect(liveValidationCliMocks.captureLinkedInSession).toHaveBeenCalledWith({
+      sessionName: "smoke",
+      timeoutMs: 600_000
+    });
+    expect(JSON.parse(String(consoleLogSpy.mock.calls.at(-1)?.[0] ?? ""))).toMatchObject({
+      authenticated: true,
+      session_name: "smoke"
+    });
+  });
+
+  it("requires --read-only for live validation", async () => {
+    await expect(
+      runCli(["node", "linkedin", "test:live", "--yes"])
+    ).rejects.toThrow("--read-only");
+  });
+
+  it("refuses interactive live validation when no TTY is available", async () => {
+    setInteractiveMode(false, false);
+
+    await expect(
+      runCli(["node", "linkedin", "test:live", "--read-only"])
+    ).rejects.toThrow("non-interactive mode");
+  });
+
+  it("prints JSON and sets exit code when the validation report fails", async () => {
+    setInteractiveMode(false, false);
+    liveValidationCliMocks.runReadOnlyLinkedInLiveValidation.mockResolvedValue(
+      createValidationReport("fail")
+    );
+
+    await runCli([
+      "node",
+      "linkedin",
+      "test:live",
+      "--read-only",
+      "--yes",
+      "--json"
+    ]);
+
+    expect(process.exitCode).toBe(1);
+    expect(
+      JSON.parse(String(consoleLogSpy.mock.calls.at(-1)?.[0] ?? ""))
+    ).toMatchObject({
+      outcome: "fail"
+    });
+  });
+
+  it("prompts for re-auth, captures a fresh session, and retries once", async () => {
+    liveValidationCliMocks.answers = ["yes"];
+    liveValidationCliMocks.captureLinkedInSession.mockResolvedValue({
+      authenticated: true,
+      capturedAt: "2026-03-09T09:30:00.000Z",
+      checkedAt: "2026-03-09T09:31:00.000Z",
+      currentUrl: "https://www.linkedin.com/feed/",
+      filePath: "/tmp/stored-session.enc.json",
+      liAtCookieExpiresAt: "2026-04-01T00:00:00.000Z",
+      sessionName: "smoke"
+    });
+    liveValidationCliMocks.runReadOnlyLinkedInLiveValidation
+      .mockRejectedValueOnce(
+        new LinkedInAssistantError(
+          "AUTH_REQUIRED",
+          "Stored session is expired.",
+          { session_name: "smoke" }
+        )
+      )
+      .mockResolvedValueOnce(createValidationReport("pass"));
+
+    await runCli([
+      "node",
+      "linkedin",
+      "test:live",
+      "--read-only",
+      "--json",
+      "--session",
+      "smoke"
+    ]);
+
+    expect(liveValidationCliMocks.captureLinkedInSession).toHaveBeenCalledTimes(1);
+    expect(liveValidationCliMocks.runReadOnlyLinkedInLiveValidation).toHaveBeenCalledTimes(2);
+    expect(
+      JSON.parse(String(consoleLogSpy.mock.calls.at(-1)?.[0] ?? ""))
+    ).toMatchObject({
+      outcome: "pass",
+      session: {
+        session_name: "smoke"
+      }
+    });
+  });
+});

--- a/packages/core/src/__tests__/liveValidation.test.ts
+++ b/packages/core/src/__tests__/liveValidation.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import {
+  ReadOnlyOperationRateLimiter,
+  computeReadOnlyValidationDiff,
+  isAllowedLinkedInReadOnlyRequest,
+  type ReadOnlyValidationOperationResult,
+  type ReadOnlyValidationReport
+} from "../liveValidation.js";
+
+function createOperationResult(
+  operation: ReadOnlyValidationOperationResult["operation"],
+  selectorResults: ReadOnlyValidationOperationResult["selector_results"]
+): ReadOnlyValidationOperationResult {
+  return {
+    completed_at: "2026-03-09T10:00:05.000Z",
+    failed_count: selectorResults.filter((result) => result.status === "fail").length,
+    final_url: `https://www.linkedin.com/${operation}/`,
+    matched_count: selectorResults.filter((result) => result.status === "pass").length,
+    operation,
+    page_load_ms: 1200,
+    selector_results: selectorResults,
+    started_at: "2026-03-09T10:00:00.000Z",
+    status: selectorResults.some((result) => result.status === "fail")
+      ? "fail"
+      : "pass",
+    summary: `summary:${operation}`,
+    url: `https://www.linkedin.com/${operation}/`,
+    warnings: []
+  };
+}
+
+function createReport(
+  operations: ReadOnlyValidationOperationResult[],
+  reportPath: string
+): Pick<ReadOnlyValidationReport, "operations" | "report_path"> {
+  return {
+    operations,
+    report_path: reportPath
+  };
+}
+
+describe("read-only live validation helpers", () => {
+  it("allows only GET requests to LinkedIn-owned domains", () => {
+    expect(
+      isAllowedLinkedInReadOnlyRequest(
+        "https://www.linkedin.com/feed/",
+        "GET"
+      )
+    ).toBe(true);
+    expect(
+      isAllowedLinkedInReadOnlyRequest(
+        "https://media.licdn.com/dms/image/v2/sample",
+        "GET"
+      )
+    ).toBe(true);
+    expect(
+      isAllowedLinkedInReadOnlyRequest(
+        "https://www.linkedin.com/voyager/api/graphql",
+        "POST"
+      )
+    ).toBe(false);
+    expect(
+      isAllowedLinkedInReadOnlyRequest(
+        "https://example.com/tracker.js",
+        "GET"
+      )
+    ).toBe(false);
+  });
+
+  it("enforces the per-session request cap and minimum interval", async () => {
+    let currentTimeMs = 0;
+    const sleepCalls: number[] = [];
+    const limiter = new ReadOnlyOperationRateLimiter(
+      2,
+      5_000,
+      () => currentTimeMs,
+      async (delayMs) => {
+        sleepCalls.push(delayMs);
+        currentTimeMs += delayMs;
+      }
+    );
+
+    await limiter.waitTurn("feed");
+    currentTimeMs += 1_000;
+    await limiter.waitTurn("profile");
+
+    expect(limiter.getRequestCount()).toBe(2);
+    expect(sleepCalls).toEqual([4_000]);
+    await expect(limiter.waitTurn("notifications")).rejects.toMatchObject({
+      code: "RATE_LIMITED"
+    });
+  });
+
+  it("reports new failures, fallback drift, and recoveries against the previous run", () => {
+    const previousReport = createReport(
+      [
+        createOperationResult("feed", [
+          {
+            description: "Feed content surface",
+            matched_candidate_key: "feed-update-card",
+            matched_candidate_rank: 0,
+            matched_selector: "div.feed-shared-update-v2",
+            selector_key: "feed_surface",
+            status: "pass"
+          },
+          {
+            description: "Authenticated global navigation",
+            matched_candidate_key: "global-nav",
+            matched_candidate_rank: 0,
+            matched_selector: "nav.global-nav",
+            selector_key: "global_nav",
+            status: "pass"
+          }
+        ]),
+        createOperationResult("profile", [
+          {
+            description: "Profile header",
+            error: "No selector candidate matched profile_header.",
+            matched_candidate_key: null,
+            matched_candidate_rank: null,
+            matched_selector: null,
+            selector_key: "profile_header",
+            status: "fail"
+          }
+        ])
+      ],
+      "/tmp/previous.json"
+    );
+
+    const currentReport = createReport([
+      createOperationResult("feed", [
+        {
+          description: "Feed content surface",
+          error: "No selector candidate matched feed_surface.",
+          matched_candidate_key: null,
+          matched_candidate_rank: null,
+          matched_selector: null,
+          selector_key: "feed_surface",
+          status: "fail"
+        },
+        {
+          description: "Authenticated global navigation",
+          matched_candidate_key: "global-nav-link",
+          matched_candidate_rank: 2,
+          matched_selector: "a[href='/feed/']",
+          selector_key: "global_nav",
+          status: "pass"
+        }
+      ]),
+      createOperationResult("profile", [
+        {
+          description: "Profile header",
+          matched_candidate_key: "profile-h1",
+          matched_candidate_rank: 0,
+          matched_selector: "main h1",
+          selector_key: "profile_header",
+          status: "pass"
+        }
+      ])
+    ], "/tmp/current.json");
+
+    const diff = computeReadOnlyValidationDiff(currentReport, previousReport);
+
+    expect(diff.previous_report_path).toBe("/tmp/previous.json");
+    expect(diff.regressions).toEqual([
+      expect.objectContaining({
+        change: "new_failure",
+        operation: "feed",
+        selector_key: "feed_surface"
+      }),
+      expect.objectContaining({
+        change: "fallback_drift",
+        operation: "feed",
+        selector_key: "global_nav"
+      })
+    ]);
+    expect(diff.recoveries).toEqual([
+      expect.objectContaining({
+        change: "recovered",
+        operation: "profile",
+        selector_key: "profile_header"
+      })
+    ]);
+  });
+});

--- a/packages/core/src/__tests__/sessionStore.test.ts
+++ b/packages/core/src/__tests__/sessionStore.test.ts
@@ -1,0 +1,77 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  LinkedInSessionStore,
+  resolveStoredLinkedInSessionPath,
+  type LinkedInBrowserStorageState
+} from "../auth/sessionStore.js";
+
+function createStorageState(): LinkedInBrowserStorageState {
+  return {
+    cookies: [
+      {
+        name: "li_at",
+        value: "super-secret-cookie",
+        domain: ".linkedin.com",
+        path: "/",
+        expires: 1_900_000_000,
+        httpOnly: true,
+        secure: true,
+        sameSite: "Lax"
+      }
+    ],
+    origins: [
+      {
+        origin: "https://www.linkedin.com",
+        localStorage: [
+          {
+            name: "li_theme",
+            value: "dark"
+          }
+        ]
+      }
+    ]
+  };
+}
+
+describe("LinkedInSessionStore", () => {
+  it("encrypts stored session state and round-trips it correctly", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-session-store-"));
+
+    try {
+      const store = new LinkedInSessionStore(tempDir);
+      const storageState = createStorageState();
+
+      const metadata = await store.save("smoke", storageState);
+      const storedFile = resolveStoredLinkedInSessionPath("smoke", tempDir);
+      const rawEnvelope = await readFile(storedFile, "utf8");
+      const loaded = await store.load("smoke");
+
+      expect(metadata.filePath).toBe(storedFile);
+      expect(metadata.hasLinkedInAuthCookie).toBe(true);
+      expect(rawEnvelope).not.toContain("super-secret-cookie");
+      expect(rawEnvelope).not.toContain('"origins"');
+      expect(loaded.metadata.sessionName).toBe("smoke");
+      expect(loaded.storageState).toEqual(storageState);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws AUTH_REQUIRED for a missing stored session", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-session-store-"));
+
+    try {
+      const store = new LinkedInSessionStore(tempDir);
+
+      await expect(store.load("missing")).rejects.toMatchObject({
+        code: "AUTH_REQUIRED",
+        message: expect.stringContaining("owa auth:session")
+      });
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/auth/sessionStore.ts
+++ b/packages/core/src/auth/sessionStore.ts
@@ -1,0 +1,598 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  randomBytes
+} from "node:crypto";
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  chromium,
+  type Browser,
+  type BrowserContext
+} from "playwright-core";
+import { ensureConfigPaths, resolveConfigPaths } from "../config.js";
+import { LinkedInAssistantError, asLinkedInAssistantError } from "../errors.js";
+import {
+  inspectLinkedInSession,
+  type LinkedInSessionInspection
+} from "./sessionInspection.js";
+
+export type LinkedInBrowserStorageState = Awaited<
+  ReturnType<BrowserContext["storageState"]>
+>;
+
+const DEFAULT_CAPTURE_TIMEOUT_MS = 10 * 60_000;
+const DEFAULT_CAPTURE_POLL_INTERVAL_MS = 2_000;
+const SESSION_STORE_KEY_FILE_NAME = ".session-store.key";
+const SESSION_FILE_SUFFIX = ".session.enc.json";
+const SESSION_STORE_SCHEMA_VERSION = 1;
+const AES_GCM_IV_BYTES = 12;
+
+interface StoredLinkedInSessionEnvelope {
+  version: number;
+  algorithm: "aes-256-gcm";
+  ciphertext: string;
+  iv: string;
+  tag: string;
+  metadata: StoredLinkedInSessionMetadataRecord;
+}
+
+interface StoredLinkedInSessionMetadataRecord {
+  capturedAt: string;
+  cookieCount: number;
+  hasLinkedInAuthCookie: boolean;
+  liAtCookieExpiresAt: string | null;
+  originCount: number;
+  sessionName: string;
+}
+
+export interface StoredLinkedInSessionMetadata {
+  capturedAt: string;
+  cookieCount: number;
+  filePath: string;
+  hasLinkedInAuthCookie: boolean;
+  liAtCookieExpiresAt: string | null;
+  originCount: number;
+  sessionName: string;
+}
+
+export interface LoadStoredLinkedInSessionResult {
+  metadata: StoredLinkedInSessionMetadata;
+  storageState: LinkedInBrowserStorageState;
+}
+
+export interface CaptureLinkedInSessionOptions {
+  baseDir?: string;
+  pollIntervalMs?: number;
+  sessionName?: string;
+  timeoutMs?: number;
+}
+
+export interface CaptureLinkedInSessionResult
+  extends StoredLinkedInSessionMetadata {
+  authenticated: true;
+  checkedAt: string;
+  currentUrl: string;
+}
+
+function withPlaywrightInstallHint(error: unknown): Error {
+  if (error instanceof Error && error.message.includes("Executable doesn't exist")) {
+    return new Error(
+      'Playwright browser executable is missing. Install Chromium with "npx playwright install chromium" or set PLAYWRIGHT_EXECUTABLE_PATH.'
+    );
+  }
+
+  if (error instanceof Error) {
+    return error;
+  }
+
+  return new Error(String(error));
+}
+
+function normalizeSessionName(sessionName: string | undefined): string {
+  const normalized = (sessionName ?? "default").trim();
+  if (normalized.length === 0) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "session name must not be empty."
+    );
+  }
+
+  if (normalized === "." || normalized === ".." || /[\\/]/u.test(normalized)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "session name must not contain path separators or relative path segments.",
+      {
+        session_name: normalized
+      }
+    );
+  }
+
+  return normalized;
+}
+
+function encodeBase64Url(value: Buffer): string {
+  return value.toString("base64url");
+}
+
+function decodeBase64Url(value: string, label: string): Buffer {
+  try {
+    return Buffer.from(value, "base64url");
+  } catch (error) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `Stored LinkedIn session ${label} is malformed. Capture a fresh session and retry.`,
+      {
+        label
+      },
+      {
+        cause: error instanceof Error ? error : undefined
+      }
+    );
+  }
+}
+
+function getLinkedInAuthCookieExpiry(
+  storageState: LinkedInBrowserStorageState
+): string | null {
+  const authCookie = storageState.cookies.find((cookie) => cookie.name === "li_at");
+  if (!authCookie || typeof authCookie.expires !== "number" || authCookie.expires <= 0) {
+    return null;
+  }
+
+  return new Date(authCookie.expires * 1_000).toISOString();
+}
+
+function createStoredSessionMetadata(
+  sessionName: string,
+  filePath: string,
+  storageState: LinkedInBrowserStorageState,
+  capturedAt: string = new Date().toISOString()
+): StoredLinkedInSessionMetadata {
+  const hasLinkedInAuthCookie = storageState.cookies.some(
+    (cookie) => cookie.name === "li_at" && cookie.value.trim().length > 0
+  );
+
+  return {
+    capturedAt,
+    cookieCount: storageState.cookies.length,
+    filePath,
+    hasLinkedInAuthCookie,
+    liAtCookieExpiresAt: getLinkedInAuthCookieExpiry(storageState),
+    originCount: storageState.origins.length,
+    sessionName
+  };
+}
+
+function toStoredMetadataRecord(
+  metadata: StoredLinkedInSessionMetadata
+): StoredLinkedInSessionMetadataRecord {
+  return {
+    capturedAt: metadata.capturedAt,
+    cookieCount: metadata.cookieCount,
+    hasLinkedInAuthCookie: metadata.hasLinkedInAuthCookie,
+    liAtCookieExpiresAt: metadata.liAtCookieExpiresAt,
+    originCount: metadata.originCount,
+    sessionName: metadata.sessionName
+  };
+}
+
+function toStoredMetadata(
+  metadata: StoredLinkedInSessionMetadataRecord,
+  filePath: string
+): StoredLinkedInSessionMetadata {
+  return {
+    capturedAt: metadata.capturedAt,
+    cookieCount: metadata.cookieCount,
+    filePath,
+    hasLinkedInAuthCookie: metadata.hasLinkedInAuthCookie,
+    liAtCookieExpiresAt: metadata.liAtCookieExpiresAt,
+    originCount: metadata.originCount,
+    sessionName: metadata.sessionName
+  };
+}
+
+async function ensureOwnerOnlyPermissions(targetPath: string): Promise<void> {
+  try {
+    await chmod(targetPath, 0o600);
+  } catch {
+    // Best effort: chmod is not reliable across every platform/filesystem.
+  }
+}
+
+async function readOrCreateMasterKey(storeDir: string): Promise<Buffer> {
+  const keyPath = path.join(storeDir, SESSION_STORE_KEY_FILE_NAME);
+
+  try {
+    const existingKey = await readFile(keyPath);
+    if (existingKey.length === 32) {
+      return createHash("sha256")
+        .update(existingKey)
+        .update("\0")
+        .update(os.hostname())
+        .update("\0")
+        .update(os.userInfo().username)
+        .digest();
+    }
+  } catch (error) {
+    if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  const rawKey = randomBytes(32);
+  await writeFile(keyPath, rawKey);
+  await ensureOwnerOnlyPermissions(keyPath);
+  return createHash("sha256")
+    .update(rawKey)
+    .update("\0")
+    .update(os.hostname())
+    .update("\0")
+    .update(os.userInfo().username)
+    .digest();
+}
+
+function validateEnvelope(
+  envelope: unknown,
+  sessionName: string,
+  filePath: string
+): StoredLinkedInSessionEnvelope {
+  if (
+    typeof envelope !== "object" ||
+    envelope === null ||
+    !("version" in envelope) ||
+    !("algorithm" in envelope) ||
+    !("ciphertext" in envelope) ||
+    !("iv" in envelope) ||
+    !("tag" in envelope) ||
+    !("metadata" in envelope)
+  ) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `Stored LinkedIn session "${sessionName}" is malformed. Capture a fresh session and retry.`,
+      {
+        file_path: filePath,
+        session_name: sessionName
+      }
+    );
+  }
+
+  const normalizedEnvelope = envelope as Partial<StoredLinkedInSessionEnvelope>;
+  if (
+    normalizedEnvelope.version !== SESSION_STORE_SCHEMA_VERSION ||
+    normalizedEnvelope.algorithm !== "aes-256-gcm" ||
+    typeof normalizedEnvelope.ciphertext !== "string" ||
+    typeof normalizedEnvelope.iv !== "string" ||
+    typeof normalizedEnvelope.tag !== "string" ||
+    typeof normalizedEnvelope.metadata !== "object" ||
+    normalizedEnvelope.metadata === null
+  ) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `Stored LinkedIn session "${sessionName}" is unreadable. Capture a fresh session and retry.`,
+      {
+        file_path: filePath,
+        session_name: sessionName
+      }
+    );
+  }
+
+  const metadata = normalizedEnvelope.metadata as Partial<StoredLinkedInSessionMetadataRecord>;
+  if (
+    typeof metadata.sessionName !== "string" ||
+    typeof metadata.capturedAt !== "string" ||
+    typeof metadata.cookieCount !== "number" ||
+    typeof metadata.originCount !== "number" ||
+    typeof metadata.hasLinkedInAuthCookie !== "boolean" ||
+    !(
+      metadata.liAtCookieExpiresAt === null ||
+      typeof metadata.liAtCookieExpiresAt === "string"
+    )
+  ) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `Stored LinkedIn session "${sessionName}" is unreadable. Capture a fresh session and retry.`,
+      {
+        file_path: filePath,
+        session_name: sessionName
+      }
+    );
+  }
+
+  return {
+    version: normalizedEnvelope.version,
+    algorithm: normalizedEnvelope.algorithm,
+    ciphertext: normalizedEnvelope.ciphertext,
+    iv: normalizedEnvelope.iv,
+    tag: normalizedEnvelope.tag,
+    metadata: {
+      capturedAt: metadata.capturedAt,
+      cookieCount: metadata.cookieCount,
+      hasLinkedInAuthCookie: metadata.hasLinkedInAuthCookie,
+      liAtCookieExpiresAt: metadata.liAtCookieExpiresAt ?? null,
+      originCount: metadata.originCount,
+      sessionName: metadata.sessionName
+    }
+  };
+}
+
+function validateStorageState(
+  value: unknown,
+  sessionName: string,
+  filePath: string
+): LinkedInBrowserStorageState {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("cookies" in value) ||
+    !("origins" in value) ||
+    !Array.isArray((value as { cookies: unknown }).cookies) ||
+    !Array.isArray((value as { origins: unknown }).origins)
+  ) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `Stored LinkedIn session "${sessionName}" could not be decoded. Capture a fresh session and retry.`,
+      {
+        file_path: filePath,
+        session_name: sessionName
+      }
+    );
+  }
+
+  return value as LinkedInBrowserStorageState;
+}
+
+export function resolveLinkedInSessionStoreDir(baseDir?: string): string {
+  return path.join(resolveConfigPaths(baseDir).profilesDir, "stored-sessions");
+}
+
+export function resolveStoredLinkedInSessionPath(
+  sessionName: string = "default",
+  baseDir?: string
+): string {
+  const normalizedSessionName = normalizeSessionName(sessionName);
+  return path.join(
+    resolveLinkedInSessionStoreDir(baseDir),
+    `${normalizedSessionName}${SESSION_FILE_SUFFIX}`
+  );
+}
+
+export class LinkedInSessionStore {
+  constructor(private readonly baseDir?: string) {}
+
+  getSessionPath(sessionName: string = "default"): string {
+    return resolveStoredLinkedInSessionPath(sessionName, this.baseDir);
+  }
+
+  async save(
+    sessionName: string,
+    storageState: LinkedInBrowserStorageState
+  ): Promise<StoredLinkedInSessionMetadata> {
+    const normalizedSessionName = normalizeSessionName(sessionName);
+    const paths = resolveConfigPaths(this.baseDir);
+    ensureConfigPaths(paths);
+    const storeDir = resolveLinkedInSessionStoreDir(this.baseDir);
+    await mkdir(storeDir, { recursive: true });
+
+    const filePath = this.getSessionPath(normalizedSessionName);
+    const metadata = createStoredSessionMetadata(
+      normalizedSessionName,
+      filePath,
+      storageState
+    );
+
+    const encryptionKey = await readOrCreateMasterKey(storeDir);
+    const iv = randomBytes(AES_GCM_IV_BYTES);
+    const cipher = createCipheriv("aes-256-gcm", encryptionKey, iv);
+    const plaintext = JSON.stringify(storageState);
+    const ciphertext = Buffer.concat([
+      cipher.update(plaintext, "utf8"),
+      cipher.final()
+    ]);
+    const tag = cipher.getAuthTag();
+
+    const envelope: StoredLinkedInSessionEnvelope = {
+      version: SESSION_STORE_SCHEMA_VERSION,
+      algorithm: "aes-256-gcm",
+      ciphertext: encodeBase64Url(ciphertext),
+      iv: encodeBase64Url(iv),
+      tag: encodeBase64Url(tag),
+      metadata: toStoredMetadataRecord(metadata)
+    };
+
+    await writeFile(filePath, `${JSON.stringify(envelope, null, 2)}\n`, "utf8");
+    await ensureOwnerOnlyPermissions(filePath);
+
+    return metadata;
+  }
+
+  async exists(sessionName: string = "default"): Promise<boolean> {
+    try {
+      await readFile(this.getSessionPath(sessionName), "utf8");
+      return true;
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async load(sessionName: string = "default"): Promise<LoadStoredLinkedInSessionResult> {
+    const normalizedSessionName = normalizeSessionName(sessionName);
+    const filePath = this.getSessionPath(normalizedSessionName);
+
+    let rawEnvelope: string;
+    try {
+      rawEnvelope = await readFile(filePath, "utf8");
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+        throw new LinkedInAssistantError(
+          "AUTH_REQUIRED",
+          `No stored LinkedIn session named "${normalizedSessionName}" was found. Run "owa auth:session --session ${normalizedSessionName}" first.`,
+          {
+            file_path: filePath,
+            session_name: normalizedSessionName
+          }
+        );
+      }
+      throw error;
+    }
+
+    const parsedEnvelope = validateEnvelope(
+      JSON.parse(rawEnvelope) as unknown,
+      normalizedSessionName,
+      filePath
+    );
+    const storeDir = resolveLinkedInSessionStoreDir(this.baseDir);
+    const encryptionKey = await readOrCreateMasterKey(storeDir);
+
+    let storageState: LinkedInBrowserStorageState;
+    try {
+      const decipher = createDecipheriv(
+        "aes-256-gcm",
+        encryptionKey,
+        decodeBase64Url(parsedEnvelope.iv, "iv")
+      );
+      decipher.setAuthTag(decodeBase64Url(parsedEnvelope.tag, "tag"));
+      const decryptedPayload = Buffer.concat([
+        decipher.update(decodeBase64Url(parsedEnvelope.ciphertext, "ciphertext")),
+        decipher.final()
+      ]).toString("utf8");
+      storageState = validateStorageState(
+        JSON.parse(decryptedPayload) as unknown,
+        normalizedSessionName,
+        filePath
+      );
+    } catch (error) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `Stored LinkedIn session "${normalizedSessionName}" could not be decrypted. Capture a fresh session and retry.`,
+        {
+          file_path: filePath,
+          session_name: normalizedSessionName
+        },
+        {
+          cause: error instanceof Error ? error : undefined
+        }
+      );
+    }
+
+    return {
+      metadata: toStoredMetadata(parsedEnvelope.metadata, filePath),
+      storageState
+    };
+  }
+}
+
+async function getOrCreatePage(context: BrowserContext) {
+  const existingPage = context.pages()[0];
+  if (existingPage) {
+    return existingPage;
+  }
+
+  return context.newPage();
+}
+
+async function waitForManualLogin(
+  context: BrowserContext,
+  timeoutMs: number,
+  pollIntervalMs: number
+): Promise<LinkedInSessionInspection> {
+  const page = await getOrCreatePage(context);
+  await page.goto("https://www.linkedin.com/login", {
+    waitUntil: "domcontentloaded"
+  });
+
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus = await inspectLinkedInSession(page);
+
+  while (!lastStatus.authenticated && Date.now() < deadline) {
+    await page.waitForTimeout(pollIntervalMs);
+    lastStatus = await inspectLinkedInSession(page);
+  }
+
+  if (!lastStatus.authenticated) {
+    throw new LinkedInAssistantError(
+      "AUTH_REQUIRED",
+      "Timed out waiting for a manual LinkedIn login. Finish the login in the opened browser and rerun the session capture command.",
+      {
+        current_url: lastStatus.currentUrl,
+        reason: lastStatus.reason,
+        timeout_ms: timeoutMs
+      }
+    );
+  }
+
+  return lastStatus;
+}
+
+export async function captureLinkedInSession(
+  options: CaptureLinkedInSessionOptions = {}
+): Promise<CaptureLinkedInSessionResult> {
+  const sessionName = normalizeSessionName(options.sessionName);
+  const timeoutMs = options.timeoutMs ?? DEFAULT_CAPTURE_TIMEOUT_MS;
+  const pollIntervalMs =
+    options.pollIntervalMs ?? DEFAULT_CAPTURE_POLL_INTERVAL_MS;
+
+  if (timeoutMs <= 0 || !Number.isFinite(timeoutMs)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "timeoutMs must be a positive number."
+    );
+  }
+  if (pollIntervalMs <= 0 || !Number.isFinite(pollIntervalMs)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "pollIntervalMs must be a positive number."
+    );
+  }
+
+  let browser: Browser | undefined;
+  let context: BrowserContext | undefined;
+  try {
+    const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
+    browser = await chromium.launch({
+      headless: false,
+      ...(executablePath ? { executablePath } : {})
+    });
+    context = await browser.newContext();
+    const status = await waitForManualLogin(context, timeoutMs, pollIntervalMs);
+    const storageState = await context.storageState();
+    const store = new LinkedInSessionStore(options.baseDir);
+    const metadata = await store.save(sessionName, storageState);
+
+    if (!metadata.hasLinkedInAuthCookie) {
+      throw new LinkedInAssistantError(
+        "AUTH_REQUIRED",
+        "LinkedIn login appeared successful, but no authenticated session cookie was captured. Capture the session again after the home feed loads fully.",
+        {
+          current_url: status.currentUrl,
+          session_name: sessionName
+        }
+      );
+    }
+
+    return {
+      ...metadata,
+      authenticated: true,
+      checkedAt: status.checkedAt,
+      currentUrl: status.currentUrl
+    };
+  } catch (error) {
+    throw asLinkedInAssistantError(
+      withPlaywrightInstallHint(error),
+      error instanceof LinkedInAssistantError ? error.code : "UNKNOWN",
+      "Failed to capture the LinkedIn browser session."
+    );
+  } finally {
+    if (context) {
+      await context.close().catch(() => undefined);
+    }
+    if (browser) {
+      await browser.close().catch(() => undefined);
+    }
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./artifacts.js";
 export * from "./auth/rateLimitState.js";
 export * from "./auth/session.js";
+export * from "./auth/sessionStore.js";
 export * from "./connectionPool.js";
 export * from "./config.js";
 export * from "./confirmArtifacts.js";
@@ -13,6 +14,7 @@ export * from "./healthCheck.js";
 export * from "./humanize.js";
 export * from "./keepAlive.js";
 export * from "./localData.js";
+export * from "./liveValidation.js";
 export * from "./linkedinConnections.js";
 export * from "./linkedinFeed.js";
 export * from "./linkedinFollowups.js";
@@ -28,8 +30,7 @@ export * from "./profileManager.js";
 export * from "./rateLimiter.js";
 export * from "./run.js";
 export * from "./runtime.js";
-export * from "./selectorLocale.js";
-export * from "./selectorAudit.js";
-export * from "./twoPhaseCommit.js";
-
 export * from "./scheduler.js";
+export * from "./selectorAudit.js";
+export * from "./selectorLocale.js";
+export * from "./twoPhaseCommit.js";

--- a/packages/core/src/liveValidation.ts
+++ b/packages/core/src/liveValidation.ts
@@ -1,0 +1,1186 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  chromium,
+  type Browser,
+  type BrowserContext,
+  type Page,
+  type Request,
+  type Route
+} from "playwright-core";
+import { ArtifactHelpers } from "./artifacts.js";
+import {
+  ensureConfigPaths,
+  resolveConfigPaths,
+  type ConfigPaths
+} from "./config.js";
+import { LinkedInAssistantError, asLinkedInAssistantError } from "./errors.js";
+import { JsonEventLogger } from "./logging.js";
+import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
+import { createRunId } from "./run.js";
+import {
+  LinkedInSessionStore,
+  type LoadStoredLinkedInSessionResult
+} from "./auth/sessionStore.js";
+import { inspectLinkedInSession } from "./auth/sessionInspection.js";
+
+export const LINKEDIN_READ_ONLY_VALIDATION_OPERATIONS = [
+  {
+    id: "feed",
+    summary: "Load the LinkedIn feed and verify the main feed surface."
+  },
+  {
+    id: "profile",
+    summary: "Open the signed-in profile and verify the header selectors."
+  },
+  {
+    id: "notifications",
+    summary: "Open notifications and verify the notifications surface."
+  },
+  {
+    id: "inbox",
+    summary: "Open messaging and verify the inbox plus one readable thread when available."
+  },
+  {
+    id: "connections",
+    summary: "Open connections and verify the connections list surface."
+  }
+] as const;
+
+export type LinkedInReadOnlyValidationOperation =
+  (typeof LINKEDIN_READ_ONLY_VALIDATION_OPERATIONS)[number];
+
+export type LinkedInReadOnlyValidationOperationId =
+  LinkedInReadOnlyValidationOperation["id"];
+
+export type ReadOnlyValidationStatus = "pass" | "fail";
+export type ReadOnlyValidationDiffChange =
+  | "fallback_drift"
+  | "new_failure"
+  | "recovered";
+
+interface ReadOnlySelectorCandidateDefinition {
+  key: string;
+  selector: string;
+}
+
+interface ReadOnlySelectorDefinition {
+  candidates: ReadOnlySelectorCandidateDefinition[];
+  description: string;
+  key: string;
+}
+
+interface ReadOnlyOperationDefinition {
+  expectedPath: RegExp;
+  id: LinkedInReadOnlyValidationOperationId;
+  selectors: ReadOnlySelectorDefinition[];
+  summary: string;
+  url: string;
+}
+
+interface ReadOnlyOperationExecutionResult {
+  additionalWarnings: string[];
+  finalUrl: string;
+  selectorResults: ReadOnlyValidationSelectorResult[];
+  threadUrl?: string;
+}
+
+export interface ReadOnlyValidationSelectorResult {
+  description: string;
+  error?: string;
+  matched_candidate_key: string | null;
+  matched_candidate_rank: number | null;
+  matched_selector: string | null;
+  selector_key: string;
+  status: ReadOnlyValidationStatus;
+}
+
+export interface ReadOnlyValidationOperationResult {
+  completed_at: string;
+  failed_count: number;
+  final_url: string;
+  matched_count: number;
+  operation: LinkedInReadOnlyValidationOperationId;
+  page_load_ms: number;
+  selector_results: ReadOnlyValidationSelectorResult[];
+  started_at: string;
+  status: ReadOnlyValidationStatus;
+  summary: string;
+  thread_url?: string;
+  url: string;
+  warnings: string[];
+}
+
+export interface ReadOnlyValidationDiffEntry {
+  change: ReadOnlyValidationDiffChange;
+  current_candidate_key: string | null;
+  current_status: ReadOnlyValidationStatus;
+  operation: LinkedInReadOnlyValidationOperationId;
+  previous_candidate_key: string | null;
+  previous_status: ReadOnlyValidationStatus;
+  selector_key: string;
+}
+
+export interface ReadOnlyValidationDiff {
+  previous_report_path?: string;
+  recoveries: ReadOnlyValidationDiffEntry[];
+  regressions: ReadOnlyValidationDiffEntry[];
+  unchanged_count: number;
+}
+
+export interface ReadOnlyValidationBlockedRequest {
+  blocked_at: string;
+  method: string;
+  reason: "non_get" | "non_linkedin_domain";
+  resource_type: string;
+  url: string;
+}
+
+export interface ReadOnlyValidationReport {
+  blocked_request_count: number;
+  blocked_requests: ReadOnlyValidationBlockedRequest[];
+  checked_at: string;
+  diff: ReadOnlyValidationDiff;
+  events_path: string;
+  fail_count: number;
+  latest_report_path: string;
+  operation_count: number;
+  operations: ReadOnlyValidationOperationResult[];
+  outcome: ReadOnlyValidationStatus;
+  pass_count: number;
+  previous_report_path?: string;
+  recommended_actions: string[];
+  report_path: string;
+  request_limits: {
+    max_requests: number;
+    max_requests_reached: boolean;
+    min_interval_ms: number;
+    used_requests: number;
+  };
+  run_id: string;
+  session: {
+    captured_at: string;
+    file_path: string;
+    li_at_expires_at: string | null;
+    session_name: string;
+  };
+  summary: string;
+}
+
+export interface RunReadOnlyValidationOptions {
+  baseDir?: string;
+  maxRequests?: number;
+  minIntervalMs?: number;
+  onBeforeOperation?: (
+    operation: LinkedInReadOnlyValidationOperation
+  ) => Promise<void>;
+  sessionName?: string;
+  timeoutMs?: number;
+}
+
+const DEFAULT_OPERATION_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_REQUESTS = 20;
+const DEFAULT_MIN_INTERVAL_MS = 5_000;
+const READ_ONLY_REPORT_DIR = "live-readonly";
+const READ_ONLY_LATEST_REPORT_NAME = "latest-report.json";
+const ALLOWED_LINKEDIN_HOST_SUFFIXES = ["linkedin.com", "licdn.com"] as const;
+
+const READ_ONLY_OPERATION_REGISTRY: ReadonlyArray<ReadOnlyOperationDefinition> = [
+  {
+    id: "feed",
+    summary: "Load the LinkedIn feed and verify the main feed surface.",
+    url: "https://www.linkedin.com/feed/",
+    expectedPath: /^\/feed\//u,
+    selectors: [
+      {
+        key: "feed_surface",
+        description: "Feed content surface",
+        candidates: [
+          { key: "feed-update-card", selector: "div.feed-shared-update-v2" },
+          { key: "feed-data-urn", selector: "main [data-urn]" },
+          { key: "feed-main", selector: "main[role='main']" }
+        ]
+      },
+      {
+        key: "global_nav",
+        description: "Authenticated global navigation",
+        candidates: [
+          { key: "global-nav", selector: "nav.global-nav" },
+          { key: "header-nav", selector: "header nav" },
+          { key: "global-nav-link", selector: "a[href='/feed/']" }
+        ]
+      }
+    ]
+  },
+  {
+    id: "profile",
+    summary: "Open the signed-in profile and verify the header selectors.",
+    url: "https://www.linkedin.com/in/me/",
+    expectedPath: /^\/in\//u,
+    selectors: [
+      {
+        key: "profile_header",
+        description: "Profile headline card",
+        candidates: [
+          { key: "profile-h1", selector: "main h1" },
+          { key: "profile-heading", selector: "h1.text-heading-xlarge" },
+          { key: "profile-card", selector: "main section.artdeco-card" }
+        ]
+      },
+      {
+        key: "profile_main",
+        description: "Profile main content area",
+        candidates: [
+          { key: "profile-main", selector: "main" },
+          { key: "profile-top-card", selector: "section.artdeco-card" },
+          { key: "profile-about", selector: "#about" }
+        ]
+      }
+    ]
+  },
+  {
+    id: "notifications",
+    summary: "Open notifications and verify the notifications surface.",
+    url: "https://www.linkedin.com/notifications/",
+    expectedPath: /^\/notifications\//u,
+    selectors: [
+      {
+        key: "notification_surface",
+        description: "Notifications list or container",
+        candidates: [
+          { key: "notification-list", selector: "main ul[role='list']" },
+          { key: "notification-card", selector: "main li.notification-card" },
+          { key: "notification-main", selector: "main" }
+        ]
+      },
+      {
+        key: "notification_link",
+        description: "Notification entry link",
+        candidates: [
+          { key: "notification-anchor", selector: "a[href*='/notifications/']" },
+          { key: "notification-update-link", selector: "a[href*='/feed/update/']" },
+          { key: "notification-list-item", selector: "main li" }
+        ]
+      }
+    ]
+  },
+  {
+    id: "connections",
+    summary: "Open connections and verify the connections list surface.",
+    url: "https://www.linkedin.com/mynetwork/invite-connect/connections/",
+    expectedPath: /^\/mynetwork\/invite-connect\/connections\//u,
+    selectors: [
+      {
+        key: "connections_surface",
+        description: "Connections list or container",
+        candidates: [
+          { key: "connections-list", selector: "main ul[role='list']" },
+          { key: "connection-card", selector: "main li.mn-connection-card" },
+          { key: "connections-main", selector: "main" }
+        ]
+      },
+      {
+        key: "connection_entry",
+        description: "Connection profile entry",
+        candidates: [
+          { key: "connection-profile-link", selector: "main a[href*='/in/']" },
+          { key: "connection-name", selector: "main span.mn-connection-card__name" },
+          { key: "connection-list-item", selector: "main li" }
+        ]
+      }
+    ]
+  }
+];
+
+const INBOX_OPERATION: ReadOnlyOperationDefinition = {
+  id: "inbox",
+  summary: "Open messaging and verify the inbox plus one readable thread when available.",
+  url: "https://www.linkedin.com/messaging/",
+  expectedPath: /^\/messaging\//u,
+  selectors: [
+    {
+      key: "conversation_list",
+      description: "Conversation list surface",
+      candidates: [
+        {
+          key: "conversation-list",
+          selector: ".msg-conversations-container__conversations-list"
+        },
+        { key: "conversation-thread-link", selector: "a[href*='/messaging/thread/']" },
+        { key: "messaging-main", selector: "main" }
+      ]
+    },
+    {
+      key: "message_thread",
+      description: "Readable message thread",
+      candidates: [
+        { key: "message-event", selector: "li.msg-s-message-list__event" },
+        {
+          key: "message-list-container",
+          selector: ".msg-s-message-list-container"
+        },
+        { key: "message-group", selector: ".msg-s-message-group__messages" }
+      ]
+    }
+  ]
+};
+
+function withPlaywrightInstallHint(error: unknown): Error {
+  if (error instanceof Error && error.message.includes("Executable doesn't exist")) {
+    return new Error(
+      'Playwright browser executable is missing. Install Chromium with "npx playwright install chromium" or set PLAYWRIGHT_EXECUTABLE_PATH.'
+    );
+  }
+
+  if (error instanceof Error) {
+    return error;
+  }
+
+  return new Error(String(error));
+}
+
+function isFinitePositiveNumber(value: number): boolean {
+  return Number.isFinite(value) && value > 0;
+}
+
+function resolvePositiveInt(
+  value: number | undefined,
+  fallback: number,
+  label: string
+): number {
+  if (typeof value === "undefined") {
+    return fallback;
+  }
+
+  if (!isFinitePositiveNumber(value)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must be a positive number.`
+    );
+  }
+
+  return Math.floor(value);
+}
+
+function resolveLatestReportPath(paths: ConfigPaths): string {
+  return path.join(paths.artifactsDir, READ_ONLY_REPORT_DIR, READ_ONLY_LATEST_REPORT_NAME);
+}
+
+async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T | null> {
+  try {
+    const raw = await readFile(filePath, "utf8");
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return null;
+    }
+
+    return null;
+  }
+}
+
+function isAllowedLinkedInHost(hostname: string): boolean {
+  const normalizedHost = hostname.toLowerCase();
+  return ALLOWED_LINKEDIN_HOST_SUFFIXES.some(
+    (suffix) =>
+      normalizedHost === suffix || normalizedHost.endsWith(`.${suffix}`)
+  );
+}
+
+export function isAllowedLinkedInReadOnlyRequest(
+  urlString: string,
+  method: string
+): boolean {
+  if (method.trim().toUpperCase() !== "GET") {
+    return false;
+  }
+
+  try {
+    const parsedUrl = new URL(urlString);
+    if (!/^https?:$/u.test(parsedUrl.protocol)) {
+      return true;
+    }
+
+    return isAllowedLinkedInHost(parsedUrl.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function getOperationDefinition(
+  operationId: LinkedInReadOnlyValidationOperationId
+): ReadOnlyOperationDefinition {
+  if (operationId === "inbox") {
+    return INBOX_OPERATION;
+  }
+
+  const definition = READ_ONLY_OPERATION_REGISTRY.find(
+    (candidate) => candidate.id === operationId
+  );
+
+  if (!definition) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `Unsupported read-only live validation operation: ${operationId}.`
+    );
+  }
+
+  return definition;
+}
+
+async function getOrCreatePage(context: BrowserContext): Promise<Page> {
+  const existingPage = context.pages()[0];
+  if (existingPage) {
+    return existingPage;
+  }
+
+  return context.newPage();
+}
+
+async function assertHealthyStoredSession(
+  page: Page,
+  sessionName: string,
+  operationId: LinkedInReadOnlyValidationOperationId
+): Promise<void> {
+  const status = await inspectLinkedInSession(page);
+  if (status.authenticated) {
+    return;
+  }
+
+  const challengeDetected =
+    status.currentUrl.includes("/checkpoint") || status.currentUrl.includes("/challenge");
+
+  throw new LinkedInAssistantError(
+    challengeDetected ? "CAPTCHA_OR_CHALLENGE" : "AUTH_REQUIRED",
+    challengeDetected
+      ? `Stored LinkedIn session "${sessionName}" triggered a challenge while running ${operationId}. Capture a fresh session with "owa auth:session --session ${sessionName}" and retry.`
+      : `Stored LinkedIn session "${sessionName}" is missing or expired while running ${operationId}. Capture a fresh session with "owa auth:session --session ${sessionName}" and retry.`,
+    {
+      checked_at: status.checkedAt,
+      current_url: status.currentUrl,
+      operation: operationId,
+      reason: status.reason,
+      session_name: sessionName
+    }
+  );
+}
+
+function assertExpectedOperationUrl(
+  currentUrl: string,
+  definition: ReadOnlyOperationDefinition
+): void {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(currentUrl);
+  } catch (error) {
+    throw new LinkedInAssistantError(
+      "NETWORK_ERROR",
+      `Unexpected redirect while running ${definition.id}: ${currentUrl}`,
+      {
+        current_url: currentUrl,
+        operation: definition.id
+      },
+      {
+        cause: error instanceof Error ? error : undefined
+      }
+    );
+  }
+
+  if (!isAllowedLinkedInHost(parsedUrl.hostname) || !definition.expectedPath.test(parsedUrl.pathname)) {
+    throw new LinkedInAssistantError(
+      "NETWORK_ERROR",
+      `Unexpected redirect while running ${definition.id}. Expected a LinkedIn ${definition.id} page but reached ${currentUrl}.`,
+      {
+        current_url: currentUrl,
+        expected_path: definition.expectedPath.source,
+        operation: definition.id
+      }
+    );
+  }
+}
+
+async function resolveSelectorResult(
+  page: Page,
+  selectorDefinition: ReadOnlySelectorDefinition,
+  timeoutMs: number
+): Promise<ReadOnlyValidationSelectorResult> {
+  for (const [index, candidate] of selectorDefinition.candidates.entries()) {
+    try {
+      await page
+        .locator(candidate.selector)
+        .first()
+        .waitFor({ state: "visible", timeout: timeoutMs });
+
+      return {
+        description: selectorDefinition.description,
+        matched_candidate_key: candidate.key,
+        matched_candidate_rank: index,
+        matched_selector: candidate.selector,
+        selector_key: selectorDefinition.key,
+        status: "pass"
+      };
+    } catch {
+      // Try the next selector candidate.
+    }
+  }
+
+  return {
+    description: selectorDefinition.description,
+    error: `No selector candidate matched ${selectorDefinition.key}.`,
+    matched_candidate_key: null,
+    matched_candidate_rank: null,
+    matched_selector: null,
+    selector_key: selectorDefinition.key,
+    status: "fail"
+  };
+}
+
+async function resolveSelectorResults(
+  page: Page,
+  selectorDefinitions: readonly ReadOnlySelectorDefinition[],
+  timeoutMs: number
+): Promise<ReadOnlyValidationSelectorResult[]> {
+  const results: ReadOnlyValidationSelectorResult[] = [];
+
+  for (const selectorDefinition of selectorDefinitions) {
+    results.push(await resolveSelectorResult(page, selectorDefinition, timeoutMs));
+  }
+
+  return results;
+}
+
+function buildBlockedRequest(
+  request: Request,
+  reason: ReadOnlyValidationBlockedRequest["reason"]
+): ReadOnlyValidationBlockedRequest {
+  return {
+    blocked_at: new Date().toISOString(),
+    method: request.method(),
+    reason,
+    resource_type: request.resourceType(),
+    url: request.url()
+  };
+}
+
+async function installReadOnlyNetworkGuard(
+  context: BrowserContext,
+  blockedRequests: ReadOnlyValidationBlockedRequest[]
+): Promise<void> {
+  await context.route("**/*", async (route: Route) => {
+    const request = route.request();
+    const method = request.method();
+    const url = request.url();
+
+    if (isAllowedLinkedInReadOnlyRequest(url, method)) {
+      await route.continue();
+      return;
+    }
+
+    blockedRequests.push(
+      buildBlockedRequest(
+        request,
+        method.trim().toUpperCase() !== "GET" ? "non_get" : "non_linkedin_domain"
+      )
+    );
+    await route.abort();
+  });
+}
+
+export class ReadOnlyOperationRateLimiter {
+  private lastRequestAtMs: number | null = null;
+
+  private requestCount = 0;
+
+  constructor(
+    private readonly maxRequests: number = DEFAULT_MAX_REQUESTS,
+    private readonly minIntervalMs: number = DEFAULT_MIN_INTERVAL_MS,
+    private readonly now: () => number = () => Date.now(),
+    private readonly sleep: (delayMs: number) => Promise<void> = async (
+      delayMs
+    ) => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, delayMs);
+      });
+    }
+  ) {
+    if (!isFinitePositiveNumber(maxRequests)) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        "maxRequests must be a positive number."
+      );
+    }
+
+    if (!isFinitePositiveNumber(minIntervalMs)) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        "minIntervalMs must be a positive number."
+      );
+    }
+  }
+
+  async waitTurn(operationId: LinkedInReadOnlyValidationOperationId): Promise<void> {
+    if (this.requestCount >= this.maxRequests) {
+      throw new LinkedInAssistantError(
+        "RATE_LIMITED",
+        `Read-only live validation reached the per-session request cap (${this.maxRequests}) before ${operationId}.`,
+        {
+          max_requests: this.maxRequests,
+          operation: operationId,
+          used_requests: this.requestCount
+        }
+      );
+    }
+
+    const currentTimeMs = this.now();
+    if (this.lastRequestAtMs !== null) {
+      const elapsedMs = currentTimeMs - this.lastRequestAtMs;
+      const remainingDelayMs = this.minIntervalMs - elapsedMs;
+      if (remainingDelayMs > 0) {
+        await this.sleep(remainingDelayMs);
+      }
+    }
+
+    this.lastRequestAtMs = this.now();
+    this.requestCount += 1;
+  }
+
+  getRequestCount(): number {
+    return this.requestCount;
+  }
+
+  hasReachedLimit(): boolean {
+    return this.requestCount >= this.maxRequests;
+  }
+}
+
+function summarizeReport(
+  operations: readonly ReadOnlyValidationOperationResult[],
+  diff: ReadOnlyValidationDiff
+): string {
+  const passCount = operations.filter((operation) => operation.status === "pass").length;
+  const failCount = operations.length - passCount;
+  const regressionSuffix = diff.regressions.length > 0
+    ? ` ${diff.regressions.length} selector regression${diff.regressions.length === 1 ? "" : "s"} detected versus the previous run.`
+    : "";
+
+  return `Checked ${operations.length} read-only LinkedIn operation${operations.length === 1 ? "" : "s"}. ${passCount} passed. ${failCount} failed.${regressionSuffix}`;
+}
+
+function buildRecommendedActions(
+  sessionName: string,
+  reportPath: string,
+  diff: ReadOnlyValidationDiff,
+  operations: readonly ReadOnlyValidationOperationResult[]
+): string[] {
+  const actions = [
+    `Open ${reportPath} to review selector matches, failures, timings, and blocked requests.`
+  ];
+
+  if (operations.some((operation) => operation.status === "fail")) {
+    actions.push(
+      `Capture a fresh session with "owa auth:session --session ${sessionName}" if the report shows login or challenge redirects.`
+    );
+    actions.push(
+      "Review failed selector groups and update the read-only validation selectors if LinkedIn changed the UI."
+    );
+  }
+
+  if (diff.regressions.length > 0 && diff.previous_report_path) {
+    actions.push(
+      `Compare this run with ${diff.previous_report_path} to confirm whether the regression is a real UI change or environment-specific drift.`
+    );
+  }
+
+  return actions;
+}
+
+function buildSelectorIndex(
+  report: Pick<ReadOnlyValidationReport, "operations">
+): Map<
+  string,
+  {
+    matchedCandidateKey: string | null;
+    matchedCandidateRank: number | null;
+    status: ReadOnlyValidationStatus;
+  }
+> {
+  const index = new Map<
+    string,
+    {
+      matchedCandidateKey: string | null;
+      matchedCandidateRank: number | null;
+      status: ReadOnlyValidationStatus;
+    }
+  >();
+
+  for (const operation of report.operations) {
+    for (const selectorResult of operation.selector_results) {
+      index.set(`${operation.operation}:${selectorResult.selector_key}`, {
+        matchedCandidateKey: selectorResult.matched_candidate_key,
+        matchedCandidateRank: selectorResult.matched_candidate_rank,
+        status: selectorResult.status
+      });
+    }
+  }
+
+  return index;
+}
+
+function isReadOnlyValidationReport(value: unknown): value is ReadOnlyValidationReport {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "operations" in value &&
+    Array.isArray((value as { operations: unknown }).operations)
+  );
+}
+
+export function computeReadOnlyValidationDiff(
+  currentReport: Pick<ReadOnlyValidationReport, "operations">,
+  previousReport:
+    | Pick<ReadOnlyValidationReport, "operations" | "report_path">
+    | null
+): ReadOnlyValidationDiff {
+  if (!previousReport) {
+    return {
+      recoveries: [],
+      regressions: [],
+      unchanged_count: currentReport.operations.reduce(
+        (total, operation) => total + operation.selector_results.length,
+        0
+      )
+    };
+  }
+
+  const previousIndex = buildSelectorIndex(previousReport);
+  const regressions: ReadOnlyValidationDiffEntry[] = [];
+  const recoveries: ReadOnlyValidationDiffEntry[] = [];
+  let unchangedCount = 0;
+
+  for (const operation of currentReport.operations) {
+    for (const selectorResult of operation.selector_results) {
+      const entryKey = `${operation.operation}:${selectorResult.selector_key}`;
+      const previousEntry = previousIndex.get(entryKey);
+      if (!previousEntry) {
+        unchangedCount += 1;
+        continue;
+      }
+
+      if (previousEntry.status === selectorResult.status) {
+        if (
+          previousEntry.status === "pass" &&
+          selectorResult.status === "pass" &&
+          previousEntry.matchedCandidateRank !== null &&
+          selectorResult.matched_candidate_rank !== null &&
+          selectorResult.matched_candidate_rank > previousEntry.matchedCandidateRank
+        ) {
+          regressions.push({
+            change: "fallback_drift",
+            current_candidate_key: selectorResult.matched_candidate_key,
+            current_status: selectorResult.status,
+            operation: operation.operation,
+            previous_candidate_key: previousEntry.matchedCandidateKey,
+            previous_status: previousEntry.status,
+            selector_key: selectorResult.selector_key
+          });
+          continue;
+        }
+
+        unchangedCount += 1;
+        continue;
+      }
+
+      if (previousEntry.status === "pass" && selectorResult.status === "fail") {
+        regressions.push({
+          change: "new_failure",
+          current_candidate_key: selectorResult.matched_candidate_key,
+          current_status: selectorResult.status,
+          operation: operation.operation,
+          previous_candidate_key: previousEntry.matchedCandidateKey,
+          previous_status: previousEntry.status,
+          selector_key: selectorResult.selector_key
+        });
+        continue;
+      }
+
+      recoveries.push({
+        change: "recovered",
+        current_candidate_key: selectorResult.matched_candidate_key,
+        current_status: selectorResult.status,
+        operation: operation.operation,
+        previous_candidate_key: previousEntry.matchedCandidateKey,
+        previous_status: previousEntry.status,
+        selector_key: selectorResult.selector_key
+      });
+    }
+  }
+
+  return {
+    previous_report_path: previousReport.report_path,
+    recoveries,
+    regressions,
+    unchanged_count: unchangedCount
+  };
+}
+
+async function runGenericOperation(
+  page: Page,
+  definition: ReadOnlyOperationDefinition,
+  sessionName: string,
+  timeoutMs: number
+): Promise<ReadOnlyOperationExecutionResult> {
+  await page.goto(definition.url, {
+    timeout: timeoutMs,
+    waitUntil: "domcontentloaded"
+  });
+  await waitForNetworkIdleBestEffort(page, Math.min(timeoutMs, 5_000));
+  await assertHealthyStoredSession(page, sessionName, definition.id);
+  assertExpectedOperationUrl(page.url(), definition);
+
+  return {
+    additionalWarnings: [],
+    finalUrl: page.url(),
+    selectorResults: await resolveSelectorResults(
+      page,
+      definition.selectors,
+      Math.min(timeoutMs, 5_000)
+    )
+  };
+}
+
+async function clickFirstVisibleThreadLink(page: Page, timeoutMs: number): Promise<boolean> {
+  const threadLinkSelectors = [
+    "a[href*='/messaging/thread/']",
+    "a[href*='/messaging/detail/']"
+  ];
+
+  for (const selector of threadLinkSelectors) {
+    const locator = page.locator(selector).first();
+    try {
+      await locator.waitFor({ state: "visible", timeout: timeoutMs });
+      await locator.click({ timeout: timeoutMs });
+      return true;
+    } catch {
+      // Try the next selector.
+    }
+  }
+
+  return false;
+}
+
+async function runInboxOperation(
+  page: Page,
+  sessionName: string,
+  timeoutMs: number
+): Promise<ReadOnlyOperationExecutionResult> {
+  await page.goto(INBOX_OPERATION.url, {
+    timeout: timeoutMs,
+    waitUntil: "domcontentloaded"
+  });
+  await waitForNetworkIdleBestEffort(page, Math.min(timeoutMs, 5_000));
+  await assertHealthyStoredSession(page, sessionName, INBOX_OPERATION.id);
+  assertExpectedOperationUrl(page.url(), INBOX_OPERATION);
+
+  const conversationSelectorDefinition = INBOX_OPERATION.selectors[0];
+  const messageSelectorDefinition = INBOX_OPERATION.selectors[1];
+  if (!conversationSelectorDefinition || !messageSelectorDefinition) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "Inbox live validation is misconfigured because required selector groups are missing."
+    );
+  }
+
+  const selectorTimeoutMs = Math.min(timeoutMs, 5_000);
+  const conversationSelector = await resolveSelectorResult(
+    page,
+    conversationSelectorDefinition,
+    selectorTimeoutMs
+  );
+
+  const warnings: string[] = [];
+  const threadClicked = await clickFirstVisibleThreadLink(page, selectorTimeoutMs);
+  let threadUrl: string | undefined;
+  if (threadClicked) {
+    await waitForNetworkIdleBestEffort(page, Math.min(timeoutMs, 5_000));
+    await assertHealthyStoredSession(page, sessionName, INBOX_OPERATION.id);
+    assertExpectedOperationUrl(page.url(), INBOX_OPERATION);
+    threadUrl = page.url();
+  } else {
+    warnings.push(
+      "No inbox thread was available to validate message-thread selectors; only the conversation list surface was checked."
+    );
+  }
+
+  const messageSelector = threadClicked
+    ? await resolveSelectorResult(page, messageSelectorDefinition, selectorTimeoutMs)
+    : {
+        description: messageSelectorDefinition.description,
+        error: "No inbox thread was available to validate message-thread selectors.",
+        matched_candidate_key: null,
+        matched_candidate_rank: null,
+        matched_selector: null,
+        selector_key: messageSelectorDefinition.key,
+        status: "fail" as const
+      };
+
+  return {
+    additionalWarnings: warnings,
+    finalUrl: page.url(),
+    selectorResults: [conversationSelector, messageSelector],
+    ...(threadUrl ? { threadUrl } : {})
+  };
+}
+
+function createOperationResult(
+  definition: ReadOnlyOperationDefinition,
+  startedAt: string,
+  completedAt: string,
+  pageLoadMs: number,
+  execution: ReadOnlyOperationExecutionResult
+): ReadOnlyValidationOperationResult {
+  const matchedCount = execution.selectorResults.filter(
+    (result) => result.status === "pass"
+  ).length;
+  const failedCount = execution.selectorResults.length - matchedCount;
+
+  return {
+    completed_at: completedAt,
+    failed_count: failedCount,
+    final_url: execution.finalUrl,
+    matched_count: matchedCount,
+    operation: definition.id,
+    page_load_ms: pageLoadMs,
+    selector_results: execution.selectorResults,
+    started_at: startedAt,
+    status: failedCount > 0 ? "fail" : "pass",
+    summary: definition.summary,
+    ...(execution.threadUrl ? { thread_url: execution.threadUrl } : {}),
+    url: definition.url,
+    warnings: execution.additionalWarnings
+  };
+}
+
+async function runOperation(
+  page: Page,
+  definition: ReadOnlyOperationDefinition,
+  sessionName: string,
+  timeoutMs: number
+): Promise<ReadOnlyValidationOperationResult> {
+  const startedAt = new Date().toISOString();
+  const startedAtMs = Date.now();
+
+  const execution = definition.id === "inbox"
+    ? await runInboxOperation(page, sessionName, timeoutMs)
+    : await runGenericOperation(page, definition, sessionName, timeoutMs);
+
+  return createOperationResult(
+    definition,
+    startedAt,
+    new Date().toISOString(),
+    Date.now() - startedAtMs,
+    execution
+  );
+}
+
+async function createBrowserContext(
+  loadedSession: LoadStoredLinkedInSessionResult,
+  timeoutMs: number,
+  blockedRequests: ReadOnlyValidationBlockedRequest[]
+): Promise<{ browser: Browser; context: BrowserContext }> {
+  const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
+  const browser = await chromium.launch({
+    headless: true,
+    ...(executablePath ? { executablePath } : {})
+  });
+  const context = await browser.newContext({
+    storageState: loadedSession.storageState
+  });
+  context.setDefaultNavigationTimeout(timeoutMs);
+  context.setDefaultTimeout(timeoutMs);
+  await installReadOnlyNetworkGuard(context, blockedRequests);
+
+  return { browser, context };
+}
+
+export async function runReadOnlyLinkedInLiveValidation(
+  options: RunReadOnlyValidationOptions = {}
+): Promise<ReadOnlyValidationReport> {
+  const sessionName = (options.sessionName ?? "default").trim() || "default";
+  const timeoutMs = resolvePositiveInt(
+    options.timeoutMs,
+    DEFAULT_OPERATION_TIMEOUT_MS,
+    "timeoutMs"
+  );
+  const maxRequests = resolvePositiveInt(
+    options.maxRequests,
+    DEFAULT_MAX_REQUESTS,
+    "maxRequests"
+  );
+  const minIntervalMs = resolvePositiveInt(
+    options.minIntervalMs,
+    DEFAULT_MIN_INTERVAL_MS,
+    "minIntervalMs"
+  );
+
+  const store = new LinkedInSessionStore(options.baseDir);
+  const loadedSession = await store.load(sessionName);
+
+  const paths = resolveConfigPaths(options.baseDir);
+  ensureConfigPaths(paths);
+
+  const runId = createRunId();
+  const logger = new JsonEventLogger(paths, runId);
+  const artifacts = new ArtifactHelpers(paths, runId);
+  const reportPath = artifacts.resolve(`${READ_ONLY_REPORT_DIR}/report.json`);
+  const latestReportPath = resolveLatestReportPath(paths);
+  const previousReportValue = await readJsonFile<unknown>(latestReportPath);
+  const previousReport = isReadOnlyValidationReport(previousReportValue)
+    ? previousReportValue
+    : null;
+  const blockedRequests: ReadOnlyValidationBlockedRequest[] = [];
+  const rateLimiter = new ReadOnlyOperationRateLimiter(
+    maxRequests,
+    minIntervalMs
+  );
+
+  logger.log("info", "live_validation.start", {
+    max_requests: maxRequests,
+    min_interval_ms: minIntervalMs,
+    report_path: reportPath,
+    session_name: sessionName,
+    timeout_ms: timeoutMs
+  });
+
+  let browser: Browser | undefined;
+  let context: BrowserContext | undefined;
+  try {
+    const browserContext = await createBrowserContext(
+      loadedSession,
+      timeoutMs,
+      blockedRequests
+    );
+    browser = browserContext.browser;
+    context = browserContext.context;
+
+    const page = await getOrCreatePage(context);
+    page.setDefaultNavigationTimeout(timeoutMs);
+    page.setDefaultTimeout(timeoutMs);
+
+    const operationResults: ReadOnlyValidationOperationResult[] = [];
+    for (const operation of LINKEDIN_READ_ONLY_VALIDATION_OPERATIONS) {
+      if (options.onBeforeOperation) {
+        await options.onBeforeOperation(operation);
+      }
+
+      logger.log("info", "live_validation.operation.start", {
+        operation: operation.id,
+        session_name: sessionName
+      });
+      await rateLimiter.waitTurn(operation.id);
+
+      const operationDefinition = getOperationDefinition(operation.id);
+      const operationResult = await runOperation(
+        page,
+        operationDefinition,
+        sessionName,
+        timeoutMs
+      );
+      operationResults.push(operationResult);
+
+      logger.log("info", "live_validation.operation.done", {
+        failed_count: operationResult.failed_count,
+        matched_count: operationResult.matched_count,
+        operation: operation.id,
+        page_load_ms: operationResult.page_load_ms,
+        status: operationResult.status,
+        warnings: operationResult.warnings
+      });
+    }
+
+    const diff = computeReadOnlyValidationDiff({ operations: operationResults }, previousReport);
+    const failCount = operationResults.filter(
+      (operation) => operation.status === "fail"
+    ).length;
+    const passCount = operationResults.length - failCount;
+    const report: ReadOnlyValidationReport = {
+      blocked_request_count: blockedRequests.length,
+      blocked_requests: blockedRequests,
+      checked_at: new Date().toISOString(),
+      diff,
+      events_path: logger.getEventsPath(),
+      fail_count: failCount,
+      latest_report_path: latestReportPath,
+      operation_count: operationResults.length,
+      operations: operationResults,
+      outcome: failCount > 0 ? "fail" : "pass",
+      pass_count: passCount,
+      ...(diff.previous_report_path
+        ? { previous_report_path: diff.previous_report_path }
+        : {}),
+      recommended_actions: [],
+      report_path: reportPath,
+      request_limits: {
+        max_requests: maxRequests,
+        max_requests_reached: rateLimiter.hasReachedLimit(),
+        min_interval_ms: minIntervalMs,
+        used_requests: rateLimiter.getRequestCount()
+      },
+      run_id: runId,
+      session: {
+        captured_at: loadedSession.metadata.capturedAt,
+        file_path: loadedSession.metadata.filePath,
+        li_at_expires_at: loadedSession.metadata.liAtCookieExpiresAt,
+        session_name: loadedSession.metadata.sessionName
+      },
+      summary: summarizeReport(operationResults, diff)
+    };
+
+    report.recommended_actions = buildRecommendedActions(
+      sessionName,
+      reportPath,
+      diff,
+      operationResults
+    );
+
+    artifacts.writeJson(`${READ_ONLY_REPORT_DIR}/report.json`, report, {
+      blocked_request_count: report.blocked_request_count,
+      fail_count: report.fail_count,
+      pass_count: report.pass_count,
+      session_name: sessionName
+    });
+    await writeJsonFile(latestReportPath, report);
+
+    logger.log("info", "live_validation.done", {
+      blocked_request_count: report.blocked_request_count,
+      fail_count: report.fail_count,
+      pass_count: report.pass_count,
+      report_path: report.report_path,
+      session_name: sessionName
+    });
+
+    return report;
+  } catch (error) {
+    logger.log("error", "live_validation.failed", {
+      error: asLinkedInAssistantError(error).message,
+      session_name: sessionName
+    });
+    throw asLinkedInAssistantError(
+      withPlaywrightInstallHint(error),
+      error instanceof LinkedInAssistantError ? error.code : "UNKNOWN",
+      "Failed to run the read-only LinkedIn live validation."
+    );
+  } finally {
+    if (context) {
+      await context.close().catch(() => undefined);
+    }
+    if (browser) {
+      await browser.close().catch(() => undefined);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add an encrypted stored-session capture flow via `owa auth:session`
- add `owa test:live --read-only` with per-step confirmations, GET-only request guards, rate limiting, and regression reports
- add unit coverage and operator docs for the live smoke-test workflow

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #88
