### PR TITLE
feat: polish Tier 2 live validation CLI UX

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -86,6 +86,7 @@ import {
   resolveDraftQualityOutputMode
 } from "../draftQualityOutput.js";
 import {
+  ReadOnlyValidationProgressReporter,
   formatReadOnlyValidationError,
   formatReadOnlyValidationReport,
   resolveReadOnlyValidationOutputMode,
@@ -118,6 +119,9 @@ const SELECTOR_AUDIT_DOC_PATH = "docs/selector-audit.md";
 const SELECTOR_AUDIT_DOC_REFERENCE =
   `See ${SELECTOR_AUDIT_DOC_PATH} for sample output, configuration, and troubleshooting.`;
 const MAX_JSON_INPUT_BYTES = 10 * 1024 * 1024;
+const LIVE_VALIDATION_HELP_COMMAND = "linkedin test live --help";
+const LIVE_VALIDATION_FAIL_EXIT_CODE = 1;
+const LIVE_VALIDATION_ERROR_EXIT_CODE = 2;
 let cliSelectorLocale: string | undefined;
 
 function writeCliWarning(message: string): void {
@@ -1088,10 +1092,13 @@ async function sleep(ms: number): Promise<void> {
   });
 }
 
-async function promptYesNo(question: string): Promise<boolean> {
+async function promptYesNo(
+  question: string,
+  output: typeof stdout | typeof process.stderr = stdout
+): Promise<boolean> {
   const readline = createInterface({
     input: stdin,
-    output: stdout
+    output
   });
 
   try {
@@ -1100,6 +1107,17 @@ async function promptYesNo(question: string): Promise<boolean> {
   } finally {
     readline.close();
   }
+}
+
+function shouldUseAnsiColor(
+  stream: { isTTY?: boolean }
+): boolean {
+  return (
+    Boolean(stream.isTTY) &&
+    typeof process.env.NO_COLOR === "undefined" &&
+    process.env.NODE_DISABLE_COLORS !== "1" &&
+    process.env.TERM !== "dumb"
+  );
 }
 
 function assertInteractiveTerminal(operation: string): void {
@@ -1655,16 +1673,22 @@ async function maybeRefreshStoredSession(
     timeoutMinutes: number;
     yes: boolean;
   },
-  error: unknown
+  error: unknown,
+  promptOutput: typeof stdout | typeof process.stderr
 ): Promise<boolean> {
   if (input.yes || !stdin.isTTY || !stdout.isTTY || !isStoredSessionRefreshError(error)) {
     return false;
   }
 
   const errorPayload = toLinkedInAssistantErrorPayload(error, cliPrivacyConfig);
-  process.stderr.write(`${formatReadOnlyValidationError(errorPayload)}\n`);
+  writeCliNotice(
+    errorPayload.code === "CAPTCHA_OR_CHALLENGE"
+      ? "LinkedIn requested extra verification before the validation could continue."
+      : `Stored session "${input.sessionName}" needs to be refreshed before the validation can continue.`
+  );
   const confirmed = await promptYesNo(
-    `Capture a fresh stored session named "${input.sessionName}" now?`
+    `Capture a fresh stored session named "${input.sessionName}" now?`,
+    promptOutput
   );
   if (!confirmed) {
     return false;
@@ -1678,11 +1702,12 @@ async function maybeRefreshStoredSession(
 }
 
 function createReadOnlyValidationPrompter(
-  sessionName: string
+  sessionName: string,
+  promptOutput: typeof stdout | typeof process.stderr
 ): (operation: LinkedInReadOnlyValidationOperation) => Promise<void> {
   return async (operation) => {
-    console.log(`Read-only step: ${operation.summary}`);
-    const confirmed = await promptYesNo("Continue with this step?");
+    promptOutput.write(`Read-only step: ${operation.summary}\n`);
+    const confirmed = await promptYesNo("Continue with this step?", promptOutput);
     if (!confirmed) {
       throw new LinkedInAssistantError(
         "ACTION_PRECONDITION_FAILED",
@@ -1708,11 +1733,15 @@ function emitReadOnlyValidationResult(
       cliPrivacyConfig,
       "cli"
     ) as typeof report;
-    console.log(formatReadOnlyValidationReport(redactedReport));
+    console.log(
+      formatReadOnlyValidationReport(redactedReport, {
+        color: shouldUseAnsiColor(stdout)
+      })
+    );
   }
 
   if (report.outcome === "fail") {
-    process.exitCode = 1;
+    process.exitCode = LIVE_VALIDATION_FAIL_EXIT_CODE;
   }
 }
 
@@ -1720,13 +1749,19 @@ function emitReadOnlyValidationFailure(
   error: unknown,
   outputMode: ReadOnlyValidationOutputMode
 ): void {
+  process.exitCode = LIVE_VALIDATION_ERROR_EXIT_CODE;
+
   if (outputMode === "json") {
     throw error;
   }
 
   const errorPayload = toLinkedInAssistantErrorPayload(error, cliPrivacyConfig);
-  process.stderr.write(`${formatReadOnlyValidationError(errorPayload)}\n`);
-  process.exitCode = 1;
+  process.stderr.write(
+    `${formatReadOnlyValidationError(errorPayload, {
+      color: shouldUseAnsiColor(process.stderr),
+      helpCommand: LIVE_VALIDATION_HELP_COMMAND
+    })}\n`
+  );
 }
 
 function validateReadOnlyValidationCliInput(input: {
@@ -1750,6 +1785,7 @@ async function runLiveReadOnlyValidation(input: {
   maxRequests: number;
   maxRetries: number;
   minIntervalMs: number;
+  progress: boolean;
   readOnly: boolean;
   retryBaseDelayMs: number;
   retryMaxDelayMs: number;
@@ -1757,64 +1793,83 @@ async function runLiveReadOnlyValidation(input: {
   timeoutSeconds: number;
   yes: boolean;
 }, cdpUrl?: string): Promise<void> {
-  assertNoExternalSessionOverrideForStoredSession(cdpUrl);
-  validateReadOnlyValidationCliInput(input);
-
-  if (!input.readOnly) {
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
-      'Live validation is currently restricted to read-only mode. Rerun the command with "--read-only".'
-    );
-  }
-
-  if (!input.yes) {
-    assertInteractiveTerminal("run interactive live validation without --yes");
-  }
-
   const outputMode = resolveReadOnlyValidationOutputMode(
     { json: input.json },
     Boolean(stdout.isTTY)
   );
-  const runValidation = async () => {
-    const onBeforeOperation = input.yes
-      ? undefined
-      : createReadOnlyValidationPrompter(input.sessionName);
-
-    return runReadOnlyLinkedInLiveValidation({
-      maxRequests: input.maxRequests,
-      maxRetries: input.maxRetries,
-      minIntervalMs: input.minIntervalMs,
-      sessionName: input.sessionName,
-      ...(onBeforeOperation ? { onBeforeOperation } : {}),
-      retryBaseDelayMs: input.retryBaseDelayMs,
-      retryMaxDelayMs: input.retryMaxDelayMs,
-      timeoutMs: input.timeoutSeconds * 1_000
-    });
-  };
+  const promptOutput = outputMode === "json" ? process.stderr : stdout;
+  const progressEnabled =
+    outputMode === "human" && input.progress && Boolean(process.stderr.isTTY);
+  const progressReporter = new ReadOnlyValidationProgressReporter({
+    enabled: progressEnabled
+  });
 
   try {
-    const report = await runValidation();
-    emitReadOnlyValidationResult(report, outputMode);
-  } catch (error) {
-    const refreshed = await maybeRefreshStoredSession(
-      {
-        sessionName: input.sessionName,
-        timeoutMinutes: Math.max(1, Math.ceil(input.timeoutSeconds / 60)),
-        yes: input.yes
-      },
-      error
-    );
+    assertNoExternalSessionOverrideForStoredSession(cdpUrl);
+    validateReadOnlyValidationCliInput(input);
 
-    if (refreshed) {
-      try {
-        const report = await runValidation();
-        emitReadOnlyValidationResult(report, outputMode);
-      } catch (retryError) {
-        emitReadOnlyValidationFailure(retryError, outputMode);
-      }
-      return;
+    if (!input.readOnly) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        'Live validation is currently restricted to read-only mode. Rerun the command with "--read-only".'
+      );
     }
 
+    if (!input.yes) {
+      assertInteractiveTerminal("run interactive live validation without --yes");
+    }
+
+    const runValidation = async () => {
+      const onBeforeOperation = input.yes
+        ? undefined
+        : createReadOnlyValidationPrompter(input.sessionName, promptOutput);
+
+      return runReadOnlyLinkedInLiveValidation({
+        maxRequests: input.maxRequests,
+        maxRetries: input.maxRetries,
+        minIntervalMs: input.minIntervalMs,
+        ...(progressEnabled
+          ? {
+              onLog: (entry) => {
+                progressReporter.handleLog(entry);
+              }
+            }
+          : {}),
+        sessionName: input.sessionName,
+        ...(onBeforeOperation ? { onBeforeOperation } : {}),
+        retryBaseDelayMs: input.retryBaseDelayMs,
+        retryMaxDelayMs: input.retryMaxDelayMs,
+        timeoutMs: input.timeoutSeconds * 1_000
+      });
+    };
+
+    try {
+      const report = await runValidation();
+      emitReadOnlyValidationResult(report, outputMode);
+    } catch (error) {
+      const refreshed = await maybeRefreshStoredSession(
+        {
+          sessionName: input.sessionName,
+          timeoutMinutes: Math.max(1, Math.ceil(input.timeoutSeconds / 60)),
+          yes: input.yes
+        },
+        error,
+        promptOutput
+      );
+
+      if (refreshed) {
+        try {
+          const report = await runValidation();
+          emitReadOnlyValidationResult(report, outputMode);
+        } catch (retryError) {
+          emitReadOnlyValidationFailure(retryError, outputMode);
+        }
+        return;
+      }
+
+      emitReadOnlyValidationFailure(error, outputMode);
+    }
+  } catch (error) {
     emitReadOnlyValidationFailure(error, outputMode);
   }
 }
@@ -4065,8 +4120,9 @@ export function createCliProgram(): Command {
           "  - never prints cookies or storage contents",
           "",
           "Examples:",
-          "  owa auth:session",
-          "  owa auth:session --session smoke --timeout-minutes 15"
+          "  linkedin auth session",
+          "  linkedin auth session --session smoke --timeout-minutes 15",
+          "  linkedin auth:session --session smoke"
         ].join("\n")
       )
       .action(
@@ -4131,11 +4187,32 @@ export function createCliProgram(): Command {
         "Maximum exponential backoff delay for transient retries",
         "10000"
       )
-      .option("-y, --yes", "Skip per-step confirmation prompts", false)
-      .option("--json", "Print the structured report JSON", false)
+      .option(
+        "--no-progress",
+        "Hide per-step progress updates in human-readable output"
+      )
+      .option(
+        "-y, --yes",
+        "Skip per-step confirmation prompts for unattended runs",
+        false
+      )
+      .option(
+        "--json",
+        "Print the structured report JSON (recommended for scripts)",
+        false
+      )
       .addHelpText(
         "after",
         [
+          "",
+          "Output:",
+          "  - interactive terminals default to a human-readable summary with per-step progress",
+          "  - --json prints only the structured report to stdout; prompts stay on stderr",
+          "",
+          "Exit codes:",
+          "  - 0 all validation steps passed",
+          "  - 1 one or more validation steps failed (including partial reports)",
+          "  - 2 the run could not complete because of a preflight, session, or runtime error",
           "",
           "Safety guardrails:",
           "  - requires --read-only",
@@ -4145,8 +4222,9 @@ export function createCliProgram(): Command {
           "  - returns partial results if a later step hits a blocking failure",
           "",
           "Examples:",
-          "  owa test:live --read-only",
-          "  owa test:live --read-only --yes --session smoke --max-retries 3 --json"
+          "  linkedin test live --read-only",
+          "  linkedin test live --read-only --yes --session smoke --max-retries 3",
+          "  linkedin test:live --read-only --yes --json"
         ].join("\n")
       )
       .action(
@@ -4155,6 +4233,7 @@ export function createCliProgram(): Command {
           maxRequests: string;
           maxRetries: string;
           minIntervalMs: string;
+          progress: boolean;
           readOnly: boolean;
           retryBaseDelayMs: string;
           retryMaxDelayMs: string;
@@ -4171,6 +4250,7 @@ export function createCliProgram(): Command {
                 options.minIntervalMs,
                 "min-interval-ms"
               ),
+              progress: options.progress,
               readOnly: options.readOnly,
               retryBaseDelayMs: coercePositiveInt(
                 options.retryBaseDelayMs,
@@ -5254,6 +5334,6 @@ if (isDirectExecution(import.meta.url)) {
   runCli().catch((error: unknown) => {
     const payload = toLinkedInAssistantErrorPayload(error, cliPrivacyConfig);
     console.error(JSON.stringify(payload, null, 2));
-    process.exit(1);
+    process.exit(process.exitCode ?? 1);
   });
 }

--- a/packages/cli/src/liveValidationOutput.ts
+++ b/packages/cli/src/liveValidationOutput.ts
@@ -1,19 +1,138 @@
-import type {
-  LinkedInAssistantErrorPayload,
-  ReadOnlyValidationDiffChange,
-  ReadOnlyValidationDiffEntry,
-  ReadOnlyValidationOperationResult,
-  ReadOnlyValidationReport,
-  ReadOnlyValidationStatus
+import {
+  LINKEDIN_READ_ONLY_VALIDATION_OPERATIONS,
+  type JsonLogEntry,
+  type LinkedInReadOnlyValidationOperationId,
+  type LinkedInAssistantErrorPayload,
+  type ReadOnlyValidationDiffChange,
+  type ReadOnlyValidationDiffEntry,
+  type ReadOnlyValidationOperationResult,
+  type ReadOnlyValidationReport,
+  type ReadOnlyValidationStatus
 } from "@linkedin-assistant/core";
 
 export type ReadOnlyValidationOutputMode = "human" | "json";
+export interface FormatReadOnlyValidationReportOptions {
+  color?: boolean;
+}
+
+export interface FormatReadOnlyValidationErrorOptions {
+  color?: boolean;
+  helpCommand?: string;
+}
+
+export interface ReadOnlyValidationProgressReporterOptions {
+  enabled?: boolean;
+  writeLine?: (line: string) => void;
+}
+
 const BLOCKED_REQUEST_PREVIEW_LIMIT = 5;
+const TOTAL_READ_ONLY_OPERATIONS = LINKEDIN_READ_ONLY_VALIDATION_OPERATIONS.length;
 const DIFF_CHANGE_LABELS: Record<ReadOnlyValidationDiffChange, string> = {
   fallback_drift: "Selector drift",
   new_failure: "New failure",
   recovered: "Recovered"
 };
+const CONTROL_CHARACTER_PATTERN = new RegExp(
+  `[${String.fromCharCode(0)}-${String.fromCharCode(31)}${String.fromCharCode(127)}-${String.fromCharCode(159)}]+`,
+  "g"
+);
+const ANSI_ESCAPE_PATTERN = new RegExp(
+  `${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`,
+  "g"
+);
+
+type TerminalStyle = "bold" | "dim" | "red" | "green" | "yellow" | "cyan";
+
+type ReadOnlyValidationProgressLogEntry = Pick<JsonLogEntry, "event" | "payload">;
+
+const TERMINAL_STYLE_CODES: Record<TerminalStyle, string> = {
+  bold: "\u001B[1m",
+  cyan: "\u001B[36m",
+  dim: "\u001B[2m",
+  green: "\u001B[32m",
+  red: "\u001B[31m",
+  yellow: "\u001B[33m"
+};
+
+function sanitizeConsoleText(value: string): string {
+  const sanitized = value
+    .replace(ANSI_ESCAPE_PATTERN, " ")
+    .replace(CONTROL_CHARACTER_PATTERN, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return sanitized.length > 0 ? sanitized : "[sanitized]";
+}
+
+function formatCountLabel(
+  count: number,
+  singular: string,
+  plural: string = `${singular}s`
+): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function formatValueForDisplay(value: unknown): string {
+  if (typeof value === "string") {
+    return sanitizeConsoleText(value);
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  if (value === null || value === undefined) {
+    return String(value);
+  }
+
+  try {
+    return sanitizeConsoleText(JSON.stringify(value));
+  } catch {
+    return sanitizeConsoleText(String(value));
+  }
+}
+
+function applyTextStyle(
+  text: string,
+  enabled: boolean,
+  ...styles: TerminalStyle[]
+): string {
+  if (!enabled || styles.length === 0) {
+    return text;
+  }
+
+  const prefix = styles.map((style) => TERMINAL_STYLE_CODES[style]).join("");
+  return `${prefix}${text}\u001B[0m`;
+}
+
+function formatSectionTitle(title: string, color: boolean): string {
+  return applyTextStyle(title, color, "bold", "cyan");
+}
+
+function formatDurationMs(value: number): string {
+  if (!Number.isFinite(value) || value < 1_000) {
+    return `${Math.max(0, Math.round(value))}ms`;
+  }
+
+  return `${(value / 1_000).toFixed(value >= 10_000 ? 0 : 1)}s`;
+}
+
+function readString(payload: Record<string, unknown>, key: string): string | null {
+  const value = payload[key];
+  return typeof value === "string" ? value : null;
+}
+
+function readNumber(payload: Record<string, unknown>, key: string): number | null {
+  const value = payload[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function readWarningCount(payload: Record<string, unknown>): number {
+  const warnings = payload.warnings;
+  return Array.isArray(warnings)
+    ? warnings.filter((warning) => typeof warning === "string").length
+    : 0;
+}
 
 function appendSection(lines: string[], title: string, entries: string[]): void {
   if (entries.length === 0) {
@@ -25,11 +144,52 @@ function appendSection(lines: string[], title: string, entries: string[]): void 
   lines.push(...entries);
 }
 
-function formatStatusLabel(status: ReadOnlyValidationStatus): string {
-  return status === "fail" ? "FAIL" : "PASS";
+function isMixedValidationReport(report: ReadOnlyValidationReport): boolean {
+  return report.pass_count > 0 && report.fail_count > 0;
 }
 
-function formatOperationSummary(operation: ReadOnlyValidationOperationResult): string {
+function formatRunStatusLabel(
+  report: ReadOnlyValidationReport,
+  color: boolean
+): string {
+  if (isMixedValidationReport(report)) {
+    return applyTextStyle("MIXED", color, "bold", "yellow");
+  }
+
+  return report.outcome === "fail"
+    ? applyTextStyle("FAIL", color, "bold", "red")
+    : applyTextStyle("PASS", color, "bold", "green");
+}
+
+function formatOperationStatusLabel(
+  status: ReadOnlyValidationStatus,
+  color: boolean
+): string {
+  return status === "fail"
+    ? applyTextStyle("FAIL", color, "bold", "red")
+    : applyTextStyle("PASS", color, "bold", "green");
+}
+
+function formatProgressStatusLabel(
+  status: ReadOnlyValidationStatus,
+  warningCount: number,
+  color: boolean
+): string {
+  if (status === "fail") {
+    return applyTextStyle("FAIL", color, "bold", "red");
+  }
+
+  if (warningCount > 0) {
+    return applyTextStyle("WARN", color, "bold", "yellow");
+  }
+
+  return applyTextStyle("PASS", color, "bold", "green");
+}
+
+function formatOperationSummary(
+  operation: ReadOnlyValidationOperationResult,
+  color: boolean
+): string {
   const warningSuffix = operation.warnings.length > 0
     ? ` | ${operation.warnings.length} warning${operation.warnings.length === 1 ? "" : "s"}`
     : "";
@@ -37,21 +197,21 @@ function formatOperationSummary(operation: ReadOnlyValidationOperationResult): s
     ? ` | ${operation.attempt_count} attempts`
     : "";
   const errorSuffix = operation.error_code ? ` | ${operation.error_code}` : "";
-  return `- ${formatStatusLabel(operation.status)} ${operation.operation}: ${operation.matched_count} matched, ${operation.failed_count} failed, ${operation.page_load_ms}ms${warningSuffix}${retrySuffix}${errorSuffix}`;
+  return `- ${formatOperationStatusLabel(operation.status, color)} ${sanitizeConsoleText(operation.operation)}: ${operation.matched_count} matched, ${operation.failed_count} failed, ${formatDurationMs(operation.page_load_ms)}${warningSuffix}${retrySuffix}${errorSuffix}`;
 }
 
 function formatDiffEntry(entry: ReadOnlyValidationDiffEntry): string {
   const previousCandidate = entry.previous_candidate_key ?? "none";
   const currentCandidate = entry.current_candidate_key ?? "none";
 
-  return `- ${DIFF_CHANGE_LABELS[entry.change]}: ${entry.operation}/${entry.selector_key} (${previousCandidate} → ${currentCandidate})`;
+  return `- ${DIFF_CHANGE_LABELS[entry.change]}: ${sanitizeConsoleText(entry.operation)}/${sanitizeConsoleText(entry.selector_key)} (${sanitizeConsoleText(previousCandidate)} → ${sanitizeConsoleText(currentCandidate)})`;
 }
 
 function formatBlockedRequests(
   blockedRequests: ReadOnlyValidationReport["blocked_requests"]
 ): string[] {
   return blockedRequests.slice(0, BLOCKED_REQUEST_PREVIEW_LIMIT).map((blockedRequest) => {
-    return `- ${blockedRequest.method} ${blockedRequest.url} [${blockedRequest.reason}]`;
+    return `- ${sanitizeConsoleText(blockedRequest.method)} ${sanitizeConsoleText(blockedRequest.url)} [${sanitizeConsoleText(blockedRequest.reason)}]`;
   });
 }
 
@@ -66,8 +226,18 @@ function formatFailedSelectorBlocks(
     return operation.selector_results
       .filter((selectorResult) => selectorResult.status === "fail")
       .map((selectorResult) => {
-        return `- ${operation.operation}/${selectorResult.selector_key} — ${selectorResult.error ?? "No selector candidate matched."}`;
+        return `- ${sanitizeConsoleText(operation.operation)}/${sanitizeConsoleText(selectorResult.selector_key)} — ${sanitizeConsoleText(selectorResult.error ?? "No selector candidate matched.")}`;
       });
+  });
+}
+
+function formatOperationWarnings(
+  operations: ReadOnlyValidationReport["operations"]
+): string[] {
+  return operations.flatMap((operation) => {
+    return operation.warnings.map((warning) => {
+      return `- ${sanitizeConsoleText(operation.operation)} — ${sanitizeConsoleText(warning)}`;
+    });
   });
 }
 
@@ -79,8 +249,266 @@ function formatOperationErrors(
       return [];
     }
 
-    return [`- ${operation.operation} [${operation.error_code}] — ${operation.error_message}`];
+    return [
+      `- ${sanitizeConsoleText(operation.operation)} [${sanitizeConsoleText(operation.error_code)}] — ${sanitizeConsoleText(operation.error_message)}`
+    ];
   });
+}
+
+function formatOverviewEntries(report: ReadOnlyValidationReport): string[] {
+  const warningCount = report.operations.reduce((count, operation) => {
+    return count + operation.warnings.length;
+  }, 0);
+  const overviewEntries = [
+    `- Operations: ${formatCountLabel(report.pass_count, "passed operation")} | ${formatCountLabel(report.fail_count, "failed operation")} | ${formatCountLabel(warningCount, "warning")}`,
+    `- Requests: ${report.request_limits.used_requests}/${report.request_limits.max_requests} used | ${formatCountLabel(report.blocked_request_count, "blocked request")}`,
+    `- Selector diff: ${formatCountLabel(report.diff.regressions.length, "regression")} | ${formatCountLabel(report.diff.recoveries.length, "recovery")} | ${formatCountLabel(report.diff.unchanged_count, "unchanged selector")}`
+  ];
+
+  if (isMixedValidationReport(report)) {
+    overviewEntries.unshift(
+      "- Mixed result: at least one validation step passed and at least one failed in the same run."
+    );
+  }
+
+  if (report.operation_count < TOTAL_READ_ONLY_OPERATIONS) {
+    overviewEntries.push(
+      `- Coverage: ${report.operation_count}/${TOTAL_READ_ONLY_OPERATIONS} steps ran before the validation stopped early.`
+    );
+  }
+
+  if (report.request_limits.max_requests_reached) {
+    overviewEntries.push(
+      "- Request cap reached: the run stopped when the configured request budget was exhausted."
+    );
+  }
+
+  return overviewEntries;
+}
+
+function formatBlockedRequestEntries(report: ReadOnlyValidationReport): string[] {
+  const entries = [
+    `- ${formatCountLabel(report.blocked_request_count, "request")} blocked by the read-only guard`,
+    ...formatBlockedRequests(report.blocked_requests)
+  ];
+
+  if (report.blocked_request_count > BLOCKED_REQUEST_PREVIEW_LIMIT) {
+    entries.push(
+      `- ${report.blocked_request_count - BLOCKED_REQUEST_PREVIEW_LIMIT} more blocked request${report.blocked_request_count - BLOCKED_REQUEST_PREVIEW_LIMIT === 1 ? "" : "s"} recorded in the report JSON.`
+    );
+  }
+
+  return entries;
+}
+
+function formatErrorDetailEntries(details: Record<string, unknown>): string | null {
+  const detailEntries = Object.entries(details);
+
+  if (detailEntries.length === 0) {
+    return null;
+  }
+
+  return detailEntries
+    .map(([key, value]) => `${key}=${formatValueForDisplay(value)}`)
+    .join(", ");
+}
+
+function readSessionName(details: Record<string, unknown>): string | null {
+  const sessionName = details.session_name;
+  return typeof sessionName === "string" && sessionName.trim().length > 0
+    ? sanitizeConsoleText(sessionName)
+    : null;
+}
+
+function formatReadOnlyValidationSuggestion(
+  payload: LinkedInAssistantErrorPayload
+): string {
+  switch (payload.code) {
+    case "ACTION_PRECONDITION_FAILED":
+      return "Review the command flags, fix the precondition, and rerun the validation.";
+    case "AUTH_REQUIRED": {
+      const sessionName = readSessionName(payload.details) ?? "default";
+      return `Capture a fresh stored session with "linkedin auth session --session ${sessionName}" and rerun.`;
+    }
+    case "CAPTCHA_OR_CHALLENGE":
+      return "Complete the LinkedIn challenge in a manual browser session, capture a fresh stored session, and rerun.";
+    case "NETWORK_ERROR":
+      return "Check browser/network connectivity, then rerun. If LinkedIn is flaky, keep retries enabled or increase the retry window.";
+    case "RATE_LIMITED":
+      return "Wait for the session to cool down, then rerun. If this happens often, raise --min-interval-ms or lower the workload per run.";
+    case "TIMEOUT":
+      return "Rerun with a larger --timeout-seconds value after confirming the stored session still loads LinkedIn normally.";
+    default:
+      return "Rerun the command. If it keeps failing, inspect the event log or rerun with --json for the structured payload.";
+  }
+}
+
+function formatProgressIndex(index: number): string {
+  return `${index}/${TOTAL_READ_ONLY_OPERATIONS}`;
+}
+
+function readOperationId(
+  payload: Record<string, unknown>
+): LinkedInReadOnlyValidationOperationId | null {
+  const operation = payload.operation;
+  return typeof operation === "string"
+    ? (operation as LinkedInReadOnlyValidationOperationId)
+    : null;
+}
+
+export class ReadOnlyValidationProgressReporter {
+  private readonly enabled: boolean;
+  private readonly writeLine: (line: string) => void;
+  private readonly operationIndexes = new Map<string, number>();
+  private nextOperationIndex = 1;
+
+  constructor(options: ReadOnlyValidationProgressReporterOptions = {}) {
+    this.enabled = options.enabled ?? true;
+    this.writeLine = options.writeLine ?? ((line: string) => process.stderr.write(`${line}\n`));
+  }
+
+  handleLog(entry: ReadOnlyValidationProgressLogEntry): void {
+    if (!this.enabled) {
+      return;
+    }
+
+    if (entry.event === "live_validation.start") {
+      const sessionName = readString(entry.payload, "session_name") ?? "default";
+      const maxRequests = readNumber(entry.payload, "max_requests");
+      const minIntervalMs = readNumber(entry.payload, "min_interval_ms");
+      const summaryParts = [formatCountLabel(TOTAL_READ_ONLY_OPERATIONS, "step")];
+
+      if (maxRequests !== null) {
+        summaryParts.push(`request cap ${maxRequests}`);
+      }
+
+      if (minIntervalMs !== null) {
+        summaryParts.push(`min interval ${formatDurationMs(minIntervalMs)}`);
+      }
+
+      this.writeLine(
+        `Starting live validation for session ${sanitizeConsoleText(sessionName)} (${summaryParts.join(", ")}).`
+      );
+      return;
+    }
+
+    if (entry.event === "live_validation.operation.start") {
+      const operation = readOperationId(entry.payload) ?? "feed";
+      const operationIndex = this.getOperationIndex(operation);
+      this.writeLine(
+        `Checking ${formatProgressIndex(operationIndex)}: ${sanitizeConsoleText(operation)}...`
+      );
+      return;
+    }
+
+    if (
+      entry.event === "live_validation.operation.done" ||
+      entry.event === "live_validation.operation.degraded"
+    ) {
+      const operation = readOperationId(entry.payload) ?? "feed";
+      const operationIndex = this.getOperationIndex(operation);
+      const status = readString(entry.payload, "status") === "fail" ? "fail" : "pass";
+      const warningCount = readWarningCount(entry.payload);
+      const lineParts = [
+        `Finished ${formatProgressIndex(operationIndex)}: ${sanitizeConsoleText(operation)} — ${formatProgressStatusLabel(status, warningCount, false)}`
+      ];
+      const matchedCount = readNumber(entry.payload, "matched_count");
+      const failedCount = readNumber(entry.payload, "failed_count");
+      const pageLoadMs = readNumber(entry.payload, "page_load_ms");
+      const attemptCount = readNumber(entry.payload, "attempt_count");
+      const detailParts: string[] = [];
+
+      if (matchedCount !== null) {
+        detailParts.push(`${matchedCount} matched`);
+      }
+
+      if (failedCount !== null) {
+        detailParts.push(`${failedCount} failed`);
+      }
+
+      if (pageLoadMs !== null) {
+        detailParts.push(formatDurationMs(pageLoadMs));
+      }
+
+      if (warningCount > 0) {
+        detailParts.push(formatCountLabel(warningCount, "warning"));
+      }
+
+      if (attemptCount !== null && attemptCount > 1) {
+        detailParts.push(formatCountLabel(attemptCount, "attempt"));
+      }
+
+      if (detailParts.length > 0) {
+        lineParts.push(`| ${detailParts.join(" | ")}`);
+      }
+
+      this.writeLine(lineParts.join(" "));
+      return;
+    }
+
+    if (entry.event === "live_validation.operation.failed") {
+      const operation = readOperationId(entry.payload) ?? "feed";
+      const operationIndex = this.getOperationIndex(operation);
+      const code = readString(entry.payload, "code");
+      const pageLoadMs = readNumber(entry.payload, "page_load_ms");
+      const attemptCount = readNumber(entry.payload, "attempt_count");
+      const warningCount = readWarningCount(entry.payload);
+      const detailParts: string[] = [];
+
+      if (code) {
+        detailParts.push(sanitizeConsoleText(code));
+      }
+
+      if (attemptCount !== null) {
+        detailParts.push(formatCountLabel(attemptCount, "attempt"));
+      }
+
+      if (pageLoadMs !== null) {
+        detailParts.push(formatDurationMs(pageLoadMs));
+      }
+
+      if (warningCount > 0) {
+        detailParts.push(formatCountLabel(warningCount, "warning"));
+      }
+
+      this.writeLine(
+        `Finished ${formatProgressIndex(operationIndex)}: ${sanitizeConsoleText(operation)} — FAIL${detailParts.length > 0 ? ` | ${detailParts.join(" | ")}` : ""}`
+      );
+      return;
+    }
+
+    if (entry.event === "live_validation.stopped_early") {
+      const operation = readOperationId(entry.payload) ?? "feed";
+      const operationIndex = this.getOperationIndex(operation);
+      const code = readString(entry.payload, "code") ?? "UNKNOWN";
+      const remainingOperations = readNumber(entry.payload, "remaining_operations") ?? 0;
+      this.writeLine(
+        `Stopping early after ${formatProgressIndex(operationIndex)}: ${sanitizeConsoleText(operation)} [${sanitizeConsoleText(code)}] left ${formatCountLabel(remainingOperations, "remaining step")}.`
+      );
+      return;
+    }
+
+    if (entry.event === "live_validation.done") {
+      const passCount = readNumber(entry.payload, "pass_count") ?? 0;
+      const failCount = readNumber(entry.payload, "fail_count") ?? 0;
+      const reportPath = readString(entry.payload, "report_path");
+      this.writeLine(
+        `Live validation finished — ${passCount} passed, ${failCount} failed${reportPath ? `. Report: ${sanitizeConsoleText(reportPath)}` : "."}`
+      );
+    }
+  }
+
+  private getOperationIndex(operation: string): number {
+    const existing = this.operationIndexes.get(operation);
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const operationIndex = this.nextOperationIndex;
+    this.operationIndexes.set(operation, operationIndex);
+    this.nextOperationIndex += 1;
+    return operationIndex;
+  }
 }
 
 export function resolveReadOnlyValidationOutputMode(
@@ -91,63 +519,94 @@ export function resolveReadOnlyValidationOutputMode(
 }
 
 export function formatReadOnlyValidationReport(
-  report: ReadOnlyValidationReport
+  report: ReadOnlyValidationReport,
+  options: FormatReadOnlyValidationReportOptions = {}
 ): string {
+  const color = options.color ?? false;
   const lines = [
-    `Live Validation: ${formatStatusLabel(report.outcome)}`,
-    `Summary: ${report.summary}`,
-    `Session: ${report.session.session_name} (captured ${report.session.captured_at})`,
-    `Report JSON: ${report.report_path}`,
-    `Events: ${report.events_path}`
+    `${formatSectionTitle("Live Validation", color)}: ${formatRunStatusLabel(report, color)}`,
+    `Summary: ${sanitizeConsoleText(report.summary)}`,
+    `Session: ${sanitizeConsoleText(report.session.session_name)} (captured ${sanitizeConsoleText(report.session.captured_at)})`,
+    `Report JSON: ${sanitizeConsoleText(report.report_path)}`,
+    `Events: ${sanitizeConsoleText(report.events_path)}`
   ];
 
   appendSection(
     lines,
-    "Operations",
-    report.operations.map((operation) => formatOperationSummary(operation))
+    formatSectionTitle("Overview", color),
+    formatOverviewEntries(report)
   );
 
-  appendSection(lines, "Operation Errors", formatOperationErrors(report.operations));
-  appendSection(lines, "Failures", formatFailedSelectorBlocks(report.operations));
   appendSection(
     lines,
-    "Regressions",
+    formatSectionTitle("Operations", color),
+    report.operations.map((operation) => formatOperationSummary(operation, color))
+  );
+
+  appendSection(
+    lines,
+    formatSectionTitle("Warnings", color),
+    formatOperationWarnings(report.operations)
+  );
+  appendSection(
+    lines,
+    formatSectionTitle("Operation Errors", color),
+    formatOperationErrors(report.operations)
+  );
+  appendSection(
+    lines,
+    formatSectionTitle("Failures", color),
+    formatFailedSelectorBlocks(report.operations)
+  );
+  appendSection(
+    lines,
+    formatSectionTitle("Regressions", color),
     report.diff.regressions.map((entry) => formatDiffEntry(entry))
   );
   appendSection(
     lines,
-    "Recoveries",
+    formatSectionTitle("Recoveries", color),
     report.diff.recoveries.map((entry) => formatDiffEntry(entry))
   );
 
   if (report.blocked_request_count > 0) {
     appendSection(
       lines,
-      "Blocked Requests",
-      [
-        `- ${report.blocked_request_count} request${report.blocked_request_count === 1 ? "" : "s"} blocked by the read-only guard`,
-        ...formatBlockedRequests(report.blocked_requests)
-      ]
+      formatSectionTitle("Blocked Requests", color),
+      formatBlockedRequestEntries(report)
     );
   }
 
   appendSection(
     lines,
-    "Next Steps",
-    report.recommended_actions.map((action) => `- ${action}`)
+    formatSectionTitle("Next Steps", color),
+    report.recommended_actions.map((action) => `- ${sanitizeConsoleText(action)}`)
   );
 
   return `${lines.join("\n")}\n`;
 }
 
 export function formatReadOnlyValidationError(
-  payload: LinkedInAssistantErrorPayload
+  payload: LinkedInAssistantErrorPayload,
+  options: FormatReadOnlyValidationErrorOptions = {}
 ): string {
-  const lines = [`Live validation failed [${payload.code}]`, payload.message];
+  const color = options.color ?? false;
+  const helpCommand = options.helpCommand ?? "linkedin test live --help";
+  const lines = [
+    applyTextStyle(`Live validation failed [${payload.code}]`, color, "bold", "red"),
+    sanitizeConsoleText(payload.message),
+    `Suggested fix: ${formatReadOnlyValidationSuggestion(payload)}`
+  ];
 
-  if (Object.keys(payload.details).length > 0) {
-    lines.push(`Details: ${JSON.stringify(payload.details)}`);
+  const detailSummary = formatErrorDetailEntries(payload.details);
+
+  if (detailSummary) {
+    lines.push(`Details: ${detailSummary}`);
   }
+
+  lines.push(
+    `Tip: run ${helpCommand} for usage and exit codes, or rerun with --json for the structured error payload.`
+  );
 
   return lines.join("\n");
 }

--- a/packages/cli/test/liveValidationCli.integration.test.ts
+++ b/packages/cli/test/liveValidationCli.integration.test.ts
@@ -1139,7 +1139,7 @@ describe("linkedin live validation CLI integration", () => {
       "smoke"
     ]);
 
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBe(2);
     expect(stderrChunks.join("")).toContain("Live validation failed [AUTH_REQUIRED]");
     expect(stderrChunks.join("")).toContain(
       'Stored LinkedIn session "smoke" is missing or expired while running feed.'

--- a/packages/cli/test/liveValidationCli.test.ts
+++ b/packages/cli/test/liveValidationCli.test.ts
@@ -1,3 +1,4 @@
+import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -180,9 +181,14 @@ describe("linkedin live validation CLI", () => {
   });
 
   it("requires --read-only for live validation", async () => {
-    await expect(
-      runCli(["node", "linkedin", "test:live", "--yes"])
-    ).rejects.toThrow("--read-only");
+    await runCli(["node", "linkedin", "test:live", "--yes"]);
+
+    expect(process.exitCode).toBe(2);
+    expect(stderrChunks.join("")).toContain(
+      "Live validation failed [ACTION_PRECONDITION_FAILED]"
+    );
+    expect(stderrChunks.join("")).toContain("--read-only");
+    expect(liveValidationCliMocks.runReadOnlyLinkedInLiveValidation).not.toHaveBeenCalled();
   });
 
   it("refuses interactive live validation when no TTY is available", async () => {
@@ -191,6 +197,8 @@ describe("linkedin live validation CLI", () => {
     await expect(
       runCli(["node", "linkedin", "test:live", "--read-only"])
     ).rejects.toThrow("non-interactive mode");
+
+    expect(process.exitCode).toBe(2);
   });
 
   it("prints JSON and sets exit code when the validation report fails", async () => {
@@ -273,28 +281,29 @@ describe("linkedin live validation CLI", () => {
       "--yes"
     ]);
 
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBe(2);
     expect(liveValidationCliMocks.captureLinkedInSession).not.toHaveBeenCalled();
     expect(liveValidationCliMocks.runReadOnlyLinkedInLiveValidation).toHaveBeenCalledTimes(1);
     expect(stderrChunks.join("")).toContain("Live validation failed [RATE_LIMITED]");
     expect(stderrChunks.join("")).toContain("per-session request cap");
+    expect(stderrChunks.join("")).toContain("Suggested fix:");
   });
 
   it("rejects retry windows where the max delay is smaller than the base delay", async () => {
-    await expect(
-      runCli([
-        "node",
-        "linkedin",
-        "test:live",
-        "--read-only",
-        "--yes",
-        "--retry-base-delay-ms",
-        "2000",
-        "--retry-max-delay-ms",
-        "1000"
-      ])
-    ).rejects.toThrow("retry-max-delay-ms");
+    await runCli([
+      "node",
+      "linkedin",
+      "test:live",
+      "--read-only",
+      "--yes",
+      "--retry-base-delay-ms",
+      "2000",
+      "--retry-max-delay-ms",
+      "1000"
+    ]);
 
+    expect(process.exitCode).toBe(2);
+    expect(stderrChunks.join("")).toContain("retry-max-delay-ms");
     expect(liveValidationCliMocks.runReadOnlyLinkedInLiveValidation).not.toHaveBeenCalled();
   });
 
@@ -313,6 +322,7 @@ describe("linkedin live validation CLI", () => {
       ])
     ).rejects.toThrow("do not support --cdp-url");
 
+    expect(process.exitCode).toBe(2);
     expect(liveValidationCliMocks.runReadOnlyLinkedInLiveValidation).not.toHaveBeenCalled();
   });
 
@@ -357,6 +367,7 @@ describe("linkedin live validation CLI", () => {
         session_name: "smoke"
       }
     });
+    expect(vi.mocked(createInterface).mock.calls.at(-1)?.[0]?.output).toBe(process.stderr);
   });
 
   it("formats a second failure cleanly after refreshing the stored session", async () => {
@@ -399,10 +410,68 @@ describe("linkedin live validation CLI", () => {
       "smoke"
     ]);
 
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBe(2);
     expect(stderrChunks.join(""))
       .toContain("Live validation failed [RATE_LIMITED]");
     expect(liveValidationCliMocks.captureLinkedInSession).toHaveBeenCalledTimes(1);
     expect(liveValidationCliMocks.runReadOnlyLinkedInLiveValidation).toHaveBeenCalledTimes(2);
+  });
+
+  it("documents live validation help with progress controls and exit codes", async () => {
+    const readHelpOutput = async (argv: string[]): Promise<string> => {
+      const stdoutChunks: string[] = [];
+      const stdoutWriteSpy = vi
+        .spyOn(stdout, "write")
+        .mockImplementation((...args: Parameters<typeof stdout.write>) => {
+          const [chunk] = args;
+          stdoutChunks.push(String(chunk));
+          return true;
+        });
+      const exitSpy = vi
+        .spyOn(process, "exit")
+        .mockImplementation((((code?: Parameters<typeof process.exit>[0]) => {
+          throw new Error(`process.exit:${String(code ?? 0)}`);
+        }) as typeof process.exit));
+
+      try {
+        await expect(runCli(argv)).rejects.toThrow("process.exit:0");
+      } finally {
+        stdoutWriteSpy.mockRestore();
+        exitSpy.mockRestore();
+      }
+
+      return stdoutChunks.join("");
+    };
+
+    const liveHelp = await readHelpOutput([
+      "node",
+      "linkedin",
+      "test",
+      "live",
+      "--help"
+    ]);
+    const aliasHelp = await readHelpOutput([
+      "node",
+      "linkedin",
+      "test:live",
+      "--help"
+    ]);
+    const authHelp = await readHelpOutput([
+      "node",
+      "linkedin",
+      "auth",
+      "session",
+      "--help"
+    ]);
+
+    expect(liveHelp).toContain("--no-progress");
+    expect(liveHelp).toContain("Exit codes:");
+    expect(liveHelp).toContain(
+      "interactive terminals default to a human-readable summary with per-step progress"
+    );
+    expect(liveHelp).toContain("linkedin test live --read-only");
+    expect(aliasHelp).toContain("--no-progress");
+    expect(authHelp).toContain("linkedin auth session");
+    expect(authHelp).toContain("linkedin auth:session");
   });
 });

--- a/packages/cli/test/liveValidationOutput.test.ts
+++ b/packages/cli/test/liveValidationOutput.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatReadOnlyValidationError,
   formatReadOnlyValidationReport,
+  ReadOnlyValidationProgressReporter,
   resolveReadOnlyValidationOutputMode
 } from "../src/liveValidationOutput.js";
 
@@ -242,18 +243,28 @@ describe("live validation output helpers", () => {
   it("renders a scannable human-readable report", () => {
     const output = formatReadOnlyValidationReport(createReportFixture());
 
-    expect(output).toContain("Live Validation: FAIL");
+    expect(output).toContain("Live Validation: MIXED");
     expect(output).toContain(
       "Summary: Checked 3 read-only LinkedIn operations. 1 passed. 2 failed. 2 selector regressions detected versus the previous run."
     );
-    expect(output).toContain("Operations");
-    expect(output).toContain("- PASS feed: 2 matched, 0 failed, 1200ms");
+    expect(output).toContain("Overview");
     expect(output).toContain(
-      "- FAIL notifications: 1 matched, 1 failed, 1600ms | 2 warnings | 2 attempts"
+      "- Mixed result: at least one validation step passed and at least one failed in the same run."
+    );
+    expect(output).toContain(
+      "- Operations: 1 passed operation | 2 failed operations | 3 warnings"
+    );
+    expect(output).toContain("- Coverage: 3/5 steps ran before the validation stopped early.");
+    expect(output).toContain("Operations");
+    expect(output).toContain("- PASS feed: 2 matched, 0 failed, 1.2s");
+    expect(output).toContain(
+      "- FAIL notifications: 1 matched, 1 failed, 1.6s | 2 warnings | 2 attempts"
     );
     expect(output).toContain(
       "- FAIL connections: 0 matched, 2 failed, 900ms | 1 warning | 3 attempts | TIMEOUT"
     );
+    expect(output).toContain("Warnings");
+    expect(output).toContain("- notifications — Recovered after 1 transient retry.");
     expect(output).toContain("Operation Errors");
     expect(output).toContain("- connections [TIMEOUT] — Timed out after 30000ms while running connections.");
     expect(output).toContain("Failures");
@@ -273,21 +284,34 @@ describe("live validation output helpers", () => {
     expect(output).toContain("- 6 requests blocked by the read-only guard");
     expect(output).toContain("https://www.linkedin.com/voyager/api/graphql");
     expect(output).not.toContain("https://cdn.example.org/font.woff2");
+    expect(output).toContain("- 1 more blocked request recorded in the report JSON.");
     expect(output).toContain("Next Steps");
   });
 
   it("matches the full human-readable report snapshot", () => {
     expect(formatReadOnlyValidationReport(createReportFixture())).toMatchInlineSnapshot(`
-      "Live Validation: FAIL
+      "Live Validation: MIXED
       Summary: Checked 3 read-only LinkedIn operations. 1 passed. 2 failed. 2 selector regressions detected versus the previous run.
       Session: smoke (captured 2026-03-09T09:00:00.000Z)
       Report JSON: /tmp/live-readonly/report.json
       Events: /tmp/live-readonly/events.jsonl
 
+      Overview
+      - Mixed result: at least one validation step passed and at least one failed in the same run.
+      - Operations: 1 passed operation | 2 failed operations | 3 warnings
+      - Requests: 5/20 used | 6 blocked requests
+      - Selector diff: 2 regressions | 1 recovery | 3 unchanged selectors
+      - Coverage: 3/5 steps ran before the validation stopped early.
+
       Operations
-      - PASS feed: 2 matched, 0 failed, 1200ms
-      - FAIL notifications: 1 matched, 1 failed, 1600ms | 2 warnings | 2 attempts
+      - PASS feed: 2 matched, 0 failed, 1.2s
+      - FAIL notifications: 1 matched, 1 failed, 1.6s | 2 warnings | 2 attempts
       - FAIL connections: 0 matched, 2 failed, 900ms | 1 warning | 3 attempts | TIMEOUT
+
+      Warnings
+      - notifications — Recovered after 1 transient retry.
+      - notifications — Notifications loaded with a slower-than-usual response.
+      - connections — Retried 2 times before the page still failed.
 
       Operation Errors
       - connections [TIMEOUT] — Timed out after 30000ms while running connections. LinkedIn may be slow or the page may be incomplete; rerun the live validation or increase the timeout.
@@ -309,6 +333,7 @@ describe("live validation output helpers", () => {
       - POST https://www.linkedin.com/voyager/api/identity [non_get]
       - GET https://analytics.example.net/pixel [non_linkedin_domain]
       - POST https://www.linkedin.com/voyager/api/feed [non_get]
+      - 1 more blocked request recorded in the report JSON.
 
       Next Steps
       - Open /tmp/live-readonly/report.json to review selector matches.
@@ -334,7 +359,11 @@ describe("live validation output helpers", () => {
     expect(output).toContain(
       "Live validation is currently restricted to read-only mode."
     );
-    expect(output).toContain('Details: {"option":"read-only"}');
+    expect(output).toContain(
+      "Suggested fix: Review the command flags, fix the precondition, and rerun the validation."
+    );
+    expect(output).toContain("Details: option=read-only");
+    expect(output).toContain("Tip: run linkedin test live --help");
   });
 
   it("matches the human-readable error snapshot", () => {
@@ -347,7 +376,76 @@ describe("live validation output helpers", () => {
     };
 
     expect(formatReadOnlyValidationError(error)).toMatchInlineSnapshot(
-      `"Live validation failed [ACTION_PRECONDITION_FAILED]\nLive validation is currently restricted to read-only mode.\nDetails: {"option":"read-only"}"`
+      `"Live validation failed [ACTION_PRECONDITION_FAILED]\nLive validation is currently restricted to read-only mode.\nSuggested fix: Review the command flags, fix the precondition, and rerun the validation.\nDetails: option=read-only\nTip: run linkedin test live --help for usage and exit codes, or rerun with --json for the structured error payload."`
     );
+  });
+
+  it("emits progress lines from stable live-validation log events", () => {
+    const lines: string[] = [];
+    const reporter = new ReadOnlyValidationProgressReporter({
+      writeLine(line) {
+        lines.push(line);
+      }
+    });
+
+    reporter.handleLog({
+      event: "live_validation.start",
+      payload: {
+        max_requests: 20,
+        min_interval_ms: 5000,
+        session_name: "smoke"
+      }
+    });
+    reporter.handleLog({
+      event: "live_validation.operation.start",
+      payload: {
+        operation: "feed"
+      }
+    });
+    reporter.handleLog({
+      event: "live_validation.operation.done",
+      payload: {
+        attempt_count: 1,
+        failed_count: 0,
+        matched_count: 2,
+        operation: "feed",
+        page_load_ms: 1200,
+        status: "pass",
+        warnings: []
+      }
+    });
+    reporter.handleLog({
+      event: "live_validation.operation.start",
+      payload: {
+        operation: "connections"
+      }
+    });
+    reporter.handleLog({
+      event: "live_validation.operation.failed",
+      payload: {
+        attempt_count: 3,
+        code: "TIMEOUT",
+        operation: "connections",
+        page_load_ms: 900,
+        warnings: ["Retried 2 times before the page still failed."]
+      }
+    });
+    reporter.handleLog({
+      event: "live_validation.done",
+      payload: {
+        fail_count: 1,
+        pass_count: 1,
+        report_path: "/tmp/live-readonly/report.json"
+      }
+    });
+
+    expect(lines).toEqual([
+      "Starting live validation for session smoke (5 steps, request cap 20, min interval 5.0s).",
+      "Checking 1/5: feed...",
+      "Finished 1/5: feed — PASS | 2 matched | 0 failed | 1.2s",
+      "Checking 2/5: connections...",
+      "Finished 2/5: connections — FAIL | TIMEOUT | 3 attempts | 900ms | 1 warning",
+      "Live validation finished — 1 passed, 1 failed. Report: /tmp/live-readonly/report.json"
+    ]);
   });
 });

--- a/packages/core/src/liveValidation.ts
+++ b/packages/core/src/liveValidation.ts
@@ -20,7 +20,7 @@ import {
   asLinkedInAssistantError,
   type LinkedInAssistantErrorCode
 } from "./errors.js";
-import { JsonEventLogger } from "./logging.js";
+import { JsonEventLogger, type JsonLogEntry } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import { createRunId } from "./run.js";
 import {
@@ -183,11 +183,16 @@ export interface RunReadOnlyValidationOptions {
   onBeforeOperation?: (
     operation: LinkedInReadOnlyValidationOperation
   ) => Promise<void>;
+  onLog?: (entry: JsonLogEntry) => void;
   retryBaseDelayMs?: number;
   retryMaxDelayMs?: number;
   sessionName?: string;
   timeoutMs?: number;
 }
+
+type ReadOnlyValidationLogger = Pick<JsonEventLogger, "getEventsPath"> & {
+  log: (...args: Parameters<JsonEventLogger["log"]>) => JsonLogEntry;
+};
 
 const DEFAULT_OPERATION_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_REQUESTS = 20;
@@ -481,6 +486,13 @@ function validateRunReadOnlyValidationOptions(
     throw new LinkedInAssistantError(
       "ACTION_PRECONDITION_FAILED",
       "onBeforeOperation must be a function when provided."
+    );
+  }
+
+  if (typeof options.onLog !== "undefined" && typeof options.onLog !== "function") {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "onLog must be a function when provided."
     );
   }
 
@@ -1394,7 +1406,7 @@ async function runOperationWithRetries(
   maxRetries: number,
   retryBaseDelayMs: number,
   retryMaxDelayMs: number,
-  logger: JsonEventLogger
+  logger: ReadOnlyValidationLogger
 ): Promise<ReadOnlyRetriedOperationExecutionResult> {
   const maxAttempts = maxRetries + 1;
   let lastError: LinkedInAssistantError | undefined;
@@ -1545,7 +1557,17 @@ export async function runReadOnlyLinkedInLiveValidation(
   ensureConfigPaths(paths);
 
   const runId = createRunId();
-  const logger = new JsonEventLogger(paths, runId);
+  const eventLogger = new JsonEventLogger(paths, runId);
+  const logger: ReadOnlyValidationLogger = {
+    getEventsPath() {
+      return eventLogger.getEventsPath();
+    },
+    log(level, event, payload = {}) {
+      const entry = eventLogger.log(level, event, payload);
+      validatedOptions.onLog?.(entry);
+      return entry;
+    }
+  };
   const artifacts = new ArtifactHelpers(paths, runId);
   const reportPath = artifacts.resolve(`${READ_ONLY_REPORT_DIR}/report.json`);
   const latestReportPath = resolveLatestReportPath(paths);


### PR DESCRIPTION
## Summary\n- improve live validation human output with a mixed-result overview, warning grouping, blocked-request overflow notes, and actionable error tips\n- add per-step progress updates in human mode, keep prompts off stdout in JSON mode, and use exit code 2 for command/runtime errors\n- polish live validation and session-capture help text, plus update CLI and formatter coverage for the new UX\n\n## Validation\n- npm run typecheck\n- npm run lint\n- npm test\n- npm run build\n\nCloses #138