### PR TITLE
docs: document Tier 2 live validation CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,39 +249,65 @@ Failures
 
 ### Live read-only validation
 
-Live read-only validation is a human-triggered smoke test for the production
+Live read-only validation is the Tier 2 smoke test for the production
 LinkedIn UI. It uses an encrypted stored browser session, verifies only
 read-only surfaces, blocks non-GET traffic during the run, and records a local
 report with selector matches, failures, timings, and regressions versus the
 previous run.
 
-See `docs/live-validation.md` for the full workflow.
+Examples below use the `linkedin` binary; `owa` is an equivalent alias.
+See `docs/live-validation.md` for the operator guide and
+`docs/live-validation-architecture.md` for the pipeline internals.
 
 ```bash
-# Capture an encrypted stored session from a manual login
-npm exec -w @linkedin-assistant/cli -- owa auth:session --session smoke
+# Capture or refresh an encrypted stored session from a manual login
+npm exec -w @linkedin-assistant/cli -- linkedin auth session --session smoke
 
-# Run the read-only smoke test interactively
-npm exec -w @linkedin-assistant/cli -- owa test:live --read-only --session smoke
+# Run the smoke test interactively with per-step prompts
+npm exec -w @linkedin-assistant/cli -- linkedin test live --read-only --session smoke
 
-# Skip per-step confirmations but keep every guardrail enabled
-npm exec -w @linkedin-assistant/cli -- owa test:live --read-only --session smoke --yes --json
+# Keep the human-readable summary and progress output, but skip prompts
+npm exec -w @linkedin-assistant/cli -- linkedin test live --read-only --session smoke --yes
+
+# Emit structured JSON for CI or scripts
+npm exec -w @linkedin-assistant/cli -- linkedin test live --read-only --session smoke --yes --json
+
+# Inspect one operation from the JSON output
+npm exec -w @linkedin-assistant/cli -- linkedin test live --read-only --session smoke --yes --json | jq '.operations[] | select(.operation == "notifications")'
 ```
 
-- `owa auth:session` opens a dedicated browser window, waits for a manual
+- `linkedin auth session` opens a dedicated browser window, waits for a manual
   LinkedIn login, and stores Playwright session state encrypted at rest under
   the tool-owned profile directory.
-- `owa test:live --read-only` validates the feed, profile, notifications,
+- `linkedin test live --read-only` validates the feed, profile, notifications,
   messaging, and connections surfaces only.
-- Interactive mode pauses before every step; `--yes` keeps the run read-only
-  and only skips the confirmation prompts.
+- `--session <name>` selects the encrypted stored session created by
+  `linkedin auth session`.
+- Interactive TTYs default to a human-readable report plus per-step progress;
+  non-interactive terminals default to JSON. `--json` forces machine-readable
+  output, while `--no-progress` hides progress lines in human mode.
+- There is no separate `--verbose` flag for this command; human mode already
+  prints the most detailed built-in view.
+- `--yes` skips per-step confirmation prompts only; it does not relax any
+  read-only guardrails.
 - The live validator enforces a minimum 5-second gap between steps and a
   maximum of 20 steps per session.
+- The CLI always runs the fixed five-step suite in order: `feed`, `profile`,
+  `notifications`, `inbox`, and `connections`. To focus on one step, filter
+  the JSON report or call the Core API from a custom harness.
 - Any session expiry, challenge, captcha, or unexpected redirect stops the run.
-- The validator writes a run-scoped JSON report and updates a stable
-  `latest-report.json` snapshot used for regression diffing on the next run.
+- Reports live under `LINKEDIN_ASSISTANT_HOME`, including the run-scoped
+  `artifacts/<run-id>/live-readonly/report.json`, the corresponding
+  `artifacts/<run-id>/events.jsonl`, and the rolling
+  `artifacts/live-readonly/latest-report.json` snapshot used for regression
+  diffing.
 - If the stored session is missing or expired in an interactive terminal, the
-  CLI prompts to refresh it via `owa auth:session` and retries once.
+  CLI prompts to refresh it via `linkedin auth session` and retries once.
+- Exit codes: `0` when all steps pass, `1` when one or more steps fail
+  (including partial reports after a later blocking failure), and `2` when the
+  run cannot complete because of preflight, session, or runtime errors.
+- Set `PLAYWRIGHT_EXECUTABLE_PATH` if Playwright cannot find Chromium on the
+  current machine.
 
 ### Draft quality evaluation
 

--- a/docs/live-validation-architecture.md
+++ b/docs/live-validation-architecture.md
@@ -1,0 +1,113 @@
+# Live validation architecture
+
+`linkedin test live --read-only` is the Tier 2 live validation pipeline for
+the production LinkedIn UI. The command is intentionally narrow: it reuses a
+stored session, exercises only read-only surfaces, and emits structured output
+that operators and automation can compare between runs.
+
+For day-to-day operator usage, examples, and CLI flags, see
+`docs/live-validation.md`.
+
+## Components
+
+- `packages/cli/src/bin/linkedin.ts`: defines the `linkedin test live`
+  command, validates CLI flags, prompts before each step in interactive mode,
+  and optionally refreshes the stored session when LinkedIn rejects it.
+- `packages/core/src/liveValidation.ts`: owns the Tier 2 execution pipeline,
+  including session loading, guarded browser setup, endpoint execution,
+  retries, diffing, and report persistence.
+- `packages/core/src/auth/sessionStore.ts`: encrypts Playwright storage state
+  at rest and reloads it for the live validation run.
+- `packages/cli/src/liveValidationOutput.ts`: formats the structured report
+  into the human-readable terminal summary and translates live JSON log events
+  into progress lines.
+
+## End-to-end pipeline
+
+1. The operator captures or refreshes a stored session with
+   `linkedin auth session --session <name>`.
+2. The CLI validates that `--read-only` is present, rejects `--cdp-url`,
+   resolves output mode, and creates an optional per-step confirmation hook.
+3. `runReadOnlyLinkedInLiveValidation()` loads the encrypted session,
+   resolves artifact paths, creates a run id, and opens a JSON event log.
+4. The core runtime loads the previous `latest-report.json` snapshot, when it
+   exists, so the new run can compute selector regressions and recoveries.
+5. The validator launches headless Chromium with the stored Playwright
+   `storageState`, applies navigation and selector timeouts, and installs the
+   read-only network guard.
+6. The pipeline walks the fixed operation list in order: `feed`, `profile`,
+   `notifications`, `inbox`, and `connections`.
+7. Each operation waits for the rate limiter, verifies that the stored session
+   still looks authenticated, loads the page, checks the relevant selector
+   groups, and records warnings, matches, failures, and timing data.
+8. Transient timeouts or network failures retry with exponential backoff. Hard
+   failures such as auth redirects, challenges, and non-recoverable page
+   errors stop the run early and return a partial report.
+9. After the operation loop, the core runtime computes the diff versus the
+   previous snapshot, persists `report.json`, updates `latest-report.json`, and
+   logs the final summary event.
+10. The CLI either prints the structured JSON report or formats the report into
+    a human-readable summary.
+
+## Session management
+
+- Session capture is intentionally manual. The CLI opens Chromium in headed
+  mode, waits for the operator to finish the LinkedIn login flow, and stores
+  the resulting Playwright `storageState`.
+- Stored sessions are encrypted on disk by `LinkedInSessionStore`, so the
+  validator never depends on a plaintext cookie jar.
+- Tier 2 validation always uses the stored-session flow. `--cdp-url` is
+  rejected because the validator must control the browser context so it can
+  enforce the network guard and generate comparable reports.
+- If the first operation fails because the stored session is expired or hits a
+  LinkedIn challenge, the interactive CLI can prompt the operator to rerun
+  `linkedin auth session` and then retry the validation once.
+
+## Endpoint execution and safety
+
+- The CLI always runs the full five-step suite in a fixed order. There is no
+  single-endpoint CLI flag, which keeps diffs comparable between runs and makes
+  the request budget predictable.
+- The network guard allows only `GET` requests to LinkedIn-owned domains. Any
+  non-`GET` request or non-LinkedIn domain is aborted and recorded in the final
+  report.
+- `ReadOnlyOperationRateLimiter` enforces both a minimum interval between live
+  requests and a hard maximum request count for the session.
+- The `inbox` step has special handling: it verifies the message list first and
+  then opens one readable thread when one is available. If no thread is
+  available, the step can still pass with a warning after validating the inbox
+  surface.
+- Retry logic is limited to transient timeout and connectivity failures. The
+  retry count and exponential backoff bounds are configurable from the CLI.
+
+## Output formatting and persistence
+
+- Every run writes `artifacts/<run-id>/live-readonly/report.json` and the
+  corresponding `artifacts/<run-id>/events.jsonl` event stream.
+- The rolling snapshot at
+  `artifacts/live-readonly/latest-report.json` is the comparison baseline for
+  the next run.
+- `computeReadOnlyValidationDiff()` classifies selector changes into three
+  buckets:
+  - `new_failure`: a selector used to pass and now fails
+  - `fallback_drift`: a selector still passes, but only with a weaker fallback
+  - `recovered`: a selector previously failed and now passes again
+- `ReadOnlyValidationProgressReporter` consumes JSON log events and writes
+  concise progress lines to `stderr` in human mode.
+- `formatReadOnlyValidationReport()` turns the structured report into the
+  multi-section terminal summary with overview, operations, warnings, failures,
+  regressions, blocked requests, and next steps.
+- `formatReadOnlyValidationError()` turns structured CLI/runtime failures into
+  a short operator-focused message with the error code, a suggested fix, and a
+  pointer to `linkedin test live --help`.
+
+## CI and automation notes
+
+- Interactive terminals default to the human-readable summary; non-interactive
+  terminals default to JSON. `--json` forces JSON in both cases.
+- `--yes` skips the per-step confirmation prompts so the command can run
+  unattended, but it does not disable the read-only guardrails.
+- The final report is stable enough for CI assertions because the operation ids
+  and diff categories are fixed. If you need to focus on one operation, filter
+  the `operations` array from the JSON output rather than trying to skip the
+  rest of the suite.

--- a/docs/live-validation.md
+++ b/docs/live-validation.md
@@ -1,40 +1,133 @@
 # Live read-only validation
 
-The live validation workflow is a Tier 2 smoke test for selector and page-shape
-drift on real LinkedIn pages. It is designed for a human operator, stays
-strictly read-only, and favors local safety over broad automation.
+`linkedin test live --read-only` is the Tier 2 smoke test for selector and
+page-shape drift on real LinkedIn pages. It is designed for a human operator,
+stays strictly read-only, and favors local safety over broad automation.
 
-## Commands
+Examples below use the `linkedin` binary; `owa` is an equivalent alias.
+
+The feature is also exported from `@linkedin-assistant/core` through
+`packages/core/src/liveValidation.ts` for custom harnesses.
+
+For pipeline internals, see `docs/live-validation-architecture.md`.
+
+## Quick start
 
 Capture an encrypted stored session from a manual LinkedIn login:
 
 ```bash
-npm exec -w @linkedin-assistant/cli -- owa auth:session --session smoke
+npm exec -w @linkedin-assistant/cli -- linkedin auth session --session smoke
 ```
 
 Run the live read-only validation interactively:
 
 ```bash
-npm exec -w @linkedin-assistant/cli -- owa test:live --read-only --session smoke
+npm exec -w @linkedin-assistant/cli -- linkedin test live --read-only --session smoke
 ```
 
 Run the same validation in batch mode while keeping every guardrail enabled:
 
 ```bash
-npm exec -w @linkedin-assistant/cli -- owa test:live --read-only --session smoke --yes --json
+npm exec -w @linkedin-assistant/cli -- linkedin test live --read-only --session smoke --yes --json
 ```
 
 ## What the validator checks
 
-The validator only exercises read-only flows:
+The validator always exercises the same five read-only flows, in order:
 
-- feed surface
-- signed-in profile header
-- notifications surface
-- inbox conversation list and one readable thread when available
-- connections surface
+- `feed`: signed-in home feed surface
+- `profile`: signed-in profile header
+- `notifications`: notifications surface
+- `inbox`: conversation list and one readable thread when available
+- `connections`: connections list surface
 
 Every step records selector matches, failures, warnings, and page-load timing.
+
+The CLI currently does **not** support running a single step in isolation. To
+focus on one step, filter the JSON report or call the Core API from a custom
+harness.
+
+## Common workflows
+
+### Interactive smoke test
+
+Use the default human-readable summary and approve each step manually:
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin test live --read-only --session smoke
+```
+
+### Detailed human-readable output
+
+There is no separate `--verbose` flag for this command. Human mode already
+prints live progress plus the most detailed built-in summary. Use `--yes` when
+you want the full human-readable output without stopping for step-by-step
+prompts:
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin test live --read-only --session smoke --yes
+```
+
+### CI or script integration
+
+Force JSON output and skip prompts so the command can run unattended:
+
+```bash
+mkdir -p reports
+npm exec -w @linkedin-assistant/cli -- linkedin test live --read-only --session smoke --yes --json > reports/live-validation.json
+```
+
+The command exits with `1` for selector or operation failures and `2` for
+preflight/session/runtime errors that prevent the run from completing.
+
+### Inspect one operation from the JSON report
+
+The CLI still runs the full suite, but you can isolate one operation in the
+structured output:
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin test live --read-only --session smoke --yes --json | jq '.operations[] | select(.operation == "notifications")'
+```
+
+### Tune retries and pacing for a slower session
+
+Increase the timeout and retry envelope without changing the read-only safety
+model:
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin test live --read-only --session smoke --yes --timeout-seconds 45 --max-retries 3 --retry-max-delay-ms 15000
+```
+
+## CLI options
+
+- `--read-only`: required acknowledgement that the run must stay strictly
+  read-only
+- `--session <name>`: stored session name captured by `linkedin auth session`
+- `--timeout-seconds <seconds>`: navigation and selector timeout per step
+- `--max-requests <count>`: maximum allowed live page requests before the run
+  stops
+- `--min-interval-ms <ms>`: minimum delay between live page requests
+- `--max-retries <count>`: transient retry count per step
+- `--retry-base-delay-ms <ms>`: initial exponential backoff delay
+- `--retry-max-delay-ms <ms>`: upper bound for exponential backoff delay
+- `--no-progress`: hide live progress lines in human-readable mode
+- `--yes`: skip per-step confirmation prompts
+- `--json`: print the structured JSON report instead of the human-readable
+  summary
+
+Use `npm exec -w @linkedin-assistant/cli -- linkedin test live --help` for the
+built-in help text and examples. The hidden `linkedin test:live` alias accepts
+the same options.
+
+## Configuration
+
+- `LINKEDIN_ASSISTANT_HOME` controls where stored sessions, artifacts, and the
+  rolling `latest-report.json` snapshot live.
+- `PLAYWRIGHT_EXECUTABLE_PATH` overrides the Chromium executable when
+  Playwright cannot find one on the current machine.
+- `--session <name>` selects the encrypted stored session captured earlier.
+- `--cdp-url` is intentionally unsupported for Tier 2 validation so the CLI can
+  enforce the guarded stored-session flow.
 
 ## Safety guardrails
 
@@ -53,13 +146,13 @@ Every step records selector matches, failures, warnings, and page-load timing.
 
 ## Session capture and refresh
 
-- `owa auth:session` opens a dedicated Chromium window.
+- `linkedin auth session` opens a dedicated Chromium window.
 - Sign in manually and wait for LinkedIn to land on an authenticated page.
 - The CLI captures Playwright storage state and stores it encrypted at rest.
 - Session contents are never printed to stdout/stderr.
-- If `owa test:live --read-only` detects an expired or challenged session in an
-  interactive terminal, it prompts to capture a fresh session and retries the
-  validation once.
+- If `linkedin test live --read-only` detects an expired or challenged session
+  in an interactive terminal, it prompts to capture a fresh session and retries
+  the validation once.
 
 ## Reports and exit codes
 
@@ -78,5 +171,31 @@ The stable snapshot is compared with the next run to highlight:
 Exit behavior:
 
 - `0` when every read-only operation passes
-- `1` when one or more operations fail, or when the workflow is blocked by
-  authentication / challenge / redirect guardrails
+- `1` when one or more operations fail, including partial reports after a later
+  blocking failure
+- `2` when preflight, session, or runtime errors prevent the run from
+  completing
+
+## Reading the result
+
+Human-readable output includes:
+
+- a top-level summary with the session name, checked-at timestamp, and report
+  paths
+- an overview section with pass/fail counts, warning counts, request budget
+  usage, and diff coverage
+- per-operation summaries with selector match counts, retries, warnings, and
+  timings
+- optional sections for warnings, operation errors, selector failures,
+  regressions, recoveries, blocked requests, and recommended next steps
+
+JSON output preserves the full structured report, including:
+
+- `operations[]`: page-by-page outcomes and selector-level results
+- `diff`: regressions and recoveries versus the previous run
+- `blocked_requests[]`: every aborted non-GET or non-LinkedIn request
+- `request_limits`: request cap usage and the minimum interval policy
+- `session`: stored-session metadata used for the run
+
+If you want to compare only one page between runs, filter the `operations`
+array by `operation` rather than trying to skip the rest of the suite.

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -4156,15 +4156,19 @@ export function createCliProgram(): Command {
         "Confirm that the live validation should run in strictly read-only mode",
         false
       )
-      .option("-s, --session <session>", "Stored session name", "default")
+      .option(
+        "-s, --session <session>",
+        "Stored session name captured by linkedin auth session",
+        "default"
+      )
       .option(
         "--timeout-seconds <seconds>",
-        "Maximum time allowed per validation step",
+        "Navigation and selector timeout per validation step",
         "30"
       )
       .option(
         "--max-requests <count>",
-        "Maximum live page requests allowed before the run stops",
+        "Maximum live page requests allowed before the run stops (retries included)",
         "20"
       )
       .option(
@@ -4189,25 +4193,35 @@ export function createCliProgram(): Command {
       )
       .option(
         "--no-progress",
-        "Hide per-step progress updates in human-readable output"
+        "Hide per-step progress updates in human-readable output (stderr)"
       )
       .option(
         "-y, --yes",
-        "Skip per-step confirmation prompts for unattended runs",
+        "Skip per-step confirmation prompts; read-only guardrails still apply",
         false
       )
       .option(
         "--json",
-        "Print the structured report JSON (recommended for scripts)",
+        "Print the structured report JSON to stdout (recommended for CI/scripts)",
         false
       )
       .addHelpText(
         "after",
         [
           "",
+          "Workflow:",
+          "  - capture or refresh a stored session first with linkedin auth session --session <name>",
+          "  - the validator always runs this fixed suite in order: feed, profile, notifications, inbox, connections",
+          "",
           "Output:",
           "  - interactive terminals default to a human-readable summary with per-step progress",
-          "  - --json prints only the structured report to stdout; prompts stay on stderr",
+          "  - non-interactive terminals default to JSON",
+          "  - --json prints the structured report to stdout; prompts and progress stay on stderr",
+          "  - there is no separate --verbose flag; human mode is already the most detailed built-in view",
+          "",
+          "Configuration:",
+          "  - LINKEDIN_ASSISTANT_HOME stores the encrypted session, reports, and latest-report.json",
+          "  - PLAYWRIGHT_EXECUTABLE_PATH overrides Chromium if Playwright cannot find one",
           "",
           "Exit codes:",
           "  - 0 all validation steps passed",
@@ -4222,9 +4236,15 @@ export function createCliProgram(): Command {
           "  - returns partial results if a later step hits a blocking failure",
           "",
           "Examples:",
-          "  linkedin test live --read-only",
-          "  linkedin test live --read-only --yes --session smoke --max-retries 3",
-          "  linkedin test:live --read-only --yes --json"
+          "  linkedin auth session --session smoke",
+          "  linkedin test live --read-only --session smoke",
+          "  linkedin test live --read-only --session smoke --yes",
+          "  linkedin test live --read-only --session smoke --yes --json",
+          "  linkedin test live --read-only --session smoke --yes --json | jq '.operations[] | select(.operation == \"notifications\")'",
+          "",
+          "Docs:",
+          "  - docs/live-validation.md",
+          "  - docs/live-validation-architecture.md"
         ].join("\n")
       )
       .action(

--- a/packages/cli/src/liveValidationOutput.ts
+++ b/packages/cli/src/liveValidationOutput.ts
@@ -10,18 +10,39 @@ import {
   type ReadOnlyValidationStatus
 } from "@linkedin-assistant/core";
 
+/**
+ * Console output modes supported by the live validation CLI.
+ */
 export type ReadOnlyValidationOutputMode = "human" | "json";
+
+/**
+ * Rendering options for the human-readable live validation report.
+ */
 export interface FormatReadOnlyValidationReportOptions {
+  /** Enable ANSI colors in the formatted output. */
   color?: boolean;
 }
 
+/**
+ * Rendering options for the human-readable live validation error summary.
+ */
 export interface FormatReadOnlyValidationErrorOptions {
+  /** Enable ANSI colors in the formatted output. */
   color?: boolean;
+
+  /** Help command shown in the final remediation hint. */
   helpCommand?: string;
 }
 
+/**
+ * Options for the progress reporter that mirrors structured log events to the
+ * terminal.
+ */
 export interface ReadOnlyValidationProgressReporterOptions {
+  /** Disable all progress output when set to `false`. */
   enabled?: boolean;
+
+  /** Custom line writer used by tests or alternative terminals. */
   writeLine?: (line: string) => void;
 }
 
@@ -356,6 +377,10 @@ function readOperationId(
     : null;
 }
 
+/**
+ * Converts structured live validation log events into concise terminal progress
+ * lines.
+ */
 export class ReadOnlyValidationProgressReporter {
   private readonly enabled: boolean;
   private readonly writeLine: (line: string) => void;
@@ -367,6 +392,9 @@ export class ReadOnlyValidationProgressReporter {
     this.writeLine = options.writeLine ?? ((line: string) => process.stderr.write(`${line}\n`));
   }
 
+  /**
+   * Feeds one structured live validation log entry into the progress renderer.
+   */
   handleLog(entry: ReadOnlyValidationProgressLogEntry): void {
     if (!this.enabled) {
       return;
@@ -511,6 +539,10 @@ export class ReadOnlyValidationProgressReporter {
   }
 }
 
+/**
+ * Resolves whether the CLI should print the human-readable report or the raw
+ * structured JSON payload.
+ */
 export function resolveReadOnlyValidationOutputMode(
   options: { json: boolean },
   isInteractiveOutput: boolean
@@ -518,6 +550,10 @@ export function resolveReadOnlyValidationOutputMode(
   return options.json || !isInteractiveOutput ? "json" : "human";
 }
 
+/**
+ * Formats a structured live validation report for human-readable terminal
+ * output.
+ */
 export function formatReadOnlyValidationReport(
   report: ReadOnlyValidationReport,
   options: FormatReadOnlyValidationReportOptions = {}
@@ -586,6 +622,10 @@ export function formatReadOnlyValidationReport(
   return `${lines.join("\n")}\n`;
 }
 
+/**
+ * Formats a structured live validation failure into a concise operator-facing
+ * error summary.
+ */
 export function formatReadOnlyValidationError(
   payload: LinkedInAssistantErrorPayload,
   options: FormatReadOnlyValidationErrorOptions = {}

--- a/packages/cli/test/liveValidationCli.test.ts
+++ b/packages/cli/test/liveValidationCli.test.ts
@@ -417,7 +417,7 @@ describe("linkedin live validation CLI", () => {
     expect(liveValidationCliMocks.runReadOnlyLinkedInLiveValidation).toHaveBeenCalledTimes(2);
   });
 
-  it("documents live validation help with progress controls and exit codes", async () => {
+  it("documents live validation help with workflow, configuration, and examples", async () => {
     const readHelpOutput = async (argv: string[]): Promise<string> => {
       const stdoutChunks: string[] = [];
       const stdoutWriteSpy = vi
@@ -469,7 +469,13 @@ describe("linkedin live validation CLI", () => {
     expect(liveHelp).toContain(
       "interactive terminals default to a human-readable summary with per-step progress"
     );
+    expect(liveHelp).toContain("-s, --session <session>");
+    expect(liveHelp).toMatch(/Stored session name captured by linkedin auth\s+session/);
+    expect(liveHelp).toContain("LINKEDIN_ASSISTANT_HOME");
+    expect(liveHelp).toContain("PLAYWRIGHT_EXECUTABLE_PATH");
+    expect(liveHelp).toContain("linkedin auth session --session smoke");
     expect(liveHelp).toContain("linkedin test live --read-only");
+    expect(liveHelp).toContain("docs/live-validation.md");
     expect(aliasHelp).toContain("--no-progress");
     expect(authHelp).toContain("linkedin auth session");
     expect(authHelp).toContain("linkedin auth:session");

--- a/packages/core/src/liveValidation.ts
+++ b/packages/core/src/liveValidation.ts
@@ -29,6 +29,12 @@ import {
 } from "./auth/sessionStore.js";
 import { inspectLinkedInSession } from "./auth/sessionInspection.js";
 
+/**
+ * Fixed Tier 2 live validation operations executed by the CLI and Core API.
+ *
+ * The run always walks this list in order so report diffs stay comparable from
+ * one execution to the next.
+ */
 export const LINKEDIN_READ_ONLY_VALIDATION_OPERATIONS = [
   {
     id: "feed",
@@ -52,13 +58,27 @@ export const LINKEDIN_READ_ONLY_VALIDATION_OPERATIONS = [
   }
 ] as const;
 
+/**
+ * Descriptor for one built-in read-only live validation operation.
+ */
 export type LinkedInReadOnlyValidationOperation =
   (typeof LINKEDIN_READ_ONLY_VALIDATION_OPERATIONS)[number];
 
+/**
+ * Stable identifier for a built-in read-only live validation operation.
+ */
 export type LinkedInReadOnlyValidationOperationId =
   LinkedInReadOnlyValidationOperation["id"];
 
+/**
+ * Top-level pass/fail status used by selector, operation, and report results.
+ */
 export type ReadOnlyValidationStatus = "pass" | "fail";
+
+/**
+ * Diff category emitted when the current run is compared against the rolling
+ * `latest-report.json` snapshot.
+ */
 export type ReadOnlyValidationDiffChange =
   | "fallback_drift"
   | "new_failure"
@@ -90,6 +110,9 @@ interface ReadOnlyOperationExecutionResult {
   threadUrl?: string;
 }
 
+/**
+ * Selector-level outcome recorded for one validation step.
+ */
 export interface ReadOnlyValidationSelectorResult {
   description: string;
   error?: string;
@@ -100,6 +123,9 @@ export interface ReadOnlyValidationSelectorResult {
   status: ReadOnlyValidationStatus;
 }
 
+/**
+ * Aggregated result for one page-level live validation operation.
+ */
 export interface ReadOnlyValidationOperationResult {
   attempt_count: number;
   completed_at: string;
@@ -119,6 +145,9 @@ export interface ReadOnlyValidationOperationResult {
   warnings: string[];
 }
 
+/**
+ * Selector diff entry comparing the current run against the previous snapshot.
+ */
 export interface ReadOnlyValidationDiffEntry {
   change: ReadOnlyValidationDiffChange;
   current_candidate_key: string | null;
@@ -129,6 +158,9 @@ export interface ReadOnlyValidationDiffEntry {
   selector_key: string;
 }
 
+/**
+ * Regression and recovery summary for the current run.
+ */
 export interface ReadOnlyValidationDiff {
   previous_report_path?: string;
   recoveries: ReadOnlyValidationDiffEntry[];
@@ -136,6 +168,9 @@ export interface ReadOnlyValidationDiff {
   unchanged_count: number;
 }
 
+/**
+ * Network request blocked by the read-only guard during the run.
+ */
 export interface ReadOnlyValidationBlockedRequest {
   blocked_at: string;
   method: string;
@@ -144,6 +179,9 @@ export interface ReadOnlyValidationBlockedRequest {
   url: string;
 }
 
+/**
+ * Full structured report returned by the Tier 2 live validation pipeline.
+ */
 export interface ReadOnlyValidationReport {
   blocked_request_count: number;
   blocked_requests: ReadOnlyValidationBlockedRequest[];
@@ -175,18 +213,40 @@ export interface ReadOnlyValidationReport {
   summary: string;
 }
 
+/**
+ * Optional overrides and hooks for `runReadOnlyLinkedInLiveValidation()`.
+ */
 export interface RunReadOnlyValidationOptions {
+  /** Override the assistant home used for stored sessions, artifacts, and logs. */
   baseDir?: string;
+
+  /** Maximum live requests allowed across the run, including retries. */
   maxRequests?: number;
+
+  /** Maximum transient retries allowed per operation. */
   maxRetries?: number;
+
+  /** Minimum delay enforced between live requests. */
   minIntervalMs?: number;
+
+  /** Called before each operation so the CLI can prompt or pause the run. */
   onBeforeOperation?: (
     operation: LinkedInReadOnlyValidationOperation
   ) => Promise<void>;
+
+  /** Receives structured log events as the run progresses. */
   onLog?: (entry: JsonLogEntry) => void;
+
+  /** Initial exponential-backoff delay for transient retries. */
   retryBaseDelayMs?: number;
+
+  /** Maximum exponential-backoff delay for transient retries. */
   retryMaxDelayMs?: number;
+
+  /** Stored session name previously captured with `linkedin auth session`. */
   sessionName?: string;
+
+  /** Navigation and selector timeout applied to each operation. */
   timeoutMs?: number;
 }
 
@@ -556,6 +616,12 @@ function isAllowedLinkedInHost(hostname: string): boolean {
   );
 }
 
+/**
+ * Returns whether the request is allowed through the Tier 2 read-only network
+ * guard.
+ *
+ * Only `GET` requests to LinkedIn-owned hosts are allowed to continue.
+ */
 export function isAllowedLinkedInReadOnlyRequest(
   urlString: string,
   method: string
@@ -905,6 +971,9 @@ async function installReadOnlyNetworkGuard(
   });
 }
 
+/**
+ * Enforces the per-run request cap and minimum interval between live requests.
+ */
 export class ReadOnlyOperationRateLimiter {
   private lastRequestAtMs: number | null = null;
 
@@ -937,6 +1006,10 @@ export class ReadOnlyOperationRateLimiter {
     }
   }
 
+  /**
+   * Waits until the next request slot is available or throws `RATE_LIMITED`
+   * when the request budget has already been exhausted.
+   */
   async waitTurn(operationId: LinkedInReadOnlyValidationOperationId): Promise<void> {
     if (this.requestCount >= this.maxRequests) {
       throw new LinkedInAssistantError(
@@ -963,10 +1036,16 @@ export class ReadOnlyOperationRateLimiter {
     this.requestCount += 1;
   }
 
+  /**
+   * Returns how many live requests have been consumed so far.
+   */
   getRequestCount(): number {
     return this.requestCount;
   }
 
+  /**
+   * Returns whether the configured request cap has been reached.
+   */
   hasReachedLimit(): boolean {
     return this.requestCount >= this.maxRequests;
   }
@@ -1084,6 +1163,10 @@ function isReadOnlyValidationReport(value: unknown): value is ReadOnlyValidation
   );
 }
 
+/**
+ * Compares the current run with the previous rolling snapshot and classifies
+ * selector regressions, recoveries, and unchanged results.
+ */
 export function computeReadOnlyValidationDiff(
   currentReport: Pick<ReadOnlyValidationReport, "operations">,
   previousReport:
@@ -1504,6 +1587,15 @@ async function createBrowserContext(
   }
 }
 
+/**
+ * Runs the Tier 2 read-only LinkedIn live validation workflow and returns the
+ * structured report persisted under the current run artifact directory.
+ *
+ * The pipeline loads an encrypted stored session, installs a read-only network
+ * guard, walks the fixed operation suite, compares the result against the
+ * previous snapshot, and writes both the run-scoped report and the rolling
+ * `latest-report.json` snapshot.
+ */
 export async function runReadOnlyLinkedInLiveValidation(
   options: RunReadOnlyValidationOptions = {}
 ): Promise<ReadOnlyValidationReport> {


### PR DESCRIPTION
## Summary
- expand the README and live validation guide with Tier 2 workflow, configuration, exit codes, and common command examples
- add a dedicated architecture note covering stored-session management, endpoint execution, retries, and output formatting
- document the public live validation API surface with JSDoc and tighten `linkedin test live --help` coverage

Closes #140
Related to #88