### PR TITLE
refactor: simplify write-validation harness internals

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -4393,28 +4393,7 @@ export function createCliProgram(): Command {
           writeValidation: boolean;
           yes: boolean;
         }) => {
-          if (options.writeValidation && options.readOnly) {
-            throw new LinkedInAssistantError(
-              "ACTION_PRECONDITION_FAILED",
-              'Choose either "--read-only" or "--write-validation", not both.'
-            );
-          }
-
           if (options.writeValidation) {
-            if (!options.account) {
-              throw new LinkedInAssistantError(
-                "ACTION_PRECONDITION_FAILED",
-                'Write validation requires "--account <id>".'
-              );
-            }
-
-            if (options.session !== "default") {
-              throw new LinkedInAssistantError(
-                "ACTION_PRECONDITION_FAILED",
-                'Write validation resolves stored sessions through the account registry. Remove "--session" and rerun.'
-              );
-            }
-
             await runLiveWriteValidation(
               {
                 accountId: options.account,
@@ -4423,6 +4402,8 @@ export function createCliProgram(): Command {
                   "cooldown-seconds"
                 ),
                 json: options.json,
+                readOnly: options.readOnly,
+                session: options.session,
                 timeoutSeconds: coercePositiveInt(
                   options.timeoutSeconds,
                   "timeout-seconds"
@@ -5556,12 +5537,14 @@ function buildWriteValidationAccountTargets(input: {
   reactionPost: string | undefined;
 }): WriteValidationAccountTargets {
   const targets: WriteValidationAccountTargets = {};
+  const messageParticipantPattern = input.messageParticipantPattern?.trim();
+  const inviteNote = input.inviteNote?.trim();
 
   if (input.messageThread) {
     targets.send_message = {
       thread: input.messageThread,
-      ...(input.messageParticipantPattern
-        ? { participantPattern: input.messageParticipantPattern.trim() }
+      ...(messageParticipantPattern
+        ? { participantPattern: messageParticipantPattern }
         : {})
     };
   }
@@ -5569,8 +5552,8 @@ function buildWriteValidationAccountTargets(input: {
   if (input.inviteProfile) {
     targets["connections.send_invitation"] = {
       targetProfile: input.inviteProfile,
-      ...(input.inviteNote && input.inviteNote.trim().length > 0
-        ? { note: input.inviteNote.trim() }
+      ...(inviteNote
+        ? { note: inviteNote }
         : {})
     };
   }
@@ -5597,6 +5580,35 @@ function buildWriteValidationAccountTargets(input: {
   }
 
   return targets;
+}
+
+function resolveLiveWriteValidationAccountId(input: {
+  account?: string | undefined;
+  readOnly: boolean;
+  session: string;
+}): string {
+  if (input.readOnly) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      'Choose either "--read-only" or "--write-validation", not both.'
+    );
+  }
+
+  if (!input.account) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      'Write validation requires "--account <id>".'
+    );
+  }
+
+  if (input.session !== "default") {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      'Write validation resolves stored sessions through the account registry. Remove "--session" and rerun.'
+    );
+  }
+
+  return input.account;
 }
 
 function formatWriteValidationPrompt(
@@ -5666,10 +5678,27 @@ function emitWriteValidationFailure(
   );
 }
 
+function assertWriteValidationExecutionPreconditions(
+  input: { yes: boolean },
+  cdpUrl?: string
+): void {
+  assertNoExternalSessionOverrideForStoredSession(cdpUrl);
+  assertInteractiveTerminal("run write validation");
+
+  if (input.yes) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      'Write validation requires typing "yes" for every action. Remove "--yes" and rerun.'
+    );
+  }
+}
+
 async function runLiveWriteValidation(input: {
-  accountId: string;
+  accountId?: string | undefined;
   cooldownSeconds: number;
   json: boolean;
+  readOnly: boolean;
+  session: string;
   timeoutSeconds: number;
   yes: boolean;
 }, cdpUrl?: string): Promise<void> {
@@ -5680,23 +5709,21 @@ async function runLiveWriteValidation(input: {
   const promptOutput = outputMode === "json" ? process.stderr : stdout;
 
   try {
-    assertNoExternalSessionOverrideForStoredSession(cdpUrl);
-    assertInteractiveTerminal("run write validation");
+    const accountId = resolveLiveWriteValidationAccountId({
+      account: input.accountId,
+      readOnly: input.readOnly,
+      session: input.session
+    });
 
-    if (input.yes) {
-      throw new LinkedInAssistantError(
-        "ACTION_PRECONDITION_FAILED",
-        'Write validation requires typing "yes" for every action. Remove "--yes" and rerun.'
-      );
-    }
+    assertWriteValidationExecutionPreconditions(input, cdpUrl);
 
     writeCliWarning(`${WRITE_VALIDATION_WARNING}.`);
     writeCliNotice(
-      `Running write validation against account "${input.accountId}". See ${WRITE_VALIDATION_DOC_PATH} for account setup and approved targets.`
+      `Running write validation against account "${accountId}". See ${WRITE_VALIDATION_DOC_PATH} for account setup and approved targets.`
     );
 
     const report = await runLinkedInWriteValidation({
-      accountId: coerceProfileName(input.accountId, "account"),
+      accountId: coerceProfileName(accountId, "account"),
       cooldownMs: input.cooldownSeconds * 1_000,
       interactive: Boolean(stdin.isTTY && stdout.isTTY),
       onBeforeAction: createWriteValidationPrompter(promptOutput),

--- a/packages/cli/src/writeValidationOutput.ts
+++ b/packages/cli/src/writeValidationOutput.ts
@@ -16,7 +16,7 @@ export interface FormatWriteValidationErrorOptions {
   helpCommand?: string;
 }
 
-type TerminalStyle = "bold" | "cyan" | "dim" | "green" | "red" | "yellow";
+type TerminalStyle = "bold" | "cyan" | "green" | "red" | "yellow";
 
 const CONTROL_CHARACTER_PATTERN = new RegExp(
   `[${String.fromCharCode(0)}-${String.fromCharCode(31)}${String.fromCharCode(127)}-${String.fromCharCode(159)}]+`,
@@ -29,7 +29,6 @@ const ANSI_ESCAPE_PATTERN = new RegExp(
 const TERMINAL_STYLE_CODES: Record<TerminalStyle, string> = {
   bold: "\u001B[1m",
   cyan: "\u001B[36m",
-  dim: "\u001B[2m",
   green: "\u001B[32m",
   red: "\u001B[31m",
   yellow: "\u001B[33m"
@@ -112,16 +111,30 @@ function formatActionSummary(
   color: boolean
 ): string {
   const verification = action.verification?.verified === true ? "verified" : "unverified";
-  const sync =
-    action.state_synced === null
-      ? "state=n/a"
-      : action.state_synced
-        ? "state=ok"
-        : "state=failed";
+  const sync = formatStateSyncLabel(action.state_synced);
   const artifactCount = action.artifact_paths.length;
   const errorSuffix = action.error_code ? ` | ${sanitizeConsoleText(action.error_code)}` : "";
 
   return `- ${formatActionStatusLabel(action.status, color)} ${sanitizeConsoleText(action.action_type)} | ${verification} | ${sync} | ${artifactCount} artifact${artifactCount === 1 ? "" : "s"}${errorSuffix}`;
+}
+
+function formatStateSyncLabel(stateSynced: boolean | null): string {
+  if (stateSynced === null) {
+    return "state=n/a";
+  }
+
+  return stateSynced ? "state=ok" : "state=failed";
+}
+
+function formatArtifactPathList(
+  label: string,
+  artifactPaths: readonly string[]
+): string | null {
+  if (artifactPaths.length === 0) {
+    return null;
+  }
+
+  return `  ${label}: ${artifactPaths.map(sanitizeConsoleText).join(", ")}`;
 }
 
 function formatActionDetails(action: WriteValidationActionResult): string[] {
@@ -143,16 +156,14 @@ function formatActionDetails(action: WriteValidationActionResult): string[] {
     detailLines.push(`  error: ${sanitizeConsoleText(action.error_message)}`);
   }
 
-  if (action.before_screenshot_paths.length > 0) {
-    detailLines.push(
-      `  before: ${action.before_screenshot_paths.map(sanitizeConsoleText).join(", ")}`
-    );
+  const beforePaths = formatArtifactPathList("before", action.before_screenshot_paths);
+  if (beforePaths) {
+    detailLines.push(beforePaths);
   }
 
-  if (action.after_screenshot_paths.length > 0) {
-    detailLines.push(
-      `  after: ${action.after_screenshot_paths.map(sanitizeConsoleText).join(", ")}`
-    );
+  const afterPaths = formatArtifactPathList("after", action.after_screenshot_paths);
+  if (afterPaths) {
+    detailLines.push(afterPaths);
   }
 
   return detailLines;

--- a/packages/cli/test/writeValidationCli.test.ts
+++ b/packages/cli/test/writeValidationCli.test.ts
@@ -219,6 +219,40 @@ describe("write validation CLI", () => {
     expect(stderrOutput).toContain('Remove "--yes" and rerun');
   });
 
+  it("requires an account id for write validation", async () => {
+    await runCli([
+      "node",
+      "linkedin",
+      "test:live",
+      "--write-validation"
+    ]);
+
+    const stderrOutput = stripVTControlCharacters(stderrChunks.join(""));
+
+    expect(process.exitCode).toBe(2);
+    expect(stderrOutput).toContain('Write validation requires "--account <id>".');
+  });
+
+  it("rejects session overrides for write validation", async () => {
+    await runCli([
+      "node",
+      "linkedin",
+      "test:live",
+      "--write-validation",
+      "--account",
+      "secondary",
+      "--session",
+      "custom-session"
+    ]);
+
+    const stderrOutput = stripVTControlCharacters(stderrChunks.join(""));
+
+    expect(process.exitCode).toBe(2);
+    expect(stderrOutput).toContain(
+      'Write validation resolves stored sessions through the account registry. Remove "--session" and rerun.'
+    );
+  });
+
   it("prompts per action and runs the write-validation harness", async () => {
     writeValidationCliMocks.answers = ["yes"];
     writeValidationCliMocks.runLinkedInWriteValidation.mockImplementation(

--- a/packages/cli/test/writeValidationOutput.test.ts
+++ b/packages/cli/test/writeValidationOutput.test.ts
@@ -1,0 +1,133 @@
+import type {
+  LinkedInAssistantErrorPayload,
+  WriteValidationReport
+} from "@linkedin-assistant/core";
+import { describe, expect, it } from "vitest";
+import {
+  formatWriteValidationError,
+  formatWriteValidationReport,
+  resolveWriteValidationOutputMode
+} from "../src/writeValidationOutput.js";
+
+function createReportFixture(
+  outcome: WriteValidationReport["outcome"] = "pass"
+): WriteValidationReport {
+  const status = outcome === "cancelled" ? "cancelled" : outcome;
+
+  return {
+    account: {
+      designation: "secondary",
+      id: "secondary",
+      label: "Secondary",
+      profile_name: "secondary-profile",
+      session_name: "secondary-session"
+    },
+    action_count: 1,
+    actions: [
+      {
+        action_type: "send_message",
+        after_screenshot_paths:
+          status === "pass" ? ["live-write-validation/send-message-after.png"] : [],
+        artifact_paths: ["live-write-validation/send-message-before.png"],
+        before_screenshot_paths: ["live-write-validation/send-message-before.png"],
+        cleanup_guidance: [],
+        completed_at: "2026-03-09T10:00:05.000Z",
+        confirm_artifacts: [],
+        ...(status === "fail"
+          ? {
+              error_code: "ACTION_PRECONDITION_FAILED",
+              error_message: "The approved thread could not be verified."
+            }
+          : {}),
+        expected_outcome:
+          "The outbound message is echoed in the approved conversation thread.",
+        linkedin_response: status === "pass" ? { sent: true } : undefined,
+        prepared_action_id: "prepared_123",
+        preview: {
+          action_type: "send_message",
+          expected_outcome:
+            "The outbound message is echoed in the approved conversation thread.",
+          outbound: {
+            text: "Quick validation ping • 2026-03-09T10:00:00.000Z"
+          },
+          risk_class: "private",
+          summary:
+            "Send a message in the approved thread and verify the outbound message appears.",
+          target: {
+            thread_id: "abc123"
+          }
+        },
+        risk_class: "private",
+        started_at: "2026-03-09T10:00:00.000Z",
+        state_synced: null,
+        status,
+        summary:
+          "Send a message in the approved thread and verify the outbound message appears.",
+        verification:
+          status === "pass"
+            ? {
+                details: {
+                  thread_id: "abc123"
+                },
+                message:
+                  "Sent message was re-observed in the approved conversation thread.",
+                source: "inbox.getThread",
+                verified: true
+              }
+            : undefined
+      }
+    ],
+    audit_log_path: "/tmp/events.jsonl",
+    cancelled_count: status === "cancelled" ? 1 : 0,
+    checked_at: "2026-03-09T10:00:06.000Z",
+    cooldown_ms: 10_000,
+    fail_count: status === "fail" ? 1 : 0,
+    latest_report_path: "/tmp/latest-report.json",
+    outcome,
+    pass_count: status === "pass" ? 1 : 0,
+    recommended_actions: ["Review /tmp/report.json"],
+    report_path: "/tmp/report.json",
+    run_id: "run_write_validation_test",
+    summary:
+      "Checked 1 write-validation actions. 1 passed. 0 failed. 0 cancelled. Overall outcome: pass.",
+    warning: "This will perform REAL actions on LinkedIn."
+  };
+}
+
+describe("write validation output", () => {
+  it("formats a human-readable report with action details", () => {
+    const output = formatWriteValidationReport(createReportFixture("fail"));
+
+    expect(output).toContain("Write Validation FAIL");
+    expect(output).toContain("Actions");
+    expect(output).toContain("send_message");
+    expect(output).toContain("error: The approved thread could not be verified.");
+    expect(output).toContain("Recommendations");
+  });
+
+  it("formats validation errors with details and help guidance", () => {
+    const error: LinkedInAssistantErrorPayload = {
+      code: "ACTION_PRECONDITION_FAILED",
+      details: {
+        account: "secondary"
+      },
+      message: "Write validation requires typing \"yes\" for every action."
+    };
+
+    const output = formatWriteValidationError(error, {
+      helpCommand: "linkedin test live --help"
+    });
+
+    expect(output).toContain(
+      "Write validation failed [ACTION_PRECONDITION_FAILED]"
+    );
+    expect(output).toContain("account: secondary");
+    expect(output).toContain("linkedin test live --help");
+  });
+
+  it("resolves json mode for explicit json and non-tty stdout", () => {
+    expect(resolveWriteValidationOutputMode({ json: true }, true)).toBe("json");
+    expect(resolveWriteValidationOutputMode({}, false)).toBe("json");
+    expect(resolveWriteValidationOutputMode({}, true)).toBe("human");
+  });
+});

--- a/packages/core/src/__tests__/e2e/helpers.ts
+++ b/packages/core/src/__tests__/e2e/helpers.ts
@@ -408,6 +408,60 @@ async function withOptionalTimeout<T>(
   });
 }
 
+async function withCommandExecutionEnvironment<T>(
+  options: CommandExecutionOptions,
+  execute: (cdpUrl: string | undefined) => Promise<T>
+): Promise<T> {
+  const run = () => execute(getCdpUrl());
+
+  if (options.assistantHome) {
+    return withAssistantHome(options.assistantHome, run);
+  }
+
+  return withE2EEnvironment(run);
+}
+
+async function retryTransientExecution<T>(input: {
+  execute: () => Promise<T>;
+  getRetryError?: (result: T) => unknown;
+  maxAttempts: number;
+  retryDelayMs: number;
+}): Promise<T> {
+  let lastError: unknown;
+  let lastResult: T | undefined;
+
+  for (let attempt = 1; attempt <= input.maxAttempts; attempt += 1) {
+    try {
+      const result = await input.execute();
+      lastResult = result;
+      const retryError = input.getRetryError?.(result);
+
+      if (
+        retryError === undefined ||
+        !shouldRetryTransientError(retryError) ||
+        attempt >= input.maxAttempts
+      ) {
+        return result;
+      }
+
+      lastError = retryError;
+    } catch (error) {
+      lastError = error;
+      if (!shouldRetryTransientError(error) || attempt >= input.maxAttempts) {
+        throw error;
+      }
+    }
+
+    await sleep(input.retryDelayMs);
+  }
+
+  if (lastResult !== undefined) {
+    return lastResult;
+  }
+
+  throw lastError ?? new Error("Command did not produce a result.");
+}
+
 async function captureCommandExecution(
   execute: () => Promise<void>
 ): Promise<CapturedCommandResult> {
@@ -567,50 +621,27 @@ export async function runCliCommandWith(
   const maxAttempts = resolveMaxAttempts(options.maxAttempts);
   const retryDelayMs = resolveRetryDelayMs(options.retryDelayMs);
   const timeoutMs = getTimeoutMs(options.timeoutMs);
-  let lastResult: CapturedCommandResult | undefined;
 
-  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    const execute = async (): Promise<void> => {
-      const cdpUrl = getCdpUrl();
-      await runner([
-        "node",
-        "linkedin",
-        ...(cdpUrl ? ["--cdp-url", cdpUrl] : []),
-        ...args
-      ]);
-    };
-
-    const wrappedExecution = async (): Promise<void> => {
-      if (options.assistantHome) {
-        await withAssistantHome(options.assistantHome, execute);
-        return;
-      }
-
-      await withE2EEnvironment(execute);
-    };
-
-    const result = await captureCommandExecution(() =>
-      withOptionalTimeout(
-        wrappedExecution(),
-        `CLI command ${args.join(" ")}`,
-        timeoutMs
-      )
-    );
-    lastResult = result;
-
-    if (!result.error || !shouldRetryTransientError(result.error) || attempt >= maxAttempts) {
-      return result;
-    }
-
-    await sleep(retryDelayMs);
-  }
-
-  return lastResult ?? {
-    stdout: "",
-    stderr: "",
-    exitCode: 1,
-    error: new Error("CLI command did not produce a result.")
-  };
+  return retryTransientExecution({
+    maxAttempts,
+    retryDelayMs,
+    execute: () =>
+      captureCommandExecution(() =>
+        withOptionalTimeout(
+          withCommandExecutionEnvironment(options, async (cdpUrl) => {
+            await runner([
+              "node",
+              "linkedin",
+              ...(cdpUrl ? ["--cdp-url", cdpUrl] : []),
+              ...args
+            ]);
+          }),
+          `CLI command ${args.join(" ")}`,
+          timeoutMs
+        )
+      ),
+    getRetryError: (result) => result.error
+  });
 }
 
 /** Invokes the real CLI entrypoint used by the contract suites. */
@@ -644,43 +675,24 @@ export async function callMcpToolWith(
   const maxAttempts = resolveMaxAttempts(options.maxAttempts);
   const retryDelayMs = resolveRetryDelayMs(options.retryDelayMs);
   const timeoutMs = getTimeoutMs(options.timeoutMs);
-  let lastError: unknown;
 
-  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    const execute = async (): Promise<unknown> => {
-      const cdpUrl = getCdpUrl();
-      return caller(name, {
-        ...args,
-        ...(cdpUrl ? { cdpUrl } : {})
-      });
-    };
-
-    const wrappedExecution = async (): Promise<unknown> => {
-      if (options.assistantHome) {
-        return await withAssistantHome(options.assistantHome, execute);
-      }
-
-      return await withE2EEnvironment(execute);
-    };
-
-    try {
-      const rawResult = await withOptionalTimeout(
-        wrappedExecution(),
+  const rawResult = await retryTransientExecution({
+    maxAttempts,
+    retryDelayMs,
+    execute: () =>
+      withOptionalTimeout(
+        withCommandExecutionEnvironment(options, (cdpUrl) => {
+          return caller(name, {
+            ...args,
+            ...(cdpUrl ? { cdpUrl } : {})
+          });
+        }),
         `MCP tool ${name}`,
         timeoutMs
-      );
-      return mapMcpToolResult(name, rawResult);
-    } catch (error) {
-      lastError = error;
-      if (!shouldRetryTransientError(error) || attempt >= maxAttempts) {
-        throw error;
-      }
+      )
+  });
 
-      await sleep(retryDelayMs);
-    }
-  }
-
-  throw lastError;
+  return mapMcpToolResult(name, rawResult);
 }
 
 /** Invokes the real MCP tool handler used by the contract suites. */

--- a/packages/core/src/__tests__/writeValidation.test.ts
+++ b/packages/core/src/__tests__/writeValidation.test.ts
@@ -6,7 +6,11 @@ import {
   runLinkedInWriteValidation,
   validateWriteValidationOptions
 } from "../writeValidation.js";
-import { upsertWriteValidationAccount } from "../writeValidationAccounts.js";
+import {
+  loadWriteValidationAccounts,
+  resolveWriteValidationAccount,
+  upsertWriteValidationAccount
+} from "../writeValidationAccounts.js";
 
 const tempDirs: string[] = [];
 
@@ -68,5 +72,72 @@ describe("write validation helpers", () => {
     ).rejects.toThrow(
       'Write validation can run only against a registered secondary account.'
     );
+  });
+
+  it("returns an empty registry when no accounts are configured", () => {
+    const baseDir = createTempBaseDir();
+
+    expect(loadWriteValidationAccounts(baseDir)).toEqual({
+      accounts: {},
+      configPath: expect.stringContaining("config.json")
+    });
+  });
+
+  it("normalizes stored account defaults and targets", async () => {
+    const baseDir = createTempBaseDir();
+
+    await upsertWriteValidationAccount({
+      accountId: "secondary-account",
+      baseDir,
+      designation: "secondary",
+      targets: {
+        "connections.send_invitation": {
+          note: "  Hello there  ",
+          targetProfile: "test-user"
+        },
+        "feed.like_post": {
+          postUrl: "/feed/update/urn:li:activity:123/",
+          reaction: "like"
+        },
+        "network.followup_after_accept": {
+          profileUrlKey: "test-user"
+        },
+        "post.create": {
+          visibility: "connections"
+        },
+        send_message: {
+          participantPattern: "  Test User  ",
+          thread: "/messaging/thread/abc123/"
+        }
+      }
+    });
+
+    expect(resolveWriteValidationAccount("secondary-account", baseDir)).toEqual({
+      designation: "secondary",
+      id: "secondary-account",
+      label: "secondary-account",
+      profileName: "secondary-account",
+      sessionName: "secondary-account",
+      targets: {
+        "connections.send_invitation": {
+          note: "Hello there",
+          targetProfile: "https://www.linkedin.com/in/test-user/"
+        },
+        "feed.like_post": {
+          postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+          reaction: "like"
+        },
+        "network.followup_after_accept": {
+          profileUrlKey: "https://www.linkedin.com/in/test-user/"
+        },
+        "post.create": {
+          visibility: "connections"
+        },
+        send_message: {
+          participantPattern: "Test User",
+          thread: "https://www.linkedin.com/messaging/thread/abc123/"
+        }
+      }
+    });
   });
 });

--- a/packages/core/src/__tests__/writeValidationAccounts.test.ts
+++ b/packages/core/src/__tests__/writeValidationAccounts.test.ts
@@ -1,0 +1,109 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  loadWriteValidationAccounts,
+  resolveWriteValidationAccount,
+  upsertWriteValidationAccount
+} from "../writeValidationAccounts.js";
+
+const tempDirs: string[] = [];
+
+function createTempBaseDir(): string {
+  const baseDir = mkdtempSync(path.join(os.tmpdir(), "linkedin-write-validation-accounts-"));
+  tempDirs.push(baseDir);
+  return baseDir;
+}
+
+afterEach(() => {
+  for (const tempDir of tempDirs.splice(0)) {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+describe("write-validation account registry", () => {
+  it("normalizes and persists approved targets", async () => {
+    const baseDir = createTempBaseDir();
+
+    await upsertWriteValidationAccount({
+      accountId: "secondary",
+      baseDir,
+      designation: "secondary",
+      label: " Secondary Account ",
+      profileName: " secondary-profile ",
+      sessionName: " secondary-session ",
+      targets: {
+        send_message: {
+          thread: "/messaging/thread/abc123/",
+          participantPattern: "  Simon Miller  "
+        },
+        "connections.send_invitation": {
+          note: "  hello there  ",
+          targetProfile: "realsimonmiller"
+        },
+        "network.followup_after_accept": {
+          profileUrlKey: "realsimonmiller"
+        },
+        "feed.like_post": {
+          postUrl: "/feed/update/urn:li:activity:123/",
+          reaction: "like"
+        },
+        "post.create": {
+          visibility: "connections"
+        }
+      }
+    });
+
+    expect(resolveWriteValidationAccount("secondary", baseDir)).toEqual({
+      id: "secondary",
+      designation: "secondary",
+      label: "Secondary Account",
+      profileName: "secondary-profile",
+      sessionName: "secondary-session",
+      targets: {
+        send_message: {
+          thread: "https://www.linkedin.com/messaging/thread/abc123/",
+          participantPattern: "Simon Miller"
+        },
+        "connections.send_invitation": {
+          note: "hello there",
+          targetProfile: "https://www.linkedin.com/in/realsimonmiller/"
+        },
+        "network.followup_after_accept": {
+          profileUrlKey: "https://www.linkedin.com/in/realsimonmiller/"
+        },
+        "feed.like_post": {
+          postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+          reaction: "like"
+        },
+        "post.create": {
+          visibility: "connections"
+        }
+      }
+    });
+  });
+
+  it("rejects non-object account registries with a clear config error", () => {
+    const baseDir = createTempBaseDir();
+    const configPath = path.join(baseDir, "config.json");
+
+    writeFileSync(
+      configPath,
+      `${JSON.stringify(
+        {
+          writeValidation: {
+            accounts: []
+          }
+        },
+        null,
+        2
+      )}\n`,
+      "utf8"
+    );
+
+    expect(() => loadWriteValidationAccounts(baseDir)).toThrow(
+      `writeValidation.accounts in ${configPath} must be a JSON object.`
+    );
+  });
+});

--- a/packages/core/src/writeValidation.ts
+++ b/packages/core/src/writeValidation.ts
@@ -1,237 +1,61 @@
-import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
-import {
-  chromium,
-  type Browser,
-  type BrowserContext,
-  type Page
-} from "playwright-core";
 import { ensureConfigPaths, resolveConfigPaths } from "./config.js";
 import {
   LinkedInAssistantError,
   asLinkedInAssistantError,
   type LinkedInAssistantErrorCode
 } from "./errors.js";
+import type { PreparedActionResult } from "./twoPhaseCommit.js";
+import { resolveWriteValidationAccount } from "./writeValidationAccounts.js";
+import type { WriteValidationProfileManager } from "./writeValidationRuntime.js";
+import { createWriteValidationRuntime } from "./writeValidationRuntime.js";
 import {
-  LIKE_POST_ACTION_TYPE,
-  normalizeLinkedInFeedReaction,
-  type LinkedInFeedReaction
-} from "./linkedinFeed.js";
+  LINKEDIN_WRITE_VALIDATION_ACTIONS,
+  WRITE_VALIDATION_SCENARIOS
+} from "./writeValidationScenarios.js";
 import {
-  SEND_INVITATION_ACTION_TYPE,
-  type LinkedInPendingInvitation
-} from "./linkedinConnections.js";
-import { FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE } from "./linkedinFollowups.js";
-import {
-  normalizeLinkedInProfileUrl,
-  resolveProfileUrl
-} from "./linkedinProfile.js";
-import {
-  CREATE_POST_ACTION_TYPE,
-  normalizeLinkedInPostVisibility
-} from "./linkedinPosts.js";
-import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
-import { LinkedInAuthService, type SessionStatus } from "./auth/session.js";
-import {
-  inspectLinkedInSession,
-  type LinkedInSessionInspection
-} from "./auth/sessionInspection.js";
-import {
-  LinkedInSessionStore,
-  type LinkedInBrowserStorageState
-} from "./auth/sessionStore.js";
-import {
-  ProfileManager,
-  type PersistentContextOptions
-} from "./profileManager.js";
-import { createCoreRuntime, type CoreRuntime } from "./runtime.js";
-import type {
-  ConfirmByTokenResult,
-  PreparedActionResult
-} from "./twoPhaseCommit.js";
-import {
-  resolveWriteValidationAccount,
-  type WriteValidationAccount,
-  type WriteValidationAccountTargets
-} from "./writeValidationAccounts.js";
+  DEFAULT_WRITE_VALIDATION_COOLDOWN_MS,
+  DEFAULT_WRITE_VALIDATION_TIMEOUT_MS,
+  WRITE_VALIDATION_LATEST_REPORT_NAME,
+  WRITE_VALIDATION_REPORT_DIR,
+  WRITE_VALIDATION_WARNING,
+  buildPreview,
+  buildRecommendedActions,
+  buildWriteValidationReportAccount,
+  buildWriteValidationSummary,
+  countActionStatuses,
+  dedupeStrings,
+  determineActionStatus,
+  determineOutcome,
+  isScreenshotPath,
+  readPreviewArtifacts,
+  writeJsonFile,
+  type LinkedInWriteValidationActionDefinition,
+  type RunLinkedInWriteValidationOptions,
+  type WriteValidationActionPreview,
+  type WriteValidationActionResult,
+  type WriteValidationReport,
+  type WriteValidationResultStatus,
+  type WriteValidationScenarioDefinition,
+  type WriteValidationVerificationResult
+} from "./writeValidationShared.js";
 
-const SEND_MESSAGE_ACTION_TYPE = "send_message";
-const WRITE_VALIDATION_WARNING = "This will perform REAL actions on LinkedIn.";
-const WRITE_VALIDATION_REPORT_DIR = "live-write-validation";
-const WRITE_VALIDATION_LATEST_REPORT_NAME = "latest-report.json";
-const DEFAULT_WRITE_VALIDATION_COOLDOWN_MS = 10_000;
-const DEFAULT_WRITE_VALIDATION_TIMEOUT_MS = 30_000;
-const WRITE_VALIDATION_FEED_URL = "https://www.linkedin.com/feed/";
+export { LINKEDIN_WRITE_VALIDATION_ACTIONS } from "./writeValidationScenarios.js";
+export type {
+  LinkedInWriteValidationActionType,
+  LinkedInWriteValidationActionDefinition,
+  RunLinkedInWriteValidationOptions,
+  WriteValidationActionPreview,
+  WriteValidationActionResult,
+  WriteValidationOutcome,
+  WriteValidationReport,
+  WriteValidationResultStatus,
+  WriteValidationVerificationResult
+} from "./writeValidationShared.js";
 
-type WriteValidationRiskClass = "private" | "network" | "public";
-export type LinkedInWriteValidationActionType =
-  | typeof CREATE_POST_ACTION_TYPE
-  | typeof SEND_INVITATION_ACTION_TYPE
-  | typeof SEND_MESSAGE_ACTION_TYPE
-  | typeof FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE
-  | typeof LIKE_POST_ACTION_TYPE;
-
-export type WriteValidationResultStatus = "pass" | "fail" | "cancelled";
-export type WriteValidationOutcome = WriteValidationResultStatus;
-
-export interface LinkedInWriteValidationActionDefinition {
-  actionType: LinkedInWriteValidationActionType;
-  expectedOutcome: string;
-  riskClass: WriteValidationRiskClass;
-  summary: string;
-}
-
-export const LINKEDIN_WRITE_VALIDATION_ACTIONS: readonly LinkedInWriteValidationActionDefinition[] = [
-  {
-    actionType: CREATE_POST_ACTION_TYPE,
-    summary: "Create a connections-only post and verify it appears in the feed.",
-    expectedOutcome: "A new post is published successfully and visible in the feed.",
-    riskClass: "public"
-  },
-  {
-    actionType: SEND_INVITATION_ACTION_TYPE,
-    summary: "Send a connection invitation to the approved profile and verify it appears in sent invitations.",
-    expectedOutcome:
-      "The approved profile shows a pending invitation or sent-invitation confirmation.",
-    riskClass: "network"
-  },
-  {
-    actionType: SEND_MESSAGE_ACTION_TYPE,
-    summary: "Send a message in the approved thread and verify the outbound message appears.",
-    expectedOutcome:
-      "The outbound message is echoed in the approved conversation thread.",
-    riskClass: "private"
-  },
-  {
-    actionType: FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE,
-    summary: "Send the approved follow-up after an accepted connection and verify it records as sent.",
-    expectedOutcome:
-      "The follow-up send succeeds and local follow-up state records the confirmation.",
-    riskClass: "network"
-  },
-  {
-    actionType: LIKE_POST_ACTION_TYPE,
-    summary: "React to the approved post and verify the reaction is registered.",
-    expectedOutcome: "The approved reaction is active on the approved post.",
-    riskClass: "public"
-  }
-] as const;
-
-export interface WriteValidationActionPreview {
-  action_type: LinkedInWriteValidationActionType;
-  expected_outcome: string;
-  outbound: Record<string, unknown>;
-  risk_class: WriteValidationRiskClass;
-  summary: string;
-  target: Record<string, unknown>;
-}
-
-export interface WriteValidationVerificationResult {
-  details: Record<string, unknown>;
-  message: string;
-  source: string;
-  state_synced: boolean | null;
-  verified: boolean;
-}
-
-export interface WriteValidationActionResult {
-  action_type: LinkedInWriteValidationActionType;
-  after_screenshot_paths: string[];
-  artifact_paths: string[];
-  before_screenshot_paths: string[];
-  cleanup_guidance: string[];
-  completed_at: string;
-  confirm_artifacts: string[];
-  error_code?: LinkedInAssistantErrorCode;
-  error_message?: string;
-  expected_outcome: string;
-  linkedin_response?: Record<string, unknown>;
-  prepared_action_id?: string;
-  preview?: WriteValidationActionPreview;
-  risk_class: WriteValidationRiskClass;
-  started_at: string;
-  status: WriteValidationResultStatus;
-  state_synced: boolean | null;
-  summary: string;
-  verification?: {
-    details: Record<string, unknown>;
-    message: string;
-    source: string;
-    verified: boolean;
-  };
-}
-
-export interface WriteValidationReport {
-  account: {
-    designation: WriteValidationAccount["designation"];
-    id: string;
-    label: string;
-    profile_name: string;
-    session_name: string;
-  };
-  action_count: number;
-  actions: WriteValidationActionResult[];
-  audit_log_path: string;
-  checked_at: string;
-  cooldown_ms: number;
-  fail_count: number;
-  latest_report_path: string;
-  outcome: WriteValidationOutcome;
-  pass_count: number;
-  cancelled_count: number;
-  recommended_actions: string[];
-  report_path: string;
-  run_id: string;
-  summary: string;
-  warning: string;
-}
-
-export interface RunLinkedInWriteValidationOptions {
-  accountId: string;
-  baseDir?: string;
-  cooldownMs?: number;
-  interactive?: boolean;
-  onBeforeAction?: (
-    preview: WriteValidationActionPreview
-  ) => Promise<boolean> | boolean;
-  timeoutMs?: number;
-}
-
-interface ScenarioPrepareResult {
-  beforeScreenshotUrl?: string;
-  cleanupGuidance: string[];
-  prepared: PreparedActionResult;
-  verificationContext: Record<string, unknown>;
-}
-
-interface WriteValidationScenarioDefinition {
-  actionType: LinkedInWriteValidationActionType;
-  expectedOutcome: string;
-  riskClass: WriteValidationRiskClass;
-  summary: string;
-  prepare: (
-    runtime: CoreRuntime,
-    account: WriteValidationAccount
-  ) => Promise<ScenarioPrepareResult>;
-  resolveAfterScreenshotUrl: (
-    account: WriteValidationAccount,
-    prepared: ScenarioPrepareResult,
-    confirmed: ConfirmByTokenResult
-  ) => string | null;
-  verify: (
-    runtime: CoreRuntime,
-    account: WriteValidationAccount,
-    prepared: ScenarioPrepareResult,
-    confirmed: ConfirmByTokenResult
-  ) => Promise<WriteValidationVerificationResult>;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function normalizeText(value: string | null | undefined): string {
-  return (value ?? "").replace(/\s+/gu, " ").trim();
+interface PreparedArtifacts {
+  beforeScreenshotPaths: string[];
+  previewArtifacts: string[];
 }
 
 function isTruthyCiValue(value: string | undefined): boolean {
@@ -243,45 +67,18 @@ function isTruthyCiValue(value: string | undefined): boolean {
   return normalized.length > 0 && normalized !== "0" && normalized !== "false";
 }
 
-function createWriteValidationTag(): string {
-  return new Date().toISOString();
+function readPreparedArtifacts(prepared: PreparedActionResult): PreparedArtifacts {
+  const previewArtifacts = dedupeStrings(readPreviewArtifacts(prepared.preview));
+
+  return {
+    previewArtifacts,
+    beforeScreenshotPaths: previewArtifacts.filter(isScreenshotPath)
+  };
 }
 
-function buildWriteValidationPostText(): string {
-  return `Quick validation update • ${createWriteValidationTag()}`;
-}
-
-function buildWriteValidationMessageText(): string {
-  return `Quick validation ping • ${createWriteValidationTag()}`;
-}
-
-function dedupeStrings(values: readonly string[]): string[] {
-  return [...new Set(values.filter((value) => value.trim().length > 0))];
-}
-
-function isScreenshotPath(value: string): boolean {
-  return /\.png$/iu.test(value.trim());
-}
-
-function readPreviewArtifacts(preview: Record<string, unknown>): string[] {
-  const artifacts = preview.artifacts;
-  if (!Array.isArray(artifacts)) {
-    return [];
-  }
-
-  return artifacts
-    .map((artifact) => {
-      if (!isRecord(artifact)) {
-        return null;
-      }
-
-      const pathValue = artifact.path;
-      return typeof pathValue === "string" ? pathValue : null;
-    })
-    .filter((artifactPath): artifactPath is string => typeof artifactPath === "string");
-}
-
-function assertInteractiveWriteValidation(options: RunLinkedInWriteValidationOptions): void {
+function assertInteractiveWriteValidation(
+  options: RunLinkedInWriteValidationOptions
+): void {
   if (options.interactive === false) {
     throw new LinkedInAssistantError(
       "ACTION_PRECONDITION_FAILED",
@@ -303,7 +100,7 @@ export function validateWriteValidationOptions(
   cooldownMs: number;
   timeoutMs: number;
 } {
-  const accountId = normalizeText(options.accountId);
+  const accountId = options.accountId.trim();
   if (!accountId) {
     throw new LinkedInAssistantError(
       "ACTION_PRECONDITION_FAILED",
@@ -319,8 +116,7 @@ export function validateWriteValidationOptions(
     );
   }
 
-  const cooldownMs =
-    options.cooldownMs ?? DEFAULT_WRITE_VALIDATION_COOLDOWN_MS;
+  const cooldownMs = options.cooldownMs ?? DEFAULT_WRITE_VALIDATION_COOLDOWN_MS;
   if (!Number.isInteger(cooldownMs) || cooldownMs < 0) {
     throw new LinkedInAssistantError(
       "ACTION_PRECONDITION_FAILED",
@@ -335,836 +131,322 @@ export function validateWriteValidationOptions(
   };
 }
 
-function resolveThreadUrl(thread: string): string {
-  const trimmedThread = thread.trim();
-  if (!trimmedThread) {
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
-      "Thread identifier is required."
-    );
-  }
-
-  if (/^https?:\/\//iu.test(trimmedThread)) {
-    const parsedUrl = new URL(trimmedThread);
-    return `${parsedUrl.origin}${parsedUrl.pathname}${parsedUrl.search}`.replace(
-      /\/$/u,
-      "/"
-    );
-  }
-
-  if (trimmedThread.startsWith("/messaging/thread/")) {
-    return `https://www.linkedin.com${trimmedThread}`;
-  }
-
-  return `https://www.linkedin.com/messaging/thread/${encodeURIComponent(trimmedThread)}/`;
-}
-
-function getRequiredTarget<T>(
-  targets: WriteValidationAccountTargets,
-  actionType: keyof WriteValidationAccountTargets,
-  accountId: string
-): T {
-  const target = targets[actionType];
-  if (target !== undefined) {
-    return target as T;
+function ensureSecondaryWriteValidationAccount(account: {
+  designation: string;
+  id: string;
+}): void {
+  if (account.designation === "secondary") {
+    return;
   }
 
   throw new LinkedInAssistantError(
     "ACTION_PRECONDITION_FAILED",
-    `Write-validation account "${accountId}" is missing targets.${String(actionType)} in config.json.`,
+    `Write validation can run only against a registered secondary account. Account "${account.id}" is marked as ${account.designation}.`,
     {
-      account_id: accountId,
-      missing_target_key: actionType
+      account_id: account.id,
+      designation: account.designation
     }
   );
 }
 
-function matchPendingInvitation(
-  invitations: LinkedInPendingInvitation[],
-  targetProfile: string
-): LinkedInPendingInvitation | null {
-  const normalizedTargetProfile = normalizeLinkedInProfileUrl(
-    resolveProfileUrl(targetProfile)
-  );
-  const targetSlug = /\/in\/([^/?#]+)/u.exec(normalizedTargetProfile)?.[1] ?? null;
-
-  for (const invitation of invitations) {
-    const normalizedInvitationProfile = normalizeLinkedInProfileUrl(
-      resolveProfileUrl(invitation.profile_url)
-    );
-
-    if (normalizedInvitationProfile === normalizedTargetProfile) {
-      return invitation;
-    }
-
-    if (
-      targetSlug !== null &&
-      typeof invitation.vanity_name === "string" &&
-      invitation.vanity_name.trim().toLowerCase() === targetSlug.toLowerCase()
-    ) {
-      return invitation;
-    }
-  }
-
-  return null;
-}
-
-function extractRecentMessageText(messages: readonly { text: string }[]): string | null {
-  const lastMessage = [...messages]
-    .reverse()
-    .find((message) => normalizeText(message.text).length > 0);
-  return lastMessage ? normalizeText(lastMessage.text) : null;
-}
-
-function buildWriteValidationSummary(report: Pick<WriteValidationReport, "action_count" | "pass_count" | "fail_count" | "cancelled_count" | "outcome">): string {
-  const parts = [
-    `Checked ${report.action_count} write-validation actions.`,
-    `${report.pass_count} passed.`,
-    `${report.fail_count} failed.`,
-    `${report.cancelled_count} cancelled.`
-  ];
-  return `${parts.join(" ")} Overall outcome: ${report.outcome}.`;
-}
-
-function buildRecommendedActions(report: Pick<WriteValidationReport, "actions" | "report_path" | "audit_log_path">): string[] {
-  const actions: string[] = [
-    `Review ${report.report_path} for the full per-action report and screenshots.`,
-    `Open ${report.audit_log_path} to inspect the structured audit log for this run.`
-  ];
-
-  for (const action of report.actions) {
-    actions.push(...action.cleanup_guidance);
-    if (action.status === "fail") {
-      actions.push(
-        `Re-check ${action.action_type} after reviewing ${report.report_path} and the attached screenshots.`
-      );
-    }
-  }
-
-  return dedupeStrings(actions);
-}
-
-async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
-  await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
-}
-
-async function getOrCreatePage(context: BrowserContext): Promise<Page> {
-  const existing = context.pages()[0];
-  if (existing) {
-    return existing;
-  }
-
-  return context.newPage();
-}
-
-class StoredSessionProfileManager extends ProfileManager {
-  private browser: Browser | null = null;
-  private browserPromise: Promise<Browser> | null = null;
-
-  constructor(
-    paths: ReturnType<typeof resolveConfigPaths>,
-    private readonly storageState: LinkedInBrowserStorageState,
-    private readonly timeoutMs: number,
-    private readonly runtime: CoreRuntime
-  ) {
-    super(paths);
-  }
-
-  private async getBrowser(): Promise<Browser> {
-    if (this.browser) {
-      return this.browser;
-    }
-
-    if (this.browserPromise) {
-      return this.browserPromise;
-    }
-
-    const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
-    this.browserPromise = chromium
-      .launch({
-        headless: false,
-        ...(executablePath ? { executablePath } : {})
-      })
-      .then((browser) => {
-        this.browser = browser;
-        return browser;
-      });
-
-    return this.browserPromise;
-  }
-
-  override async runWithPersistentContext<T>(
-    profileName: string,
-    options: PersistentContextOptions,
-    callback: (context: BrowserContext) => Promise<T>
-  ): Promise<T> {
-    void profileName;
-    void options;
-    const browser = await this.getBrowser();
-    const context = await browser.newContext({
-      storageState: this.storageState
-    });
-
-    context.setDefaultNavigationTimeout(this.timeoutMs);
-    context.setDefaultTimeout(this.timeoutMs);
-
-    try {
-      return await callback(context);
-    } finally {
-      await context.close().catch(() => undefined);
-    }
-  }
-
-  override async runWithCDP<T>(
-    cdpUrl: string,
-    callback: (context: BrowserContext) => Promise<T>
-  ): Promise<T> {
-    void cdpUrl;
-    void callback;
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
-      "Stored-session write validation does not support CDP or external browser attachment."
-    );
-  }
-
-  override async runWithCDPResilient<T>(
-    cdpUrl: string,
-    callback: (context: BrowserContext) => Promise<T>,
-    options?: { maxRetries?: number; retryDelayMs?: number }
-  ): Promise<T> {
-    void cdpUrl;
-    void callback;
-    void options;
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
-      "Stored-session write validation does not support CDP or external browser attachment."
-    );
-  }
-
-  override async runWithContext<T>(
-    options: { cdpUrl?: string | undefined; profileName: string; headless?: boolean },
-    callback: (context: BrowserContext) => Promise<T>
-  ): Promise<T> {
-    if (options.cdpUrl) {
-      throw new LinkedInAssistantError(
-        "ACTION_PRECONDITION_FAILED",
-        "Stored-session write validation does not support CDP or external browser attachment."
-      );
-    }
-
-    return this.runWithPersistentContext(options.profileName, { headless: false }, callback);
-  }
-
-  async inspectSession(): Promise<LinkedInSessionInspection> {
-    return this.runWithPersistentContext(
-      "session-inspection",
-      { headless: false },
-      async (context) => {
-        const page = await getOrCreatePage(context);
-        await page.goto(WRITE_VALIDATION_FEED_URL, {
-          waitUntil: "domcontentloaded"
-        });
-        await waitForNetworkIdleBestEffort(page, this.timeoutMs);
-        return inspectLinkedInSession(page, {
-          selectorLocale: this.runtime.selectorLocale
-        });
-      }
-    );
-  }
-
-  async capturePageScreenshot(input: {
-    actionType: LinkedInWriteValidationActionType;
-    stage: "before" | "after";
-    url: string;
-  }): Promise<string> {
-    const relativePath = `${WRITE_VALIDATION_REPORT_DIR}/${slugifyActionType(input.actionType)}-${input.stage}-${Date.now()}.png`;
-
-    await this.runWithPersistentContext(
-      `screenshot-${input.stage}`,
-      { headless: false },
-      async (context) => {
-        const page = await getOrCreatePage(context);
-        await page.goto(input.url, {
-          waitUntil: "domcontentloaded"
-        });
-        await waitForNetworkIdleBestEffort(page, this.timeoutMs);
-        const absolutePath = this.runtime.artifacts.resolve(relativePath);
-        await page.screenshot({ fullPage: true, path: absolutePath });
-      }
-    );
-
-    this.runtime.artifacts.registerArtifact(relativePath, "image/png", {
-      action: input.actionType,
-      capture_stage: input.stage,
-      capture_url: input.url
-    });
-
-    return relativePath;
-  }
-
-  async dispose(): Promise<void> {
-    this.browserPromise = null;
-    const browser = this.browser;
-    this.browser = null;
-    if (browser) {
-      await browser.close().catch(() => undefined);
-    }
-  }
-}
-
-class StoredSessionAuthService extends LinkedInAuthService {
-  constructor(
-    profileManager: ProfileManager,
-    private readonly sessionStatus: SessionStatus
-  ) {
-    super(profileManager, undefined);
-  }
-
-  override async status(): Promise<SessionStatus> {
-    return {
-      ...this.sessionStatus,
-      checkedAt: new Date().toISOString()
-    };
-  }
-
-  override async ensureAuthenticated(): Promise<SessionStatus> {
-    if (!this.sessionStatus.authenticated) {
-      throw new LinkedInAssistantError(
-        this.sessionStatus.currentUrl.includes("/checkpoint")
-          ? "CAPTCHA_OR_CHALLENGE"
-          : "AUTH_REQUIRED",
-        this.sessionStatus.reason,
-        {
-          checked_at: this.sessionStatus.checkedAt,
-          current_url: this.sessionStatus.currentUrl
-        }
-      );
-    }
-
-    return {
-      ...this.sessionStatus,
-      checkedAt: new Date().toISOString()
-    };
-  }
-}
-
-function slugifyActionType(actionType: string): string {
-  return actionType
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/gu, "-")
-    .replace(/^-+|-+$/gu, "") || "action";
-}
-
-const WRITE_VALIDATION_SCENARIOS: Record<
-  LinkedInWriteValidationActionType,
-  WriteValidationScenarioDefinition
-> = {
-  [CREATE_POST_ACTION_TYPE]: {
-    actionType: CREATE_POST_ACTION_TYPE,
-    summary:
-      "Create a connections-only post and verify it appears in the feed.",
-    expectedOutcome:
-      "A new post is published successfully and visible in the feed.",
-    riskClass: "public",
-    async prepare(runtime, account) {
-      const visibility = normalizeLinkedInPostVisibility(
-        account.targets["post.create"]?.visibility,
-        "connections"
-      );
-      const text = buildWriteValidationPostText();
-      const prepared = await runtime.posts.prepareCreate({
-        profileName: account.profileName,
-        text,
-        visibility,
-        operatorNote: "Tier 3 write-validation harness"
-      });
-
-      return {
-        prepared,
-        beforeScreenshotUrl: WRITE_VALIDATION_FEED_URL,
-        cleanupGuidance: [
-          "Delete the validation post manually after review if you do not want it to remain in the feed."
-        ],
-        verificationContext: {
-          post_text: text,
-          visibility
-        }
-      };
-    },
-    resolveAfterScreenshotUrl(_account, _prepared, confirmed) {
-      const publishedPostUrl = confirmed.result.published_post_url;
-      return typeof publishedPostUrl === "string" ? publishedPostUrl : WRITE_VALIDATION_FEED_URL;
-    },
-    async verify(runtime, account, prepared, confirmed) {
-      const publishedPostUrl = confirmed.result.published_post_url;
-      const expectedText =
-        typeof prepared.verificationContext.post_text === "string"
-          ? prepared.verificationContext.post_text
-          : "";
-
-      if (typeof publishedPostUrl !== "string") {
-        return {
-          verified: false,
-          state_synced: null,
-          source: "post_publish_result",
-          message: "Post publish result did not include a published_post_url.",
-          details: {
-            result: confirmed.result
-          }
-        };
-      }
-
-      const post = await runtime.feed.viewPost({
-        profileName: account.profileName,
-        postUrl: publishedPostUrl
-      });
-
-      const verified = normalizeText(post.text).includes(normalizeText(expectedText));
-
-      return {
-        verified,
-        state_synced: null,
-        source: "feed.viewPost",
-        message: verified
-          ? "Published post was re-observed in LinkedIn feed content."
-          : "Published post could not be matched by text in the feed after confirmation.",
-        details: {
-          post_url: publishedPostUrl,
-          observed_text: post.text
-        }
-      };
-    }
-  },
-  [SEND_INVITATION_ACTION_TYPE]: {
-    actionType: SEND_INVITATION_ACTION_TYPE,
-    summary:
-      "Send a connection invitation to the approved profile and verify it appears in sent invitations.",
-    expectedOutcome:
-      "The approved profile shows a pending invitation or sent-invitation confirmation.",
-    riskClass: "network",
-    async prepare(runtime, account) {
-      const target = getRequiredTarget<{
-        note?: string;
-        targetProfile: string;
-      }>(
-        account.targets,
-        "connections.send_invitation",
-        account.id
-      );
-
-      const prepared = runtime.connections.prepareSendInvitation({
-        profileName: account.profileName,
-        targetProfile: target.targetProfile,
-        ...(target.note ? { note: target.note } : {}),
-        operatorNote: "Tier 3 write-validation harness"
-      });
-
-      return {
-        prepared,
-        beforeScreenshotUrl: resolveProfileUrl(target.targetProfile),
-        cleanupGuidance: [
-          "Withdraw the validation invitation manually after review if the recipient should not keep it pending."
-        ],
-        verificationContext: {
-          target_profile: target.targetProfile
-        }
-      };
-    },
-    resolveAfterScreenshotUrl(_account, prepared) {
-      const targetProfile = prepared.verificationContext.target_profile;
-      return typeof targetProfile === "string"
-        ? resolveProfileUrl(targetProfile)
-        : null;
-    },
-    async verify(runtime, account, prepared) {
-      const targetProfile = prepared.verificationContext.target_profile;
-      if (typeof targetProfile !== "string") {
-        return {
-          verified: false,
-          state_synced: false,
-          source: "connections.listPendingInvitations",
-          message: "Connection target profile was missing from the verification context.",
-          details: {}
-        };
-      }
-
-      const invitations = await runtime.connections.listPendingInvitations({
-        profileName: account.profileName,
-        filter: "sent"
-      });
-      const matchedInvitation = matchPendingInvitation(invitations, targetProfile);
-      const stateRow = runtime.db.getSentInvitationState({
-        profileName: account.profileName,
-        profileUrlKey: normalizeLinkedInProfileUrl(resolveProfileUrl(targetProfile))
-      });
-
-      return {
-        verified: matchedInvitation !== null,
-        state_synced: stateRow !== undefined,
-        source: "connections.listPendingInvitations",
-        message:
-          matchedInvitation !== null
-            ? "Sent invitation was re-observed in the pending sent-invitations list."
-            : "Sent invitation could not be re-observed in the pending sent-invitations list.",
-        details: {
-          target_profile: targetProfile,
-          matched_invitation: matchedInvitation,
-          state_synced: stateRow !== undefined
-        }
-      };
-    }
-  },
-  [SEND_MESSAGE_ACTION_TYPE]: {
-    actionType: SEND_MESSAGE_ACTION_TYPE,
-    summary:
-      "Send a message in the approved thread and verify the outbound message appears.",
-    expectedOutcome:
-      "The outbound message is echoed in the approved conversation thread.",
-    riskClass: "private",
-    async prepare(runtime, account) {
-      const target = getRequiredTarget<{
-        participantPattern?: string;
-        thread: string;
-      }>(account.targets, "send_message", account.id);
-      const text = buildWriteValidationMessageText();
-
-      const prepared = await runtime.inbox.prepareReply({
-        profileName: account.profileName,
-        thread: target.thread,
-        text,
-        operatorNote: "Tier 3 write-validation harness"
-      });
-
-      return {
-        prepared,
-        beforeScreenshotUrl: resolveThreadUrl(target.thread),
-        cleanupGuidance: [],
-        verificationContext: {
-          message_text: text,
-          participant_pattern: target.participantPattern,
-          thread: target.thread
-        }
-      };
-    },
-    resolveAfterScreenshotUrl(_account, prepared) {
-      const thread = prepared.verificationContext.thread;
-      return typeof thread === "string" ? resolveThreadUrl(thread) : null;
-    },
-    async verify(runtime, account, prepared) {
-      const expectedText = prepared.verificationContext.message_text;
-      const thread = prepared.verificationContext.thread;
-
-      if (typeof expectedText !== "string" || typeof thread !== "string") {
-        return {
-          verified: false,
-          state_synced: null,
-          source: "inbox.getThread",
-          message: "Message verification context was incomplete.",
-          details: {}
-        };
-      }
-
-      const detail = await runtime.inbox.getThread({
-        profileName: account.profileName,
-        thread,
-        limit: 8
-      });
-      const recentMessageText = extractRecentMessageText(detail.messages);
-      const verified = recentMessageText === normalizeText(expectedText);
-
-      return {
-        verified,
-        state_synced: null,
-        source: "inbox.getThread",
-        message: verified
-          ? "Sent message was re-observed in the approved conversation thread."
-          : "Sent message was not found as the most recent thread message after confirmation.",
-        details: {
-          thread_id: detail.thread_id,
-          recent_message_text: recentMessageText,
-          expected_text: expectedText
-        }
-      };
-    }
-  },
-  [FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE]: {
-    actionType: FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE,
-    summary:
-      "Send the approved follow-up after an accepted connection and verify it records as sent.",
-    expectedOutcome:
-      "The follow-up send succeeds and local follow-up state records the confirmation.",
-    riskClass: "network",
-    async prepare(runtime, account) {
-      const target = getRequiredTarget<{
-        profileUrlKey: string;
-      }>(account.targets, "network.followup_after_accept", account.id);
-
-      const preparedFollowup = await runtime.followups.prepareFollowupForAcceptedConnection({
-        profileName: account.profileName,
-        profileUrlKey: target.profileUrlKey,
-        refreshState: true,
-        operatorNote: "Tier 3 write-validation harness"
-      });
-
-      if (!preparedFollowup) {
-        throw new LinkedInAssistantError(
-          "ACTION_PRECONDITION_FAILED",
-          `No accepted connection follow-up could be prepared for ${target.profileUrlKey}.`,
-          {
-            account_id: account.id,
-            profile_name: account.profileName,
-            profile_url_key: target.profileUrlKey
-          }
-        );
-      }
-
-      return {
-        prepared: {
-          preparedActionId: preparedFollowup.preparedActionId,
-          confirmToken: preparedFollowup.confirmToken,
-          expiresAtMs: preparedFollowup.expiresAtMs,
-          preview: preparedFollowup.preview
-        },
-        beforeScreenshotUrl: resolveProfileUrl(target.profileUrlKey),
-        cleanupGuidance: [],
-        verificationContext: {
-          profile_url_key: target.profileUrlKey
-        }
-      };
-    },
-    resolveAfterScreenshotUrl(_account, prepared, confirmed) {
-      const profileUrl = confirmed.result.profile_url;
-      if (typeof profileUrl === "string") {
-        return resolveProfileUrl(profileUrl);
-      }
-
-      const profileUrlKey = prepared.verificationContext.profile_url_key;
-      return typeof profileUrlKey === "string"
-        ? resolveProfileUrl(profileUrlKey)
-        : null;
-    },
-    async verify(runtime, account, prepared, confirmed) {
-      const profileUrlKey = prepared.verificationContext.profile_url_key;
-      if (typeof profileUrlKey !== "string") {
-        return {
-          verified: false,
-          state_synced: false,
-          source: "followups.confirm_result",
-          message: "Follow-up verification context was incomplete.",
-          details: {}
-        };
-      }
-
-      const stateRow = runtime.db.getSentInvitationState({
-        profileName: account.profileName,
-        profileUrlKey
-      });
-
-      return {
-        verified: confirmed.result.sent === true,
-        state_synced: stateRow?.followup_confirmed_at !== null,
-        source: "followups.confirm_result",
-        message:
-          confirmed.result.sent === true
-            ? "Follow-up send returned a positive message-echo confirmation."
-            : "Follow-up send did not report a positive message-echo confirmation.",
-        details: {
-          profile_url_key: profileUrlKey,
-          followup_confirmed_at: stateRow?.followup_confirmed_at ?? null,
-          confirm_result: confirmed.result
-        }
-      };
-    }
-  },
-  [LIKE_POST_ACTION_TYPE]: {
-    actionType: LIKE_POST_ACTION_TYPE,
-    summary:
-      "React to the approved post and verify the reaction is registered.",
-    expectedOutcome: "The approved reaction is active on the approved post.",
-    riskClass: "public",
-    async prepare(runtime, account) {
-      const target = getRequiredTarget<{
-        postUrl: string;
-        reaction?: LinkedInFeedReaction;
-      }>(account.targets, "feed.like_post", account.id);
-      const reaction = normalizeLinkedInFeedReaction(target.reaction, "like");
-
-      const prepared = runtime.feed.prepareLikePost({
-        profileName: account.profileName,
-        postUrl: target.postUrl,
-        reaction,
-        operatorNote: "Tier 3 write-validation harness"
-      });
-
-      return {
-        prepared,
-        beforeScreenshotUrl: target.postUrl,
-        cleanupGuidance: [
-          "Remove the validation reaction manually after review if you do not want it to remain on the post."
-        ],
-        verificationContext: {
-          post_url: target.postUrl,
-          reaction
-        }
-      };
-    },
-    resolveAfterScreenshotUrl(_account, prepared) {
-      const postUrl = prepared.verificationContext.post_url;
-      return typeof postUrl === "string" ? postUrl : null;
-    },
-    async verify(_runtime, _account, _prepared, confirmed) {
-      const reaction = confirmed.result.reaction;
-      const verified = confirmed.result.reacted === true;
-
-      return {
-        verified,
-        state_synced: null,
-        source: "feed.like_post.confirm_result",
-        message: verified
-          ? "Reaction executor reported the target reaction as active after confirmation."
-          : "Reaction executor did not report the target reaction as active after confirmation.",
-        details: {
-          confirm_result: confirmed.result,
-          reaction
-        }
-      };
-    }
-  }
-};
-
-async function sleep(ms: number): Promise<void> {
-  await new Promise<void>((resolve) => {
+function sleep(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => {
     setTimeout(resolve, ms);
   });
 }
 
-function toSessionStatus(inspection: LinkedInSessionInspection): SessionStatus {
-  return {
-    authenticated: inspection.authenticated,
-    checkedAt: inspection.checkedAt,
-    currentUrl: inspection.currentUrl,
-    reason: inspection.reason
-  };
-}
+async function ensureScenarioScreenshotPaths(input: {
+  actionType: WriteValidationActionResult["action_type"];
+  existingPaths: readonly string[];
+  profileManager: WriteValidationProfileManager;
+  stage: "before" | "after";
+  url?: string | null | undefined;
+}): Promise<string[]> {
+  const screenshotPaths = [...input.existingPaths];
 
-function buildPreview(
-  scenario: WriteValidationScenarioDefinition,
-  prepared: PreparedActionResult
-): WriteValidationActionPreview {
-  const target = isRecord(prepared.preview.target) ? prepared.preview.target : {};
-  const outbound = isRecord(prepared.preview.outbound)
-    ? prepared.preview.outbound
-    : {};
-
-  return {
-    action_type: scenario.actionType,
-    expected_outcome: scenario.expectedOutcome,
-    outbound,
-    risk_class: scenario.riskClass,
-    summary: scenario.summary,
-    target
-  };
-}
-
-function determineActionStatus(verification: WriteValidationVerificationResult): WriteValidationResultStatus {
-  if (!verification.verified) {
-    return "fail";
-  }
-
-  if (verification.state_synced === false) {
-    return "fail";
-  }
-
-  return "pass";
-}
-
-async function createWriteValidationRuntime(input: {
-  account: WriteValidationAccount;
-  baseDir?: string;
-  timeoutMs: number;
-}): Promise<{
-  profileManager: StoredSessionProfileManager;
-  runtime: CoreRuntime;
-}> {
-  const runtime = createCoreRuntime(
-    input.baseDir
-      ? {
-          baseDir: input.baseDir
-        }
-      : {}
-  );
-  const store = new LinkedInSessionStore(input.baseDir);
-  const loadedSession = await store.load(input.account.sessionName);
-  const profileManager = new StoredSessionProfileManager(
-    runtime.paths,
-    loadedSession.storageState,
-    input.timeoutMs,
-    runtime
-  );
-  const inspection = await profileManager.inspectSession();
-
-  if (!inspection.authenticated) {
-    throw new LinkedInAssistantError(
-      inspection.currentUrl.includes("/checkpoint")
-        ? "CAPTCHA_OR_CHALLENGE"
-        : "AUTH_REQUIRED",
-      inspection.reason,
-      {
-        checked_at: inspection.checkedAt,
-        current_url: inspection.currentUrl,
-        session_name: input.account.sessionName
-      }
+  if (screenshotPaths.length === 0 && typeof input.url === "string") {
+    screenshotPaths.push(
+      await input.profileManager.capturePageScreenshot({
+        actionType: input.actionType,
+        stage: input.stage,
+        url: input.url
+      })
     );
   }
 
-  runtime.profileManager = profileManager;
-  runtime.auth = new StoredSessionAuthService(
-    profileManager,
-    toSessionStatus(inspection)
-  );
+  return dedupeStrings(screenshotPaths);
+}
 
+function buildCancelledActionResult(input: {
+  preview: WriteValidationActionPreview;
+  prepared: PreparedActionResult;
+  preparedArtifacts: PreparedArtifacts;
+  scenario: WriteValidationScenarioDefinition;
+  startedAt: string;
+  cleanupGuidance: string[];
+}): WriteValidationActionResult {
   return {
-    runtime,
-    profileManager
+    action_type: input.scenario.actionType,
+    after_screenshot_paths: [],
+    artifact_paths: input.preparedArtifacts.previewArtifacts,
+    before_screenshot_paths: input.preparedArtifacts.beforeScreenshotPaths,
+    cleanup_guidance: input.cleanupGuidance,
+    completed_at: new Date().toISOString(),
+    confirm_artifacts: [],
+    expected_outcome: input.scenario.expectedOutcome,
+    prepared_action_id: input.prepared.preparedActionId,
+    preview: input.preview,
+    risk_class: input.scenario.riskClass,
+    started_at: input.startedAt,
+    state_synced: null,
+    status: "cancelled",
+    summary: input.scenario.summary
   };
 }
 
-function countActionStatuses(actions: readonly WriteValidationActionResult[]): {
-  cancelledCount: number;
-  failCount: number;
-  passCount: number;
-} {
-  return actions.reduce(
-    (counts, action) => {
-      if (action.status === "pass") {
-        counts.passCount += 1;
-      } else if (action.status === "fail") {
-        counts.failCount += 1;
-      } else {
-        counts.cancelledCount += 1;
-      }
-      return counts;
-    },
-    {
-      cancelledCount: 0,
-      failCount: 0,
-      passCount: 0
+function buildCompletedActionResult(input: {
+  afterScreenshotPaths: string[];
+  beforeScreenshotPaths: string[];
+  cleanupGuidance: string[];
+  confirmArtifacts: string[];
+  linkedinResponse: Record<string, unknown>;
+  prepared: PreparedActionResult;
+  preparedArtifacts: PreparedArtifacts;
+  preview: WriteValidationActionPreview;
+  scenario: WriteValidationScenarioDefinition;
+  startedAt: string;
+  status: WriteValidationResultStatus;
+  verification: WriteValidationVerificationResult;
+}): WriteValidationActionResult {
+  return {
+    action_type: input.scenario.actionType,
+    after_screenshot_paths: input.afterScreenshotPaths,
+    artifact_paths: dedupeStrings([
+      ...input.preparedArtifacts.previewArtifacts,
+      ...input.beforeScreenshotPaths,
+      ...input.confirmArtifacts,
+      ...input.afterScreenshotPaths
+    ]),
+    before_screenshot_paths: input.beforeScreenshotPaths,
+    cleanup_guidance: input.cleanupGuidance,
+    completed_at: new Date().toISOString(),
+    confirm_artifacts: input.confirmArtifacts,
+    expected_outcome: input.scenario.expectedOutcome,
+    linkedin_response: input.linkedinResponse,
+    prepared_action_id: input.prepared.preparedActionId,
+    preview: input.preview,
+    risk_class: input.scenario.riskClass,
+    started_at: input.startedAt,
+    state_synced: input.verification.state_synced,
+    status: input.status,
+    summary: input.scenario.summary,
+    verification: {
+      details: input.verification.details,
+      message: input.verification.message,
+      source: input.verification.source,
+      verified: input.verification.verified
     }
-  );
+  };
 }
 
-function determineOutcome(actions: readonly WriteValidationActionResult[]): WriteValidationOutcome {
-  if (actions.some((action) => action.status === "fail")) {
-    return "fail";
-  }
+function buildFailedActionResult(input: {
+  errorCode: LinkedInAssistantErrorCode;
+  errorMessage: string;
+  scenario: WriteValidationScenarioDefinition;
+  startedAt: string;
+}): WriteValidationActionResult {
+  return {
+    action_type: input.scenario.actionType,
+    after_screenshot_paths: [],
+    artifact_paths: [],
+    before_screenshot_paths: [],
+    cleanup_guidance: [],
+    completed_at: new Date().toISOString(),
+    confirm_artifacts: [],
+    error_code: input.errorCode,
+    error_message: input.errorMessage,
+    expected_outcome: input.scenario.expectedOutcome,
+    risk_class: input.scenario.riskClass,
+    started_at: input.startedAt,
+    state_synced: null,
+    status: "fail",
+    summary: input.scenario.summary
+  };
+}
 
-  if (actions.some((action) => action.status === "cancelled")) {
-    return "cancelled";
-  }
+async function executeWriteValidationScenario(input: {
+  account: ReturnType<typeof resolveWriteValidationAccount>;
+  onBeforeAction?: RunLinkedInWriteValidationOptions["onBeforeAction"];
+  profileManager: WriteValidationProfileManager;
+  runtime: Awaited<ReturnType<typeof createWriteValidationRuntime>>["runtime"];
+  scenario: WriteValidationScenarioDefinition;
+}): Promise<WriteValidationActionResult> {
+  const startedAt = new Date().toISOString();
 
-  return "pass";
+  input.runtime.logger.log("info", "write_validation.action.start", {
+    account_id: input.account.id,
+    action_type: input.scenario.actionType
+  });
+
+  try {
+    const prepared = await input.scenario.prepare(input.runtime, input.account);
+    const preview = buildPreview(input.scenario, prepared.prepared);
+
+    input.runtime.logger.log("info", "write_validation.action.prepared", {
+      account_id: input.account.id,
+      action_type: input.scenario.actionType,
+      prepared_action_id: prepared.prepared.preparedActionId,
+      preview
+    });
+
+    const preparedArtifacts = readPreparedArtifacts(prepared.prepared);
+    const proceed = input.onBeforeAction
+      ? await input.onBeforeAction(preview)
+      : true;
+
+    if (!proceed) {
+      input.runtime.logger.log("warn", "write_validation.action.cancelled", {
+        account_id: input.account.id,
+        action_type: input.scenario.actionType,
+        prepared_action_id: prepared.prepared.preparedActionId
+      });
+
+      return buildCancelledActionResult({
+        preview,
+        prepared: prepared.prepared,
+        preparedArtifacts,
+        scenario: input.scenario,
+        startedAt,
+        cleanupGuidance: prepared.cleanupGuidance
+      });
+    }
+
+    const beforeScreenshotPaths = await ensureScenarioScreenshotPaths({
+      actionType: input.scenario.actionType,
+      existingPaths: preparedArtifacts.beforeScreenshotPaths,
+      profileManager: input.profileManager,
+      stage: "before",
+      url: prepared.beforeScreenshotUrl
+    });
+
+    const confirmed = await input.runtime.twoPhaseCommit.confirmByToken({
+      confirmToken: prepared.prepared.confirmToken
+    });
+    const confirmArtifacts = dedupeStrings([...confirmed.artifacts]);
+    const afterScreenshotPaths = await ensureScenarioScreenshotPaths({
+      actionType: input.scenario.actionType,
+      existingPaths: confirmArtifacts.filter(isScreenshotPath),
+      profileManager: input.profileManager,
+      stage: "after",
+      url: input.scenario.resolveAfterScreenshotUrl(
+        input.account,
+        prepared,
+        confirmed
+      )
+    });
+
+    const verification = await input.scenario.verify(
+      input.runtime,
+      input.account,
+      prepared,
+      confirmed
+    );
+    const status = determineActionStatus(verification);
+
+    input.runtime.logger.log(
+      status === "pass" ? "info" : "warn",
+      "write_validation.action.completed",
+      {
+        account_id: input.account.id,
+        action_type: input.scenario.actionType,
+        prepared_action_id: prepared.prepared.preparedActionId,
+        verified: verification.verified,
+        state_synced: verification.state_synced,
+        status
+      }
+    );
+
+    return buildCompletedActionResult({
+      afterScreenshotPaths,
+      beforeScreenshotPaths,
+      cleanupGuidance: prepared.cleanupGuidance,
+      confirmArtifacts,
+      linkedinResponse: confirmed.result,
+      prepared: prepared.prepared,
+      preparedArtifacts,
+      preview,
+      scenario: input.scenario,
+      startedAt,
+      status,
+      verification
+    });
+  } catch (error) {
+    const normalizedError = asLinkedInAssistantError(
+      error,
+      error instanceof LinkedInAssistantError ? error.code : "UNKNOWN",
+      `Write validation failed while executing ${input.scenario.actionType}.`
+    );
+
+    input.runtime.logger.log("error", "write_validation.action.failed", {
+      account_id: input.account.id,
+      action_type: input.scenario.actionType,
+      code: normalizedError.code,
+      error_message: normalizedError.message,
+      error_details: normalizedError.details
+    });
+
+    return buildFailedActionResult({
+      errorCode: normalizedError.code,
+      errorMessage: normalizedError.message,
+      scenario: input.scenario,
+      startedAt
+    });
+  }
+}
+
+function buildWriteValidationReport(input: {
+  account: ReturnType<typeof resolveWriteValidationAccount>;
+  actions: WriteValidationActionResult[];
+  cooldownMs: number;
+  latestReportPath: string;
+  runtime: Awaited<ReturnType<typeof createWriteValidationRuntime>>["runtime"];
+}): WriteValidationReport {
+  const counts = countActionStatuses(input.actions);
+  const outcome = determineOutcome(input.actions);
+  const reportPath = input.runtime.artifacts.resolve(
+    `${WRITE_VALIDATION_REPORT_DIR}/report.json`
+  );
+  const checkedAt = new Date().toISOString();
+  const summary = buildWriteValidationSummary({
+    action_count: input.actions.length,
+    cancelled_count: counts.cancelledCount,
+    fail_count: counts.failCount,
+    outcome,
+    pass_count: counts.passCount
+  });
+
+  const report: WriteValidationReport = {
+    account: buildWriteValidationReportAccount(input.account),
+    action_count: input.actions.length,
+    actions: input.actions,
+    audit_log_path: input.runtime.logger.getEventsPath(),
+    checked_at: checkedAt,
+    cooldown_ms: input.cooldownMs,
+    fail_count: counts.failCount,
+    latest_report_path: input.latestReportPath,
+    outcome,
+    pass_count: counts.passCount,
+    cancelled_count: counts.cancelledCount,
+    recommended_actions: [],
+    report_path: reportPath,
+    run_id: input.runtime.runId,
+    summary,
+    warning: WRITE_VALIDATION_WARNING
+  };
+
+  report.recommended_actions = buildRecommendedActions(report);
+
+  return report;
 }
 
 export async function runLinkedInWriteValidation(
@@ -1176,17 +458,7 @@ export async function runLinkedInWriteValidation(
     validatedOptions.accountId,
     options.baseDir
   );
-
-  if (account.designation !== "secondary") {
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
-      `Write validation can run only against a registered secondary account. Account "${account.id}" is marked as ${account.designation}.`,
-      {
-        account_id: account.id,
-        designation: account.designation
-      }
-    );
-  }
+  ensureSecondaryWriteValidationAccount(account);
 
   const paths = resolveConfigPaths(options.baseDir);
   ensureConfigPaths(paths);
@@ -1215,183 +487,21 @@ export async function runLinkedInWriteValidation(
   const actions: WriteValidationActionResult[] = [];
 
   try {
-    for (const scenario of LINKEDIN_WRITE_VALIDATION_ACTIONS) {
-      const startedAt = new Date().toISOString();
-
-      runtime.logger.log("info", "write_validation.action.start", {
-        account_id: account.id,
-        action_type: scenario.actionType
-      });
-
-      try {
-        const scenarioDefinition = WRITE_VALIDATION_SCENARIOS[scenario.actionType];
-        const prepared = await scenarioDefinition.prepare(runtime, account);
-        const preview = buildPreview(scenarioDefinition, prepared.prepared);
-
-        runtime.logger.log("info", "write_validation.action.prepared", {
-          account_id: account.id,
-          action_type: scenario.actionType,
-          prepared_action_id: prepared.prepared.preparedActionId,
-          preview
-        });
-
-        const proceed = options.onBeforeAction
-          ? await options.onBeforeAction(preview)
-          : true;
-
-        if (!proceed) {
-          runtime.logger.log("warn", "write_validation.action.cancelled", {
-            account_id: account.id,
-            action_type: scenario.actionType,
-            prepared_action_id: prepared.prepared.preparedActionId
-          });
-
-          actions.push({
-            action_type: scenario.actionType,
-            after_screenshot_paths: [],
-            artifact_paths: dedupeStrings(readPreviewArtifacts(prepared.prepared.preview)),
-            before_screenshot_paths: readPreviewArtifacts(prepared.prepared.preview).filter(
-              isScreenshotPath
-            ),
-            cleanup_guidance: prepared.cleanupGuidance,
-            completed_at: new Date().toISOString(),
-            confirm_artifacts: [],
-            expected_outcome: scenario.expectedOutcome,
-            prepared_action_id: prepared.prepared.preparedActionId,
-            preview,
-            risk_class: scenario.riskClass,
-            started_at: startedAt,
-            state_synced: null,
-            status: "cancelled",
-            summary: scenario.summary
-          });
-          continue;
-        }
-
-        const previewArtifacts = readPreviewArtifacts(prepared.prepared.preview);
-        const beforeScreenshotPaths = previewArtifacts.filter(isScreenshotPath);
-
-        if (
-          beforeScreenshotPaths.length === 0 &&
-          typeof prepared.beforeScreenshotUrl === "string"
-        ) {
-          beforeScreenshotPaths.push(
-            await profileManager.capturePageScreenshot({
-              actionType: scenario.actionType,
-              stage: "before",
-              url: prepared.beforeScreenshotUrl
-            })
-          );
-        }
-
-        const confirmed = await runtime.twoPhaseCommit.confirmByToken({
-          confirmToken: prepared.prepared.confirmToken
-        });
-
-        const confirmArtifacts = [...confirmed.artifacts];
-        const afterScreenshotPaths = confirmArtifacts.filter(isScreenshotPath);
-        const afterScreenshotUrl = scenarioDefinition.resolveAfterScreenshotUrl(
+    for (const [index, scenario] of WRITE_VALIDATION_SCENARIOS.entries()) {
+      actions.push(
+        await executeWriteValidationScenario({
           account,
-          prepared,
-          confirmed
-        );
-
-        if (afterScreenshotPaths.length === 0 && typeof afterScreenshotUrl === "string") {
-          afterScreenshotPaths.push(
-            await profileManager.capturePageScreenshot({
-              actionType: scenario.actionType,
-              stage: "after",
-              url: afterScreenshotUrl
-            })
-          );
-        }
-
-        const verification = await scenarioDefinition.verify(
+          onBeforeAction: options.onBeforeAction,
+          profileManager,
           runtime,
-          account,
-          prepared,
-          confirmed
-        );
-        const status = determineActionStatus(verification);
-        const artifactPaths = dedupeStrings([
-          ...previewArtifacts,
-          ...beforeScreenshotPaths,
-          ...confirmArtifacts,
-          ...afterScreenshotPaths
-        ]);
+          scenario
+        })
+      );
 
-        runtime.logger.log(
-          status === "pass" ? "info" : "warn",
-          "write_validation.action.completed",
-          {
-            account_id: account.id,
-            action_type: scenario.actionType,
-            prepared_action_id: prepared.prepared.preparedActionId,
-            verified: verification.verified,
-            state_synced: verification.state_synced,
-            status
-          }
-        );
-
-        actions.push({
-          action_type: scenario.actionType,
-          after_screenshot_paths: dedupeStrings(afterScreenshotPaths),
-          artifact_paths: artifactPaths,
-          before_screenshot_paths: dedupeStrings(beforeScreenshotPaths),
-          cleanup_guidance: prepared.cleanupGuidance,
-          completed_at: new Date().toISOString(),
-          confirm_artifacts: dedupeStrings(confirmArtifacts),
-          expected_outcome: scenario.expectedOutcome,
-          linkedin_response: confirmed.result,
-          prepared_action_id: prepared.prepared.preparedActionId,
-          preview,
-          risk_class: scenario.riskClass,
-          started_at: startedAt,
-          state_synced: verification.state_synced,
-          status,
-          summary: scenario.summary,
-          verification: {
-            details: verification.details,
-            message: verification.message,
-            source: verification.source,
-            verified: verification.verified
-          }
-        });
-      } catch (error) {
-        const normalizedError = asLinkedInAssistantError(
-          error,
-          error instanceof LinkedInAssistantError ? error.code : "UNKNOWN",
-          `Write validation failed while executing ${scenario.actionType}.`
-        );
-
-        runtime.logger.log("error", "write_validation.action.failed", {
-          account_id: account.id,
-          action_type: scenario.actionType,
-          code: normalizedError.code,
-          error_message: normalizedError.message,
-          error_details: normalizedError.details
-        });
-
-        actions.push({
-          action_type: scenario.actionType,
-          after_screenshot_paths: [],
-          artifact_paths: [],
-          before_screenshot_paths: [],
-          cleanup_guidance: [],
-          completed_at: new Date().toISOString(),
-          confirm_artifacts: [],
-          error_code: normalizedError.code,
-          error_message: normalizedError.message,
-          expected_outcome: scenario.expectedOutcome,
-          risk_class: scenario.riskClass,
-          started_at: startedAt,
-          state_synced: null,
-          status: "fail",
-          summary: scenario.summary
-        });
-      }
-
-      if (validatedOptions.cooldownMs > 0 && scenario !== LINKEDIN_WRITE_VALIDATION_ACTIONS.at(-1)) {
+      if (
+        validatedOptions.cooldownMs > 0 &&
+        index < WRITE_VALIDATION_SCENARIOS.length - 1
+      ) {
         runtime.logger.log("info", "write_validation.cooldown.start", {
           account_id: account.id,
           cooldown_ms: validatedOptions.cooldownMs
@@ -1400,88 +510,28 @@ export async function runLinkedInWriteValidation(
       }
     }
 
-    const counts = countActionStatuses(actions);
-    const outcome = determineOutcome(actions);
-    const reportPath = runtime.artifacts.writeJson(
-      `${WRITE_VALIDATION_REPORT_DIR}/report.json`,
-      {
-        account: {
-          designation: account.designation,
-          id: account.id,
-          label: account.label,
-          profile_name: account.profileName,
-          session_name: account.sessionName
-        },
-        action_count: actions.length,
-        actions,
-        audit_log_path: runtime.logger.getEventsPath(),
-        checked_at: new Date().toISOString(),
-        cooldown_ms: validatedOptions.cooldownMs,
-        fail_count: counts.failCount,
-        latest_report_path: latestReportPath,
-        outcome,
-        pass_count: counts.passCount,
-        cancelled_count: counts.cancelledCount,
-        report_path: runtime.artifacts.resolve(`${WRITE_VALIDATION_REPORT_DIR}/report.json`),
-        run_id: runtime.runId,
-        summary: buildWriteValidationSummary({
-          action_count: actions.length,
-          cancelled_count: counts.cancelledCount,
-          fail_count: counts.failCount,
-          outcome,
-          pass_count: counts.passCount
-        }),
-        warning: WRITE_VALIDATION_WARNING
-      },
-      {
-        account_id: account.id,
-        action_count: actions.length,
-        outcome
-      }
-    );
-
-    const report: WriteValidationReport = {
-      account: {
-        designation: account.designation,
-        id: account.id,
-        label: account.label,
-        profile_name: account.profileName,
-        session_name: account.sessionName
-      },
-      action_count: actions.length,
+    const report = buildWriteValidationReport({
+      account,
       actions,
-      audit_log_path: runtime.logger.getEventsPath(),
-      checked_at: new Date().toISOString(),
-      cooldown_ms: validatedOptions.cooldownMs,
-      fail_count: counts.failCount,
-      latest_report_path: latestReportPath,
-      outcome,
-      pass_count: counts.passCount,
-      cancelled_count: counts.cancelledCount,
-      recommended_actions: [],
-      report_path: reportPath,
-      run_id: runtime.runId,
-      summary: buildWriteValidationSummary({
-        action_count: actions.length,
-        cancelled_count: counts.cancelledCount,
-        fail_count: counts.failCount,
-        outcome,
-        pass_count: counts.passCount
-      }),
-      warning: WRITE_VALIDATION_WARNING
-    };
+      cooldownMs: validatedOptions.cooldownMs,
+      latestReportPath,
+      runtime
+    });
 
-    report.recommended_actions = buildRecommendedActions(report);
-
+    runtime.artifacts.writeJson(`${WRITE_VALIDATION_REPORT_DIR}/report.json`, report, {
+      account_id: account.id,
+      action_count: actions.length,
+      outcome: report.outcome
+    });
     await writeJsonFile(latestReportPath, report);
 
     runtime.logger.log("info", "write_validation.completed", {
       account_id: account.id,
       action_count: actions.length,
-      fail_count: counts.failCount,
-      outcome,
-      pass_count: counts.passCount,
-      cancelled_count: counts.cancelledCount,
+      fail_count: report.fail_count,
+      outcome: report.outcome,
+      pass_count: report.pass_count,
+      cancelled_count: report.cancelled_count,
       report_path: report.report_path
     });
 

--- a/packages/core/src/writeValidationAccounts.ts
+++ b/packages/core/src/writeValidationAccounts.ts
@@ -88,6 +88,34 @@ function isRecord(value: unknown): value is JsonRecord {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function assertJsonRecord(
+  value: unknown,
+  message: string,
+  details?: JsonRecord
+): JsonRecord {
+  if (isRecord(value)) {
+    return value;
+  }
+
+  throw new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    message,
+    details
+  );
+}
+
+function parseOptionalTarget<T>(
+  value: unknown,
+  label: string,
+  parse: (target: JsonRecord) => T
+): T | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return parse(assertJsonRecord(value, `${label} must be a JSON object.`));
+}
+
 function assertNonEmptyString(value: unknown, label: string): string {
   if (typeof value !== "string") {
     throw new LinkedInAssistantError(
@@ -201,6 +229,34 @@ function readConfigShape(baseDir?: string): { config: JsonRecord; configPath: st
   };
 }
 
+function readOptionalConfigObject(
+  value: unknown,
+  objectPath: string,
+  configPath: string
+): JsonRecord | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return assertJsonRecord(
+    value,
+    `${objectPath} in ${configPath} must be a JSON object.`,
+    {
+      config_path: configPath,
+      provided_value: value
+    }
+  );
+}
+
+function cloneConfigObject(
+  value: unknown,
+  objectPath: string,
+  configPath: string
+): JsonRecord {
+  const configObject = readOptionalConfigObject(value, objectPath, configPath);
+  return configObject ? { ...configObject } : {};
+}
+
 function normalizeAccountId(value: string, label: string): string {
   return assertLocalIdentifier(value, label);
 }
@@ -240,128 +296,91 @@ function parseMessageTarget(
   value: unknown,
   label: string
 ): WriteValidationMessageTargetConfig | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-
-  if (!isRecord(value)) {
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
-      `${label} must be a JSON object.`
+  return parseOptionalTarget(value, label, (target) => {
+    const participantPattern = assertOptionalString(
+      target.participantPattern,
+      `${label}.participantPattern`
     );
-  }
 
-  const participantPattern = assertOptionalString(
-    value.participantPattern,
-    `${label}.participantPattern`
-  );
-
-  return {
-    thread: normalizeThreadTarget(value.thread, `${label}.thread`),
-    ...(participantPattern ? { participantPattern } : {})
-  };
+    return {
+      thread: normalizeThreadTarget(target.thread, `${label}.thread`),
+      ...(participantPattern ? { participantPattern } : {})
+    };
+  });
 }
 
 function parseConnectionTarget(
   value: unknown,
   label: string
 ): WriteValidationConnectionTargetConfig | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
+  return parseOptionalTarget(value, label, (target) => {
+    const note = assertOptionalString(target.note, `${label}.note`);
 
-  if (!isRecord(value)) {
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
-      `${label} must be a JSON object.`
-    );
-  }
-
-  const note = assertOptionalString(value.note, `${label}.note`);
-
-  return {
-    targetProfile: resolveProfileUrl(
-      assertNonEmptyString(value.targetProfile, `${label}.targetProfile`)
-    ),
-    ...(note ? { note } : {})
-  };
+    return {
+      targetProfile: resolveProfileUrl(
+        assertNonEmptyString(target.targetProfile, `${label}.targetProfile`)
+      ),
+      ...(note ? { note } : {})
+    };
+  });
 }
 
 function parseFollowupTarget(
   value: unknown,
   label: string
 ): WriteValidationFollowupTargetConfig | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-
-  if (!isRecord(value)) {
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
-      `${label} must be a JSON object.`
+  return parseOptionalTarget(value, label, (target) => {
+    const profileUrlKey = normalizeLinkedInProfileUrl(
+      resolveProfileUrl(
+        assertNonEmptyString(target.profileUrlKey, `${label}.profileUrlKey`)
+      )
     );
-  }
 
-  const profileUrlKey = normalizeLinkedInProfileUrl(
-    resolveProfileUrl(assertNonEmptyString(value.profileUrlKey, `${label}.profileUrlKey`))
-  );
-
-  return {
-    profileUrlKey
-  };
+    return {
+      profileUrlKey
+    };
+  });
 }
 
 function parseReactionTarget(
   value: unknown,
   label: string
 ): WriteValidationReactionTargetConfig | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
+  return parseOptionalTarget(value, label, (target) => {
+    const reaction = assertOptionalString(target.reaction, `${label}.reaction`);
 
-  if (!isRecord(value)) {
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
-      `${label} must be a JSON object.`
-    );
-  }
-
-  const reaction = assertOptionalString(value.reaction, `${label}.reaction`);
-
-  return {
-    postUrl: normalizePostUrl(value.postUrl, `${label}.postUrl`),
-    ...(reaction
-      ? {
-          reaction: normalizeLinkedInFeedReaction(reaction)
-        }
-      : {})
-  };
+    return {
+      postUrl: normalizePostUrl(target.postUrl, `${label}.postUrl`),
+      ...(reaction
+        ? {
+            reaction: normalizeLinkedInFeedReaction(reaction)
+          }
+        : {})
+    };
+  });
 }
 
 function parsePostTarget(
   value: unknown,
   label: string
 ): WriteValidationPostTargetConfig | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-
-  if (!isRecord(value)) {
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
-      `${label} must be a JSON object.`
+  return parseOptionalTarget(value, label, (target) => {
+    const visibility = assertOptionalString(
+      target.visibility,
+      `${label}.visibility`
     );
-  }
 
-  const visibility = assertOptionalString(value.visibility, `${label}.visibility`);
-
-  return {
-    ...(visibility
-      ? {
-          visibility: normalizeLinkedInPostVisibility(visibility, "connections")
-        }
-      : {})
-  };
+    return {
+      ...(visibility
+        ? {
+            visibility: normalizeLinkedInPostVisibility(
+              visibility,
+              "connections"
+            )
+          }
+        : {})
+    };
+  });
 }
 
 function parseTargets(
@@ -418,35 +437,37 @@ function parseAccount(
   value: unknown,
   configPath: string
 ): WriteValidationAccount {
-  if (!isRecord(value)) {
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
-      `writeValidation.accounts.${accountId} in ${configPath} must be a JSON object.`,
-      {
-        config_path: configPath,
-        account_id: accountId
-      }
-    );
-  }
+  const account = assertJsonRecord(
+    value,
+    `writeValidation.accounts.${accountId} in ${configPath} must be a JSON object.`,
+    {
+      config_path: configPath,
+      account_id: accountId
+    }
+  );
 
   const normalizedAccountId = normalizeAccountId(
     accountId,
     `writeValidation.accounts.${accountId}`
   );
   const designation = parseAccountDesignation(
-    value.designation,
+    account.designation,
     `writeValidation.accounts.${accountId}.designation`
   );
   const label = assertNonEmptyString(
-    value.label ?? normalizedAccountId,
+    account.label ?? normalizedAccountId,
     `writeValidation.accounts.${accountId}.label`
   );
   const profileName = normalizeAccountId(
-    typeof value.profileName === "string" ? value.profileName : normalizedAccountId,
+    typeof account.profileName === "string"
+      ? account.profileName
+      : normalizedAccountId,
     `writeValidation.accounts.${accountId}.profileName`
   );
   const sessionName = normalizeAccountId(
-    typeof value.sessionName === "string" ? value.sessionName : normalizedAccountId,
+    typeof account.sessionName === "string"
+      ? account.sessionName
+      : normalizedAccountId,
     `writeValidation.accounts.${accountId}.sessionName`
   );
 
@@ -457,7 +478,7 @@ function parseAccount(
     profileName,
     sessionName,
     targets: parseTargets(
-      value.targets,
+      account.targets,
       `writeValidation.accounts.${accountId}.targets`
     )
   };
@@ -477,43 +498,29 @@ export function loadWriteValidationAccounts(
   baseDir?: string
 ): WriteValidationAccountRegistry {
   const { config, configPath } = readConfigShape(baseDir);
-  const writeValidation = config.writeValidation;
+  const writeValidation = readOptionalConfigObject(
+    config.writeValidation,
+    "writeValidation",
+    configPath
+  );
 
-  if (writeValidation === undefined) {
+  if (!writeValidation) {
     return {
       accounts: {},
       configPath
     };
   }
 
-  if (!isRecord(writeValidation)) {
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
-      `writeValidation in ${configPath} must be a JSON object.`,
-      {
-        config_path: configPath,
-        provided_value: writeValidation
-      }
-    );
-  }
-
-  const accountsShape = writeValidation.accounts;
-  if (accountsShape === undefined) {
+  const accountsShape = readOptionalConfigObject(
+    writeValidation.accounts,
+    "writeValidation.accounts",
+    configPath
+  );
+  if (!accountsShape) {
     return {
       accounts: {},
       configPath
     };
-  }
-
-  if (!isRecord(accountsShape)) {
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
-      `writeValidation.accounts in ${configPath} must be a JSON object.`,
-      {
-        config_path: configPath,
-        provided_value: accountsShape
-      }
-    );
   }
 
   const accounts = Object.fromEntries(
@@ -559,36 +566,16 @@ export async function upsertWriteValidationAccount(
   ensureConfigPaths(paths);
 
   const { config, configPath } = readConfigShape(input.baseDir);
-  const existingWriteValidation = config.writeValidation;
-  const writeValidation = existingWriteValidation
-    ? isRecord(existingWriteValidation)
-      ? { ...existingWriteValidation }
-      : (() => {
-          throw new LinkedInAssistantError(
-            "ACTION_PRECONDITION_FAILED",
-            `writeValidation in ${configPath} must be a JSON object.`,
-            {
-              config_path: configPath,
-              provided_value: existingWriteValidation
-            }
-          );
-        })()
-    : {};
-  const existingAccounts = writeValidation.accounts;
-  const accounts = existingAccounts
-    ? isRecord(existingAccounts)
-      ? { ...existingAccounts }
-      : (() => {
-          throw new LinkedInAssistantError(
-            "ACTION_PRECONDITION_FAILED",
-            `writeValidation.accounts in ${configPath} must be a JSON object.`,
-            {
-              config_path: configPath,
-              provided_value: existingAccounts
-            }
-          );
-        })()
-    : {};
+  const writeValidation = cloneConfigObject(
+    config.writeValidation,
+    "writeValidation",
+    configPath
+  );
+  const accounts = cloneConfigObject(
+    writeValidation.accounts,
+    "writeValidation.accounts",
+    configPath
+  );
 
   if (accounts[normalizedAccountId] !== undefined && !input.overwrite) {
     throw new LinkedInAssistantError(

--- a/packages/core/src/writeValidationRuntime.ts
+++ b/packages/core/src/writeValidationRuntime.ts
@@ -1,0 +1,299 @@
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright-core";
+import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
+import {
+  LinkedInAuthService,
+  type SessionStatus
+} from "./auth/session.js";
+import {
+  inspectLinkedInSession,
+  type LinkedInSessionInspection
+} from "./auth/sessionInspection.js";
+import {
+  LinkedInSessionStore,
+  type LinkedInBrowserStorageState
+} from "./auth/sessionStore.js";
+import { LinkedInAssistantError } from "./errors.js";
+import {
+  ProfileManager,
+  type PersistentContextOptions
+} from "./profileManager.js";
+import { createCoreRuntime, type CoreRuntime } from "./runtime.js";
+import type { WriteValidationAccount } from "./writeValidationAccounts.js";
+import {
+  WRITE_VALIDATION_FEED_URL,
+  WRITE_VALIDATION_REPORT_DIR,
+  type LinkedInWriteValidationActionType
+} from "./writeValidationShared.js";
+
+function getOrCreatePage(context: BrowserContext): Promise<Page> {
+  const existing = context.pages()[0];
+  return existing ? Promise.resolve(existing) : context.newPage();
+}
+
+function createStoredSessionCdpError(): LinkedInAssistantError {
+  return new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    "Stored-session write validation does not support CDP or external browser attachment."
+  );
+}
+
+class StoredSessionProfileManager extends ProfileManager {
+  private browser: Browser | null = null;
+  private browserPromise: Promise<Browser> | null = null;
+
+  constructor(
+    paths: CoreRuntime["paths"],
+    private readonly storageState: LinkedInBrowserStorageState,
+    private readonly timeoutMs: number,
+    private readonly runtime: CoreRuntime
+  ) {
+    super(paths);
+  }
+
+  private async getBrowser(): Promise<Browser> {
+    if (this.browser) {
+      return this.browser;
+    }
+
+    if (!this.browserPromise) {
+      const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
+      this.browserPromise = chromium
+        .launch({
+          headless: false,
+          ...(executablePath ? { executablePath } : {})
+        })
+        .then((browser) => {
+          this.browser = browser;
+          return browser;
+        });
+    }
+
+    return this.browserPromise;
+  }
+
+  override async runWithPersistentContext<T>(
+    _profileName: string,
+    _options: PersistentContextOptions,
+    callback: (context: BrowserContext) => Promise<T>
+  ): Promise<T> {
+    const browser = await this.getBrowser();
+    const context = await browser.newContext({
+      storageState: this.storageState
+    });
+
+    context.setDefaultNavigationTimeout(this.timeoutMs);
+    context.setDefaultTimeout(this.timeoutMs);
+
+    try {
+      return await callback(context);
+    } finally {
+      await context.close().catch(() => undefined);
+    }
+  }
+
+  override async runWithCDP<T>(
+    cdpUrl: string,
+    callback: (context: BrowserContext) => Promise<T>
+  ): Promise<T> {
+    void cdpUrl;
+    void callback;
+    throw createStoredSessionCdpError();
+  }
+
+  override async runWithCDPResilient<T>(
+    cdpUrl: string,
+    callback: (context: BrowserContext) => Promise<T>,
+    options?: { maxRetries?: number; retryDelayMs?: number }
+  ): Promise<T> {
+    void cdpUrl;
+    void callback;
+    void options;
+    throw createStoredSessionCdpError();
+  }
+
+  override async runWithContext<T>(
+    options: {
+      cdpUrl?: string | undefined;
+      profileName: string;
+      headless?: boolean;
+    },
+    callback: (context: BrowserContext) => Promise<T>
+  ): Promise<T> {
+    if (options.cdpUrl) {
+      throw createStoredSessionCdpError();
+    }
+
+    return this.runWithPersistentContext(options.profileName, { headless: false }, callback);
+  }
+
+  async inspectSession(): Promise<LinkedInSessionInspection> {
+    return this.runWithPersistentContext(
+      "session-inspection",
+      { headless: false },
+      async (context) => {
+        const page = await getOrCreatePage(context);
+        await page.goto(WRITE_VALIDATION_FEED_URL, {
+          waitUntil: "domcontentloaded"
+        });
+        await waitForNetworkIdleBestEffort(page, this.timeoutMs);
+        return inspectLinkedInSession(page, {
+          selectorLocale: this.runtime.selectorLocale
+        });
+      }
+    );
+  }
+
+  async capturePageScreenshot(input: {
+    actionType: LinkedInWriteValidationActionType;
+    stage: "before" | "after";
+    url: string;
+  }): Promise<string> {
+    const relativePath = `${WRITE_VALIDATION_REPORT_DIR}/${slugifyActionType(input.actionType)}-${input.stage}-${Date.now()}.png`;
+
+    await this.runWithPersistentContext(
+      `screenshot-${input.stage}`,
+      { headless: false },
+      async (context) => {
+        const page = await getOrCreatePage(context);
+        await page.goto(input.url, {
+          waitUntil: "domcontentloaded"
+        });
+        await waitForNetworkIdleBestEffort(page, this.timeoutMs);
+        const absolutePath = this.runtime.artifacts.resolve(relativePath);
+        await page.screenshot({ fullPage: true, path: absolutePath });
+      }
+    );
+
+    this.runtime.artifacts.registerArtifact(relativePath, "image/png", {
+      action: input.actionType,
+      capture_stage: input.stage,
+      capture_url: input.url
+    });
+
+    return relativePath;
+  }
+
+  async dispose(): Promise<void> {
+    this.browserPromise = null;
+    const browser = this.browser;
+    this.browser = null;
+    if (browser) {
+      await browser.close().catch(() => undefined);
+    }
+  }
+}
+
+class StoredSessionAuthService extends LinkedInAuthService {
+  constructor(
+    profileManager: ProfileManager,
+    private readonly sessionStatus: SessionStatus
+  ) {
+    super(profileManager, undefined);
+  }
+
+  override async status(): Promise<SessionStatus> {
+    return {
+      ...this.sessionStatus,
+      checkedAt: new Date().toISOString()
+    };
+  }
+
+  override async ensureAuthenticated(): Promise<SessionStatus> {
+    if (!this.sessionStatus.authenticated) {
+      throw new LinkedInAssistantError(
+        this.sessionStatus.currentUrl.includes("/checkpoint")
+          ? "CAPTCHA_OR_CHALLENGE"
+          : "AUTH_REQUIRED",
+        this.sessionStatus.reason,
+        {
+          checked_at: this.sessionStatus.checkedAt,
+          current_url: this.sessionStatus.currentUrl
+        }
+      );
+    }
+
+    return {
+      ...this.sessionStatus,
+      checkedAt: new Date().toISOString()
+    };
+  }
+}
+
+function slugifyActionType(actionType: string): string {
+  return actionType
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, "-")
+    .replace(/^-+|-+$/gu, "") || "action";
+}
+
+function toSessionStatus(inspection: LinkedInSessionInspection): SessionStatus {
+  return {
+    authenticated: inspection.authenticated,
+    checkedAt: inspection.checkedAt,
+    currentUrl: inspection.currentUrl,
+    reason: inspection.reason
+  };
+}
+
+export interface WriteValidationProfileManager {
+  capturePageScreenshot(input: {
+    actionType: LinkedInWriteValidationActionType;
+    stage: "before" | "after";
+    url: string;
+  }): Promise<string>;
+  dispose(): Promise<void>;
+}
+
+export interface WriteValidationRuntimeHandle {
+  profileManager: WriteValidationProfileManager;
+  runtime: CoreRuntime;
+}
+
+export async function createWriteValidationRuntime(input: {
+  account: WriteValidationAccount;
+  baseDir?: string;
+  timeoutMs: number;
+}): Promise<WriteValidationRuntimeHandle> {
+  const runtime = createCoreRuntime(
+    input.baseDir
+      ? {
+          baseDir: input.baseDir
+        }
+      : {}
+  );
+  const store = new LinkedInSessionStore(input.baseDir);
+  const loadedSession = await store.load(input.account.sessionName);
+  const profileManager = new StoredSessionProfileManager(
+    runtime.paths,
+    loadedSession.storageState,
+    input.timeoutMs,
+    runtime
+  );
+  const inspection = await profileManager.inspectSession();
+
+  if (!inspection.authenticated) {
+    throw new LinkedInAssistantError(
+      inspection.currentUrl.includes("/checkpoint")
+        ? "CAPTCHA_OR_CHALLENGE"
+        : "AUTH_REQUIRED",
+      inspection.reason,
+      {
+        checked_at: inspection.checkedAt,
+        current_url: inspection.currentUrl,
+        session_name: input.account.sessionName
+      }
+    );
+  }
+
+  runtime.profileManager = profileManager;
+  runtime.auth = new StoredSessionAuthService(
+    profileManager,
+    toSessionStatus(inspection)
+  );
+
+  return {
+    runtime,
+    profileManager
+  };
+}

--- a/packages/core/src/writeValidationScenarios.ts
+++ b/packages/core/src/writeValidationScenarios.ts
@@ -1,0 +1,512 @@
+import { LinkedInAssistantError } from "./errors.js";
+import {
+  LIKE_POST_ACTION_TYPE,
+  normalizeLinkedInFeedReaction,
+  type LinkedInFeedReaction
+} from "./linkedinFeed.js";
+import {
+  SEND_INVITATION_ACTION_TYPE,
+  type LinkedInPendingInvitation
+} from "./linkedinConnections.js";
+import { FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE } from "./linkedinFollowups.js";
+import {
+  normalizeLinkedInProfileUrl,
+  resolveProfileUrl
+} from "./linkedinProfile.js";
+import {
+  CREATE_POST_ACTION_TYPE,
+  normalizeLinkedInPostVisibility
+} from "./linkedinPosts.js";
+import type {
+  LinkedInWriteValidationActionDefinition,
+  ScenarioPrepareResult,
+  WriteValidationScenarioDefinition
+} from "./writeValidationShared.js";
+import {
+  SEND_MESSAGE_ACTION_TYPE,
+  WRITE_VALIDATION_FEED_URL
+} from "./writeValidationShared.js";
+import type { WriteValidationAccountTargets } from "./writeValidationAccounts.js";
+
+const WRITE_VALIDATION_OPERATOR_NOTE = "Tier 3 write-validation harness";
+
+function normalizeText(value: string | null | undefined): string {
+  return (value ?? "").replace(/\s+/gu, " ").trim();
+}
+
+function createWriteValidationTag(): string {
+  return new Date().toISOString();
+}
+
+function buildWriteValidationPostText(): string {
+  return `Quick validation update • ${createWriteValidationTag()}`;
+}
+
+function buildWriteValidationMessageText(): string {
+  return `Quick validation ping • ${createWriteValidationTag()}`;
+}
+
+function resolveThreadUrl(thread: string): string {
+  const trimmedThread = thread.trim();
+  if (!trimmedThread) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "Thread identifier is required."
+    );
+  }
+
+  if (/^https?:\/\//iu.test(trimmedThread)) {
+    const parsedUrl = new URL(trimmedThread);
+    return `${parsedUrl.origin}${parsedUrl.pathname}${parsedUrl.search}`.replace(
+      /\/$/u,
+      "/"
+    );
+  }
+
+  if (trimmedThread.startsWith("/messaging/thread/")) {
+    return `https://www.linkedin.com${trimmedThread}`;
+  }
+
+  return `https://www.linkedin.com/messaging/thread/${encodeURIComponent(trimmedThread)}/`;
+}
+
+function getRequiredTarget<T>(
+  targets: WriteValidationAccountTargets,
+  actionType: keyof WriteValidationAccountTargets,
+  accountId: string
+): T {
+  const target = targets[actionType];
+  if (target !== undefined) {
+    return target as T;
+  }
+
+  throw new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    `Write-validation account "${accountId}" is missing targets.${String(actionType)} in config.json.`,
+    {
+      account_id: accountId,
+      missing_target_key: actionType
+    }
+  );
+}
+
+function matchPendingInvitation(
+  invitations: LinkedInPendingInvitation[],
+  targetProfile: string
+): LinkedInPendingInvitation | null {
+  const normalizedTargetProfile = normalizeLinkedInProfileUrl(
+    resolveProfileUrl(targetProfile)
+  );
+  const targetSlug =
+    /\/in\/([^/?#]+)/u.exec(normalizedTargetProfile)?.[1] ?? null;
+
+  for (const invitation of invitations) {
+    const normalizedInvitationProfile = normalizeLinkedInProfileUrl(
+      resolveProfileUrl(invitation.profile_url)
+    );
+
+    if (normalizedInvitationProfile === normalizedTargetProfile) {
+      return invitation;
+    }
+
+    if (
+      targetSlug !== null &&
+      typeof invitation.vanity_name === "string" &&
+      invitation.vanity_name.trim().toLowerCase() === targetSlug.toLowerCase()
+    ) {
+      return invitation;
+    }
+  }
+
+  return null;
+}
+
+function extractRecentMessageText(messages: readonly { text: string }[]): string | null {
+  const lastMessage = [...messages]
+    .reverse()
+    .find((message) => normalizeText(message.text).length > 0);
+  return lastMessage ? normalizeText(lastMessage.text) : null;
+}
+
+export const WRITE_VALIDATION_SCENARIOS = [
+  {
+    actionType: CREATE_POST_ACTION_TYPE,
+    summary:
+      "Create a connections-only post and verify it appears in the feed.",
+    expectedOutcome:
+      "A new post is published successfully and visible in the feed.",
+    riskClass: "public",
+    async prepare(runtime, account) {
+      const visibility = normalizeLinkedInPostVisibility(
+        account.targets["post.create"]?.visibility,
+        "connections"
+      );
+      const text = buildWriteValidationPostText();
+      const prepared = await runtime.posts.prepareCreate({
+        profileName: account.profileName,
+        text,
+        visibility,
+        operatorNote: WRITE_VALIDATION_OPERATOR_NOTE
+      });
+
+      return {
+        prepared,
+        beforeScreenshotUrl: WRITE_VALIDATION_FEED_URL,
+        cleanupGuidance: [
+          "Delete the validation post manually after review if you do not want it to remain in the feed."
+        ],
+        verificationContext: {
+          post_text: text,
+          visibility
+        }
+      } satisfies ScenarioPrepareResult;
+    },
+    resolveAfterScreenshotUrl(_account, _prepared, confirmed) {
+      const publishedPostUrl = confirmed.result.published_post_url;
+      return typeof publishedPostUrl === "string"
+        ? publishedPostUrl
+        : WRITE_VALIDATION_FEED_URL;
+    },
+    async verify(runtime, account, prepared, confirmed) {
+      const publishedPostUrl = confirmed.result.published_post_url;
+      const expectedText =
+        typeof prepared.verificationContext.post_text === "string"
+          ? prepared.verificationContext.post_text
+          : "";
+
+      if (typeof publishedPostUrl !== "string") {
+        return {
+          verified: false,
+          state_synced: null,
+          source: "post_publish_result",
+          message: "Post publish result did not include a published_post_url.",
+          details: {
+            result: confirmed.result
+          }
+        };
+      }
+
+      const post = await runtime.feed.viewPost({
+        profileName: account.profileName,
+        postUrl: publishedPostUrl
+      });
+
+      const verified = normalizeText(post.text).includes(normalizeText(expectedText));
+
+      return {
+        verified,
+        state_synced: null,
+        source: "feed.viewPost",
+        message: verified
+          ? "Published post was re-observed in LinkedIn feed content."
+          : "Published post could not be matched by text in the feed after confirmation.",
+        details: {
+          post_url: publishedPostUrl,
+          observed_text: post.text
+        }
+      };
+    }
+  },
+  {
+    actionType: SEND_INVITATION_ACTION_TYPE,
+    summary:
+      "Send a connection invitation to the approved profile and verify it appears in sent invitations.",
+    expectedOutcome:
+      "The approved profile shows a pending invitation or sent-invitation confirmation.",
+    riskClass: "network",
+    async prepare(runtime, account) {
+      const target = getRequiredTarget<{
+        note?: string;
+        targetProfile: string;
+      }>(account.targets, "connections.send_invitation", account.id);
+
+      const prepared = runtime.connections.prepareSendInvitation({
+        profileName: account.profileName,
+        targetProfile: target.targetProfile,
+        ...(target.note ? { note: target.note } : {}),
+        operatorNote: WRITE_VALIDATION_OPERATOR_NOTE
+      });
+
+      return {
+        prepared,
+        beforeScreenshotUrl: resolveProfileUrl(target.targetProfile),
+        cleanupGuidance: [
+          "Withdraw the validation invitation manually after review if the recipient should not keep it pending."
+        ],
+        verificationContext: {
+          target_profile: target.targetProfile
+        }
+      } satisfies ScenarioPrepareResult;
+    },
+    resolveAfterScreenshotUrl(_account, prepared) {
+      const targetProfile = prepared.verificationContext.target_profile;
+      return typeof targetProfile === "string"
+        ? resolveProfileUrl(targetProfile)
+        : null;
+    },
+    async verify(runtime, account, prepared) {
+      const targetProfile = prepared.verificationContext.target_profile;
+      if (typeof targetProfile !== "string") {
+        return {
+          verified: false,
+          state_synced: false,
+          source: "connections.listPendingInvitations",
+          message: "Connection target profile was missing from the verification context.",
+          details: {}
+        };
+      }
+
+      const invitations = await runtime.connections.listPendingInvitations({
+        profileName: account.profileName,
+        filter: "sent"
+      });
+      const matchedInvitation = matchPendingInvitation(invitations, targetProfile);
+      const stateRow = runtime.db.getSentInvitationState({
+        profileName: account.profileName,
+        profileUrlKey: normalizeLinkedInProfileUrl(resolveProfileUrl(targetProfile))
+      });
+
+      return {
+        verified: matchedInvitation !== null,
+        state_synced: stateRow !== undefined,
+        source: "connections.listPendingInvitations",
+        message:
+          matchedInvitation !== null
+            ? "Sent invitation was re-observed in the pending sent-invitations list."
+            : "Sent invitation could not be re-observed in the pending sent-invitations list.",
+        details: {
+          target_profile: targetProfile,
+          matched_invitation: matchedInvitation,
+          state_synced: stateRow !== undefined
+        }
+      };
+    }
+  },
+  {
+    actionType: SEND_MESSAGE_ACTION_TYPE,
+    summary:
+      "Send a message in the approved thread and verify the outbound message appears.",
+    expectedOutcome:
+      "The outbound message is echoed in the approved conversation thread.",
+    riskClass: "private",
+    async prepare(runtime, account) {
+      const target = getRequiredTarget<{
+        participantPattern?: string;
+        thread: string;
+      }>(account.targets, "send_message", account.id);
+      const text = buildWriteValidationMessageText();
+
+      const prepared = await runtime.inbox.prepareReply({
+        profileName: account.profileName,
+        thread: target.thread,
+        text,
+        operatorNote: WRITE_VALIDATION_OPERATOR_NOTE
+      });
+
+      return {
+        prepared,
+        beforeScreenshotUrl: resolveThreadUrl(target.thread),
+        cleanupGuidance: [],
+        verificationContext: {
+          message_text: text,
+          participant_pattern: target.participantPattern,
+          thread: target.thread
+        }
+      } satisfies ScenarioPrepareResult;
+    },
+    resolveAfterScreenshotUrl(_account, prepared) {
+      const thread = prepared.verificationContext.thread;
+      return typeof thread === "string" ? resolveThreadUrl(thread) : null;
+    },
+    async verify(runtime, account, prepared) {
+      const expectedText = prepared.verificationContext.message_text;
+      const thread = prepared.verificationContext.thread;
+
+      if (typeof expectedText !== "string" || typeof thread !== "string") {
+        return {
+          verified: false,
+          state_synced: null,
+          source: "inbox.getThread",
+          message: "Message verification context was incomplete.",
+          details: {}
+        };
+      }
+
+      const detail = await runtime.inbox.getThread({
+        profileName: account.profileName,
+        thread,
+        limit: 8
+      });
+      const recentMessageText = extractRecentMessageText(detail.messages);
+      const verified = recentMessageText === normalizeText(expectedText);
+
+      return {
+        verified,
+        state_synced: null,
+        source: "inbox.getThread",
+        message: verified
+          ? "Sent message was re-observed in the approved conversation thread."
+          : "Sent message was not found as the most recent thread message after confirmation.",
+        details: {
+          thread_id: detail.thread_id,
+          recent_message_text: recentMessageText,
+          expected_text: expectedText
+        }
+      };
+    }
+  },
+  {
+    actionType: FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE,
+    summary:
+      "Send the approved follow-up after an accepted connection and verify it records as sent.",
+    expectedOutcome:
+      "The follow-up send succeeds and local follow-up state records the confirmation.",
+    riskClass: "network",
+    async prepare(runtime, account) {
+      const target = getRequiredTarget<{
+        profileUrlKey: string;
+      }>(account.targets, "network.followup_after_accept", account.id);
+
+      const preparedFollowup =
+        await runtime.followups.prepareFollowupForAcceptedConnection({
+          profileName: account.profileName,
+          profileUrlKey: target.profileUrlKey,
+          refreshState: true,
+          operatorNote: WRITE_VALIDATION_OPERATOR_NOTE
+        });
+
+      if (!preparedFollowup) {
+        throw new LinkedInAssistantError(
+          "ACTION_PRECONDITION_FAILED",
+          `No accepted connection follow-up could be prepared for ${target.profileUrlKey}.`,
+          {
+            account_id: account.id,
+            profile_name: account.profileName,
+            profile_url_key: target.profileUrlKey
+          }
+        );
+      }
+
+      return {
+        prepared: {
+          preparedActionId: preparedFollowup.preparedActionId,
+          confirmToken: preparedFollowup.confirmToken,
+          expiresAtMs: preparedFollowup.expiresAtMs,
+          preview: preparedFollowup.preview
+        },
+        beforeScreenshotUrl: resolveProfileUrl(target.profileUrlKey),
+        cleanupGuidance: [],
+        verificationContext: {
+          profile_url_key: target.profileUrlKey
+        }
+      } satisfies ScenarioPrepareResult;
+    },
+    resolveAfterScreenshotUrl(_account, prepared, confirmed) {
+      const profileUrl = confirmed.result.profile_url;
+      if (typeof profileUrl === "string") {
+        return resolveProfileUrl(profileUrl);
+      }
+
+      const profileUrlKey = prepared.verificationContext.profile_url_key;
+      return typeof profileUrlKey === "string"
+        ? resolveProfileUrl(profileUrlKey)
+        : null;
+    },
+    async verify(runtime, account, prepared, confirmed) {
+      const profileUrlKey = prepared.verificationContext.profile_url_key;
+      if (typeof profileUrlKey !== "string") {
+        return {
+          verified: false,
+          state_synced: false,
+          source: "followups.confirm_result",
+          message: "Follow-up verification context was incomplete.",
+          details: {}
+        };
+      }
+
+      const stateRow = runtime.db.getSentInvitationState({
+        profileName: account.profileName,
+        profileUrlKey
+      });
+
+      return {
+        verified: confirmed.result.sent === true,
+        state_synced: stateRow?.followup_confirmed_at !== null,
+        source: "followups.confirm_result",
+        message:
+          confirmed.result.sent === true
+            ? "Follow-up send returned a positive message-echo confirmation."
+            : "Follow-up send did not report a positive message-echo confirmation.",
+        details: {
+          profile_url_key: profileUrlKey,
+          followup_confirmed_at: stateRow?.followup_confirmed_at ?? null,
+          confirm_result: confirmed.result
+        }
+      };
+    }
+  },
+  {
+    actionType: LIKE_POST_ACTION_TYPE,
+    summary:
+      "React to the approved post and verify the reaction is registered.",
+    expectedOutcome: "The approved reaction is active on the approved post.",
+    riskClass: "public",
+    async prepare(runtime, account) {
+      const target = getRequiredTarget<{
+        postUrl: string;
+        reaction?: LinkedInFeedReaction;
+      }>(account.targets, "feed.like_post", account.id);
+      const reaction = normalizeLinkedInFeedReaction(target.reaction, "like");
+
+      const prepared = runtime.feed.prepareLikePost({
+        profileName: account.profileName,
+        postUrl: target.postUrl,
+        reaction,
+        operatorNote: WRITE_VALIDATION_OPERATOR_NOTE
+      });
+
+      return {
+        prepared,
+        beforeScreenshotUrl: target.postUrl,
+        cleanupGuidance: [
+          "Remove the validation reaction manually after review if you do not want it to remain on the post."
+        ],
+        verificationContext: {
+          post_url: target.postUrl,
+          reaction
+        }
+      } satisfies ScenarioPrepareResult;
+    },
+    resolveAfterScreenshotUrl(_account, prepared) {
+      const postUrl = prepared.verificationContext.post_url;
+      return typeof postUrl === "string" ? postUrl : null;
+    },
+    async verify(_runtime, _account, _prepared, confirmed) {
+      const reaction = confirmed.result.reaction;
+      const verified = confirmed.result.reacted === true;
+
+      return {
+        verified,
+        state_synced: null,
+        source: "feed.like_post.confirm_result",
+        message: verified
+          ? "Reaction executor reported the target reaction as active after confirmation."
+          : "Reaction executor did not report the target reaction as active after confirmation.",
+        details: {
+          confirm_result: confirmed.result,
+          reaction
+        }
+      };
+    }
+  }
+] satisfies readonly WriteValidationScenarioDefinition[];
+
+export const LINKEDIN_WRITE_VALIDATION_ACTIONS: readonly LinkedInWriteValidationActionDefinition[] =
+  WRITE_VALIDATION_SCENARIOS.map(
+    ({ actionType, expectedOutcome, riskClass, summary }) => ({
+      actionType,
+      expectedOutcome,
+      riskClass,
+      summary
+    })
+  );

--- a/packages/core/src/writeValidationShared.ts
+++ b/packages/core/src/writeValidationShared.ts
@@ -1,0 +1,309 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  LIKE_POST_ACTION_TYPE
+} from "./linkedinFeed.js";
+import {
+  SEND_INVITATION_ACTION_TYPE
+} from "./linkedinConnections.js";
+import { FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE } from "./linkedinFollowups.js";
+import { CREATE_POST_ACTION_TYPE } from "./linkedinPosts.js";
+import type { LinkedInAssistantErrorCode } from "./errors.js";
+import type { CoreRuntime } from "./runtime.js";
+import type {
+  ConfirmByTokenResult,
+  PreparedActionResult
+} from "./twoPhaseCommit.js";
+import type { WriteValidationAccount } from "./writeValidationAccounts.js";
+
+export const SEND_MESSAGE_ACTION_TYPE = "send_message";
+export const WRITE_VALIDATION_WARNING =
+  "This will perform REAL actions on LinkedIn.";
+export const WRITE_VALIDATION_REPORT_DIR = "live-write-validation";
+export const WRITE_VALIDATION_LATEST_REPORT_NAME = "latest-report.json";
+export const DEFAULT_WRITE_VALIDATION_COOLDOWN_MS = 10_000;
+export const DEFAULT_WRITE_VALIDATION_TIMEOUT_MS = 30_000;
+export const WRITE_VALIDATION_FEED_URL = "https://www.linkedin.com/feed/";
+
+export type WriteValidationRiskClass = "private" | "network" | "public";
+
+export type LinkedInWriteValidationActionType =
+  | typeof CREATE_POST_ACTION_TYPE
+  | typeof SEND_INVITATION_ACTION_TYPE
+  | typeof SEND_MESSAGE_ACTION_TYPE
+  | typeof FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE
+  | typeof LIKE_POST_ACTION_TYPE;
+
+export type WriteValidationResultStatus = "pass" | "fail" | "cancelled";
+export type WriteValidationOutcome = WriteValidationResultStatus;
+
+export interface LinkedInWriteValidationActionDefinition {
+  actionType: LinkedInWriteValidationActionType;
+  expectedOutcome: string;
+  riskClass: WriteValidationRiskClass;
+  summary: string;
+}
+
+export interface WriteValidationActionPreview {
+  action_type: LinkedInWriteValidationActionType;
+  expected_outcome: string;
+  outbound: Record<string, unknown>;
+  risk_class: WriteValidationRiskClass;
+  summary: string;
+  target: Record<string, unknown>;
+}
+
+export interface WriteValidationVerificationResult {
+  details: Record<string, unknown>;
+  message: string;
+  source: string;
+  state_synced: boolean | null;
+  verified: boolean;
+}
+
+export interface WriteValidationActionResult {
+  action_type: LinkedInWriteValidationActionType;
+  after_screenshot_paths: string[];
+  artifact_paths: string[];
+  before_screenshot_paths: string[];
+  cleanup_guidance: string[];
+  completed_at: string;
+  confirm_artifacts: string[];
+  error_code?: LinkedInAssistantErrorCode;
+  error_message?: string;
+  expected_outcome: string;
+  linkedin_response?: Record<string, unknown>;
+  prepared_action_id?: string;
+  preview?: WriteValidationActionPreview;
+  risk_class: WriteValidationRiskClass;
+  started_at: string;
+  status: WriteValidationResultStatus;
+  state_synced: boolean | null;
+  summary: string;
+  verification?: {
+    details: Record<string, unknown>;
+    message: string;
+    source: string;
+    verified: boolean;
+  };
+}
+
+export interface WriteValidationReport {
+  account: {
+    designation: WriteValidationAccount["designation"];
+    id: string;
+    label: string;
+    profile_name: string;
+    session_name: string;
+  };
+  action_count: number;
+  actions: WriteValidationActionResult[];
+  audit_log_path: string;
+  checked_at: string;
+  cooldown_ms: number;
+  fail_count: number;
+  latest_report_path: string;
+  outcome: WriteValidationOutcome;
+  pass_count: number;
+  cancelled_count: number;
+  recommended_actions: string[];
+  report_path: string;
+  run_id: string;
+  summary: string;
+  warning: string;
+}
+
+export interface RunLinkedInWriteValidationOptions {
+  accountId: string;
+  baseDir?: string;
+  cooldownMs?: number;
+  interactive?: boolean;
+  onBeforeAction?: (
+    preview: WriteValidationActionPreview
+  ) => Promise<boolean> | boolean;
+  timeoutMs?: number;
+}
+
+export interface ScenarioPrepareResult {
+  beforeScreenshotUrl?: string;
+  cleanupGuidance: string[];
+  prepared: PreparedActionResult;
+  verificationContext: Record<string, unknown>;
+}
+
+export interface WriteValidationScenarioDefinition
+  extends LinkedInWriteValidationActionDefinition {
+  prepare: (
+    runtime: CoreRuntime,
+    account: WriteValidationAccount
+  ) => Promise<ScenarioPrepareResult>;
+  resolveAfterScreenshotUrl: (
+    account: WriteValidationAccount,
+    prepared: ScenarioPrepareResult,
+    confirmed: ConfirmByTokenResult
+  ) => string | null;
+  verify: (
+    runtime: CoreRuntime,
+    account: WriteValidationAccount,
+    prepared: ScenarioPrepareResult,
+    confirmed: ConfirmByTokenResult
+  ) => Promise<WriteValidationVerificationResult>;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function normalizeText(value: string | null | undefined): string {
+  return (value ?? "").replace(/\s+/gu, " ").trim();
+}
+
+export function dedupeStrings(values: readonly string[]): string[] {
+  return [...new Set(values.filter((value) => value.trim().length > 0))];
+}
+
+export function isScreenshotPath(value: string): boolean {
+  return /\.png$/iu.test(value.trim());
+}
+
+export function readPreviewArtifacts(preview: Record<string, unknown>): string[] {
+  const artifacts = preview.artifacts;
+  if (!Array.isArray(artifacts)) {
+    return [];
+  }
+
+  return artifacts
+    .map((artifact) => {
+      if (!isRecord(artifact)) {
+        return null;
+      }
+
+      const pathValue = artifact.path;
+      return typeof pathValue === "string" ? pathValue : null;
+    })
+    .filter((artifactPath): artifactPath is string => typeof artifactPath === "string");
+}
+
+export function buildPreview(
+  scenario: WriteValidationScenarioDefinition,
+  prepared: PreparedActionResult
+): WriteValidationActionPreview {
+  const target = isRecord(prepared.preview.target) ? prepared.preview.target : {};
+  const outbound = isRecord(prepared.preview.outbound)
+    ? prepared.preview.outbound
+    : {};
+
+  return {
+    action_type: scenario.actionType,
+    expected_outcome: scenario.expectedOutcome,
+    outbound,
+    risk_class: scenario.riskClass,
+    summary: scenario.summary,
+    target
+  };
+}
+
+export function determineActionStatus(
+  verification: WriteValidationVerificationResult
+): WriteValidationResultStatus {
+  if (!verification.verified || verification.state_synced === false) {
+    return "fail";
+  }
+
+  return "pass";
+}
+
+export function countActionStatuses(
+  actions: readonly WriteValidationActionResult[]
+): {
+  cancelledCount: number;
+  failCount: number;
+  passCount: number;
+} {
+  return actions.reduce(
+    (counts, action) => {
+      if (action.status === "pass") {
+        counts.passCount += 1;
+      } else if (action.status === "fail") {
+        counts.failCount += 1;
+      } else {
+        counts.cancelledCount += 1;
+      }
+
+      return counts;
+    },
+    {
+      cancelledCount: 0,
+      failCount: 0,
+      passCount: 0
+    }
+  );
+}
+
+export function determineOutcome(
+  actions: readonly WriteValidationActionResult[]
+): WriteValidationOutcome {
+  if (actions.some((action) => action.status === "fail")) {
+    return "fail";
+  }
+
+  if (actions.some((action) => action.status === "cancelled")) {
+    return "cancelled";
+  }
+
+  return "pass";
+}
+
+export function buildWriteValidationSummary(
+  report: Pick<
+    WriteValidationReport,
+    "action_count" | "pass_count" | "fail_count" | "cancelled_count" | "outcome"
+  >
+): string {
+  const parts = [
+    `Checked ${report.action_count} write-validation actions.`,
+    `${report.pass_count} passed.`,
+    `${report.fail_count} failed.`,
+    `${report.cancelled_count} cancelled.`
+  ];
+
+  return `${parts.join(" ")} Overall outcome: ${report.outcome}.`;
+}
+
+export function buildRecommendedActions(
+  report: Pick<WriteValidationReport, "actions" | "report_path" | "audit_log_path">
+): string[] {
+  const actions: string[] = [
+    `Review ${report.report_path} for the full per-action report and screenshots.`,
+    `Open ${report.audit_log_path} to inspect the structured audit log for this run.`
+  ];
+
+  for (const action of report.actions) {
+    actions.push(...action.cleanup_guidance);
+
+    if (action.status === "fail") {
+      actions.push(
+        `Re-check ${action.action_type} after reviewing ${report.report_path} and the attached screenshots.`
+      );
+    }
+  }
+
+  return dedupeStrings(actions);
+}
+
+export async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+export function buildWriteValidationReportAccount(
+  account: WriteValidationAccount
+): WriteValidationReport["account"] {
+  return {
+    designation: account.designation,
+    id: account.id,
+    label: account.label,
+    profile_name: account.profileName,
+    session_name: account.sessionName
+  };
+}


### PR DESCRIPTION
## Summary
- split the Tier 3 write-validation implementation into shared, runtime, and scenario modules to reduce nesting and duplicated metadata without changing exported APIs or CLI flags
- simplify write-validation account/config parsing, tighten CLI option handling, and clean up human-readable output helpers
- consolidate targeted test utilities and add focused coverage for account loading and write-validation output formatting

## Validation
- npm run typecheck
- npm run lint
- npm test
- pnpm test

Closes #147