### PR TITLE
refactor: simplify live validation smoke-test helpers

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -69,8 +69,10 @@ import {
   type LinkedInFixturePageEntry,
   type LinkedInFixtureRoute,
   type LinkedInFixtureSetSummary,
+  type LinkedInReadOnlyValidationOperation,
   type LinkedInReplayPageType,
   type LocalDataDeletionFailure,
+  type ReadOnlyValidationReport,
   type SchedulerConfig,
   type SchedulerJobRow,
   type SchedulerTickResult,
@@ -86,7 +88,8 @@ import {
 import {
   formatReadOnlyValidationError,
   formatReadOnlyValidationReport,
-  resolveReadOnlyValidationOutputMode
+  resolveReadOnlyValidationOutputMode,
+  type ReadOnlyValidationOutputMode
 } from "../liveValidationOutput.js";
 import {
   formatSelectorAuditError,
@@ -1674,6 +1677,45 @@ async function maybeRefreshStoredSession(
   return true;
 }
 
+function createReadOnlyValidationPrompter(
+  sessionName: string
+): (operation: LinkedInReadOnlyValidationOperation) => Promise<void> {
+  return async (operation) => {
+    console.log(`Read-only step: ${operation.summary}`);
+    const confirmed = await promptYesNo("Continue with this step?");
+    if (!confirmed) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        "Read-only live validation was cancelled by the operator.",
+        {
+          operation: operation.id,
+          session_name: sessionName
+        }
+      );
+    }
+  };
+}
+
+function emitReadOnlyValidationResult(
+  report: ReadOnlyValidationReport,
+  outputMode: ReadOnlyValidationOutputMode
+): void {
+  if (outputMode === "json") {
+    printJson(report);
+  } else {
+    const redactedReport = redactStructuredValue(
+      report,
+      cliPrivacyConfig,
+      "cli"
+    ) as typeof report;
+    console.log(formatReadOnlyValidationReport(redactedReport));
+  }
+
+  if (report.outcome === "fail") {
+    process.exitCode = 1;
+  }
+}
+
 async function runLiveReadOnlyValidation(input: {
   json: boolean;
   readOnly: boolean;
@@ -1701,26 +1743,7 @@ async function runLiveReadOnlyValidation(input: {
   const runValidation = async () => {
     const onBeforeOperation = input.yes
       ? undefined
-      : async (operation: Parameters<
-          NonNullable<
-            NonNullable<
-              Parameters<typeof runReadOnlyLinkedInLiveValidation>[0]
-            >["onBeforeOperation"]
-          >
-        >[0]) => {
-          console.log(`Read-only step: ${operation.summary}`);
-          const confirmed = await promptYesNo("Continue with this step?");
-          if (!confirmed) {
-            throw new LinkedInAssistantError(
-              "ACTION_PRECONDITION_FAILED",
-              "Read-only live validation was cancelled by the operator.",
-              {
-                operation: operation.id,
-                session_name: input.sessionName
-              }
-            );
-          }
-        };
+      : createReadOnlyValidationPrompter(input.sessionName);
 
     return runReadOnlyLinkedInLiveValidation({
       sessionName: input.sessionName,
@@ -1731,21 +1754,7 @@ async function runLiveReadOnlyValidation(input: {
 
   try {
     const report = await runValidation();
-
-    if (outputMode === "json") {
-      printJson(report);
-    } else {
-      const redactedReport = redactStructuredValue(
-        report,
-        cliPrivacyConfig,
-        "cli"
-      ) as typeof report;
-      console.log(formatReadOnlyValidationReport(redactedReport));
-    }
-
-    if (report.outcome === "fail") {
-      process.exitCode = 1;
-    }
+    emitReadOnlyValidationResult(report, outputMode);
   } catch (error) {
     const refreshed = await maybeRefreshStoredSession(
       {
@@ -1758,20 +1767,7 @@ async function runLiveReadOnlyValidation(input: {
 
     if (refreshed) {
       const report = await runValidation();
-      if (outputMode === "json") {
-        printJson(report);
-      } else {
-        const redactedReport = redactStructuredValue(
-          report,
-          cliPrivacyConfig,
-          "cli"
-        ) as typeof report;
-        console.log(formatReadOnlyValidationReport(redactedReport));
-      }
-
-      if (report.outcome === "fail") {
-        process.exitCode = 1;
-      }
+      emitReadOnlyValidationResult(report, outputMode);
       return;
     }
 

--- a/packages/cli/src/liveValidationOutput.ts
+++ b/packages/cli/src/liveValidationOutput.ts
@@ -1,11 +1,19 @@
 import type {
   LinkedInAssistantErrorPayload,
+  ReadOnlyValidationDiffChange,
   ReadOnlyValidationDiffEntry,
   ReadOnlyValidationOperationResult,
-  ReadOnlyValidationReport
+  ReadOnlyValidationReport,
+  ReadOnlyValidationStatus
 } from "@linkedin-assistant/core";
 
 export type ReadOnlyValidationOutputMode = "human" | "json";
+const BLOCKED_REQUEST_PREVIEW_LIMIT = 5;
+const DIFF_CHANGE_LABELS: Record<ReadOnlyValidationDiffChange, string> = {
+  fallback_drift: "Selector drift",
+  new_failure: "New failure",
+  recovered: "Recovered"
+};
 
 function appendSection(lines: string[], title: string, entries: string[]): void {
   if (entries.length === 0) {
@@ -17,43 +25,36 @@ function appendSection(lines: string[], title: string, entries: string[]): void 
   lines.push(...entries);
 }
 
-function formatOutcome(report: ReadOnlyValidationReport): string {
-  return report.outcome === "fail" ? "FAIL" : "PASS";
-}
-
-function formatOperationStatus(operation: ReadOnlyValidationOperationResult): string {
-  return operation.status === "fail" ? "FAIL" : "PASS";
+function formatStatusLabel(status: ReadOnlyValidationStatus): string {
+  return status === "fail" ? "FAIL" : "PASS";
 }
 
 function formatOperationSummary(operation: ReadOnlyValidationOperationResult): string {
   const warningSuffix = operation.warnings.length > 0
     ? ` | ${operation.warnings.length} warning${operation.warnings.length === 1 ? "" : "s"}`
     : "";
-  return `- ${formatOperationStatus(operation)} ${operation.operation}: ${operation.matched_count} matched, ${operation.failed_count} failed, ${operation.page_load_ms}ms${warningSuffix}`;
+  return `- ${formatStatusLabel(operation.status)} ${operation.operation}: ${operation.matched_count} matched, ${operation.failed_count} failed, ${operation.page_load_ms}ms${warningSuffix}`;
 }
 
 function formatDiffEntry(entry: ReadOnlyValidationDiffEntry): string {
-  const changeLabel = entry.change === "new_failure"
-    ? "New failure"
-    : entry.change === "fallback_drift"
-      ? "Selector drift"
-      : "Recovered";
   const previousCandidate = entry.previous_candidate_key ?? "none";
   const currentCandidate = entry.current_candidate_key ?? "none";
 
-  return `- ${changeLabel}: ${entry.operation}/${entry.selector_key} (${previousCandidate} → ${currentCandidate})`;
+  return `- ${DIFF_CHANGE_LABELS[entry.change]}: ${entry.operation}/${entry.selector_key} (${previousCandidate} → ${currentCandidate})`;
 }
 
-function formatBlockedRequests(report: ReadOnlyValidationReport): string[] {
-  return report.blocked_requests.slice(0, 5).map((blockedRequest) => {
+function formatBlockedRequests(
+  blockedRequests: ReadOnlyValidationReport["blocked_requests"]
+): string[] {
+  return blockedRequests.slice(0, BLOCKED_REQUEST_PREVIEW_LIMIT).map((blockedRequest) => {
     return `- ${blockedRequest.method} ${blockedRequest.url} [${blockedRequest.reason}]`;
   });
 }
 
 function formatFailedSelectorBlocks(
-  report: ReadOnlyValidationReport
+  operations: ReadOnlyValidationReport["operations"]
 ): string[] {
-  return report.operations.flatMap((operation) => {
+  return operations.flatMap((operation) => {
     return operation.selector_results
       .filter((selectorResult) => selectorResult.status === "fail")
       .map((selectorResult) => {
@@ -73,7 +74,7 @@ export function formatReadOnlyValidationReport(
   report: ReadOnlyValidationReport
 ): string {
   const lines = [
-    `Live Validation: ${formatOutcome(report)}`,
+    `Live Validation: ${formatStatusLabel(report.outcome)}`,
     `Summary: ${report.summary}`,
     `Session: ${report.session.session_name} (captured ${report.session.captured_at})`,
     `Report JSON: ${report.report_path}`,
@@ -86,7 +87,7 @@ export function formatReadOnlyValidationReport(
     report.operations.map((operation) => formatOperationSummary(operation))
   );
 
-  appendSection(lines, "Failures", formatFailedSelectorBlocks(report));
+  appendSection(lines, "Failures", formatFailedSelectorBlocks(report.operations));
   appendSection(
     lines,
     "Regressions",
@@ -104,7 +105,7 @@ export function formatReadOnlyValidationReport(
       "Blocked Requests",
       [
         `- ${report.blocked_request_count} request${report.blocked_request_count === 1 ? "" : "s"} blocked by the read-only guard`,
-        ...formatBlockedRequests(report)
+        ...formatBlockedRequests(report.blocked_requests)
       ]
     );
   }

--- a/packages/cli/test/liveValidationOutput.test.ts
+++ b/packages/cli/test/liveValidationOutput.test.ts
@@ -1,0 +1,246 @@
+import type {
+  LinkedInAssistantErrorPayload,
+  ReadOnlyValidationReport
+} from "@linkedin-assistant/core";
+import { describe, expect, it } from "vitest";
+import {
+  formatReadOnlyValidationError,
+  formatReadOnlyValidationReport,
+  resolveReadOnlyValidationOutputMode
+} from "../src/liveValidationOutput.js";
+
+function createReportFixture(): ReadOnlyValidationReport {
+  return {
+    blocked_request_count: 6,
+    blocked_requests: [
+      {
+        blocked_at: "2026-03-09T10:00:01.000Z",
+        method: "POST",
+        reason: "non_get",
+        resource_type: "xhr",
+        url: "https://www.linkedin.com/voyager/api/graphql"
+      },
+      {
+        blocked_at: "2026-03-09T10:00:02.000Z",
+        method: "GET",
+        reason: "non_linkedin_domain",
+        resource_type: "script",
+        url: "https://example.com/tracker.js"
+      },
+      {
+        blocked_at: "2026-03-09T10:00:03.000Z",
+        method: "POST",
+        reason: "non_get",
+        resource_type: "xhr",
+        url: "https://www.linkedin.com/voyager/api/identity"
+      },
+      {
+        blocked_at: "2026-03-09T10:00:04.000Z",
+        method: "GET",
+        reason: "non_linkedin_domain",
+        resource_type: "image",
+        url: "https://analytics.example.net/pixel"
+      },
+      {
+        blocked_at: "2026-03-09T10:00:05.000Z",
+        method: "POST",
+        reason: "non_get",
+        resource_type: "fetch",
+        url: "https://www.linkedin.com/voyager/api/feed"
+      },
+      {
+        blocked_at: "2026-03-09T10:00:06.000Z",
+        method: "GET",
+        reason: "non_linkedin_domain",
+        resource_type: "font",
+        url: "https://cdn.example.org/font.woff2"
+      }
+    ],
+    checked_at: "2026-03-09T10:00:00.000Z",
+    diff: {
+      previous_report_path: "/tmp/live-readonly/previous-report.json",
+      recoveries: [
+        {
+          change: "recovered",
+          current_candidate_key: "profile-h1",
+          current_status: "pass",
+          operation: "profile",
+          previous_candidate_key: null,
+          previous_status: "fail",
+          selector_key: "profile_header"
+        }
+      ],
+      regressions: [
+        {
+          change: "fallback_drift",
+          current_candidate_key: "header-nav",
+          current_status: "pass",
+          operation: "feed",
+          previous_candidate_key: "global-nav",
+          previous_status: "pass",
+          selector_key: "global_nav"
+        },
+        {
+          change: "new_failure",
+          current_candidate_key: null,
+          current_status: "fail",
+          operation: "notifications",
+          previous_candidate_key: "notification-list",
+          previous_status: "pass",
+          selector_key: "notification_surface"
+        }
+      ],
+      unchanged_count: 3
+    },
+    events_path: "/tmp/live-readonly/events.jsonl",
+    fail_count: 1,
+    latest_report_path: "/tmp/live-readonly/latest-report.json",
+    operation_count: 2,
+    operations: [
+      {
+        completed_at: "2026-03-09T10:00:05.000Z",
+        failed_count: 0,
+        final_url: "https://www.linkedin.com/feed/",
+        matched_count: 2,
+        operation: "feed",
+        page_load_ms: 1200,
+        selector_results: [
+          {
+            description: "Feed content surface",
+            matched_candidate_key: "feed-update-card",
+            matched_candidate_rank: 0,
+            matched_selector: "div.feed-shared-update-v2",
+            selector_key: "feed_surface",
+            status: "pass"
+          },
+          {
+            description: "Authenticated global navigation",
+            matched_candidate_key: "header-nav",
+            matched_candidate_rank: 1,
+            matched_selector: "header nav",
+            selector_key: "global_nav",
+            status: "pass"
+          }
+        ],
+        started_at: "2026-03-09T10:00:00.000Z",
+        status: "pass",
+        summary: "Load the LinkedIn feed and verify the main feed surface.",
+        url: "https://www.linkedin.com/feed/",
+        warnings: []
+      },
+      {
+        completed_at: "2026-03-09T10:00:12.000Z",
+        failed_count: 1,
+        final_url: "https://www.linkedin.com/notifications/",
+        matched_count: 1,
+        operation: "notifications",
+        page_load_ms: 1600,
+        selector_results: [
+          {
+            description: "Notifications list or container",
+            error: "No selector candidate matched notification_surface.",
+            matched_candidate_key: null,
+            matched_candidate_rank: null,
+            matched_selector: null,
+            selector_key: "notification_surface",
+            status: "fail"
+          },
+          {
+            description: "Notification entry link",
+            matched_candidate_key: "notification-anchor",
+            matched_candidate_rank: 0,
+            matched_selector: "a[href*='/notifications/']",
+            selector_key: "notification_link",
+            status: "pass"
+          }
+        ],
+        started_at: "2026-03-09T10:00:06.000Z",
+        status: "fail",
+        summary: "Open notifications and verify the notifications surface.",
+        url: "https://www.linkedin.com/notifications/",
+        warnings: ["Notifications loaded with a slower-than-usual response."]
+      }
+    ],
+    outcome: "fail",
+    pass_count: 1,
+    previous_report_path: "/tmp/live-readonly/previous-report.json",
+    recommended_actions: [
+      "Open /tmp/live-readonly/report.json to review selector matches.",
+      "Compare with the previous report to confirm whether the regression is real."
+    ],
+    report_path: "/tmp/live-readonly/report.json",
+    request_limits: {
+      max_requests: 20,
+      max_requests_reached: false,
+      min_interval_ms: 5000,
+      used_requests: 2
+    },
+    run_id: "run_live_validation_output_test",
+    session: {
+      captured_at: "2026-03-09T09:00:00.000Z",
+      file_path: "/tmp/session.enc.json",
+      li_at_expires_at: "2026-04-01T00:00:00.000Z",
+      session_name: "smoke"
+    },
+    summary:
+      "Checked 2 read-only LinkedIn operations. 1 passed. 1 failed. 2 selector regressions detected versus the previous run."
+  };
+}
+
+describe("live validation output helpers", () => {
+  it("defaults to human output in interactive terminals unless JSON is forced", () => {
+    expect(resolveReadOnlyValidationOutputMode({ json: false }, true)).toBe("human");
+    expect(resolveReadOnlyValidationOutputMode({ json: false }, false)).toBe("json");
+    expect(resolveReadOnlyValidationOutputMode({ json: true }, true)).toBe("json");
+  });
+
+  it("renders a scannable human-readable report", () => {
+    const output = formatReadOnlyValidationReport(createReportFixture());
+
+    expect(output).toContain("Live Validation: FAIL");
+    expect(output).toContain(
+      "Summary: Checked 2 read-only LinkedIn operations. 1 passed. 1 failed. 2 selector regressions detected versus the previous run."
+    );
+    expect(output).toContain("Operations");
+    expect(output).toContain("- PASS feed: 2 matched, 0 failed, 1200ms");
+    expect(output).toContain("- FAIL notifications: 1 matched, 1 failed, 1600ms | 1 warning");
+    expect(output).toContain("Failures");
+    expect(output).toContain(
+      "- notifications/notification_surface — No selector candidate matched notification_surface."
+    );
+    expect(output).toContain("Regressions");
+    expect(output).toContain(
+      "- Selector drift: feed/global_nav (global-nav → header-nav)"
+    );
+    expect(output).toContain(
+      "- New failure: notifications/notification_surface (notification-list → none)"
+    );
+    expect(output).toContain("Recoveries");
+    expect(output).toContain("- Recovered: profile/profile_header (none → profile-h1)");
+    expect(output).toContain("Blocked Requests");
+    expect(output).toContain("- 6 requests blocked by the read-only guard");
+    expect(output).toContain("https://www.linkedin.com/voyager/api/graphql");
+    expect(output).not.toContain("https://cdn.example.org/font.woff2");
+    expect(output).toContain("Next Steps");
+  });
+
+  it("formats friendly human-readable errors", () => {
+    const error: LinkedInAssistantErrorPayload = {
+      code: "ACTION_PRECONDITION_FAILED",
+      message: "Live validation is currently restricted to read-only mode.",
+      details: {
+        option: "read-only"
+      }
+    };
+
+    const output = formatReadOnlyValidationError(error);
+
+    expect(output).toContain(
+      "Live validation failed [ACTION_PRECONDITION_FAILED]"
+    );
+    expect(output).toContain(
+      "Live validation is currently restricted to read-only mode."
+    );
+    expect(output).toContain('Details: {"option":"read-only"}');
+  });
+});

--- a/packages/core/src/auth/sessionStore.ts
+++ b/packages/core/src/auth/sessionStore.ts
@@ -30,6 +30,10 @@ const SESSION_FILE_SUFFIX = ".session.enc.json";
 const SESSION_STORE_SCHEMA_VERSION = 1;
 const AES_GCM_IV_BYTES = 12;
 
+function isNotFoundError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
 interface StoredLinkedInSessionEnvelope {
   version: number;
   algorithm: "aes-256-gcm";
@@ -113,8 +117,35 @@ function normalizeSessionName(sessionName: string | undefined): string {
   return normalized;
 }
 
+function createStoredSessionValidationError(
+  message: string,
+  sessionName: string,
+  filePath: string,
+  cause?: Error
+): LinkedInAssistantError {
+  return new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    message,
+    {
+      file_path: filePath,
+      session_name: sessionName
+    },
+    cause ? { cause } : undefined
+  );
+}
+
 function encodeBase64Url(value: Buffer): string {
   return value.toString("base64url");
+}
+
+function deriveMachineBoundKey(rawKey: Buffer): Buffer {
+  return createHash("sha256")
+    .update(rawKey)
+    .update("\0")
+    .update(os.hostname())
+    .update("\0")
+    .update(os.userInfo().username)
+    .digest();
 }
 
 function decodeBase64Url(value: string, label: string): Buffer {
@@ -208,16 +239,10 @@ async function readOrCreateMasterKey(storeDir: string): Promise<Buffer> {
   try {
     const existingKey = await readFile(keyPath);
     if (existingKey.length === 32) {
-      return createHash("sha256")
-        .update(existingKey)
-        .update("\0")
-        .update(os.hostname())
-        .update("\0")
-        .update(os.userInfo().username)
-        .digest();
+      return deriveMachineBoundKey(existingKey);
     }
   } catch (error) {
-    if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") {
+    if (!isNotFoundError(error)) {
       throw error;
     }
   }
@@ -225,13 +250,7 @@ async function readOrCreateMasterKey(storeDir: string): Promise<Buffer> {
   const rawKey = randomBytes(32);
   await writeFile(keyPath, rawKey);
   await ensureOwnerOnlyPermissions(keyPath);
-  return createHash("sha256")
-    .update(rawKey)
-    .update("\0")
-    .update(os.hostname())
-    .update("\0")
-    .update(os.userInfo().username)
-    .digest();
+  return deriveMachineBoundKey(rawKey);
 }
 
 function validateEnvelope(
@@ -249,13 +268,10 @@ function validateEnvelope(
     !("tag" in envelope) ||
     !("metadata" in envelope)
   ) {
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
+    throw createStoredSessionValidationError(
       `Stored LinkedIn session "${sessionName}" is malformed. Capture a fresh session and retry.`,
-      {
-        file_path: filePath,
-        session_name: sessionName
-      }
+      sessionName,
+      filePath
     );
   }
 
@@ -269,13 +285,10 @@ function validateEnvelope(
     typeof normalizedEnvelope.metadata !== "object" ||
     normalizedEnvelope.metadata === null
   ) {
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
+    throw createStoredSessionValidationError(
       `Stored LinkedIn session "${sessionName}" is unreadable. Capture a fresh session and retry.`,
-      {
-        file_path: filePath,
-        session_name: sessionName
-      }
+      sessionName,
+      filePath
     );
   }
 
@@ -291,13 +304,10 @@ function validateEnvelope(
       typeof metadata.liAtCookieExpiresAt === "string"
     )
   ) {
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
+    throw createStoredSessionValidationError(
       `Stored LinkedIn session "${sessionName}" is unreadable. Capture a fresh session and retry.`,
-      {
-        file_path: filePath,
-        session_name: sessionName
-      }
+      sessionName,
+      filePath
     );
   }
 
@@ -331,13 +341,10 @@ function validateStorageState(
     !Array.isArray((value as { cookies: unknown }).cookies) ||
     !Array.isArray((value as { origins: unknown }).origins)
   ) {
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
+    throw createStoredSessionValidationError(
       `Stored LinkedIn session "${sessionName}" could not be decoded. Capture a fresh session and retry.`,
-      {
-        file_path: filePath,
-        session_name: sessionName
-      }
+      sessionName,
+      filePath
     );
   }
 
@@ -371,8 +378,7 @@ export class LinkedInSessionStore {
     storageState: LinkedInBrowserStorageState
   ): Promise<StoredLinkedInSessionMetadata> {
     const normalizedSessionName = normalizeSessionName(sessionName);
-    const paths = resolveConfigPaths(this.baseDir);
-    ensureConfigPaths(paths);
+    ensureConfigPaths(resolveConfigPaths(this.baseDir));
     const storeDir = resolveLinkedInSessionStoreDir(this.baseDir);
     await mkdir(storeDir, { recursive: true });
 
@@ -413,7 +419,7 @@ export class LinkedInSessionStore {
       await readFile(this.getSessionPath(sessionName), "utf8");
       return true;
     } catch (error) {
-      if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      if (isNotFoundError(error)) {
         return false;
       }
       throw error;
@@ -428,7 +434,7 @@ export class LinkedInSessionStore {
     try {
       rawEnvelope = await readFile(filePath, "utf8");
     } catch (error) {
-      if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      if (isNotFoundError(error)) {
         throw new LinkedInAssistantError(
           "AUTH_REQUIRED",
           `No stored LinkedIn session named "${normalizedSessionName}" was found. Run "owa auth:session --session ${normalizedSessionName}" first.`,
@@ -467,16 +473,11 @@ export class LinkedInSessionStore {
         filePath
       );
     } catch (error) {
-      throw new LinkedInAssistantError(
-        "ACTION_PRECONDITION_FAILED",
+      throw createStoredSessionValidationError(
         `Stored LinkedIn session "${normalizedSessionName}" could not be decrypted. Capture a fresh session and retry.`,
-        {
-          file_path: filePath,
-          session_name: normalizedSessionName
-        },
-        {
-          cause: error instanceof Error ? error : undefined
-        }
+        normalizedSessionName,
+        filePath,
+        error instanceof Error ? error : undefined
       );
     }
 
@@ -489,11 +490,8 @@ export class LinkedInSessionStore {
 
 async function getOrCreatePage(context: BrowserContext) {
   const existingPage = context.pages()[0];
-  if (existingPage) {
-    return existingPage;
-  }
 
-  return context.newPage();
+  return existingPage ?? context.newPage();
 }
 
 async function waitForManualLogin(

--- a/packages/core/src/liveValidation.ts
+++ b/packages/core/src/liveValidation.ts
@@ -181,6 +181,7 @@ export interface RunReadOnlyValidationOptions {
 const DEFAULT_OPERATION_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_REQUESTS = 20;
 const DEFAULT_MIN_INTERVAL_MS = 5_000;
+const READ_ONLY_DOM_SETTLE_TIMEOUT_MS = 5_000;
 const READ_ONLY_REPORT_DIR = "live-readonly";
 const READ_ONLY_LATEST_REPORT_NAME = "latest-report.json";
 const ALLOWED_LINKEDIN_HOST_SUFFIXES = ["linkedin.com", "licdn.com"] as const;
@@ -325,6 +326,11 @@ const INBOX_OPERATION: ReadOnlyOperationDefinition = {
   ]
 };
 
+const READ_ONLY_OPERATION_MAP = new Map<
+  LinkedInReadOnlyValidationOperationId,
+  ReadOnlyOperationDefinition
+>([...READ_ONLY_OPERATION_REGISTRY, INBOX_OPERATION].map((definition) => [definition.id, definition]));
+
 function withPlaywrightInstallHint(error: unknown): Error {
   if (error instanceof Error && error.message.includes("Executable doesn't exist")) {
     return new Error(
@@ -375,11 +381,7 @@ async function readJsonFile<T>(filePath: string): Promise<T | null> {
   try {
     const raw = await readFile(filePath, "utf8");
     return JSON.parse(raw) as T;
-  } catch (error) {
-    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-      return null;
-    }
-
+  } catch {
     return null;
   }
 }
@@ -415,13 +417,7 @@ export function isAllowedLinkedInReadOnlyRequest(
 function getOperationDefinition(
   operationId: LinkedInReadOnlyValidationOperationId
 ): ReadOnlyOperationDefinition {
-  if (operationId === "inbox") {
-    return INBOX_OPERATION;
-  }
-
-  const definition = READ_ONLY_OPERATION_REGISTRY.find(
-    (candidate) => candidate.id === operationId
-  );
+  const definition = READ_ONLY_OPERATION_MAP.get(operationId);
 
   if (!definition) {
     throw new LinkedInAssistantError(
@@ -435,11 +431,8 @@ function getOperationDefinition(
 
 async function getOrCreatePage(context: BrowserContext): Promise<Page> {
   const existingPage = context.pages()[0];
-  if (existingPage) {
-    return existingPage;
-  }
 
-  return context.newPage();
+  return existingPage ?? context.newPage();
 }
 
 async function assertHealthyStoredSession(
@@ -530,15 +523,10 @@ async function resolveSelectorResult(
     }
   }
 
-  return {
-    description: selectorDefinition.description,
-    error: `No selector candidate matched ${selectorDefinition.key}.`,
-    matched_candidate_key: null,
-    matched_candidate_rank: null,
-    matched_selector: null,
-    selector_key: selectorDefinition.key,
-    status: "fail"
-  };
+  return createFailedSelectorResult(
+    selectorDefinition,
+    `No selector candidate matched ${selectorDefinition.key}.`
+  );
 }
 
 async function resolveSelectorResults(
@@ -546,13 +534,26 @@ async function resolveSelectorResults(
   selectorDefinitions: readonly ReadOnlySelectorDefinition[],
   timeoutMs: number
 ): Promise<ReadOnlyValidationSelectorResult[]> {
-  const results: ReadOnlyValidationSelectorResult[] = [];
+  return Promise.all(
+    selectorDefinitions.map((selectorDefinition) =>
+      resolveSelectorResult(page, selectorDefinition, timeoutMs)
+    )
+  );
+}
 
-  for (const selectorDefinition of selectorDefinitions) {
-    results.push(await resolveSelectorResult(page, selectorDefinition, timeoutMs));
-  }
-
-  return results;
+function createFailedSelectorResult(
+  selectorDefinition: Pick<ReadOnlySelectorDefinition, "description" | "key">,
+  error: string
+): ReadOnlyValidationSelectorResult {
+  return {
+    description: selectorDefinition.description,
+    error,
+    matched_candidate_key: null,
+    matched_candidate_rank: null,
+    matched_selector: null,
+    selector_key: selectorDefinition.key,
+    status: "fail"
+  };
 }
 
 function buildBlockedRequest(
@@ -721,15 +722,25 @@ function buildSelectorIndex(
 
   for (const operation of report.operations) {
     for (const selectorResult of operation.selector_results) {
-      index.set(`${operation.operation}:${selectorResult.selector_key}`, {
-        matchedCandidateKey: selectorResult.matched_candidate_key,
-        matchedCandidateRank: selectorResult.matched_candidate_rank,
-        status: selectorResult.status
-      });
+      index.set(
+        getSelectorResultKey(operation.operation, selectorResult.selector_key),
+        {
+          matchedCandidateKey: selectorResult.matched_candidate_key,
+          matchedCandidateRank: selectorResult.matched_candidate_rank,
+          status: selectorResult.status
+        }
+      );
     }
   }
 
   return index;
+}
+
+function getSelectorResultKey(
+  operationId: LinkedInReadOnlyValidationOperationId,
+  selectorKey: string
+): string {
+  return `${operationId}:${selectorKey}`;
 }
 
 function isReadOnlyValidationReport(value: unknown): value is ReadOnlyValidationReport {
@@ -765,7 +776,10 @@ export function computeReadOnlyValidationDiff(
 
   for (const operation of currentReport.operations) {
     for (const selectorResult of operation.selector_results) {
-      const entryKey = `${operation.operation}:${selectorResult.selector_key}`;
+      const entryKey = getSelectorResultKey(
+        operation.operation,
+        selectorResult.selector_key
+      );
       const previousEntry = previousIndex.get(entryKey);
       if (!previousEntry) {
         unchangedCount += 1;
@@ -835,23 +849,32 @@ async function runGenericOperation(
   sessionName: string,
   timeoutMs: number
 ): Promise<ReadOnlyOperationExecutionResult> {
-  await page.goto(definition.url, {
-    timeout: timeoutMs,
-    waitUntil: "domcontentloaded"
-  });
-  await waitForNetworkIdleBestEffort(page, Math.min(timeoutMs, 5_000));
-  await assertHealthyStoredSession(page, sessionName, definition.id);
-  assertExpectedOperationUrl(page.url(), definition);
+  const selectorTimeoutMs = Math.min(timeoutMs, READ_ONLY_DOM_SETTLE_TIMEOUT_MS);
+  await loadValidatedOperationPage(page, definition, sessionName, timeoutMs);
 
   return {
     additionalWarnings: [],
     finalUrl: page.url(),
-    selectorResults: await resolveSelectorResults(
-      page,
-      definition.selectors,
-      Math.min(timeoutMs, 5_000)
-    )
+    selectorResults: await resolveSelectorResults(page, definition.selectors, selectorTimeoutMs)
   };
+}
+
+async function loadValidatedOperationPage(
+  page: Page,
+  definition: ReadOnlyOperationDefinition,
+  sessionName: string,
+  timeoutMs: number
+): Promise<void> {
+  await page.goto(definition.url, {
+    timeout: timeoutMs,
+    waitUntil: "domcontentloaded"
+  });
+  await waitForNetworkIdleBestEffort(
+    page,
+    Math.min(timeoutMs, READ_ONLY_DOM_SETTLE_TIMEOUT_MS)
+  );
+  await assertHealthyStoredSession(page, sessionName, definition.id);
+  assertExpectedOperationUrl(page.url(), definition);
 }
 
 async function clickFirstVisibleThreadLink(page: Page, timeoutMs: number): Promise<boolean> {
@@ -879,13 +902,7 @@ async function runInboxOperation(
   sessionName: string,
   timeoutMs: number
 ): Promise<ReadOnlyOperationExecutionResult> {
-  await page.goto(INBOX_OPERATION.url, {
-    timeout: timeoutMs,
-    waitUntil: "domcontentloaded"
-  });
-  await waitForNetworkIdleBestEffort(page, Math.min(timeoutMs, 5_000));
-  await assertHealthyStoredSession(page, sessionName, INBOX_OPERATION.id);
-  assertExpectedOperationUrl(page.url(), INBOX_OPERATION);
+  await loadValidatedOperationPage(page, INBOX_OPERATION, sessionName, timeoutMs);
 
   const conversationSelectorDefinition = INBOX_OPERATION.selectors[0];
   const messageSelectorDefinition = INBOX_OPERATION.selectors[1];
@@ -896,7 +913,7 @@ async function runInboxOperation(
     );
   }
 
-  const selectorTimeoutMs = Math.min(timeoutMs, 5_000);
+  const selectorTimeoutMs = Math.min(timeoutMs, READ_ONLY_DOM_SETTLE_TIMEOUT_MS);
   const conversationSelector = await resolveSelectorResult(
     page,
     conversationSelectorDefinition,
@@ -907,7 +924,7 @@ async function runInboxOperation(
   const threadClicked = await clickFirstVisibleThreadLink(page, selectorTimeoutMs);
   let threadUrl: string | undefined;
   if (threadClicked) {
-    await waitForNetworkIdleBestEffort(page, Math.min(timeoutMs, 5_000));
+    await waitForNetworkIdleBestEffort(page, selectorTimeoutMs);
     await assertHealthyStoredSession(page, sessionName, INBOX_OPERATION.id);
     assertExpectedOperationUrl(page.url(), INBOX_OPERATION);
     threadUrl = page.url();
@@ -919,15 +936,10 @@ async function runInboxOperation(
 
   const messageSelector = threadClicked
     ? await resolveSelectorResult(page, messageSelectorDefinition, selectorTimeoutMs)
-    : {
-        description: messageSelectorDefinition.description,
-        error: "No inbox thread was available to validate message-thread selectors.",
-        matched_candidate_key: null,
-        matched_candidate_rank: null,
-        matched_selector: null,
-        selector_key: messageSelectorDefinition.key,
-        status: "fail" as const
-      };
+    : createFailedSelectorResult(
+        messageSelectorDefinition,
+        "No inbox thread was available to validate message-thread selectors."
+      );
 
   return {
     additionalWarnings: warnings,


### PR DESCRIPTION
## Summary
- simplify the new read-only live validation flow by extracting shared helpers and removing repeated output logic
- reduce repeated session-store validation and key-derivation branches without changing behavior
- add focused coverage for live validation report formatting

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #129