### PR TITLE
fix: harden Tier 2 live validation resilience and partial reporting

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -1716,14 +1716,49 @@ function emitReadOnlyValidationResult(
   }
 }
 
+function emitReadOnlyValidationFailure(
+  error: unknown,
+  outputMode: ReadOnlyValidationOutputMode
+): void {
+  if (outputMode === "json") {
+    throw error;
+  }
+
+  const errorPayload = toLinkedInAssistantErrorPayload(error, cliPrivacyConfig);
+  process.stderr.write(`${formatReadOnlyValidationError(errorPayload)}\n`);
+  process.exitCode = 1;
+}
+
+function validateReadOnlyValidationCliInput(input: {
+  retryBaseDelayMs: number;
+  retryMaxDelayMs: number;
+}): void {
+  if (input.retryMaxDelayMs < input.retryBaseDelayMs) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "retry-max-delay-ms must be greater than or equal to retry-base-delay-ms.",
+      {
+        retry_base_delay_ms: input.retryBaseDelayMs,
+        retry_max_delay_ms: input.retryMaxDelayMs
+      }
+    );
+  }
+}
+
 async function runLiveReadOnlyValidation(input: {
   json: boolean;
+  maxRequests: number;
+  maxRetries: number;
+  minIntervalMs: number;
   readOnly: boolean;
+  retryBaseDelayMs: number;
+  retryMaxDelayMs: number;
   sessionName: string;
   timeoutSeconds: number;
   yes: boolean;
 }, cdpUrl?: string): Promise<void> {
   assertNoExternalSessionOverrideForStoredSession(cdpUrl);
+  validateReadOnlyValidationCliInput(input);
 
   if (!input.readOnly) {
     throw new LinkedInAssistantError(
@@ -1746,8 +1781,13 @@ async function runLiveReadOnlyValidation(input: {
       : createReadOnlyValidationPrompter(input.sessionName);
 
     return runReadOnlyLinkedInLiveValidation({
+      maxRequests: input.maxRequests,
+      maxRetries: input.maxRetries,
+      minIntervalMs: input.minIntervalMs,
       sessionName: input.sessionName,
       ...(onBeforeOperation ? { onBeforeOperation } : {}),
+      retryBaseDelayMs: input.retryBaseDelayMs,
+      retryMaxDelayMs: input.retryMaxDelayMs,
       timeoutMs: input.timeoutSeconds * 1_000
     });
   };
@@ -1766,18 +1806,16 @@ async function runLiveReadOnlyValidation(input: {
     );
 
     if (refreshed) {
-      const report = await runValidation();
-      emitReadOnlyValidationResult(report, outputMode);
+      try {
+        const report = await runValidation();
+        emitReadOnlyValidationResult(report, outputMode);
+      } catch (retryError) {
+        emitReadOnlyValidationFailure(retryError, outputMode);
+      }
       return;
     }
 
-    if (outputMode === "json") {
-      throw error;
-    }
-
-    const errorPayload = toLinkedInAssistantErrorPayload(error, cliPrivacyConfig);
-    process.stderr.write(`${formatReadOnlyValidationError(errorPayload)}\n`);
-    process.exitCode = 1;
+    emitReadOnlyValidationFailure(error, outputMode);
   }
 }
 
@@ -4068,6 +4106,31 @@ export function createCliProgram(): Command {
         "Maximum time allowed per validation step",
         "30"
       )
+      .option(
+        "--max-requests <count>",
+        "Maximum live page requests allowed before the run stops",
+        "20"
+      )
+      .option(
+        "--min-interval-ms <ms>",
+        "Minimum delay between live page requests in milliseconds",
+        "5000"
+      )
+      .option(
+        "--max-retries <count>",
+        "Retry transient timeout or network failures this many times per step",
+        "2"
+      )
+      .option(
+        "--retry-base-delay-ms <ms>",
+        "Initial exponential backoff delay for transient retries",
+        "1000"
+      )
+      .option(
+        "--retry-max-delay-ms <ms>",
+        "Maximum exponential backoff delay for transient retries",
+        "10000"
+      )
       .option("-y, --yes", "Skip per-step confirmation prompts", false)
       .option("--json", "Print the structured report JSON", false)
       .addHelpText(
@@ -4077,18 +4140,24 @@ export function createCliProgram(): Command {
           "Safety guardrails:",
           "  - requires --read-only",
           "  - blocks non-GET requests and non-LinkedIn domains",
+          "  - retries transient timeouts and network failures with exponential backoff",
           "  - prompts before every step unless --yes is set",
-          "  - stops when the stored session expires or a challenge appears",
+          "  - returns partial results if a later step hits a blocking failure",
           "",
           "Examples:",
           "  owa test:live --read-only",
-          "  owa test:live --read-only --yes --session smoke --json"
+          "  owa test:live --read-only --yes --session smoke --max-retries 3 --json"
         ].join("\n")
       )
       .action(
         async (options: {
           json: boolean;
+          maxRequests: string;
+          maxRetries: string;
+          minIntervalMs: string;
           readOnly: boolean;
+          retryBaseDelayMs: string;
+          retryMaxDelayMs: string;
           session: string;
           timeoutSeconds: string;
           yes: boolean;
@@ -4096,7 +4165,21 @@ export function createCliProgram(): Command {
           await runLiveReadOnlyValidation(
             {
               json: options.json,
+              maxRequests: coercePositiveInt(options.maxRequests, "max-requests"),
+              maxRetries: coerceNonNegativeInt(options.maxRetries, "max-retries"),
+              minIntervalMs: coercePositiveInt(
+                options.minIntervalMs,
+                "min-interval-ms"
+              ),
               readOnly: options.readOnly,
+              retryBaseDelayMs: coercePositiveInt(
+                options.retryBaseDelayMs,
+                "retry-base-delay-ms"
+              ),
+              retryMaxDelayMs: coercePositiveInt(
+                options.retryMaxDelayMs,
+                "retry-max-delay-ms"
+              ),
               sessionName: coerceProfileName(options.session, "session"),
               timeoutSeconds: coercePositiveInt(
                 options.timeoutSeconds,

--- a/packages/cli/src/liveValidationOutput.ts
+++ b/packages/cli/src/liveValidationOutput.ts
@@ -33,7 +33,11 @@ function formatOperationSummary(operation: ReadOnlyValidationOperationResult): s
   const warningSuffix = operation.warnings.length > 0
     ? ` | ${operation.warnings.length} warning${operation.warnings.length === 1 ? "" : "s"}`
     : "";
-  return `- ${formatStatusLabel(operation.status)} ${operation.operation}: ${operation.matched_count} matched, ${operation.failed_count} failed, ${operation.page_load_ms}ms${warningSuffix}`;
+  const retrySuffix = operation.attempt_count > 1
+    ? ` | ${operation.attempt_count} attempts`
+    : "";
+  const errorSuffix = operation.error_code ? ` | ${operation.error_code}` : "";
+  return `- ${formatStatusLabel(operation.status)} ${operation.operation}: ${operation.matched_count} matched, ${operation.failed_count} failed, ${operation.page_load_ms}ms${warningSuffix}${retrySuffix}${errorSuffix}`;
 }
 
 function formatDiffEntry(entry: ReadOnlyValidationDiffEntry): string {
@@ -55,11 +59,27 @@ function formatFailedSelectorBlocks(
   operations: ReadOnlyValidationReport["operations"]
 ): string[] {
   return operations.flatMap((operation) => {
+    if (operation.error_code) {
+      return [];
+    }
+
     return operation.selector_results
       .filter((selectorResult) => selectorResult.status === "fail")
       .map((selectorResult) => {
         return `- ${operation.operation}/${selectorResult.selector_key} — ${selectorResult.error ?? "No selector candidate matched."}`;
       });
+  });
+}
+
+function formatOperationErrors(
+  operations: ReadOnlyValidationReport["operations"]
+): string[] {
+  return operations.flatMap((operation) => {
+    if (!operation.error_code || !operation.error_message) {
+      return [];
+    }
+
+    return [`- ${operation.operation} [${operation.error_code}] — ${operation.error_message}`];
   });
 }
 
@@ -87,6 +107,7 @@ export function formatReadOnlyValidationReport(
     report.operations.map((operation) => formatOperationSummary(operation))
   );
 
+  appendSection(lines, "Operation Errors", formatOperationErrors(report.operations));
   appendSection(lines, "Failures", formatFailedSelectorBlocks(report.operations));
   appendSection(
     lines,

--- a/packages/cli/test/liveValidationCli.integration.test.ts
+++ b/packages/cli/test/liveValidationCli.integration.test.ts
@@ -15,8 +15,18 @@ interface BrowserRequestDefinition {
   url: string;
 }
 
+interface GotoFailureDefinition {
+  kind: "network" | "timeout";
+  message?: string;
+  remaining: number;
+}
+
 interface BrowserMockState {
+  browserCloseCount: number;
+  contextCloseCount: number;
   extraRequestsByUrl: Map<string, BrowserRequestDefinition[]>;
+  failNewContext: boolean;
+  gotoFailuresByUrl: Map<string, GotoFailureDefinition>;
   networkIdleTimeoutUrls: Set<string>;
   redirects: Map<string, string>;
   replayBaseUrl: string;
@@ -45,7 +55,11 @@ interface CreatedReplayFixtureSet {
 }
 
 const browserMockState = vi.hoisted<BrowserMockState>(() => ({
+  browserCloseCount: 0,
+  contextCloseCount: 0,
   extraRequestsByUrl: new Map<string, BrowserRequestDefinition[]>(),
+  failNewContext: false,
+  gotoFailuresByUrl: new Map<string, GotoFailureDefinition>(),
   networkIdleTimeoutUrls: new Set<string>(),
   redirects: new Map<string, string>(),
   replayBaseUrl: ""
@@ -102,6 +116,23 @@ vi.mock("playwright-core", () => {
 
     async goto(url: string): Promise<void> {
       await this.contextInstance.dispatchRequests(url);
+
+      const gotoFailure = browserMockState.gotoFailuresByUrl.get(url);
+      if (gotoFailure && gotoFailure.remaining > 0) {
+        gotoFailure.remaining -= 1;
+        if (gotoFailure.remaining === 0) {
+          browserMockState.gotoFailuresByUrl.delete(url);
+        } else {
+          browserMockState.gotoFailuresByUrl.set(url, gotoFailure);
+        }
+        this.currentUrl = url;
+        if (gotoFailure.kind === "timeout") {
+          throw new TimeoutError(
+            gotoFailure.message ?? `Timed out loading ${url}`
+          );
+        }
+        throw new Error(gotoFailure.message ?? `net::ERR_CONNECTION_RESET while loading ${url}`);
+      }
 
       const finalUrl = browserMockState.redirects.get(url) ?? url;
       this.currentUrl = finalUrl;
@@ -214,6 +245,7 @@ vi.mock("playwright-core", () => {
     ) {}
 
     async close(): Promise<void> {
+      browserMockState.contextCloseCount += 1;
       return undefined;
     }
 
@@ -267,6 +299,7 @@ vi.mock("playwright-core", () => {
 
   class FakeBrowser {
     async close(): Promise<void> {
+      browserMockState.browserCloseCount += 1;
       return undefined;
     }
 
@@ -275,6 +308,10 @@ vi.mock("playwright-core", () => {
         cookies?: readonly Record<string, unknown>[];
       };
     }): Promise<FakeContext> {
+      if (browserMockState.failNewContext) {
+        throw new Error("Failed to create browser context.");
+      }
+
       return new FakeContext(options.storageState);
     }
   }
@@ -466,6 +503,95 @@ async function seedStoredSession(
   });
 }
 
+async function createHappyPathFixtureSet(
+  tempDir: string,
+  setName: string = "smoke"
+): Promise<CreatedReplayFixtureSet> {
+  return createReplayFixtureSet(tempDir, {
+    setName,
+    pages: [
+      {
+        bodyPath: "pages/feed.html",
+        html: [
+          "<html><body>",
+          visible("main [data-urn]"),
+          visible("header nav"),
+          "<header><nav></nav></header>",
+          '<main role="main"><div data-urn="urn:li:activity:1"></div></main>',
+          "</body></html>"
+        ].join(""),
+        pageType: "feed",
+        title: "Feed",
+        url: FEED_URL
+      },
+      {
+        bodyPath: "pages/profile.html",
+        html: [
+          "<html><body>",
+          visible("main h1"),
+          visible("main"),
+          "<main><h1>Jane Doe</h1></main>",
+          "</body></html>"
+        ].join(""),
+        pageType: "profile",
+        title: "Profile",
+        url: PROFILE_URL
+      },
+      {
+        bodyPath: "pages/notifications.html",
+        html: [
+          "<html><body>",
+          visible("main"),
+          visible("a[href*='/notifications/']"),
+          '<main><a href="/notifications/item">Notification</a></main>',
+          "</body></html>"
+        ].join(""),
+        pageType: "notifications",
+        title: "Notifications",
+        url: NOTIFICATIONS_URL
+      },
+      {
+        bodyPath: "pages/messaging.html",
+        html: [
+          "<html><body>",
+          visible(".msg-conversations-container__conversations-list"),
+          visible("a[href*='/messaging/thread/']"),
+          `<main><div class="msg-conversations-container__conversations-list"></div><a href="${MESSAGING_THREAD_URL}">Thread</a></main>`,
+          "</body></html>"
+        ].join(""),
+        pageType: "messaging",
+        title: "Messaging",
+        url: MESSAGING_URL
+      },
+      {
+        bodyPath: "pages/connections.html",
+        html: [
+          "<html><body>",
+          visible("main ul[role='list']"),
+          visible("main a[href*='/in/']"),
+          '<main><ul role="list"><li><a href="/in/jane-doe/">Jane Doe</a></li></ul></main>',
+          "</body></html>"
+        ].join(""),
+        pageType: "connections",
+        title: "Connections",
+        url: CONNECTIONS_URL
+      }
+    ],
+    extraRoutes: [
+      {
+        bodyPath: "pages/thread.html",
+        html: [
+          "<html><body>",
+          visible("li.msg-s-message-list__event"),
+          '<main><ul><li class="msg-s-message-list__event">Hi</li></ul></main>',
+          "</body></html>"
+        ].join(""),
+        url: MESSAGING_THREAD_URL
+      }
+    ]
+  });
+}
+
 function findOperation(
   report: ReadOnlyValidationReport,
   operationId: ReadOnlyValidationOperationResult["operation"]
@@ -488,7 +614,11 @@ describe("linkedin live validation CLI integration", () => {
   let stderrWriteSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    browserMockState.browserCloseCount = 0;
+    browserMockState.contextCloseCount = 0;
     browserMockState.extraRequestsByUrl.clear();
+    browserMockState.failNewContext = false;
+    browserMockState.gotoFailuresByUrl.clear();
     browserMockState.networkIdleTimeoutUrls.clear();
     browserMockState.redirects.clear();
     browserMockState.replayBaseUrl = "";
@@ -797,6 +927,167 @@ describe("linkedin live validation CLI integration", () => {
     } finally {
       setTimeoutSpy.mockRestore();
     }
+  });
+
+  it("retries transient network failures and records the recovered attempt count", async () => {
+    setInteractiveMode(false, false);
+
+    const realSetTimeout = globalThis.setTimeout;
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(
+      ((handler: Parameters<typeof setTimeout>[0], _delay?: number, ...args: unknown[]) => {
+        return realSetTimeout(handler as never, 0, ...args);
+      }) as unknown as typeof setTimeout
+    );
+
+    const assistantHome = await mkdtemp(
+      path.join(os.tmpdir(), "linkedin-live-validation-retry-")
+    );
+    tempDirs.push(assistantHome);
+
+    const { manifestPath, setName } = await createHappyPathFixtureSet(
+      assistantHome,
+      "retry"
+    );
+
+    enableReplay(manifestPath, setName);
+    const replayServer = await core.ensureSharedFixtureReplayServer();
+    if (!replayServer) {
+      throw new Error("Expected the shared fixture replay server to start.");
+    }
+    browserMockState.replayBaseUrl = replayServer.baseUrl;
+    browserMockState.gotoFailuresByUrl.set(NOTIFICATIONS_URL, {
+      kind: "network",
+      message: `net::ERR_CONNECTION_RESET while loading ${NOTIFICATIONS_URL}`,
+      remaining: 1
+    });
+
+    await seedStoredSession(assistantHome, "smoke");
+
+    try {
+      await runCli([
+        "node",
+        "linkedin",
+        "test:live",
+        "--read-only",
+        "--yes",
+        "--json",
+        "--session",
+        "smoke"
+      ]);
+
+      const report = JSON.parse(
+        String(consoleLogSpy.mock.calls.at(-1)?.[0] ?? "")
+      ) as ReadOnlyValidationReport;
+
+      expect(process.exitCode).toBeUndefined();
+      expect(report.outcome).toBe("pass");
+      expect(report.request_limits.used_requests).toBe(6);
+      expect(findOperation(report, "notifications")).toMatchObject({
+        attempt_count: 2,
+        status: "pass",
+        warnings: ["Recovered after 1 transient retry."]
+      });
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it("returns a partial report when a later step hits the request cap", async () => {
+    setInteractiveMode(false, false);
+
+    const realSetTimeout = globalThis.setTimeout;
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(
+      ((handler: Parameters<typeof setTimeout>[0], _delay?: number, ...args: unknown[]) => {
+        return realSetTimeout(handler as never, 0, ...args);
+      }) as unknown as typeof setTimeout
+    );
+
+    const assistantHome = await mkdtemp(
+      path.join(os.tmpdir(), "linkedin-live-validation-rate-limit-")
+    );
+    tempDirs.push(assistantHome);
+
+    const { manifestPath, setName } = await createHappyPathFixtureSet(
+      assistantHome,
+      "rate-limit"
+    );
+
+    enableReplay(manifestPath, setName);
+    const replayServer = await core.ensureSharedFixtureReplayServer();
+    if (!replayServer) {
+      throw new Error("Expected the shared fixture replay server to start.");
+    }
+    browserMockState.replayBaseUrl = replayServer.baseUrl;
+
+    await seedStoredSession(assistantHome, "smoke");
+
+    try {
+      await runCli([
+        "node",
+        "linkedin",
+        "test:live",
+        "--read-only",
+        "--yes",
+        "--json",
+        "--session",
+        "smoke",
+        "--max-requests",
+        "2",
+        "--min-interval-ms",
+        "1"
+      ]);
+
+      const report = JSON.parse(
+        String(consoleLogSpy.mock.calls.at(-1)?.[0] ?? "")
+      ) as ReadOnlyValidationReport;
+
+      expect(process.exitCode).toBe(1);
+      expect(report.summary).toContain("Validation stopped early");
+      expect(report.operation_count).toBe(3);
+      expect(report.request_limits).toMatchObject({
+        max_requests: 2,
+        max_requests_reached: true,
+        used_requests: 2
+      });
+      expect(findOperation(report, "notifications")).toMatchObject({
+        attempt_count: 1,
+        error_code: "RATE_LIMITED",
+        status: "fail"
+      });
+      expect(browserMockState.browserCloseCount).toBe(1);
+      expect(browserMockState.contextCloseCount).toBe(1);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it("closes the launched browser when context creation fails", async () => {
+    setInteractiveMode(false, false);
+
+    const assistantHome = await mkdtemp(
+      path.join(os.tmpdir(), "linkedin-live-validation-context-")
+    );
+    tempDirs.push(assistantHome);
+
+    await seedStoredSession(assistantHome, "smoke");
+    process.env.LINKEDIN_ASSISTANT_HOME = assistantHome;
+    browserMockState.failNewContext = true;
+
+    await expect(
+      runCli([
+        "node",
+        "linkedin",
+        "test:live",
+        "--read-only",
+        "--yes",
+        "--json",
+        "--session",
+        "smoke"
+      ])
+    ).rejects.toThrow("Failed to create browser context.");
+
+    expect(browserMockState.browserCloseCount).toBe(1);
+    expect(browserMockState.contextCloseCount).toBe(0);
   });
 
   it("formats auth failures cleanly when the stored session is missing or expired", async () => {

--- a/packages/cli/test/liveValidationCli.test.ts
+++ b/packages/cli/test/liveValidationCli.test.ts
@@ -68,6 +68,7 @@ function createValidationReport(
     operation_count: 1,
     operations: [
       {
+        attempt_count: 1,
         completed_at: "2026-03-09T10:00:05.000Z",
         failed_count: outcome === "fail" ? 1 : 0,
         final_url: "https://www.linkedin.com/feed/",
@@ -215,6 +216,42 @@ describe("linkedin live validation CLI", () => {
     });
   });
 
+  it("passes retry and pacing overrides through to core live validation", async () => {
+    setInteractiveMode(false, false);
+    liveValidationCliMocks.runReadOnlyLinkedInLiveValidation.mockResolvedValue(
+      createValidationReport("pass")
+    );
+
+    await runCli([
+      "node",
+      "linkedin",
+      "test:live",
+      "--read-only",
+      "--yes",
+      "--json",
+      "--max-requests",
+      "25",
+      "--min-interval-ms",
+      "2500",
+      "--max-retries",
+      "3",
+      "--retry-base-delay-ms",
+      "200",
+      "--retry-max-delay-ms",
+      "400"
+    ]);
+
+    expect(liveValidationCliMocks.runReadOnlyLinkedInLiveValidation).toHaveBeenCalledWith({
+      maxRequests: 25,
+      maxRetries: 3,
+      minIntervalMs: 2500,
+      retryBaseDelayMs: 200,
+      retryMaxDelayMs: 400,
+      sessionName: "default",
+      timeoutMs: 30_000
+    });
+  });
+
   it("prints a human-readable error and exits when the live validation is rate limited", async () => {
     liveValidationCliMocks.runReadOnlyLinkedInLiveValidation.mockRejectedValue(
       new LinkedInAssistantError(
@@ -241,6 +278,24 @@ describe("linkedin live validation CLI", () => {
     expect(liveValidationCliMocks.runReadOnlyLinkedInLiveValidation).toHaveBeenCalledTimes(1);
     expect(stderrChunks.join("")).toContain("Live validation failed [RATE_LIMITED]");
     expect(stderrChunks.join("")).toContain("per-session request cap");
+  });
+
+  it("rejects retry windows where the max delay is smaller than the base delay", async () => {
+    await expect(
+      runCli([
+        "node",
+        "linkedin",
+        "test:live",
+        "--read-only",
+        "--yes",
+        "--retry-base-delay-ms",
+        "2000",
+        "--retry-max-delay-ms",
+        "1000"
+      ])
+    ).rejects.toThrow("retry-max-delay-ms");
+
+    expect(liveValidationCliMocks.runReadOnlyLinkedInLiveValidation).not.toHaveBeenCalled();
   });
 
   it("rejects cdp-url overrides for the visible test live command", async () => {
@@ -302,5 +357,52 @@ describe("linkedin live validation CLI", () => {
         session_name: "smoke"
       }
     });
+  });
+
+  it("formats a second failure cleanly after refreshing the stored session", async () => {
+    liveValidationCliMocks.answers = ["yes"];
+    liveValidationCliMocks.captureLinkedInSession.mockResolvedValue({
+      authenticated: true,
+      capturedAt: "2026-03-09T09:30:00.000Z",
+      checkedAt: "2026-03-09T09:31:00.000Z",
+      currentUrl: "https://www.linkedin.com/feed/",
+      filePath: "/tmp/stored-session.enc.json",
+      liAtCookieExpiresAt: "2026-04-01T00:00:00.000Z",
+      sessionName: "smoke"
+    });
+    liveValidationCliMocks.runReadOnlyLinkedInLiveValidation
+      .mockRejectedValueOnce(
+        new LinkedInAssistantError(
+          "AUTH_REQUIRED",
+          "Stored session is expired.",
+          { session_name: "smoke" }
+        )
+      )
+      .mockRejectedValueOnce(
+        new LinkedInAssistantError(
+          "RATE_LIMITED",
+          "Read-only live validation reached the per-session request cap (20) before inbox.",
+          {
+            max_requests: 20,
+            operation: "inbox",
+            used_requests: 20
+          }
+        )
+      );
+
+    await runCli([
+      "node",
+      "linkedin",
+      "test:live",
+      "--read-only",
+      "--session",
+      "smoke"
+    ]);
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrChunks.join(""))
+      .toContain("Live validation failed [RATE_LIMITED]");
+    expect(liveValidationCliMocks.captureLinkedInSession).toHaveBeenCalledTimes(1);
+    expect(liveValidationCliMocks.runReadOnlyLinkedInLiveValidation).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/cli/test/liveValidationOutput.test.ts
+++ b/packages/cli/test/liveValidationOutput.test.ts
@@ -93,11 +93,12 @@ function createReportFixture(): ReadOnlyValidationReport {
       unchanged_count: 3
     },
     events_path: "/tmp/live-readonly/events.jsonl",
-    fail_count: 1,
+    fail_count: 2,
     latest_report_path: "/tmp/live-readonly/latest-report.json",
-    operation_count: 2,
+    operation_count: 3,
     operations: [
       {
+        attempt_count: 1,
         completed_at: "2026-03-09T10:00:05.000Z",
         failed_count: 0,
         final_url: "https://www.linkedin.com/feed/",
@@ -129,6 +130,7 @@ function createReportFixture(): ReadOnlyValidationReport {
         warnings: []
       },
       {
+        attempt_count: 2,
         completed_at: "2026-03-09T10:00:12.000Z",
         failed_count: 1,
         final_url: "https://www.linkedin.com/notifications/",
@@ -158,7 +160,50 @@ function createReportFixture(): ReadOnlyValidationReport {
         status: "fail",
         summary: "Open notifications and verify the notifications surface.",
         url: "https://www.linkedin.com/notifications/",
-        warnings: ["Notifications loaded with a slower-than-usual response."]
+        warnings: [
+          "Recovered after 1 transient retry.",
+          "Notifications loaded with a slower-than-usual response."
+        ]
+      },
+      {
+        attempt_count: 3,
+        completed_at: "2026-03-09T10:00:20.000Z",
+        error_code: "TIMEOUT",
+        error_message:
+          "Timed out after 30000ms while running connections. LinkedIn may be slow or the page may be incomplete; rerun the live validation or increase the timeout.",
+        failed_count: 2,
+        final_url:
+          "https://www.linkedin.com/mynetwork/invite-connect/connections/",
+        matched_count: 0,
+        operation: "connections",
+        page_load_ms: 900,
+        selector_results: [
+          {
+            description: "Connections list or container",
+            error:
+              "Timed out after 30000ms while running connections. LinkedIn may be slow or the page may be incomplete; rerun the live validation or increase the timeout.",
+            matched_candidate_key: null,
+            matched_candidate_rank: null,
+            matched_selector: null,
+            selector_key: "connections_surface",
+            status: "fail"
+          },
+          {
+            description: "Connection profile entry",
+            error:
+              "Timed out after 30000ms while running connections. LinkedIn may be slow or the page may be incomplete; rerun the live validation or increase the timeout.",
+            matched_candidate_key: null,
+            matched_candidate_rank: null,
+            matched_selector: null,
+            selector_key: "connection_entry",
+            status: "fail"
+          }
+        ],
+        started_at: "2026-03-09T10:00:13.000Z",
+        status: "fail",
+        summary: "Open connections and verify the connections list surface.",
+        url: "https://www.linkedin.com/mynetwork/invite-connect/connections/",
+        warnings: ["Retried 2 times before the page still failed."]
       }
     ],
     outcome: "fail",
@@ -173,7 +218,7 @@ function createReportFixture(): ReadOnlyValidationReport {
       max_requests: 20,
       max_requests_reached: false,
       min_interval_ms: 5000,
-      used_requests: 2
+      used_requests: 5
     },
     run_id: "run_live_validation_output_test",
     session: {
@@ -183,7 +228,7 @@ function createReportFixture(): ReadOnlyValidationReport {
       session_name: "smoke"
     },
     summary:
-      "Checked 2 read-only LinkedIn operations. 1 passed. 1 failed. 2 selector regressions detected versus the previous run."
+      "Checked 3 read-only LinkedIn operations. 1 passed. 2 failed. 2 selector regressions detected versus the previous run."
   };
 }
 
@@ -199,11 +244,18 @@ describe("live validation output helpers", () => {
 
     expect(output).toContain("Live Validation: FAIL");
     expect(output).toContain(
-      "Summary: Checked 2 read-only LinkedIn operations. 1 passed. 1 failed. 2 selector regressions detected versus the previous run."
+      "Summary: Checked 3 read-only LinkedIn operations. 1 passed. 2 failed. 2 selector regressions detected versus the previous run."
     );
     expect(output).toContain("Operations");
     expect(output).toContain("- PASS feed: 2 matched, 0 failed, 1200ms");
-    expect(output).toContain("- FAIL notifications: 1 matched, 1 failed, 1600ms | 1 warning");
+    expect(output).toContain(
+      "- FAIL notifications: 1 matched, 1 failed, 1600ms | 2 warnings | 2 attempts"
+    );
+    expect(output).toContain(
+      "- FAIL connections: 0 matched, 2 failed, 900ms | 1 warning | 3 attempts | TIMEOUT"
+    );
+    expect(output).toContain("Operation Errors");
+    expect(output).toContain("- connections [TIMEOUT] — Timed out after 30000ms while running connections.");
     expect(output).toContain("Failures");
     expect(output).toContain(
       "- notifications/notification_surface — No selector candidate matched notification_surface."
@@ -227,14 +279,18 @@ describe("live validation output helpers", () => {
   it("matches the full human-readable report snapshot", () => {
     expect(formatReadOnlyValidationReport(createReportFixture())).toMatchInlineSnapshot(`
       "Live Validation: FAIL
-      Summary: Checked 2 read-only LinkedIn operations. 1 passed. 1 failed. 2 selector regressions detected versus the previous run.
+      Summary: Checked 3 read-only LinkedIn operations. 1 passed. 2 failed. 2 selector regressions detected versus the previous run.
       Session: smoke (captured 2026-03-09T09:00:00.000Z)
       Report JSON: /tmp/live-readonly/report.json
       Events: /tmp/live-readonly/events.jsonl
 
       Operations
       - PASS feed: 2 matched, 0 failed, 1200ms
-      - FAIL notifications: 1 matched, 1 failed, 1600ms | 1 warning
+      - FAIL notifications: 1 matched, 1 failed, 1600ms | 2 warnings | 2 attempts
+      - FAIL connections: 0 matched, 2 failed, 900ms | 1 warning | 3 attempts | TIMEOUT
+
+      Operation Errors
+      - connections [TIMEOUT] — Timed out after 30000ms while running connections. LinkedIn may be slow or the page may be incomplete; rerun the live validation or increase the timeout.
 
       Failures
       - notifications/notification_surface — No selector candidate matched notification_surface.

--- a/packages/core/src/__tests__/liveValidation.test.ts
+++ b/packages/core/src/__tests__/liveValidation.test.ts
@@ -3,6 +3,7 @@ import {
   ReadOnlyOperationRateLimiter,
   computeReadOnlyValidationDiff,
   isAllowedLinkedInReadOnlyRequest,
+  runReadOnlyLinkedInLiveValidation,
   type ReadOnlyValidationOperationResult,
   type ReadOnlyValidationReport
 } from "../liveValidation.js";
@@ -12,6 +13,7 @@ function createOperationResult(
   selectorResults: ReadOnlyValidationOperationResult["selector_results"]
 ): ReadOnlyValidationOperationResult {
   return {
+    attempt_count: 1,
     completed_at: "2026-03-09T10:00:05.000Z",
     failed_count: selectorResults.filter((result) => result.status === "fail").length,
     final_url: `https://www.linkedin.com/${operation}/`,
@@ -65,6 +67,35 @@ describe("read-only live validation helpers", () => {
         "GET"
       )
     ).toBe(false);
+    expect(
+      isAllowedLinkedInReadOnlyRequest(
+        "wss://evil.example/socket",
+        "GET"
+      )
+    ).toBe(false);
+    expect(
+      isAllowedLinkedInReadOnlyRequest(
+        "data:text/html,<html></html>",
+        "GET"
+      )
+    ).toBe(false);
+  });
+
+  it("rejects non-integer core options before loading any stored session", async () => {
+    await expect(
+      runReadOnlyLinkedInLiveValidation({ timeoutMs: 0.5 })
+    ).rejects.toThrow("timeoutMs must be a positive integer.");
+    await expect(
+      runReadOnlyLinkedInLiveValidation({ maxRetries: -1 })
+    ).rejects.toThrow("maxRetries must be a non-negative integer.");
+    await expect(
+      runReadOnlyLinkedInLiveValidation({
+        retryBaseDelayMs: 2_000,
+        retryMaxDelayMs: 1_000
+      })
+    ).rejects.toThrow(
+      "retryMaxDelayMs must be greater than or equal to retryBaseDelayMs."
+    );
   });
 
   it("counts every selector result as unchanged when no previous report exists", () => {

--- a/packages/core/src/liveValidation.ts
+++ b/packages/core/src/liveValidation.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
   chromium,
+  errors as playwrightErrors,
   type Browser,
   type BrowserContext,
   type Page,
@@ -14,7 +15,11 @@ import {
   resolveConfigPaths,
   type ConfigPaths
 } from "./config.js";
-import { LinkedInAssistantError, asLinkedInAssistantError } from "./errors.js";
+import {
+  LinkedInAssistantError,
+  asLinkedInAssistantError,
+  type LinkedInAssistantErrorCode
+} from "./errors.js";
 import { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import { createRunId } from "./run.js";
@@ -96,7 +101,10 @@ export interface ReadOnlyValidationSelectorResult {
 }
 
 export interface ReadOnlyValidationOperationResult {
+  attempt_count: number;
   completed_at: string;
+  error_code?: LinkedInAssistantErrorCode;
+  error_message?: string;
   failed_count: number;
   final_url: string;
   matched_count: number;
@@ -170,17 +178,23 @@ export interface ReadOnlyValidationReport {
 export interface RunReadOnlyValidationOptions {
   baseDir?: string;
   maxRequests?: number;
+  maxRetries?: number;
   minIntervalMs?: number;
   onBeforeOperation?: (
     operation: LinkedInReadOnlyValidationOperation
   ) => Promise<void>;
+  retryBaseDelayMs?: number;
+  retryMaxDelayMs?: number;
   sessionName?: string;
   timeoutMs?: number;
 }
 
 const DEFAULT_OPERATION_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_REQUESTS = 20;
+const DEFAULT_MAX_RETRIES = 2;
 const DEFAULT_MIN_INTERVAL_MS = 5_000;
+const DEFAULT_RETRY_BASE_DELAY_MS = 1_000;
+const DEFAULT_RETRY_MAX_DELAY_MS = 10_000;
 const READ_ONLY_DOM_SETTLE_TIMEOUT_MS = 5_000;
 const READ_ONLY_REPORT_DIR = "live-readonly";
 const READ_ONLY_LATEST_REPORT_NAME = "latest-report.json";
@@ -345,8 +359,42 @@ function withPlaywrightInstallHint(error: unknown): Error {
   return new Error(String(error));
 }
 
+function sanitizeUserFacingText(value: string): string {
+  return value.replace(/\s+/gu, " ").trim();
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return sanitizeUserFacingText(error.message);
+  }
+
+  return sanitizeUserFacingText(String(error));
+}
+
+function createErrorOptions(error: unknown): ErrorOptions | undefined {
+  if (error instanceof Error) {
+    return { cause: error };
+  }
+
+  return undefined;
+}
+
+function isTimeoutError(error: unknown): boolean {
+  return error instanceof playwrightErrors.TimeoutError;
+}
+
+function isNetworkError(error: unknown): boolean {
+  return /(net::|ERR_|ECONN|ENOTFOUND|EAI_AGAIN|socket hang up|disconnected)/iu.test(
+    getErrorMessage(error)
+  );
+}
+
 function isFinitePositiveNumber(value: number): boolean {
-  return Number.isFinite(value) && value > 0;
+  return Number.isInteger(value) && Number.isFinite(value) && value > 0;
+}
+
+function isFiniteNonNegativeNumber(value: number): boolean {
+  return Number.isInteger(value) && Number.isFinite(value) && value >= 0;
 }
 
 function resolvePositiveInt(
@@ -361,11 +409,113 @@ function resolvePositiveInt(
   if (!isFinitePositiveNumber(value)) {
     throw new LinkedInAssistantError(
       "ACTION_PRECONDITION_FAILED",
-      `${label} must be a positive number.`
+      `${label} must be a positive integer.`
     );
   }
 
-  return Math.floor(value);
+  return value;
+}
+
+function resolveNonNegativeInt(
+  value: number | undefined,
+  fallback: number,
+  label: string
+): number {
+  if (typeof value === "undefined") {
+    return fallback;
+  }
+
+  if (!isFiniteNonNegativeNumber(value)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must be a non-negative integer.`
+    );
+  }
+
+  return value;
+}
+
+function validateSessionName(sessionName: string | undefined): string {
+  const normalized = (sessionName ?? "default").trim();
+  if (normalized.length === 0) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "sessionName must not be empty."
+    );
+  }
+
+  if (normalized === "." || normalized === ".." || /[\\/]/u.test(normalized)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "sessionName must not contain path separators or relative path segments.",
+      {
+        session_name: normalized
+      }
+    );
+  }
+
+  return normalized;
+}
+
+function validateRunReadOnlyValidationOptions(
+  options: RunReadOnlyValidationOptions | undefined
+): RunReadOnlyValidationOptions {
+  if (typeof options === "undefined") {
+    return {};
+  }
+
+  if (typeof options !== "object" || options === null || Array.isArray(options)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "read-only live validation options must be an object.",
+      {
+        received_type: Array.isArray(options) ? "array" : typeof options
+      }
+    );
+  }
+
+  if (
+    typeof options.onBeforeOperation !== "undefined" &&
+    typeof options.onBeforeOperation !== "function"
+  ) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "onBeforeOperation must be a function when provided."
+    );
+  }
+
+  if (typeof options.baseDir !== "undefined" && typeof options.baseDir !== "string") {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "baseDir must be a string when provided."
+    );
+  }
+
+  if (
+    typeof options.sessionName !== "undefined" &&
+    typeof options.sessionName !== "string"
+  ) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "sessionName must be a string when provided."
+    );
+  }
+
+  return options;
+}
+
+function calculateRetryBackoffMs(
+  attempt: number,
+  retryBaseDelayMs: number,
+  retryMaxDelayMs: number
+): number {
+  return Math.min(retryMaxDelayMs, retryBaseDelayMs * 2 ** Math.max(0, attempt - 1));
+}
+
+async function sleep(delayMs: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
 }
 
 function resolveLatestReportPath(paths: ConfigPaths): string {
@@ -405,7 +555,7 @@ export function isAllowedLinkedInReadOnlyRequest(
   try {
     const parsedUrl = new URL(urlString);
     if (!/^https?:$/u.test(parsedUrl.protocol)) {
-      return true;
+      return false;
     }
 
     return isAllowedLinkedInHost(parsedUrl.hostname);
@@ -496,6 +646,156 @@ function assertExpectedOperationUrl(
       }
     );
   }
+}
+
+function getCurrentPageUrl(page: Page): string {
+  try {
+    return page.url();
+  } catch {
+    return "about:blank";
+  }
+}
+
+function readNavigationStatus(response: unknown): number | null {
+  if (typeof response !== "object" || response === null || !("status" in response)) {
+    return null;
+  }
+
+  const status = (response as { status?: unknown }).status;
+  if (typeof status !== "function") {
+    return null;
+  }
+
+  try {
+    const value = status();
+    return typeof value === "number" && Number.isInteger(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function createNavigationStatusError(
+  definition: ReadOnlyOperationDefinition,
+  status: number,
+  currentUrl: string
+): LinkedInAssistantError {
+  const details = {
+    current_url: currentUrl,
+    http_status: status,
+    operation: definition.id
+  };
+
+  if (status === 401 || status === 403) {
+    return new LinkedInAssistantError(
+      "AUTH_REQUIRED",
+      `LinkedIn rejected the stored session while loading ${definition.id}. Capture a fresh session and rerun the live validation.`,
+      details
+    );
+  }
+
+  if (status === 429 || status === 999) {
+    return new LinkedInAssistantError(
+      "RATE_LIMITED",
+      `LinkedIn temporarily rate limited the ${definition.id} page (HTTP ${status}). Wait for the session to cool down, then rerun the live validation.`,
+      details
+    );
+  }
+
+  if (status >= 500) {
+    return new LinkedInAssistantError(
+      "NETWORK_ERROR",
+      `LinkedIn returned HTTP ${status} while loading ${definition.id}. Check connectivity and rerun the live validation.`,
+      details
+    );
+  }
+
+  return new LinkedInAssistantError(
+    "UNKNOWN",
+    `LinkedIn returned HTTP ${status} while loading ${definition.id}. Refresh the session and rerun the live validation.`,
+    details
+  );
+}
+
+function createNetworkIdleWarning(
+  definition: Pick<ReadOnlyOperationDefinition, "id">,
+  timeoutMs: number
+): string {
+  return `The ${definition.id} page did not reach network idle within ${timeoutMs}ms. Selector checks continued with the current DOM state.`;
+}
+
+function normalizeOperationError(
+  definition: ReadOnlyOperationDefinition,
+  timeoutMs: number,
+  currentUrl: string,
+  error: unknown
+): LinkedInAssistantError {
+  if (error instanceof LinkedInAssistantError) {
+    return error;
+  }
+
+  const details = {
+    current_url: currentUrl,
+    operation: definition.id,
+    page_url: definition.url
+  };
+
+  if (isTimeoutError(error)) {
+    return new LinkedInAssistantError(
+      "TIMEOUT",
+      `Timed out after ${timeoutMs}ms while running ${definition.id}. LinkedIn may be slow or the page may be incomplete; rerun the live validation or increase the timeout.`,
+      details,
+      createErrorOptions(error)
+    );
+  }
+
+  if (isNetworkError(error)) {
+    return new LinkedInAssistantError(
+      "NETWORK_ERROR",
+      `Could not load the ${definition.id} page because the browser or network connection failed: ${getErrorMessage(error)}. Check connectivity and rerun the live validation.`,
+      details,
+      createErrorOptions(error)
+    );
+  }
+
+  return new LinkedInAssistantError(
+    "UNKNOWN",
+    `Live validation failed while running ${definition.id}: ${getErrorMessage(error)}. Refresh the stored session or rerun the live validation.`,
+    details,
+    createErrorOptions(error)
+  );
+}
+
+function isRetryableOperationError(code: LinkedInAssistantErrorCode): boolean {
+  return code === "NETWORK_ERROR" || code === "TIMEOUT";
+}
+
+function isBlockingOperationErrorCode(code: LinkedInAssistantErrorCode): boolean {
+  return code === "AUTH_REQUIRED" || code === "CAPTCHA_OR_CHALLENGE" || code === "RATE_LIMITED";
+}
+
+function getOperationAttemptCount(error: LinkedInAssistantError): number {
+  const attemptCount = error.details.attempt_count;
+  return typeof attemptCount === "number" && Number.isInteger(attemptCount) && attemptCount > 0
+    ? attemptCount
+    : 1;
+}
+
+function buildRetryRecoveryWarning(attemptCount: number): string | null {
+  if (attemptCount <= 1) {
+    return null;
+  }
+
+  const retryCount = attemptCount - 1;
+  return `Recovered after ${retryCount} transient retr${retryCount === 1 ? "y" : "ies"}.`;
+}
+
+function buildRetryExhaustedWarning(attemptCount: number): string | null {
+  if (attemptCount <= 1) {
+    return null;
+  }
+
+  const retryCount = attemptCount - 1;
+  return `Retried ${retryCount} ${retryCount === 1 ? "time" : "times"} before the page still failed.`;
 }
 
 async function resolveSelectorResult(
@@ -669,8 +969,13 @@ function summarizeReport(
   const regressionSuffix = diff.regressions.length > 0
     ? ` ${diff.regressions.length} selector regression${diff.regressions.length === 1 ? "" : "s"} detected versus the previous run.`
     : "";
+  const incompleteCount =
+    LINKEDIN_READ_ONLY_VALIDATION_OPERATIONS.length - operations.length;
+  const partialSuffix = incompleteCount > 0
+    ? ` Validation stopped early; ${incompleteCount} operation${incompleteCount === 1 ? " did" : "s did"} not run after a blocking failure.`
+    : "";
 
-  return `Checked ${operations.length} read-only LinkedIn operation${operations.length === 1 ? "" : "s"}. ${passCount} passed. ${failCount} failed.${regressionSuffix}`;
+  return `Checked ${operations.length} read-only LinkedIn operation${operations.length === 1 ? "" : "s"}. ${passCount} passed. ${failCount} failed.${regressionSuffix}${partialSuffix}`;
 }
 
 function buildRecommendedActions(
@@ -682,6 +987,9 @@ function buildRecommendedActions(
   const actions = [
     `Open ${reportPath} to review selector matches, failures, timings, and blocked requests.`
   ];
+  const blockingFailure = operations.find(
+    (operation) => operation.error_code && isBlockingOperationErrorCode(operation.error_code)
+  );
 
   if (operations.some((operation) => operation.status === "fail")) {
     actions.push(
@@ -695,6 +1003,18 @@ function buildRecommendedActions(
   if (diff.regressions.length > 0 && diff.previous_report_path) {
     actions.push(
       `Compare this run with ${diff.previous_report_path} to confirm whether the regression is a real UI change or environment-specific drift.`
+    );
+  }
+
+  if (blockingFailure?.error_code === "RATE_LIMITED") {
+    actions.push(
+      "Increase the request budget or rerun with a longer interval between checks if the read-only validation keeps hitting LinkedIn rate limits."
+    );
+  }
+
+  if (blockingFailure) {
+    actions.push(
+      `Validation stopped early at ${blockingFailure.operation} [${blockingFailure.error_code}]. Address the blocking failure, then rerun the remaining checks.`
     );
   }
 
@@ -843,6 +1163,11 @@ export function computeReadOnlyValidationDiff(
   };
 }
 
+interface ReadOnlyRetriedOperationExecutionResult {
+  attemptCount: number;
+  execution: ReadOnlyOperationExecutionResult;
+}
+
 async function runGenericOperation(
   page: Page,
   definition: ReadOnlyOperationDefinition,
@@ -850,10 +1175,15 @@ async function runGenericOperation(
   timeoutMs: number
 ): Promise<ReadOnlyOperationExecutionResult> {
   const selectorTimeoutMs = Math.min(timeoutMs, READ_ONLY_DOM_SETTLE_TIMEOUT_MS);
-  await loadValidatedOperationPage(page, definition, sessionName, timeoutMs);
+  const warnings = await loadValidatedOperationPage(
+    page,
+    definition,
+    sessionName,
+    timeoutMs
+  );
 
   return {
-    additionalWarnings: [],
+    additionalWarnings: warnings,
     finalUrl: page.url(),
     selectorResults: await resolveSelectorResults(page, definition.selectors, selectorTimeoutMs)
   };
@@ -864,17 +1194,30 @@ async function loadValidatedOperationPage(
   definition: ReadOnlyOperationDefinition,
   sessionName: string,
   timeoutMs: number
-): Promise<void> {
-  await page.goto(definition.url, {
+): Promise<string[]> {
+  const warnings: string[] = [];
+  const response = await page.goto(definition.url, {
     timeout: timeoutMs,
     waitUntil: "domcontentloaded"
   });
-  await waitForNetworkIdleBestEffort(
-    page,
-    Math.min(timeoutMs, READ_ONLY_DOM_SETTLE_TIMEOUT_MS)
-  );
+  const responseStatus = readNavigationStatus(response);
+  if (responseStatus !== null && responseStatus >= 400) {
+    throw createNavigationStatusError(
+      definition,
+      responseStatus,
+      getCurrentPageUrl(page)
+    );
+  }
+
+  const networkIdleTimeoutMs = Math.min(timeoutMs, READ_ONLY_DOM_SETTLE_TIMEOUT_MS);
+  const networkIdleReached = await waitForNetworkIdleBestEffort(page, networkIdleTimeoutMs);
+  if (!networkIdleReached) {
+    warnings.push(createNetworkIdleWarning(definition, networkIdleTimeoutMs));
+  }
+
   await assertHealthyStoredSession(page, sessionName, definition.id);
   assertExpectedOperationUrl(page.url(), definition);
+  return warnings;
 }
 
 async function clickFirstVisibleThreadLink(page: Page, timeoutMs: number): Promise<boolean> {
@@ -902,7 +1245,12 @@ async function runInboxOperation(
   sessionName: string,
   timeoutMs: number
 ): Promise<ReadOnlyOperationExecutionResult> {
-  await loadValidatedOperationPage(page, INBOX_OPERATION, sessionName, timeoutMs);
+  const warnings = await loadValidatedOperationPage(
+    page,
+    INBOX_OPERATION,
+    sessionName,
+    timeoutMs
+  );
 
   const conversationSelectorDefinition = INBOX_OPERATION.selectors[0];
   const messageSelectorDefinition = INBOX_OPERATION.selectors[1];
@@ -920,11 +1268,16 @@ async function runInboxOperation(
     selectorTimeoutMs
   );
 
-  const warnings: string[] = [];
   const threadClicked = await clickFirstVisibleThreadLink(page, selectorTimeoutMs);
   let threadUrl: string | undefined;
   if (threadClicked) {
-    await waitForNetworkIdleBestEffort(page, selectorTimeoutMs);
+    const threadNetworkIdleReached = await waitForNetworkIdleBestEffort(
+      page,
+      selectorTimeoutMs
+    );
+    if (!threadNetworkIdleReached) {
+      warnings.push(createNetworkIdleWarning(INBOX_OPERATION, selectorTimeoutMs));
+    }
     await assertHealthyStoredSession(page, sessionName, INBOX_OPERATION.id);
     assertExpectedOperationUrl(page.url(), INBOX_OPERATION);
     threadUrl = page.url();
@@ -954,14 +1307,21 @@ function createOperationResult(
   startedAt: string,
   completedAt: string,
   pageLoadMs: number,
-  execution: ReadOnlyOperationExecutionResult
+  execution: ReadOnlyOperationExecutionResult,
+  attemptCount: number
 ): ReadOnlyValidationOperationResult {
   const matchedCount = execution.selectorResults.filter(
     (result) => result.status === "pass"
   ).length;
   const failedCount = execution.selectorResults.length - matchedCount;
+  const warnings = [...execution.additionalWarnings];
+  const retryRecoveryWarning = buildRetryRecoveryWarning(attemptCount);
+  if (retryRecoveryWarning) {
+    warnings.unshift(retryRecoveryWarning);
+  }
 
   return {
+    attempt_count: attemptCount,
     completed_at: completedAt,
     failed_count: failedCount,
     final_url: execution.finalUrl,
@@ -974,29 +1334,135 @@ function createOperationResult(
     summary: definition.summary,
     ...(execution.threadUrl ? { thread_url: execution.threadUrl } : {}),
     url: definition.url,
-    warnings: execution.additionalWarnings
+    warnings
   };
 }
 
-async function runOperation(
+function createOperationFailureResult(
+  definition: ReadOnlyOperationDefinition,
+  startedAt: string,
+  completedAt: string,
+  pageLoadMs: number,
+  finalUrl: string,
+  error: LinkedInAssistantError,
+  attemptCount: number
+): ReadOnlyValidationOperationResult {
+  const warnings: string[] = [];
+  const retryWarning = buildRetryExhaustedWarning(attemptCount);
+  if (retryWarning) {
+    warnings.push(retryWarning);
+  }
+
+  return {
+    attempt_count: attemptCount,
+    completed_at: completedAt,
+    error_code: error.code,
+    error_message: error.message,
+    failed_count: definition.selectors.length,
+    final_url: finalUrl,
+    matched_count: 0,
+    operation: definition.id,
+    page_load_ms: pageLoadMs,
+    selector_results: definition.selectors.map((selectorDefinition) =>
+      createFailedSelectorResult(selectorDefinition, error.message)
+    ),
+    started_at: startedAt,
+    status: "fail",
+    summary: definition.summary,
+    url: definition.url,
+    warnings
+  };
+}
+
+async function runOperationOnce(
   page: Page,
   definition: ReadOnlyOperationDefinition,
   sessionName: string,
   timeoutMs: number
-): Promise<ReadOnlyValidationOperationResult> {
-  const startedAt = new Date().toISOString();
-  const startedAtMs = Date.now();
-
-  const execution = definition.id === "inbox"
+): Promise<ReadOnlyOperationExecutionResult> {
+  return definition.id === "inbox"
     ? await runInboxOperation(page, sessionName, timeoutMs)
     : await runGenericOperation(page, definition, sessionName, timeoutMs);
+}
 
-  return createOperationResult(
-    definition,
-    startedAt,
-    new Date().toISOString(),
-    Date.now() - startedAtMs,
-    execution
+async function runOperationWithRetries(
+  page: Page,
+  definition: ReadOnlyOperationDefinition,
+  sessionName: string,
+  timeoutMs: number,
+  rateLimiter: ReadOnlyOperationRateLimiter,
+  maxRetries: number,
+  retryBaseDelayMs: number,
+  retryMaxDelayMs: number,
+  logger: JsonEventLogger
+): Promise<ReadOnlyRetriedOperationExecutionResult> {
+  const maxAttempts = maxRetries + 1;
+  let lastError: LinkedInAssistantError | undefined;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    logger.log("debug", "live_validation.operation.attempt", {
+      attempt,
+      max_attempts: maxAttempts,
+      operation: definition.id,
+      session_name: sessionName
+    });
+
+    try {
+      await rateLimiter.waitTurn(definition.id);
+      const execution = await runOperationOnce(page, definition, sessionName, timeoutMs);
+      return {
+        attemptCount: attempt,
+        execution
+      };
+    } catch (error) {
+      const normalizedError = normalizeOperationError(
+        definition,
+        timeoutMs,
+        getCurrentPageUrl(page),
+        error
+      );
+      lastError = new LinkedInAssistantError(
+        normalizedError.code,
+        normalizedError.message,
+        {
+          ...normalizedError.details,
+          attempt_count: attempt
+        },
+        { cause: normalizedError }
+      );
+
+      if (!isRetryableOperationError(normalizedError.code) || attempt >= maxAttempts) {
+        throw lastError;
+      }
+
+      const backoffMs = calculateRetryBackoffMs(
+        attempt,
+        retryBaseDelayMs,
+        retryMaxDelayMs
+      );
+      logger.log("warn", "live_validation.operation.retry", {
+        attempt,
+        backoff_ms: backoffMs,
+        code: normalizedError.code,
+        error: normalizedError.message,
+        max_attempts: maxAttempts,
+        operation: definition.id,
+        session_name: sessionName
+      });
+      await sleep(backoffMs);
+    }
+  }
+
+  throw (
+    lastError ??
+    new LinkedInAssistantError(
+      "UNKNOWN",
+      `Read-only live validation exhausted retries for ${definition.id}.`,
+      {
+        operation: definition.id,
+        session_name: sessionName
+      }
+    )
   );
 }
 
@@ -1010,40 +1476,72 @@ async function createBrowserContext(
     headless: true,
     ...(executablePath ? { executablePath } : {})
   });
-  const context = await browser.newContext({
-    storageState: loadedSession.storageState
-  });
-  context.setDefaultNavigationTimeout(timeoutMs);
-  context.setDefaultTimeout(timeoutMs);
-  await installReadOnlyNetworkGuard(context, blockedRequests);
 
-  return { browser, context };
+  try {
+    const context = await browser.newContext({
+      storageState: loadedSession.storageState
+    });
+    context.setDefaultNavigationTimeout(timeoutMs);
+    context.setDefaultTimeout(timeoutMs);
+    await installReadOnlyNetworkGuard(context, blockedRequests);
+
+    return { browser, context };
+  } catch (error) {
+    await browser.close().catch(() => undefined);
+    throw error;
+  }
 }
 
 export async function runReadOnlyLinkedInLiveValidation(
   options: RunReadOnlyValidationOptions = {}
 ): Promise<ReadOnlyValidationReport> {
-  const sessionName = (options.sessionName ?? "default").trim() || "default";
+  const validatedOptions = validateRunReadOnlyValidationOptions(options);
+  const sessionName = validateSessionName(validatedOptions.sessionName);
   const timeoutMs = resolvePositiveInt(
-    options.timeoutMs,
+    validatedOptions.timeoutMs,
     DEFAULT_OPERATION_TIMEOUT_MS,
     "timeoutMs"
   );
   const maxRequests = resolvePositiveInt(
-    options.maxRequests,
+    validatedOptions.maxRequests,
     DEFAULT_MAX_REQUESTS,
     "maxRequests"
   );
   const minIntervalMs = resolvePositiveInt(
-    options.minIntervalMs,
+    validatedOptions.minIntervalMs,
     DEFAULT_MIN_INTERVAL_MS,
     "minIntervalMs"
   );
+  const maxRetries = resolveNonNegativeInt(
+    validatedOptions.maxRetries,
+    DEFAULT_MAX_RETRIES,
+    "maxRetries"
+  );
+  const retryBaseDelayMs = resolvePositiveInt(
+    validatedOptions.retryBaseDelayMs,
+    DEFAULT_RETRY_BASE_DELAY_MS,
+    "retryBaseDelayMs"
+  );
+  const retryMaxDelayMs = resolvePositiveInt(
+    validatedOptions.retryMaxDelayMs,
+    DEFAULT_RETRY_MAX_DELAY_MS,
+    "retryMaxDelayMs"
+  );
+  if (retryMaxDelayMs < retryBaseDelayMs) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "retryMaxDelayMs must be greater than or equal to retryBaseDelayMs.",
+      {
+        retry_base_delay_ms: retryBaseDelayMs,
+        retry_max_delay_ms: retryMaxDelayMs
+      }
+    );
+  }
 
-  const store = new LinkedInSessionStore(options.baseDir);
+  const store = new LinkedInSessionStore(validatedOptions.baseDir);
   const loadedSession = await store.load(sessionName);
 
-  const paths = resolveConfigPaths(options.baseDir);
+  const paths = resolveConfigPaths(validatedOptions.baseDir);
   ensureConfigPaths(paths);
 
   const runId = createRunId();
@@ -1055,6 +1553,12 @@ export async function runReadOnlyLinkedInLiveValidation(
   const previousReport = isReadOnlyValidationReport(previousReportValue)
     ? previousReportValue
     : null;
+  if (previousReportValue !== null && !previousReport) {
+    logger.log("warn", "live_validation.previous_report.invalid", {
+      latest_report_path: latestReportPath,
+      session_name: sessionName
+    });
+  }
   const blockedRequests: ReadOnlyValidationBlockedRequest[] = [];
   const rateLimiter = new ReadOnlyOperationRateLimiter(
     maxRequests,
@@ -1063,14 +1567,88 @@ export async function runReadOnlyLinkedInLiveValidation(
 
   logger.log("info", "live_validation.start", {
     max_requests: maxRequests,
+    max_retries: maxRetries,
     min_interval_ms: minIntervalMs,
     report_path: reportPath,
+    retry_base_delay_ms: retryBaseDelayMs,
+    retry_max_delay_ms: retryMaxDelayMs,
     session_name: sessionName,
     timeout_ms: timeoutMs
   });
 
   let browser: Browser | undefined;
   let context: BrowserContext | undefined;
+  let cleanedUp = false;
+  const cleanupResources = async (
+    trigger: "finally" | "signal"
+  ): Promise<void> => {
+    if (cleanedUp) {
+      return;
+    }
+    cleanedUp = true;
+    logger.log("debug", "live_validation.cleanup.start", {
+      trigger,
+      session_name: sessionName
+    });
+
+    if (context) {
+      try {
+        await context.close();
+      } catch (error) {
+        logger.log("warn", "live_validation.cleanup.context_failed", {
+          error: getErrorMessage(error),
+          session_name: sessionName,
+          trigger
+        });
+      }
+    }
+
+    if (browser) {
+      try {
+        await browser.close();
+      } catch (error) {
+        logger.log("warn", "live_validation.cleanup.browser_failed", {
+          error: getErrorMessage(error),
+          session_name: sessionName,
+          trigger
+        });
+      }
+    }
+  };
+  const installTerminationHandlers = (): (() => void) => {
+    type ProcessSignal = "SIGINT" | "SIGTERM";
+
+    const handlers = new Map<ProcessSignal, () => void>();
+    const removeHandlers = (): void => {
+      for (const [signal, handler] of handlers) {
+        process.off(signal, handler);
+      }
+      handlers.clear();
+    };
+    const registerHandler = (signal: ProcessSignal): void => {
+      const handler = () => {
+        removeHandlers();
+        logger.log("warn", "live_validation.signal", {
+          session_name: sessionName,
+          signal
+        });
+        void cleanupResources("signal").finally(() => {
+          try {
+            process.kill(process.pid, signal);
+          } catch {
+            process.exit(signal === "SIGINT" ? 130 : 143);
+          }
+        });
+      };
+      handlers.set(signal, handler);
+      process.once(signal, handler);
+    };
+
+    registerHandler("SIGINT");
+    registerHandler("SIGTERM");
+    return removeHandlers;
+  };
+  let removeTerminationHandlers: (() => void) | undefined;
   try {
     const browserContext = await createBrowserContext(
       loadedSession,
@@ -1079,6 +1657,7 @@ export async function runReadOnlyLinkedInLiveValidation(
     );
     browser = browserContext.browser;
     context = browserContext.context;
+    removeTerminationHandlers = installTerminationHandlers();
 
     const page = await getOrCreatePage(context);
     page.setDefaultNavigationTimeout(timeoutMs);
@@ -1086,33 +1665,107 @@ export async function runReadOnlyLinkedInLiveValidation(
 
     const operationResults: ReadOnlyValidationOperationResult[] = [];
     for (const operation of LINKEDIN_READ_ONLY_VALIDATION_OPERATIONS) {
-      if (options.onBeforeOperation) {
-        await options.onBeforeOperation(operation);
+      if (validatedOptions.onBeforeOperation) {
+        await validatedOptions.onBeforeOperation(operation);
       }
 
       logger.log("info", "live_validation.operation.start", {
         operation: operation.id,
         session_name: sessionName
       });
-      await rateLimiter.waitTurn(operation.id);
 
       const operationDefinition = getOperationDefinition(operation.id);
-      const operationResult = await runOperation(
-        page,
-        operationDefinition,
-        sessionName,
-        timeoutMs
-      );
-      operationResults.push(operationResult);
+      const startedAt = new Date().toISOString();
+      const startedAtMs = Date.now();
 
-      logger.log("info", "live_validation.operation.done", {
-        failed_count: operationResult.failed_count,
-        matched_count: operationResult.matched_count,
-        operation: operation.id,
-        page_load_ms: operationResult.page_load_ms,
-        status: operationResult.status,
-        warnings: operationResult.warnings
-      });
+      try {
+        const operationExecution = await runOperationWithRetries(
+          page,
+          operationDefinition,
+          sessionName,
+          timeoutMs,
+          rateLimiter,
+          maxRetries,
+          retryBaseDelayMs,
+          retryMaxDelayMs,
+          logger
+        );
+        const operationResult = createOperationResult(
+          operationDefinition,
+          startedAt,
+          new Date().toISOString(),
+          Date.now() - startedAtMs,
+          operationExecution.execution,
+          operationExecution.attemptCount
+        );
+        operationResults.push(operationResult);
+
+        logger.log(
+          operationResult.status === "fail" || operationResult.warnings.length > 0
+            ? "warn"
+            : "info",
+          operationResult.status === "fail" || operationResult.warnings.length > 0
+            ? "live_validation.operation.degraded"
+            : "live_validation.operation.done",
+          {
+            attempt_count: operationResult.attempt_count,
+            failed_count: operationResult.failed_count,
+            matched_count: operationResult.matched_count,
+            operation: operation.id,
+            page_load_ms: operationResult.page_load_ms,
+            status: operationResult.status,
+            warnings: operationResult.warnings
+          }
+        );
+      } catch (error) {
+        const normalizedError = asLinkedInAssistantError(
+          error,
+          error instanceof LinkedInAssistantError ? error.code : "UNKNOWN",
+          `Read-only live validation failed while running ${operation.id}.`
+        );
+
+        if (
+          operationResults.length === 0 &&
+          (normalizedError.code === "AUTH_REQUIRED" ||
+            normalizedError.code === "CAPTCHA_OR_CHALLENGE")
+        ) {
+          throw normalizedError;
+        }
+
+        const operationResult = createOperationFailureResult(
+          operationDefinition,
+          startedAt,
+          new Date().toISOString(),
+          Date.now() - startedAtMs,
+          getCurrentPageUrl(page),
+          normalizedError,
+          getOperationAttemptCount(normalizedError)
+        );
+        operationResults.push(operationResult);
+
+        logger.log("error", "live_validation.operation.failed", {
+          attempt_count: operationResult.attempt_count,
+          code: normalizedError.code,
+          error_details: normalizedError.details,
+          error_message: normalizedError.message,
+          operation: operation.id,
+          page_load_ms: operationResult.page_load_ms,
+          session_name: sessionName,
+          warnings: operationResult.warnings
+        });
+
+        if (isBlockingOperationErrorCode(normalizedError.code)) {
+          logger.log("warn", "live_validation.stopped_early", {
+            code: normalizedError.code,
+            completed_operations: operationResults.length,
+            operation: operation.id,
+            remaining_operations:
+              LINKEDIN_READ_ONLY_VALIDATION_OPERATIONS.length - operationResults.length,
+            session_name: sessionName
+          });
+          break;
+        }
+      }
     }
 
     const diff = computeReadOnlyValidationDiff({ operations: operationResults }, previousReport);
@@ -1160,13 +1813,36 @@ export async function runReadOnlyLinkedInLiveValidation(
       operationResults
     );
 
-    artifacts.writeJson(`${READ_ONLY_REPORT_DIR}/report.json`, report, {
-      blocked_request_count: report.blocked_request_count,
-      fail_count: report.fail_count,
-      pass_count: report.pass_count,
-      session_name: sessionName
-    });
-    await writeJsonFile(latestReportPath, report);
+    try {
+      artifacts.writeJson(`${READ_ONLY_REPORT_DIR}/report.json`, report, {
+        blocked_request_count: report.blocked_request_count,
+        fail_count: report.fail_count,
+        pass_count: report.pass_count,
+        session_name: sessionName
+      });
+    } catch (error) {
+      logger.log("warn", "live_validation.report_persist.failed", {
+        error: getErrorMessage(error),
+        report_path: reportPath,
+        session_name: sessionName
+      });
+      report.recommended_actions.push(
+        `The report could not be written to ${reportPath}; use --json output or inspect ${report.events_path} for this run.`
+      );
+    }
+
+    try {
+      await writeJsonFile(latestReportPath, report);
+    } catch (error) {
+      logger.log("warn", "live_validation.latest_report_persist.failed", {
+        error: getErrorMessage(error),
+        latest_report_path: latestReportPath,
+        session_name: sessionName
+      });
+      report.recommended_actions.push(
+        `The rolling latest report at ${latestReportPath} was not updated, so the next diff may use an older snapshot.`
+      );
+    }
 
     logger.log("info", "live_validation.done", {
       blocked_request_count: report.blocked_request_count,
@@ -1178,21 +1854,21 @@ export async function runReadOnlyLinkedInLiveValidation(
 
     return report;
   } catch (error) {
-    logger.log("error", "live_validation.failed", {
-      error: asLinkedInAssistantError(error).message,
-      session_name: sessionName
-    });
-    throw asLinkedInAssistantError(
+    const normalizedError = asLinkedInAssistantError(
       withPlaywrightInstallHint(error),
       error instanceof LinkedInAssistantError ? error.code : "UNKNOWN",
       "Failed to run the read-only LinkedIn live validation."
     );
+    logger.log("error", "live_validation.failed", {
+      code: normalizedError.code,
+      error_details: normalizedError.details,
+      error_message: normalizedError.message,
+      source_error_name: error instanceof Error ? error.name : typeof error,
+      session_name: sessionName
+    });
+    throw normalizedError;
   } finally {
-    if (context) {
-      await context.close().catch(() => undefined);
-    }
-    if (browser) {
-      await browser.close().catch(() => undefined);
-    }
+    removeTerminationHandlers?.();
+    await cleanupResources("finally");
   }
 }


### PR DESCRIPTION
## Summary
- add stronger validation, retry/backoff controls, and graceful partial-result handling for Tier 2 live validation
- harden cleanup, report persistence, and request guards so transient failures and setup issues do not leave resources behind or crash with stack traces
- expand CLI/output coverage and integration tests for retries, partial failures, and cleanup behavior

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #136