### PR TITLE
fix: harden Tier 3 write-validation harness

### DIFF
--- a/packages/cli/src/writeValidationOutput.ts
+++ b/packages/cli/src/writeValidationOutput.ts
@@ -152,8 +152,16 @@ function formatActionDetails(action: WriteValidationActionResult): string[] {
     );
   }
 
+  if (action.failure_stage) {
+    detailLines.push(`  stage: ${sanitizeConsoleText(action.failure_stage)}`);
+  }
+
   if (action.error_message) {
     detailLines.push(`  error: ${sanitizeConsoleText(action.error_message)}`);
+  }
+
+  for (const warning of action.warnings ?? []) {
+    detailLines.push(`  warning: ${sanitizeConsoleText(warning)}`);
   }
 
   const beforePaths = formatArtifactPathList("before", action.before_screenshot_paths);

--- a/packages/cli/test/writeValidationOutput.test.ts
+++ b/packages/cli/test/writeValidationOutput.test.ts
@@ -130,6 +130,24 @@ describe("write validation output", () => {
     `);
   });
 
+  it("renders failure stages and warnings when present", () => {
+    const report = createReportFixture("fail");
+    report.actions[0] = {
+      ...report.actions[0],
+      failure_stage: "verify",
+      warnings: [
+        "Recovered after 1 transient retry while verifying the LinkedIn outcome."
+      ]
+    };
+
+    const output = formatWriteValidationReport(report);
+
+    expect(output).toContain("stage: verify");
+    expect(output).toContain(
+      "warning: Recovered after 1 transient retry while verifying the LinkedIn outcome."
+    );
+  });
+
   it("formats validation errors with details and help guidance", () => {
     const error: LinkedInAssistantErrorPayload = {
       code: "ACTION_PRECONDITION_FAILED",

--- a/packages/core/src/__tests__/writeValidationExecution.test.ts
+++ b/packages/core/src/__tests__/writeValidationExecution.test.ts
@@ -310,6 +310,233 @@ describe("runLinkedInWriteValidation execution flow", () => {
     expect(bundle.runtime.close).toHaveBeenCalledTimes(1);
   });
 
+  it("stops early after a rate limit and marks remaining actions cancelled", async () => {
+    const baseDir = createTempBaseDir();
+    createRuntimeBundle(baseDir);
+
+    const rateLimitedScenario: WriteValidationScenarioDefinition = {
+      actionType: SEND_MESSAGE_ACTION_TYPE,
+      expectedOutcome: "The message is sent successfully.",
+      riskClass: "private",
+      summary: "Send a validation message.",
+      prepare: vi.fn(async () => {
+        throw new LinkedInAssistantError(
+          "RATE_LIMITED",
+          "LinkedIn asked us to slow down before sending the validation message."
+        );
+      }),
+      resolveAfterScreenshotUrl: vi.fn(() => null),
+      verify: vi.fn(async () => createVerificationResult())
+    };
+
+    const skippedScenario: WriteValidationScenarioDefinition = {
+      actionType: LIKE_POST_ACTION_TYPE,
+      expectedOutcome: "The approved reaction remains active on the target post.",
+      riskClass: "public",
+      summary: "React to the approved post.",
+      prepare: vi.fn(async () => {
+        throw new Error("remaining scenario should not start");
+      }),
+      resolveAfterScreenshotUrl: vi.fn(() => null),
+      verify: vi.fn(async () => createVerificationResult())
+    };
+
+    writeValidationExecutionMocks.scenarios.push(rateLimitedScenario, skippedScenario);
+
+    const report = await runLinkedInWriteValidation({
+      accountId: "secondary",
+      baseDir,
+      cooldownMs: 0,
+      interactive: true
+    });
+
+    expect(report.outcome).toBe("fail");
+    expect(report.fail_count).toBe(1);
+    expect(report.cancelled_count).toBe(1);
+    expect(report.actions).toEqual([
+      expect.objectContaining({
+        action_type: SEND_MESSAGE_ACTION_TYPE,
+        error_code: "RATE_LIMITED",
+        status: "fail"
+      }),
+      expect.objectContaining({
+        action_type: LIKE_POST_ACTION_TYPE,
+        error_code: "RATE_LIMITED",
+        status: "cancelled"
+      })
+    ]);
+    expect(skippedScenario.prepare).not.toHaveBeenCalled();
+    expect(report.recommended_actions).toContain(
+      'Wait for LinkedIn to lift rate limiting on session "secondary-session" before rerunning write validation.'
+    );
+  });
+
+  it("validates scenario config before creating the runtime", async () => {
+    const baseDir = createTempBaseDir();
+
+    const scenario: WriteValidationScenarioDefinition = {
+      actionType: SEND_MESSAGE_ACTION_TYPE,
+      expectedOutcome: "The outbound message is echoed in the approved thread.",
+      riskClass: "private",
+      summary: "Send a validation message in the approved thread.",
+      validateConfig: vi.fn(() => {
+        throw new LinkedInAssistantError(
+          "ACTION_PRECONDITION_FAILED",
+          'Write-validation account "secondary" is missing targets.send_message in config.json.'
+        );
+      }),
+      prepare: vi.fn(async () => {
+        throw new Error("prepare should not run");
+      }),
+      resolveAfterScreenshotUrl: vi.fn(() => null),
+      verify: vi.fn(async () => createVerificationResult())
+    };
+
+    writeValidationExecutionMocks.scenarios.push(scenario);
+
+    await expect(
+      runLinkedInWriteValidation({
+        accountId: "secondary",
+        baseDir,
+        cooldownMs: 0,
+        interactive: true
+      })
+    ).rejects.toThrow('Write-validation account "secondary" is missing targets.send_message in config.json.');
+
+    expect(writeValidationExecutionMocks.createWriteValidationRuntime).not.toHaveBeenCalled();
+    expect(scenario.prepare).not.toHaveBeenCalled();
+  });
+
+  it("continues when screenshot capture fails and records warnings", async () => {
+    const baseDir = createTempBaseDir();
+    const bundle = createRuntimeBundle(baseDir);
+
+    bundle.profileManager.capturePageScreenshot
+      .mockRejectedValueOnce(
+        new LinkedInAssistantError("TIMEOUT", "before screenshot timed out")
+      )
+      .mockRejectedValueOnce(
+        new LinkedInAssistantError("TIMEOUT", "before screenshot timed out")
+      )
+      .mockResolvedValueOnce("send_message-after.png");
+
+    const scenario: WriteValidationScenarioDefinition = {
+      actionType: SEND_MESSAGE_ACTION_TYPE,
+      expectedOutcome: "The outbound message is echoed in the approved thread.",
+      riskClass: "private",
+      summary: "Send a validation message in the approved thread.",
+      prepare: vi.fn(async () => ({
+        beforeScreenshotUrl: "https://www.linkedin.com/messaging/thread/abc123/",
+        cleanupGuidance: [],
+        prepared: createPreparedActionResult({
+          preview: {
+            outbound: {
+              text: "Quick validation ping"
+            },
+            target: {
+              thread: "abc123"
+            }
+          }
+        }),
+        verificationContext: {}
+      })),
+      resolveAfterScreenshotUrl: vi.fn(() => "https://www.linkedin.com/messaging/thread/abc123/"),
+      verify: vi.fn(async () => createVerificationResult())
+    };
+
+    writeValidationExecutionMocks.scenarios.push(scenario);
+    bundle.runtime.twoPhaseCommit.confirmByToken.mockResolvedValue(
+      createConfirmResult({
+        result: {
+          sent: true
+        }
+      })
+    );
+
+    const report = await runLinkedInWriteValidation({
+      accountId: "secondary",
+      baseDir,
+      cooldownMs: 0,
+      interactive: true
+    });
+
+    expect(report.outcome).toBe("pass");
+    expect(report.actions).toEqual([
+      expect.objectContaining({
+        action_type: SEND_MESSAGE_ACTION_TYPE,
+        after_screenshot_paths: ["send_message-after.png"],
+        before_screenshot_paths: [],
+        status: "pass",
+        warnings: expect.arrayContaining([
+          "Retried 1 time before capturing the pre-action screenshot still failed.",
+          "before screenshot timed out"
+        ])
+      })
+    ]);
+    expect(bundle.runtime.twoPhaseCommit.confirmByToken).toHaveBeenCalledTimes(1);
+    expect(scenario.verify).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks concurrent runs for the same account", async () => {
+    const baseDir = createTempBaseDir();
+    createRuntimeBundle(baseDir);
+
+    let promptEnteredResolve: (() => void) | undefined;
+    let releaseFirstRunResolve: ((value: boolean) => void) | undefined;
+    const promptEntered = new Promise<void>((resolve) => {
+      promptEnteredResolve = resolve;
+    });
+    const releaseFirstRun = new Promise<boolean>((resolve) => {
+      releaseFirstRunResolve = resolve;
+    });
+
+    const scenario: WriteValidationScenarioDefinition = {
+      actionType: SEND_MESSAGE_ACTION_TYPE,
+      expectedOutcome: "The outbound message is echoed in the approved thread.",
+      riskClass: "private",
+      summary: "Send a validation message in the approved thread.",
+      prepare: vi.fn(async () => ({
+        beforeScreenshotUrl: "https://www.linkedin.com/messaging/thread/abc123/",
+        cleanupGuidance: [],
+        prepared: createPreparedActionResult(),
+        verificationContext: {}
+      })),
+      resolveAfterScreenshotUrl: vi.fn(() => null),
+      verify: vi.fn(async () => createVerificationResult())
+    };
+
+    writeValidationExecutionMocks.scenarios.push(scenario);
+
+    const firstRun = runLinkedInWriteValidation({
+      accountId: "secondary",
+      baseDir,
+      cooldownMs: 0,
+      interactive: true,
+      onBeforeAction: async () => {
+        promptEnteredResolve?.();
+        return releaseFirstRun;
+      }
+    });
+
+    await promptEntered;
+
+    await expect(
+      runLinkedInWriteValidation({
+        accountId: "secondary",
+        baseDir,
+        cooldownMs: 0,
+        interactive: true
+      })
+    ).rejects.toThrow('Write validation is already running for account "secondary"');
+
+    releaseFirstRunResolve?.(false);
+    await expect(firstRun).resolves.toMatchObject({
+      cancelled_count: 1,
+      outcome: "cancelled"
+    });
+    expect(writeValidationExecutionMocks.createWriteValidationRuntime).toHaveBeenCalledTimes(1);
+  });
+
   it("records cancelled actions when the operator declines execution", async () => {
     const baseDir = createTempBaseDir();
     const bundle = createRuntimeBundle(baseDir);

--- a/packages/core/src/writeValidation.ts
+++ b/packages/core/src/writeValidation.ts
@@ -1,5 +1,11 @@
+import { mkdir, open, readFile, unlink } from "node:fs/promises";
 import path from "node:path";
-import { ensureConfigPaths, resolveConfigPaths } from "./config.js";
+import { errors as playwrightErrors } from "playwright-core";
+import {
+  ensureConfigPaths,
+  resolveConfigPaths,
+  type ConfigPaths
+} from "./config.js";
 import {
   LinkedInAssistantError,
   asLinkedInAssistantError,
@@ -15,6 +21,9 @@ import {
 } from "./writeValidationScenarios.js";
 import {
   DEFAULT_WRITE_VALIDATION_COOLDOWN_MS,
+  DEFAULT_WRITE_VALIDATION_MAX_RETRIES,
+  DEFAULT_WRITE_VALIDATION_RETRY_BASE_DELAY_MS,
+  DEFAULT_WRITE_VALIDATION_RETRY_MAX_DELAY_MS,
   DEFAULT_WRITE_VALIDATION_TIMEOUT_MS,
   WRITE_VALIDATION_LATEST_REPORT_NAME,
   WRITE_VALIDATION_REPORT_DIR,
@@ -34,6 +43,7 @@ import {
   type RunLinkedInWriteValidationOptions,
   type WriteValidationActionPreview,
   type WriteValidationActionResult,
+  type WriteValidationActionStage,
   type WriteValidationReport,
   type WriteValidationResultStatus,
   type WriteValidationScenarioDefinition,
@@ -53,10 +63,70 @@ export type {
   WriteValidationVerificationResult
 } from "./writeValidationShared.js";
 
+type WriteValidationRuntime =
+  Awaited<ReturnType<typeof createWriteValidationRuntime>>["runtime"];
+type WriteValidationLogger = WriteValidationRuntime["logger"];
+
 interface PreparedArtifacts {
   beforeScreenshotPaths: string[];
   previewArtifacts: string[];
 }
+
+interface PartialActionContext {
+  afterScreenshotPaths: string[];
+  beforeScreenshotPaths: string[];
+  cleanupGuidance: string[];
+  confirmArtifacts: string[];
+  linkedinResponse?: Record<string, unknown>;
+  prepared?: PreparedActionResult;
+  preparedArtifacts?: PreparedArtifacts;
+  preview?: WriteValidationActionPreview;
+  warnings: string[];
+}
+
+interface ScenarioExecutionResult {
+  actionResult: WriteValidationActionResult;
+  shouldStop: boolean;
+}
+
+interface StageRetryResult<T> {
+  attemptCount: number;
+  result: T;
+}
+
+interface WriteValidationRunLockState {
+  account_id: string;
+  cwd: string;
+  pid: number;
+  started_at: string;
+}
+
+interface WriteValidationRunLockHandle {
+  lockPath: string;
+  release: () => Promise<void>;
+  state: WriteValidationRunLockState;
+}
+
+interface ValidatedWriteValidationOptions {
+  accountId: string;
+  baseDir?: string;
+  cooldownMs: number;
+  maxRetries: number;
+  onBeforeAction?: RunLinkedInWriteValidationOptions["onBeforeAction"];
+  retryBaseDelayMs: number;
+  retryMaxDelayMs: number;
+  timeoutMs: number;
+}
+
+const WRITE_VALIDATION_ACTION_STAGES: readonly WriteValidationActionStage[] = [
+  "prepare",
+  "prompt",
+  "before_screenshot",
+  "confirm",
+  "after_screenshot",
+  "verify"
+] as const;
+const WRITE_VALIDATION_LOCK_NAME = "run.lock.json";
 
 function isTruthyCiValue(value: string | undefined): boolean {
   if (!value) {
@@ -76,10 +146,304 @@ function readPreparedArtifacts(prepared: PreparedActionResult): PreparedArtifact
   };
 }
 
-function assertInteractiveWriteValidation(
-  options: RunLinkedInWriteValidationOptions
-): void {
-  if (options.interactive === false) {
+function sanitizeUserFacingText(value: string): string {
+  return value.replace(/\s+/gu, " ").trim();
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return sanitizeUserFacingText(error.message);
+  }
+
+  return sanitizeUserFacingText(String(error));
+}
+
+function createErrorOptions(error: unknown): ErrorOptions | undefined {
+  return error instanceof Error ? { cause: error } : undefined;
+}
+
+function isFinitePositiveInteger(value: number): boolean {
+  return Number.isInteger(value) && Number.isFinite(value) && value > 0;
+}
+
+function isFiniteNonNegativeInteger(value: number): boolean {
+  return Number.isInteger(value) && Number.isFinite(value) && value >= 0;
+}
+
+function resolvePositiveInt(
+  value: number | undefined,
+  fallback: number,
+  label: string
+): number {
+  if (typeof value === "undefined") {
+    return fallback;
+  }
+
+  if (!isFinitePositiveInteger(value)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must be a positive integer.`
+    );
+  }
+
+  return value;
+}
+
+function resolveNonNegativeInt(
+  value: number | undefined,
+  fallback: number,
+  label: string
+): number {
+  if (typeof value === "undefined") {
+    return fallback;
+  }
+
+  if (!isFiniteNonNegativeInteger(value)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must be a non-negative integer.`
+    );
+  }
+
+  return value;
+}
+
+function withPlaywrightInstallHint(error: unknown): Error {
+  if (error instanceof Error && error.message.includes("Executable doesn't exist")) {
+    return new Error(
+      'Playwright browser executable is missing. Install Chromium with "npx playwright install chromium" or set PLAYWRIGHT_EXECUTABLE_PATH.'
+    );
+  }
+
+  if (error instanceof Error) {
+    return error;
+  }
+
+  return new Error(String(error));
+}
+
+function isTimeoutError(error: unknown): boolean {
+  return error instanceof playwrightErrors.TimeoutError;
+}
+
+function isNetworkError(error: unknown): boolean {
+  return /(net::|ERR_|ECONN|ENOTFOUND|EAI_AGAIN|socket hang up|disconnected)/iu.test(
+    getErrorMessage(error)
+  );
+}
+
+function isRateLimitError(error: unknown): boolean {
+  return /rate\s*limit|http\s*(429|999)\b|\b429\b|\b999\b/iu.test(
+    getErrorMessage(error)
+  );
+}
+
+function detectAuthErrorCode(message: string): LinkedInAssistantErrorCode | null {
+  if (/checkpoint|challenge/iu.test(message)) {
+    return "CAPTCHA_OR_CHALLENGE";
+  }
+
+  if (/auth|required|session expired|not authenticated|sign in|log in|login/iu.test(message)) {
+    return "AUTH_REQUIRED";
+  }
+
+  return null;
+}
+
+function isWriteValidationActionStage(value: unknown): value is WriteValidationActionStage {
+  return WRITE_VALIDATION_ACTION_STAGES.includes(value as WriteValidationActionStage);
+}
+
+function describeActionStage(stage: WriteValidationActionStage): string {
+  switch (stage) {
+    case "prepare":
+      return "preparing the action";
+    case "prompt":
+      return "waiting for operator confirmation";
+    case "before_screenshot":
+      return "capturing the pre-action screenshot";
+    case "confirm":
+      return "executing the live action";
+    case "after_screenshot":
+      return "capturing the post-action screenshot";
+    case "verify":
+      return "verifying the LinkedIn outcome";
+  }
+}
+
+function calculateRetryBackoffMs(
+  attempt: number,
+  retryBaseDelayMs: number,
+  retryMaxDelayMs: number
+): number {
+  return Math.min(retryMaxDelayMs, retryBaseDelayMs * 2 ** Math.max(0, attempt - 1));
+}
+
+function getErrorAttemptCount(error: LinkedInAssistantError): number {
+  const attemptCount = error.details.attempt_count;
+  return typeof attemptCount === "number" && Number.isInteger(attemptCount) && attemptCount > 0
+    ? attemptCount
+    : 1;
+}
+
+function buildRetryRecoveryWarning(
+  stage: WriteValidationActionStage,
+  attemptCount: number
+): string | null {
+  if (attemptCount <= 1) {
+    return null;
+  }
+
+  const retryCount = attemptCount - 1;
+  return `Recovered after ${retryCount} transient retr${retryCount === 1 ? "y" : "ies"} while ${describeActionStage(stage)}.`;
+}
+
+function buildRetryExhaustedWarning(
+  stage: WriteValidationActionStage,
+  attemptCount: number
+): string | null {
+  if (attemptCount <= 1) {
+    return null;
+  }
+
+  const retryCount = attemptCount - 1;
+  return `Retried ${retryCount} ${retryCount === 1 ? "time" : "times"} before ${describeActionStage(stage)} still failed.`;
+}
+
+function isRetryableWriteValidationError(code: LinkedInAssistantErrorCode): boolean {
+  return code === "NETWORK_ERROR" || code === "TIMEOUT";
+}
+
+function isBlockingWriteValidationErrorCode(code: LinkedInAssistantErrorCode): boolean {
+  return code === "AUTH_REQUIRED" || code === "CAPTCHA_OR_CHALLENGE" || code === "RATE_LIMITED";
+}
+
+function normalizeWriteValidationError(input: {
+  accountId: string;
+  actionType: WriteValidationActionResult["action_type"];
+  error: unknown;
+  expectedOutcome: string;
+  sessionName: string;
+  stage: WriteValidationActionStage;
+}): LinkedInAssistantError {
+  const details = {
+    account_id: input.accountId,
+    action_type: input.actionType,
+    expected_outcome: input.expectedOutcome,
+    session_name: input.sessionName,
+    stage: input.stage
+  };
+
+  if (input.error instanceof LinkedInAssistantError) {
+    return new LinkedInAssistantError(
+      input.error.code,
+      input.error.message,
+      {
+        ...input.error.details,
+        ...details
+      },
+      { cause: input.error }
+    );
+  }
+
+  const rawMessage = getErrorMessage(input.error);
+  const authCode = detectAuthErrorCode(rawMessage);
+  if (authCode) {
+    return new LinkedInAssistantError(
+      authCode,
+      authCode === "CAPTCHA_OR_CHALLENGE"
+        ? `Stored session "${input.sessionName}" triggered a LinkedIn challenge while ${describeActionStage(input.stage)} for ${input.actionType}. Capture a fresh session with "owa auth:session --session ${input.sessionName}" and rerun the harness.`
+        : `Stored session "${input.sessionName}" is no longer authenticated while ${describeActionStage(input.stage)} for ${input.actionType}. Capture a fresh session with "owa auth:session --session ${input.sessionName}" and rerun the harness.`,
+      {
+        ...details,
+        raw_error: rawMessage
+      },
+      createErrorOptions(input.error)
+    );
+  }
+
+  if (isTimeoutError(input.error)) {
+    return new LinkedInAssistantError(
+      "TIMEOUT",
+      `Timed out while ${describeActionStage(input.stage)} for ${input.actionType}. LinkedIn may be slow; rerun the harness or increase the timeout.`,
+      {
+        ...details,
+        raw_error: rawMessage
+      },
+      createErrorOptions(input.error)
+    );
+  }
+
+  if (isRateLimitError(input.error)) {
+    return new LinkedInAssistantError(
+      "RATE_LIMITED",
+      `LinkedIn rate limited ${input.actionType} while ${describeActionStage(input.stage)}. Wait for the account to cool down, then rerun the harness.`,
+      {
+        ...details,
+        raw_error: rawMessage
+      },
+      createErrorOptions(input.error)
+    );
+  }
+
+  if (isNetworkError(input.error)) {
+    return new LinkedInAssistantError(
+      "NETWORK_ERROR",
+      `The browser or network connection failed while ${describeActionStage(input.stage)} for ${input.actionType}: ${rawMessage}. Check connectivity and rerun the harness.`,
+      {
+        ...details,
+        raw_error: rawMessage
+      },
+      createErrorOptions(input.error)
+    );
+  }
+
+  if (/selector|locator/iu.test(rawMessage)) {
+    return new LinkedInAssistantError(
+      "UI_CHANGED_SELECTOR_FAILED",
+      `LinkedIn's DOM no longer matched the expected selectors while ${describeActionStage(input.stage)} for ${input.actionType}. Review the screenshots and validator assumptions, then rerun the harness.`,
+      {
+        ...details,
+        raw_error: rawMessage
+      },
+      createErrorOptions(input.error)
+    );
+  }
+
+  return new LinkedInAssistantError(
+    "UNKNOWN",
+    `Write validation failed while ${describeActionStage(input.stage)} for ${input.actionType}: ${rawMessage}. Review the audit log and rerun the harness.`,
+    {
+      ...details,
+      raw_error: rawMessage
+    },
+    createErrorOptions(input.error)
+  );
+}
+
+function buildActionArtifactPaths(input: {
+  afterScreenshotPaths?: readonly string[];
+  beforeScreenshotPaths?: readonly string[];
+  confirmArtifacts?: readonly string[];
+  preparedArtifacts?: PreparedArtifacts;
+}): string[] {
+  return dedupeStrings([
+    ...(input.preparedArtifacts?.previewArtifacts ?? []),
+    ...(input.beforeScreenshotPaths ?? []),
+    ...(input.confirmArtifacts ?? []),
+    ...(input.afterScreenshotPaths ?? [])
+  ]);
+}
+
+function resolveFailureStage(
+  error: LinkedInAssistantError,
+  fallback: WriteValidationActionStage
+): WriteValidationActionStage {
+  return isWriteValidationActionStage(error.details.stage) ? error.details.stage : fallback;
+}
+
+function assertInteractiveWriteValidation(input: { interactive?: boolean }): void {
+  if (input.interactive === false) {
     throw new LinkedInAssistantError(
       "ACTION_PRECONDITION_FAILED",
       "Write validation requires an interactive terminal and a visible browser window."
@@ -96,10 +460,48 @@ function assertInteractiveWriteValidation(
 
 export function validateWriteValidationOptions(
   options: RunLinkedInWriteValidationOptions
-): Required<Pick<RunLinkedInWriteValidationOptions, "accountId">> & {
-  cooldownMs: number;
-  timeoutMs: number;
-} {
+): ValidatedWriteValidationOptions {
+  if (typeof options !== "object" || options === null || Array.isArray(options)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "write validation options must be an object.",
+      {
+        received_type: Array.isArray(options) ? "array" : typeof options
+      }
+    );
+  }
+
+  if (typeof options.accountId !== "string") {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "accountId is required for write validation."
+    );
+  }
+
+  if (typeof options.baseDir !== "undefined" && typeof options.baseDir !== "string") {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "baseDir must be a string when provided."
+    );
+  }
+
+  if (
+    typeof options.onBeforeAction !== "undefined" &&
+    typeof options.onBeforeAction !== "function"
+  ) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "onBeforeAction must be a function when provided."
+    );
+  }
+
+  if (typeof options.interactive !== "undefined" && typeof options.interactive !== "boolean") {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "interactive must be a boolean when provided."
+    );
+  }
+
   const accountId = options.accountId.trim();
   if (!accountId) {
     throw new LinkedInAssistantError(
@@ -108,25 +510,51 @@ export function validateWriteValidationOptions(
     );
   }
 
-  const timeoutMs = options.timeoutMs ?? DEFAULT_WRITE_VALIDATION_TIMEOUT_MS;
-  if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
-    throw new LinkedInAssistantError(
-      "ACTION_PRECONDITION_FAILED",
-      "timeoutMs must be a positive integer."
-    );
-  }
+  const timeoutMs = resolvePositiveInt(
+    options.timeoutMs,
+    DEFAULT_WRITE_VALIDATION_TIMEOUT_MS,
+    "timeoutMs"
+  );
+  const cooldownMs = resolveNonNegativeInt(
+    options.cooldownMs,
+    DEFAULT_WRITE_VALIDATION_COOLDOWN_MS,
+    "cooldownMs"
+  );
+  const maxRetries = resolveNonNegativeInt(
+    options.maxRetries,
+    DEFAULT_WRITE_VALIDATION_MAX_RETRIES,
+    "maxRetries"
+  );
+  const retryBaseDelayMs = resolvePositiveInt(
+    options.retryBaseDelayMs,
+    DEFAULT_WRITE_VALIDATION_RETRY_BASE_DELAY_MS,
+    "retryBaseDelayMs"
+  );
+  const retryMaxDelayMs = resolvePositiveInt(
+    options.retryMaxDelayMs,
+    DEFAULT_WRITE_VALIDATION_RETRY_MAX_DELAY_MS,
+    "retryMaxDelayMs"
+  );
 
-  const cooldownMs = options.cooldownMs ?? DEFAULT_WRITE_VALIDATION_COOLDOWN_MS;
-  if (!Number.isInteger(cooldownMs) || cooldownMs < 0) {
+  if (retryMaxDelayMs < retryBaseDelayMs) {
     throw new LinkedInAssistantError(
       "ACTION_PRECONDITION_FAILED",
-      "cooldownMs must be a non-negative integer."
+      "retryMaxDelayMs must be greater than or equal to retryBaseDelayMs.",
+      {
+        retry_base_delay_ms: retryBaseDelayMs,
+        retry_max_delay_ms: retryMaxDelayMs
+      }
     );
   }
 
   return {
     accountId,
+    ...(typeof options.baseDir === "string" ? { baseDir: options.baseDir } : {}),
     cooldownMs,
+    maxRetries,
+    ...(options.onBeforeAction ? { onBeforeAction: options.onBeforeAction } : {}),
+    retryBaseDelayMs,
+    retryMaxDelayMs,
     timeoutMs
   };
 }
@@ -149,32 +577,441 @@ function ensureSecondaryWriteValidationAccount(account: {
   );
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise<void>((resolve) => {
+async function sleep(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => {
     setTimeout(resolve, ms);
   });
 }
 
-async function ensureScenarioScreenshotPaths(input: {
-  actionType: WriteValidationActionResult["action_type"];
-  existingPaths: readonly string[];
-  profileManager: WriteValidationProfileManager;
-  stage: "before" | "after";
-  url?: string | null | undefined;
-}): Promise<string[]> {
-  const screenshotPaths = [...input.existingPaths];
+function validateWriteValidationScenarioDefinitions(
+  scenarios: readonly WriteValidationScenarioDefinition[]
+): void {
+  const seenActionTypes = new Set<string>();
 
-  if (screenshotPaths.length === 0 && typeof input.url === "string") {
-    screenshotPaths.push(
-      await input.profileManager.capturePageScreenshot({
-        actionType: input.actionType,
-        stage: input.stage,
-        url: input.url
-      })
-    );
+  for (const scenario of scenarios) {
+    if (typeof scenario.actionType !== "string" || scenario.actionType.trim().length === 0) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        "write-validation scenarios must define a non-empty actionType."
+      );
+    }
+
+    if (seenActionTypes.has(scenario.actionType)) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `Duplicate write-validation scenario action type: ${scenario.actionType}.`,
+        {
+          action_type: scenario.actionType
+        }
+      );
+    }
+    seenActionTypes.add(scenario.actionType);
+
+    if (typeof scenario.summary !== "string" || scenario.summary.trim().length === 0) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `write-validation scenario ${scenario.actionType} is missing a summary.`,
+        {
+          action_type: scenario.actionType
+        }
+      );
+    }
+
+    if (
+      typeof scenario.expectedOutcome !== "string" ||
+      scenario.expectedOutcome.trim().length === 0
+    ) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `write-validation scenario ${scenario.actionType} is missing an expectedOutcome.`,
+        {
+          action_type: scenario.actionType
+        }
+      );
+    }
+
+    if (!["private", "network", "public"].includes(scenario.riskClass)) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `write-validation scenario ${scenario.actionType} has an unsupported risk class.`,
+        {
+          action_type: scenario.actionType,
+          risk_class: scenario.riskClass
+        }
+      );
+    }
+
+    if (typeof scenario.prepare !== "function") {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `write-validation scenario ${scenario.actionType} is missing a prepare function.`,
+        {
+          action_type: scenario.actionType
+        }
+      );
+    }
+
+    if (typeof scenario.resolveAfterScreenshotUrl !== "function") {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `write-validation scenario ${scenario.actionType} is missing a resolveAfterScreenshotUrl function.`,
+        {
+          action_type: scenario.actionType
+        }
+      );
+    }
+
+    if (typeof scenario.verify !== "function") {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `write-validation scenario ${scenario.actionType} is missing a verify function.`,
+        {
+          action_type: scenario.actionType
+        }
+      );
+    }
+
+    if (
+      typeof scenario.validateConfig !== "undefined" &&
+      typeof scenario.validateConfig !== "function"
+    ) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `write-validation scenario ${scenario.actionType} has an invalid validateConfig hook.`,
+        {
+          action_type: scenario.actionType
+        }
+      );
+    }
+  }
+}
+
+function validateWriteValidationStartupConfig(
+  account: ReturnType<typeof resolveWriteValidationAccount>,
+  scenarios: readonly WriteValidationScenarioDefinition[]
+): void {
+  for (const scenario of scenarios) {
+    if (!scenario.validateConfig) {
+      continue;
+    }
+
+    try {
+      scenario.validateConfig(account);
+    } catch (error) {
+      const normalizedError = asLinkedInAssistantError(
+        error,
+        error instanceof LinkedInAssistantError ? error.code : "ACTION_PRECONDITION_FAILED",
+        `Invalid write-validation startup config for ${scenario.actionType}.`
+      );
+      throw new LinkedInAssistantError(
+        normalizedError.code,
+        normalizedError.message,
+        {
+          ...normalizedError.details,
+          account_id: account.id,
+          action_type: scenario.actionType,
+          session_name: account.sessionName,
+          startup_validation: true
+        },
+        { cause: normalizedError }
+      );
+    }
+  }
+}
+
+async function readRunLockState(lockPath: string): Promise<WriteValidationRunLockState | null> {
+  try {
+    const raw = await readFile(lockPath, "utf8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+
+    return typeof parsed.account_id === "string" &&
+      typeof parsed.cwd === "string" &&
+      typeof parsed.pid === "number" &&
+      Number.isInteger(parsed.pid) &&
+      typeof parsed.started_at === "string"
+      ? {
+          account_id: parsed.account_id,
+          cwd: parsed.cwd,
+          pid: parsed.pid,
+          started_at: parsed.started_at
+        }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
   }
 
-  return dedupeStrings(screenshotPaths);
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    const code =
+      typeof error === "object" && error !== null && "code" in error
+        ? String((error as { code?: unknown }).code ?? "")
+        : "";
+    return code !== "ESRCH";
+  }
+}
+
+async function acquireWriteValidationRunLock(
+  paths: ConfigPaths,
+  accountId: string
+): Promise<WriteValidationRunLockHandle> {
+  const lockDir = path.join(paths.artifactsDir, WRITE_VALIDATION_REPORT_DIR, accountId);
+  const lockPath = path.join(lockDir, WRITE_VALIDATION_LOCK_NAME);
+  const state: WriteValidationRunLockState = {
+    account_id: accountId,
+    cwd: process.cwd(),
+    pid: process.pid,
+    started_at: new Date().toISOString()
+  };
+
+  await mkdir(lockDir, { recursive: true });
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const handle = await open(lockPath, "wx");
+      try {
+        await handle.writeFile(`${JSON.stringify(state, null, 2)}\n`, "utf8");
+      } finally {
+        await handle.close();
+      }
+
+      return {
+        lockPath,
+        state,
+        async release() {
+          await unlink(lockPath).catch((error) => {
+            const code =
+              typeof error === "object" && error !== null && "code" in error
+                ? String((error as { code?: unknown }).code ?? "")
+                : "";
+            if (code !== "ENOENT") {
+              throw error;
+            }
+          });
+        }
+      };
+    } catch (error) {
+      const code =
+        typeof error === "object" && error !== null && "code" in error
+          ? String((error as { code?: unknown }).code ?? "")
+          : "";
+      if (code !== "EEXIST") {
+        throw error;
+      }
+
+      const existingLock = await readRunLockState(lockPath);
+      if (existingLock && isProcessAlive(existingLock.pid)) {
+        throw new LinkedInAssistantError(
+          "ACTION_PRECONDITION_FAILED",
+          `Write validation is already running for account "${accountId}" (pid ${existingLock.pid}, started ${existingLock.started_at}). Wait for that run to finish before starting another one.`,
+          {
+            account_id: accountId,
+            lock_path: lockPath,
+            pid: existingLock.pid,
+            started_at: existingLock.started_at
+          }
+        );
+      }
+
+      await unlink(lockPath).catch((unlinkError) => {
+        const unlinkCode =
+          typeof unlinkError === "object" && unlinkError !== null && "code" in unlinkError
+            ? String((unlinkError as { code?: unknown }).code ?? "")
+            : "";
+        if (unlinkCode !== "ENOENT") {
+          throw unlinkError;
+        }
+      });
+    }
+  }
+
+  throw new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    `Could not acquire the write-validation run lock for account "${accountId}". Remove ${lockPath} manually if no other harness is active.`,
+    {
+      account_id: accountId,
+      lock_path: lockPath
+    }
+  );
+}
+
+async function runWriteValidationStageWithRetry<T>(input: {
+  accountId: string;
+  actionType: WriteValidationActionResult["action_type"];
+  execute: () => Promise<T>;
+  expectedOutcome: string;
+  logger: WriteValidationLogger;
+  maxRetries: number;
+  retryBaseDelayMs: number;
+  retryMaxDelayMs: number;
+  sessionName: string;
+  stage: WriteValidationActionStage;
+}): Promise<StageRetryResult<T>> {
+  const maxAttempts = input.maxRetries + 1;
+  let lastError: LinkedInAssistantError | undefined;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    input.logger.log("debug", "write_validation.action.attempt", {
+      account_id: input.accountId,
+      action_type: input.actionType,
+      attempt,
+      max_attempts: maxAttempts,
+      session_name: input.sessionName,
+      stage: input.stage
+    });
+
+    try {
+      return {
+        attemptCount: attempt,
+        result: await input.execute()
+      };
+    } catch (error) {
+      const normalizedError = normalizeWriteValidationError({
+        accountId: input.accountId,
+        actionType: input.actionType,
+        error,
+        expectedOutcome: input.expectedOutcome,
+        sessionName: input.sessionName,
+        stage: input.stage
+      });
+      lastError = new LinkedInAssistantError(
+        normalizedError.code,
+        normalizedError.message,
+        {
+          ...normalizedError.details,
+          attempt_count: attempt
+        },
+        { cause: normalizedError }
+      );
+
+      if (!isRetryableWriteValidationError(normalizedError.code) || attempt >= maxAttempts) {
+        throw lastError;
+      }
+
+      const backoffMs = calculateRetryBackoffMs(
+        attempt,
+        input.retryBaseDelayMs,
+        input.retryMaxDelayMs
+      );
+      input.logger.log("warn", "write_validation.action.retry", {
+        account_id: input.accountId,
+        action_type: input.actionType,
+        attempt,
+        backoff_ms: backoffMs,
+        code: normalizedError.code,
+        error_message: normalizedError.message,
+        max_attempts: maxAttempts,
+        session_name: input.sessionName,
+        stage: input.stage
+      });
+      await sleep(backoffMs);
+    }
+  }
+
+  throw (
+    lastError ??
+    new LinkedInAssistantError(
+      "UNKNOWN",
+      `Write validation exhausted retries while ${describeActionStage(input.stage)} for ${input.actionType}.`,
+      {
+        account_id: input.accountId,
+        action_type: input.actionType,
+        session_name: input.sessionName,
+        stage: input.stage
+      }
+    )
+  );
+}
+
+async function captureScenarioScreenshotBestEffort(input: {
+  accountId: string;
+  actionType: WriteValidationActionResult["action_type"];
+  existingPaths: readonly string[];
+  expectedOutcome: string;
+  logger: WriteValidationLogger;
+  maxRetries: number;
+  profileManager: WriteValidationProfileManager;
+  retryBaseDelayMs: number;
+  retryMaxDelayMs: number;
+  sessionName: string;
+  stage: "before" | "after";
+  url?: string | null | undefined;
+}): Promise<{
+  screenshotPaths: string[];
+  warnings: string[];
+}> {
+  const screenshotPaths = [...input.existingPaths];
+  const stage: WriteValidationActionStage =
+    input.stage === "before" ? "before_screenshot" : "after_screenshot";
+
+  if (screenshotPaths.length > 0 || typeof input.url !== "string" || input.url.trim().length === 0) {
+    return {
+      screenshotPaths: dedupeStrings(screenshotPaths),
+      warnings: []
+    };
+  }
+
+  try {
+    const capture = await runWriteValidationStageWithRetry({
+      accountId: input.accountId,
+      actionType: input.actionType,
+      execute: async () =>
+        input.profileManager.capturePageScreenshot({
+          actionType: input.actionType,
+          stage: input.stage,
+          url: input.url ?? ""
+        }),
+      expectedOutcome: input.expectedOutcome,
+      logger: input.logger,
+      maxRetries: input.maxRetries,
+      retryBaseDelayMs: input.retryBaseDelayMs,
+      retryMaxDelayMs: input.retryMaxDelayMs,
+      sessionName: input.sessionName,
+      stage
+    });
+
+    screenshotPaths.push(capture.result);
+    const recoveryWarning = buildRetryRecoveryWarning(stage, capture.attemptCount);
+
+    return {
+      screenshotPaths: dedupeStrings(screenshotPaths),
+      warnings: recoveryWarning ? [recoveryWarning] : []
+    };
+  } catch (error) {
+    const normalizedError = asLinkedInAssistantError(
+      error,
+      error instanceof LinkedInAssistantError ? error.code : "UNKNOWN",
+      `Failed to capture the ${input.stage} screenshot for ${input.actionType}.`
+    );
+    const warnings: string[] = [];
+    const retryWarning = buildRetryExhaustedWarning(stage, getErrorAttemptCount(normalizedError));
+    if (retryWarning) {
+      warnings.push(retryWarning);
+    }
+    warnings.push(normalizedError.message);
+
+    input.logger.log("warn", "write_validation.action.degraded", {
+      account_id: input.accountId,
+      action_type: input.actionType,
+      code: normalizedError.code,
+      error_details: normalizedError.details,
+      error_message: normalizedError.message,
+      session_name: input.sessionName,
+      stage
+    });
+
+    return {
+      screenshotPaths: dedupeStrings(screenshotPaths),
+      warnings
+    };
+  }
 }
 
 function buildCancelledActionResult(input: {
@@ -184,15 +1021,25 @@ function buildCancelledActionResult(input: {
   scenario: WriteValidationScenarioDefinition;
   startedAt: string;
   cleanupGuidance: string[];
+  errorCode?: LinkedInAssistantErrorCode;
+  errorDetails?: Record<string, unknown>;
+  errorMessage?: string;
+  warnings?: string[];
 }): WriteValidationActionResult {
   return {
     action_type: input.scenario.actionType,
     after_screenshot_paths: [],
-    artifact_paths: input.preparedArtifacts.previewArtifacts,
+    artifact_paths: buildActionArtifactPaths({
+      beforeScreenshotPaths: input.preparedArtifacts.beforeScreenshotPaths,
+      preparedArtifacts: input.preparedArtifacts
+    }),
     before_screenshot_paths: input.preparedArtifacts.beforeScreenshotPaths,
     cleanup_guidance: input.cleanupGuidance,
     completed_at: new Date().toISOString(),
     confirm_artifacts: [],
+    ...(input.errorCode ? { error_code: input.errorCode } : {}),
+    ...(input.errorDetails ? { error_details: input.errorDetails } : {}),
+    ...(input.errorMessage ? { error_message: input.errorMessage } : {}),
     expected_outcome: input.scenario.expectedOutcome,
     prepared_action_id: input.prepared.preparedActionId,
     preview: input.preview,
@@ -200,7 +1047,10 @@ function buildCancelledActionResult(input: {
     started_at: input.startedAt,
     state_synced: null,
     status: "cancelled",
-    summary: input.scenario.summary
+    summary: input.scenario.summary,
+    ...(input.warnings && input.warnings.length > 0
+      ? { warnings: dedupeStrings(input.warnings) }
+      : {})
   };
 }
 
@@ -217,16 +1067,17 @@ function buildCompletedActionResult(input: {
   startedAt: string;
   status: WriteValidationResultStatus;
   verification: WriteValidationVerificationResult;
+  warnings?: string[];
 }): WriteValidationActionResult {
   return {
     action_type: input.scenario.actionType,
     after_screenshot_paths: input.afterScreenshotPaths,
-    artifact_paths: dedupeStrings([
-      ...input.preparedArtifacts.previewArtifacts,
-      ...input.beforeScreenshotPaths,
-      ...input.confirmArtifacts,
-      ...input.afterScreenshotPaths
-    ]),
+    artifact_paths: buildActionArtifactPaths({
+      afterScreenshotPaths: input.afterScreenshotPaths,
+      beforeScreenshotPaths: input.beforeScreenshotPaths,
+      confirmArtifacts: input.confirmArtifacts,
+      preparedArtifacts: input.preparedArtifacts
+    }),
     before_screenshot_paths: input.beforeScreenshotPaths,
     cleanup_guidance: input.cleanupGuidance,
     completed_at: new Date().toISOString(),
@@ -245,15 +1096,87 @@ function buildCompletedActionResult(input: {
       message: input.verification.message,
       source: input.verification.source,
       verified: input.verification.verified
-    }
+    },
+    ...(input.warnings && input.warnings.length > 0
+      ? { warnings: dedupeStrings(input.warnings) }
+      : {})
   };
 }
 
 function buildFailedActionResult(input: {
-  errorCode: LinkedInAssistantErrorCode;
-  errorMessage: string;
+  error: LinkedInAssistantError;
+  failureStage: WriteValidationActionStage;
+  partial: PartialActionContext;
   scenario: WriteValidationScenarioDefinition;
   startedAt: string;
+}): WriteValidationActionResult {
+  const warnings = [...input.partial.warnings];
+  const retryWarning = buildRetryExhaustedWarning(
+    input.failureStage,
+    getErrorAttemptCount(input.error)
+  );
+  if (retryWarning) {
+    warnings.unshift(retryWarning);
+  }
+
+  return {
+    action_type: input.scenario.actionType,
+    after_screenshot_paths: input.partial.afterScreenshotPaths,
+    artifact_paths: buildActionArtifactPaths({
+      afterScreenshotPaths: input.partial.afterScreenshotPaths,
+      beforeScreenshotPaths: input.partial.beforeScreenshotPaths,
+      confirmArtifacts: input.partial.confirmArtifacts,
+      ...(input.partial.preparedArtifacts
+        ? { preparedArtifacts: input.partial.preparedArtifacts }
+        : {})
+    }),
+    before_screenshot_paths: input.partial.beforeScreenshotPaths,
+    cleanup_guidance: input.partial.cleanupGuidance,
+    completed_at: new Date().toISOString(),
+    confirm_artifacts: input.partial.confirmArtifacts,
+    error_code: input.error.code,
+    error_details: input.error.details,
+    error_message: input.error.message,
+    expected_outcome: input.scenario.expectedOutcome,
+    failure_stage: input.failureStage,
+    ...(input.partial.linkedinResponse
+      ? { linkedin_response: input.partial.linkedinResponse }
+      : {}),
+    ...(input.partial.prepared
+      ? { prepared_action_id: input.partial.prepared.preparedActionId }
+      : {}),
+    ...(input.partial.preview ? { preview: input.partial.preview } : {}),
+    risk_class: input.scenario.riskClass,
+    started_at: input.startedAt,
+    state_synced: null,
+    status: "fail",
+    summary: input.scenario.summary,
+    ...(warnings.length > 0 ? { warnings: dedupeStrings(warnings) } : {})
+  };
+}
+
+function buildRemainingScenarioSkipMessage(input: {
+  blockingCode: LinkedInAssistantErrorCode;
+  blockedByActionType: string;
+  sessionName: string;
+}): string {
+  switch (input.blockingCode) {
+    case "AUTH_REQUIRED":
+      return `Skipped because the stored session expired during ${input.blockedByActionType}. Capture a fresh session with "owa auth:session --session ${input.sessionName}" before rerunning the remaining write-validation actions.`;
+    case "CAPTCHA_OR_CHALLENGE":
+      return `Skipped because LinkedIn triggered a checkpoint challenge during ${input.blockedByActionType}. Resolve the challenge and capture a fresh session before rerunning the remaining write-validation actions.`;
+    case "RATE_LIMITED":
+      return `Skipped because LinkedIn rate limited the session during ${input.blockedByActionType}. Wait for the account to cool down before rerunning the remaining write-validation actions.`;
+    default:
+      return `Skipped because ${input.blockedByActionType} failed with ${input.blockingCode}.`;
+  }
+}
+
+function buildSkippedActionResult(input: {
+  blockedByActionType: string;
+  blockingCode: LinkedInAssistantErrorCode;
+  scenario: WriteValidationScenarioDefinition;
+  sessionName: string;
 }): WriteValidationActionResult {
   return {
     action_type: input.scenario.actionType,
@@ -263,94 +1186,247 @@ function buildFailedActionResult(input: {
     cleanup_guidance: [],
     completed_at: new Date().toISOString(),
     confirm_artifacts: [],
-    error_code: input.errorCode,
-    error_message: input.errorMessage,
+    error_code: input.blockingCode,
+    error_details: {
+      blocked_by_action_type: input.blockedByActionType,
+      session_name: input.sessionName
+    },
+    error_message: buildRemainingScenarioSkipMessage({
+      blockedByActionType: input.blockedByActionType,
+      blockingCode: input.blockingCode,
+      sessionName: input.sessionName
+    }),
     expected_outcome: input.scenario.expectedOutcome,
     risk_class: input.scenario.riskClass,
-    started_at: input.startedAt,
+    started_at: new Date().toISOString(),
     state_synced: null,
-    status: "fail",
+    status: "cancelled",
     summary: input.scenario.summary
   };
 }
 
 async function executeWriteValidationScenario(input: {
   account: ReturnType<typeof resolveWriteValidationAccount>;
+  maxRetries: number;
   onBeforeAction?: RunLinkedInWriteValidationOptions["onBeforeAction"];
   profileManager: WriteValidationProfileManager;
-  runtime: Awaited<ReturnType<typeof createWriteValidationRuntime>>["runtime"];
+  retryBaseDelayMs: number;
+  retryMaxDelayMs: number;
+  runtime: WriteValidationRuntime;
   scenario: WriteValidationScenarioDefinition;
-}): Promise<WriteValidationActionResult> {
+}): Promise<ScenarioExecutionResult> {
   const startedAt = new Date().toISOString();
+  const sessionName = input.account.sessionName;
+  const partial: PartialActionContext = {
+    afterScreenshotPaths: [],
+    beforeScreenshotPaths: [],
+    cleanupGuidance: [],
+    confirmArtifacts: [],
+    warnings: []
+  };
 
   input.runtime.logger.log("info", "write_validation.action.start", {
     account_id: input.account.id,
-    action_type: input.scenario.actionType
+    action_type: input.scenario.actionType,
+    expected_outcome: input.scenario.expectedOutcome,
+    session_name: sessionName
   });
 
   try {
-    const prepared = await input.scenario.prepare(input.runtime, input.account);
-    const preview = buildPreview(input.scenario, prepared.prepared);
+    const preparedStage = await runWriteValidationStageWithRetry({
+      accountId: input.account.id,
+      actionType: input.scenario.actionType,
+      execute: async () => input.scenario.prepare(input.runtime, input.account),
+      expectedOutcome: input.scenario.expectedOutcome,
+      logger: input.runtime.logger,
+      maxRetries: input.maxRetries,
+      retryBaseDelayMs: input.retryBaseDelayMs,
+      retryMaxDelayMs: input.retryMaxDelayMs,
+      sessionName,
+      stage: "prepare"
+    });
+    const prepared = preparedStage.result;
+    partial.prepared = prepared.prepared;
+    partial.preparedArtifacts = readPreparedArtifacts(prepared.prepared);
+    partial.preview = buildPreview(input.scenario, prepared.prepared);
+    partial.cleanupGuidance = prepared.cleanupGuidance;
+
+    const prepareWarning = buildRetryRecoveryWarning("prepare", preparedStage.attemptCount);
+    if (prepareWarning) {
+      partial.warnings.push(prepareWarning);
+    }
 
     input.runtime.logger.log("info", "write_validation.action.prepared", {
       account_id: input.account.id,
       action_type: input.scenario.actionType,
       prepared_action_id: prepared.prepared.preparedActionId,
-      preview
+      preview: partial.preview,
+      retry_count: preparedStage.attemptCount - 1,
+      session_name: sessionName
     });
 
-    const preparedArtifacts = readPreparedArtifacts(prepared.prepared);
-    const proceed = input.onBeforeAction
-      ? await input.onBeforeAction(preview)
-      : true;
+    let proceed = true;
+    try {
+      proceed = input.onBeforeAction ? await input.onBeforeAction(partial.preview) : true;
+    } catch (error) {
+      const normalizedError = normalizeWriteValidationError({
+        accountId: input.account.id,
+        actionType: input.scenario.actionType,
+        error,
+        expectedOutcome: input.scenario.expectedOutcome,
+        sessionName,
+        stage: "prompt"
+      });
 
-    if (!proceed) {
+      input.runtime.logger.log("error", "write_validation.action.failed", {
+        account_id: input.account.id,
+        action_type: input.scenario.actionType,
+        code: normalizedError.code,
+        error_details: normalizedError.details,
+        error_message: normalizedError.message,
+        expected_outcome: input.scenario.expectedOutcome,
+        failure_stage: "prompt",
+        prepared_action_id: partial.prepared?.preparedActionId,
+        session_name: sessionName
+      });
+
+      return {
+        actionResult: buildFailedActionResult({
+          error: normalizedError,
+          failureStage: "prompt",
+          partial,
+          scenario: input.scenario,
+          startedAt
+        }),
+        shouldStop: false
+      };
+    }
+
+    if (!proceed && partial.preview && partial.prepared && partial.preparedArtifacts) {
       input.runtime.logger.log("warn", "write_validation.action.cancelled", {
         account_id: input.account.id,
         action_type: input.scenario.actionType,
-        prepared_action_id: prepared.prepared.preparedActionId
+        prepared_action_id: partial.prepared.preparedActionId,
+        session_name: sessionName
       });
 
-      return buildCancelledActionResult({
-        preview,
-        prepared: prepared.prepared,
-        preparedArtifacts,
-        scenario: input.scenario,
-        startedAt,
-        cleanupGuidance: prepared.cleanupGuidance
-      });
+      return {
+        actionResult: buildCancelledActionResult({
+          preview: partial.preview,
+          prepared: partial.prepared,
+          preparedArtifacts: partial.preparedArtifacts,
+          scenario: input.scenario,
+          startedAt,
+          cleanupGuidance: partial.cleanupGuidance,
+          warnings: partial.warnings
+        }),
+        shouldStop: false
+      };
     }
 
-    const beforeScreenshotPaths = await ensureScenarioScreenshotPaths({
+    const beforeCapture = await captureScenarioScreenshotBestEffort({
+      accountId: input.account.id,
       actionType: input.scenario.actionType,
-      existingPaths: preparedArtifacts.beforeScreenshotPaths,
+      existingPaths: partial.preparedArtifacts?.beforeScreenshotPaths ?? [],
+      expectedOutcome: input.scenario.expectedOutcome,
+      logger: input.runtime.logger,
+      maxRetries: input.maxRetries,
       profileManager: input.profileManager,
+      retryBaseDelayMs: input.retryBaseDelayMs,
+      retryMaxDelayMs: input.retryMaxDelayMs,
+      sessionName,
       stage: "before",
       url: prepared.beforeScreenshotUrl
     });
+    partial.beforeScreenshotPaths = beforeCapture.screenshotPaths;
+    partial.warnings.push(...beforeCapture.warnings);
 
-    const confirmed = await input.runtime.twoPhaseCommit.confirmByToken({
-      confirmToken: prepared.prepared.confirmToken
-    });
-    const confirmArtifacts = dedupeStrings([...confirmed.artifacts]);
-    const afterScreenshotPaths = await ensureScenarioScreenshotPaths({
+    const confirmStage = await runWriteValidationStageWithRetry({
+      accountId: input.account.id,
       actionType: input.scenario.actionType,
-      existingPaths: confirmArtifacts.filter(isScreenshotPath),
-      profileManager: input.profileManager,
-      stage: "after",
-      url: input.scenario.resolveAfterScreenshotUrl(
+      execute: async () =>
+        input.runtime.twoPhaseCommit.confirmByToken({
+          confirmToken: prepared.prepared.confirmToken
+        }),
+      expectedOutcome: input.scenario.expectedOutcome,
+      logger: input.runtime.logger,
+      maxRetries: 0,
+      retryBaseDelayMs: input.retryBaseDelayMs,
+      retryMaxDelayMs: input.retryMaxDelayMs,
+      sessionName,
+      stage: "confirm"
+    });
+    const confirmed = confirmStage.result;
+    partial.confirmArtifacts = dedupeStrings([...confirmed.artifacts]);
+    partial.linkedinResponse = confirmed.result;
+
+    let afterScreenshotUrl: string | null = null;
+    try {
+      afterScreenshotUrl = input.scenario.resolveAfterScreenshotUrl(
         input.account,
         prepared,
         confirmed
-      )
-    });
+      );
+    } catch (error) {
+      const normalizedError = normalizeWriteValidationError({
+        accountId: input.account.id,
+        actionType: input.scenario.actionType,
+        error,
+        expectedOutcome: input.scenario.expectedOutcome,
+        sessionName,
+        stage: "after_screenshot"
+      });
+      partial.warnings.push(normalizedError.message);
+      input.runtime.logger.log("warn", "write_validation.action.degraded", {
+        account_id: input.account.id,
+        action_type: input.scenario.actionType,
+        code: normalizedError.code,
+        error_details: normalizedError.details,
+        error_message: normalizedError.message,
+        prepared_action_id: partial.prepared?.preparedActionId,
+        session_name: sessionName,
+        stage: "after_screenshot"
+      });
+    }
 
-    const verification = await input.scenario.verify(
-      input.runtime,
-      input.account,
-      prepared,
-      confirmed
+    const afterCapture = await captureScenarioScreenshotBestEffort({
+      accountId: input.account.id,
+      actionType: input.scenario.actionType,
+      existingPaths: partial.confirmArtifacts.filter(isScreenshotPath),
+      expectedOutcome: input.scenario.expectedOutcome,
+      logger: input.runtime.logger,
+      maxRetries: input.maxRetries,
+      profileManager: input.profileManager,
+      retryBaseDelayMs: input.retryBaseDelayMs,
+      retryMaxDelayMs: input.retryMaxDelayMs,
+      sessionName,
+      stage: "after",
+      url: afterScreenshotUrl
+    });
+    partial.afterScreenshotPaths = afterCapture.screenshotPaths;
+    partial.warnings.push(...afterCapture.warnings);
+
+    const verificationStage = await runWriteValidationStageWithRetry({
+      accountId: input.account.id,
+      actionType: input.scenario.actionType,
+      execute: async () =>
+        input.scenario.verify(input.runtime, input.account, prepared, confirmed),
+      expectedOutcome: input.scenario.expectedOutcome,
+      logger: input.runtime.logger,
+      maxRetries: input.maxRetries,
+      retryBaseDelayMs: input.retryBaseDelayMs,
+      retryMaxDelayMs: input.retryMaxDelayMs,
+      sessionName,
+      stage: "verify"
+    });
+    const verification = verificationStage.result;
+    const verificationWarning = buildRetryRecoveryWarning(
+      "verify",
+      verificationStage.attemptCount
     );
+    if (verificationWarning) {
+      partial.warnings.push(verificationWarning);
+    }
     const status = determineActionStatus(verification);
 
     input.runtime.logger.log(
@@ -359,48 +1435,70 @@ async function executeWriteValidationScenario(input: {
       {
         account_id: input.account.id,
         action_type: input.scenario.actionType,
-        prepared_action_id: prepared.prepared.preparedActionId,
-        verified: verification.verified,
+        expected_outcome: input.scenario.expectedOutcome,
+        prepared_action_id: partial.prepared?.preparedActionId,
+        session_name: sessionName,
         state_synced: verification.state_synced,
-        status
+        status,
+        verification_details: verification.details,
+        verification_message: verification.message,
+        verification_source: verification.source,
+        verified: verification.verified,
+        warnings: dedupeStrings(partial.warnings)
       }
     );
 
-    return buildCompletedActionResult({
-      afterScreenshotPaths,
-      beforeScreenshotPaths,
-      cleanupGuidance: prepared.cleanupGuidance,
-      confirmArtifacts,
-      linkedinResponse: confirmed.result,
-      prepared: prepared.prepared,
-      preparedArtifacts,
-      preview,
-      scenario: input.scenario,
-      startedAt,
-      status,
-      verification
-    });
+    return {
+      actionResult: buildCompletedActionResult({
+        afterScreenshotPaths: partial.afterScreenshotPaths,
+        beforeScreenshotPaths: partial.beforeScreenshotPaths,
+        cleanupGuidance: partial.cleanupGuidance,
+        confirmArtifacts: partial.confirmArtifacts,
+        linkedinResponse: partial.linkedinResponse ?? {},
+        prepared: partial.prepared ?? prepared.prepared,
+        preparedArtifacts: partial.preparedArtifacts ?? readPreparedArtifacts(prepared.prepared),
+        preview: partial.preview ?? buildPreview(input.scenario, prepared.prepared),
+        scenario: input.scenario,
+        startedAt,
+        status,
+        verification,
+        warnings: partial.warnings
+      }),
+      shouldStop: false
+    };
   } catch (error) {
     const normalizedError = asLinkedInAssistantError(
       error,
       error instanceof LinkedInAssistantError ? error.code : "UNKNOWN",
       `Write validation failed while executing ${input.scenario.actionType}.`
     );
+    const failureStage = resolveFailureStage(
+      normalizedError,
+      partial.linkedinResponse ? "verify" : partial.prepared ? "confirm" : "prepare"
+    );
 
     input.runtime.logger.log("error", "write_validation.action.failed", {
       account_id: input.account.id,
       action_type: input.scenario.actionType,
       code: normalizedError.code,
+      error_details: normalizedError.details,
       error_message: normalizedError.message,
-      error_details: normalizedError.details
+      expected_outcome: input.scenario.expectedOutcome,
+      failure_stage: failureStage,
+      prepared_action_id: partial.prepared?.preparedActionId,
+      session_name: sessionName
     });
 
-    return buildFailedActionResult({
-      errorCode: normalizedError.code,
-      errorMessage: normalizedError.message,
-      scenario: input.scenario,
-      startedAt
-    });
+    return {
+      actionResult: buildFailedActionResult({
+        error: normalizedError,
+        failureStage,
+        partial,
+        scenario: input.scenario,
+        startedAt
+      }),
+      shouldStop: isBlockingWriteValidationErrorCode(normalizedError.code)
+    };
   }
 }
 
@@ -409,7 +1507,7 @@ function buildWriteValidationReport(input: {
   actions: WriteValidationActionResult[];
   cooldownMs: number;
   latestReportPath: string;
-  runtime: Awaited<ReturnType<typeof createWriteValidationRuntime>>["runtime"];
+  runtime: WriteValidationRuntime;
 }): WriteValidationReport {
   const counts = countActionStatuses(input.actions);
   const outcome = determineOutcome(input.actions);
@@ -449,54 +1547,185 @@ function buildWriteValidationReport(input: {
   return report;
 }
 
+async function cleanupWriteValidationResources(input: {
+  accountId: string;
+  lockHandle: WriteValidationRunLockHandle;
+  primaryError: unknown;
+  runtimeHandle?: Awaited<ReturnType<typeof createWriteValidationRuntime>>;
+}): Promise<void> {
+  const cleanupErrors: LinkedInAssistantError[] = [];
+  const runtime = input.runtimeHandle?.runtime;
+  const logger = runtime?.logger;
+
+  if (input.runtimeHandle) {
+    try {
+      await input.runtimeHandle.profileManager.dispose();
+    } catch (error) {
+      const cleanupError = new LinkedInAssistantError(
+        "UNKNOWN",
+        `Failed to dispose the write-validation browser for account "${input.accountId}".`,
+        {
+          account_id: input.accountId,
+          stage: "cleanup",
+          raw_error: getErrorMessage(error)
+        },
+        createErrorOptions(error)
+      );
+      logger?.log("warn", "write_validation.cleanup.profile_manager_failed", {
+        account_id: input.accountId,
+        error_details: cleanupError.details,
+        error_message: cleanupError.message
+      });
+      cleanupErrors.push(cleanupError);
+    }
+  }
+
+  try {
+    await input.lockHandle.release();
+    logger?.log("debug", "write_validation.lock.released", {
+      account_id: input.accountId,
+      lock_path: input.lockHandle.lockPath,
+      pid: input.lockHandle.state.pid
+    });
+  } catch (error) {
+    const cleanupError = new LinkedInAssistantError(
+      "UNKNOWN",
+      `Failed to release the write-validation run lock for account "${input.accountId}". Remove ${input.lockHandle.lockPath} manually if the next run is blocked.`,
+      {
+        account_id: input.accountId,
+        lock_path: input.lockHandle.lockPath,
+        stage: "cleanup"
+      },
+      createErrorOptions(error)
+    );
+    logger?.log("warn", "write_validation.cleanup.lock_failed", {
+      account_id: input.accountId,
+      error_details: cleanupError.details,
+      error_message: cleanupError.message,
+      lock_path: input.lockHandle.lockPath
+    });
+    cleanupErrors.push(cleanupError);
+  }
+
+  if (runtime) {
+    try {
+      runtime.close();
+    } catch (error) {
+      const cleanupError = new LinkedInAssistantError(
+        "UNKNOWN",
+        `Failed to close the write-validation runtime for account "${input.accountId}".`,
+        {
+          account_id: input.accountId,
+          stage: "cleanup",
+          raw_error: getErrorMessage(error)
+        },
+        createErrorOptions(error)
+      );
+      logger?.log("warn", "write_validation.cleanup.runtime_failed", {
+        account_id: input.accountId,
+        error_details: cleanupError.details,
+        error_message: cleanupError.message
+      });
+      cleanupErrors.push(cleanupError);
+    }
+  }
+
+  if (cleanupErrors.length > 0 && typeof input.primaryError === "undefined") {
+    throw cleanupErrors[0];
+  }
+}
+
 export async function runLinkedInWriteValidation(
   options: RunLinkedInWriteValidationOptions
 ): Promise<WriteValidationReport> {
-  assertInteractiveWriteValidation(options);
   const validatedOptions = validateWriteValidationOptions(options);
+  assertInteractiveWriteValidation(options);
+
   const account = resolveWriteValidationAccount(
     validatedOptions.accountId,
-    options.baseDir
+    validatedOptions.baseDir
   );
   ensureSecondaryWriteValidationAccount(account);
+  validateWriteValidationScenarioDefinitions(WRITE_VALIDATION_SCENARIOS);
+  validateWriteValidationStartupConfig(account, WRITE_VALIDATION_SCENARIOS);
 
-  const paths = resolveConfigPaths(options.baseDir);
+  const paths = resolveConfigPaths(validatedOptions.baseDir);
   ensureConfigPaths(paths);
 
-  const { runtime, profileManager } = await createWriteValidationRuntime({
-    account,
-    ...(options.baseDir ? { baseDir: options.baseDir } : {}),
-    timeoutMs: validatedOptions.timeoutMs
-  });
-
-  const latestReportPath = path.join(
-    paths.baseDir,
-    WRITE_VALIDATION_REPORT_DIR,
-    account.id,
-    WRITE_VALIDATION_LATEST_REPORT_NAME
-  );
-
-  runtime.logger.log("info", "write_validation.start", {
-    account_id: account.id,
-    cooldown_ms: validatedOptions.cooldownMs,
-    profile_name: account.profileName,
-    session_name: account.sessionName,
-    warning: WRITE_VALIDATION_WARNING
-  });
-
-  const actions: WriteValidationActionResult[] = [];
+  const lockHandle = await acquireWriteValidationRunLock(paths, account.id);
+  let runtimeHandle: Awaited<ReturnType<typeof createWriteValidationRuntime>> | undefined;
+  let primaryError: LinkedInAssistantError | undefined;
 
   try {
+    runtimeHandle = await createWriteValidationRuntime({
+      account,
+      ...(validatedOptions.baseDir ? { baseDir: validatedOptions.baseDir } : {}),
+      timeoutMs: validatedOptions.timeoutMs
+    });
+
+    const { runtime, profileManager } = runtimeHandle;
+    const latestReportPath = path.join(
+      paths.baseDir,
+      WRITE_VALIDATION_REPORT_DIR,
+      account.id,
+      WRITE_VALIDATION_LATEST_REPORT_NAME
+    );
+
+    runtime.logger.log("debug", "write_validation.lock.acquired", {
+      account_id: account.id,
+      lock_path: lockHandle.lockPath,
+      pid: lockHandle.state.pid,
+      started_at: lockHandle.state.started_at
+    });
+    runtime.logger.log("info", "write_validation.start", {
+      account_id: account.id,
+      cooldown_ms: validatedOptions.cooldownMs,
+      max_retries: validatedOptions.maxRetries,
+      profile_name: account.profileName,
+      retry_base_delay_ms: validatedOptions.retryBaseDelayMs,
+      retry_max_delay_ms: validatedOptions.retryMaxDelayMs,
+      session_name: account.sessionName,
+      timeout_ms: validatedOptions.timeoutMs,
+      warning: WRITE_VALIDATION_WARNING
+    });
+
+    const actions: WriteValidationActionResult[] = [];
+
     for (const [index, scenario] of WRITE_VALIDATION_SCENARIOS.entries()) {
-      actions.push(
-        await executeWriteValidationScenario({
-          account,
-          onBeforeAction: options.onBeforeAction,
-          profileManager,
-          runtime,
-          scenario
-        })
-      );
+      const execution = await executeWriteValidationScenario({
+        account,
+        maxRetries: validatedOptions.maxRetries,
+        onBeforeAction: validatedOptions.onBeforeAction,
+        profileManager,
+        retryBaseDelayMs: validatedOptions.retryBaseDelayMs,
+        retryMaxDelayMs: validatedOptions.retryMaxDelayMs,
+        runtime,
+        scenario
+      });
+      actions.push(execution.actionResult);
+
+      if (execution.shouldStop) {
+        runtime.logger.log("warn", "write_validation.stopped_early", {
+          account_id: account.id,
+          action_type: scenario.actionType,
+          code: execution.actionResult.error_code,
+          completed_actions: actions.length,
+          remaining_actions: WRITE_VALIDATION_SCENARIOS.length - actions.length,
+          session_name: account.sessionName
+        });
+
+        for (const remainingScenario of WRITE_VALIDATION_SCENARIOS.slice(index + 1)) {
+          actions.push(
+            buildSkippedActionResult({
+              blockedByActionType: scenario.actionType,
+              blockingCode: execution.actionResult.error_code ?? "UNKNOWN",
+              scenario: remainingScenario,
+              sessionName: account.sessionName
+            })
+          );
+        }
+        break;
+      }
 
       if (
         validatedOptions.cooldownMs > 0 &&
@@ -518,27 +1747,74 @@ export async function runLinkedInWriteValidation(
       runtime
     });
 
-    runtime.artifacts.writeJson(`${WRITE_VALIDATION_REPORT_DIR}/report.json`, report, {
-      account_id: account.id,
-      action_count: actions.length,
-      outcome: report.outcome
-    });
-    await writeJsonFile(latestReportPath, report);
+    try {
+      runtime.artifacts.writeJson(`${WRITE_VALIDATION_REPORT_DIR}/report.json`, report, {
+        account_id: account.id,
+        action_count: actions.length,
+        outcome: report.outcome
+      });
+    } catch (error) {
+      runtime.logger.log("warn", "write_validation.report_persist.failed", {
+        account_id: account.id,
+        error: getErrorMessage(error),
+        report_path: report.report_path
+      });
+      report.recommended_actions.push(
+        `The report could not be written to ${report.report_path}; inspect ${report.audit_log_path} for this run.`
+      );
+    }
+
+    try {
+      await writeJsonFile(latestReportPath, report);
+    } catch (error) {
+      runtime.logger.log("warn", "write_validation.latest_report_persist.failed", {
+        account_id: account.id,
+        error: getErrorMessage(error),
+        latest_report_path: latestReportPath
+      });
+      report.recommended_actions.push(
+        `The rolling latest report at ${latestReportPath} was not updated, so the next run may diff against an older snapshot.`
+      );
+    }
+
+    report.recommended_actions = dedupeStrings(report.recommended_actions);
 
     runtime.logger.log("info", "write_validation.completed", {
       account_id: account.id,
       action_count: actions.length,
+      cancelled_count: report.cancelled_count,
       fail_count: report.fail_count,
       outcome: report.outcome,
       pass_count: report.pass_count,
-      cancelled_count: report.cancelled_count,
       report_path: report.report_path
     });
 
     return report;
+  } catch (error) {
+    const normalizedError = asLinkedInAssistantError(
+      withPlaywrightInstallHint(error),
+      error instanceof LinkedInAssistantError ? error.code : "UNKNOWN",
+      "Failed to run the LinkedIn write validation harness."
+    );
+    primaryError = normalizedError;
+
+    runtimeHandle?.runtime.logger.log("error", "write_validation.failed", {
+      account_id: account.id,
+      code: normalizedError.code,
+      error_details: normalizedError.details,
+      error_message: normalizedError.message,
+      session_name: account.sessionName,
+      source_error_name: error instanceof Error ? error.name : typeof error
+    });
+
+    throw normalizedError;
   } finally {
-    await profileManager.dispose();
-    runtime.close();
+    await cleanupWriteValidationResources({
+      accountId: account.id,
+      lockHandle,
+      primaryError,
+      ...(runtimeHandle ? { runtimeHandle } : {})
+    });
   }
 }
 

--- a/packages/core/src/writeValidationAccounts.ts
+++ b/packages/core/src/writeValidationAccounts.ts
@@ -261,12 +261,51 @@ function normalizeAccountId(value: string, label: string): string {
   return assertLocalIdentifier(value, label);
 }
 
+function isLinkedInHost(hostname: string): boolean {
+  const normalizedHost = hostname.trim().toLowerCase();
+  return normalizedHost === "linkedin.com" || normalizedHost.endsWith(".linkedin.com");
+}
+
 function normalizeThreadTarget(value: unknown, label: string): string {
   const normalized = assertNonEmptyString(value, label);
+
   if (normalized.startsWith("/messaging/thread/")) {
     return `https://www.linkedin.com${normalized}`;
   }
-  return normalized;
+
+  if (!/^https?:\/\//iu.test(normalized)) {
+    return `https://www.linkedin.com/messaging/thread/${encodeURIComponent(normalized)}/`;
+  }
+
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(normalized);
+  } catch (error) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must be a valid LinkedIn messaging thread URL or thread id.`,
+      {
+        label,
+        provided_value: value,
+        message: error instanceof Error ? error.message : String(error)
+      },
+      error instanceof Error ? { cause: error } : undefined
+    );
+  }
+
+  if (!isLinkedInHost(parsedUrl.hostname) || !parsedUrl.pathname.startsWith("/messaging/thread/")) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must be a LinkedIn messaging thread URL or thread id.`,
+      {
+        label,
+        provided_value: value
+      }
+    );
+  }
+
+  return `${parsedUrl.origin}${parsedUrl.pathname}${parsedUrl.search}`.replace(/\/$/u, "/");
 }
 
 function normalizePostUrl(value: unknown, label: string): string {
@@ -277,8 +316,23 @@ function normalizePostUrl(value: unknown, label: string): string {
 
   try {
     const parsed = new URL(normalized);
+    if (!isLinkedInHost(parsed.hostname)) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `${label} must be a valid LinkedIn post URL.`,
+        {
+          label,
+          provided_value: value
+        }
+      );
+    }
+
     return parsed.toString();
   } catch (error) {
+    if (error instanceof LinkedInAssistantError) {
+      throw error;
+    }
+
     throw new LinkedInAssistantError(
       "ACTION_PRECONDITION_FAILED",
       `${label} must be a valid LinkedIn post URL.`,

--- a/packages/core/src/writeValidationScenarios.ts
+++ b/packages/core/src/writeValidationScenarios.ts
@@ -136,6 +136,12 @@ export const WRITE_VALIDATION_SCENARIOS = [
     expectedOutcome:
       "A new post is published successfully and visible in the feed.",
     riskClass: "public",
+    validateConfig(account) {
+      void normalizeLinkedInPostVisibility(
+        account.targets["post.create"]?.visibility,
+        "connections"
+      );
+    },
     async prepare(runtime, account) {
       const visibility = normalizeLinkedInPostVisibility(
         account.targets["post.create"]?.visibility,
@@ -214,6 +220,12 @@ export const WRITE_VALIDATION_SCENARIOS = [
     expectedOutcome:
       "The approved profile shows a pending invitation or sent-invitation confirmation.",
     riskClass: "network",
+    validateConfig(account) {
+      void getRequiredTarget<{
+        note?: string;
+        targetProfile: string;
+      }>(account.targets, "connections.send_invitation", account.id);
+    },
     async prepare(runtime, account) {
       const target = getRequiredTarget<{
         note?: string;
@@ -289,6 +301,13 @@ export const WRITE_VALIDATION_SCENARIOS = [
     expectedOutcome:
       "The outbound message is echoed in the approved conversation thread.",
     riskClass: "private",
+    validateConfig(account) {
+      const target = getRequiredTarget<{
+        participantPattern?: string;
+        thread: string;
+      }>(account.targets, "send_message", account.id);
+      void resolveThreadUrl(target.thread);
+    },
     async prepare(runtime, account) {
       const target = getRequiredTarget<{
         participantPattern?: string;
@@ -362,6 +381,11 @@ export const WRITE_VALIDATION_SCENARIOS = [
     expectedOutcome:
       "The follow-up send succeeds and local follow-up state records the confirmation.",
     riskClass: "network",
+    validateConfig(account) {
+      void getRequiredTarget<{
+        profileUrlKey: string;
+      }>(account.targets, "network.followup_after_accept", account.id);
+    },
     async prepare(runtime, account) {
       const target = getRequiredTarget<{
         profileUrlKey: string;
@@ -451,6 +475,13 @@ export const WRITE_VALIDATION_SCENARIOS = [
       "React to the approved post and verify the reaction is registered.",
     expectedOutcome: "The approved reaction is active on the approved post.",
     riskClass: "public",
+    validateConfig(account) {
+      const target = getRequiredTarget<{
+        postUrl: string;
+        reaction?: LinkedInFeedReaction;
+      }>(account.targets, "feed.like_post", account.id);
+      void normalizeLinkedInFeedReaction(target.reaction, "like");
+    },
     async prepare(runtime, account) {
       const target = getRequiredTarget<{
         postUrl: string;

--- a/packages/core/src/writeValidationShared.ts
+++ b/packages/core/src/writeValidationShared.ts
@@ -23,6 +23,9 @@ export const WRITE_VALIDATION_REPORT_DIR = "live-write-validation";
 export const WRITE_VALIDATION_LATEST_REPORT_NAME = "latest-report.json";
 export const DEFAULT_WRITE_VALIDATION_COOLDOWN_MS = 10_000;
 export const DEFAULT_WRITE_VALIDATION_TIMEOUT_MS = 30_000;
+export const DEFAULT_WRITE_VALIDATION_MAX_RETRIES = 1;
+export const DEFAULT_WRITE_VALIDATION_RETRY_BASE_DELAY_MS = 1_000;
+export const DEFAULT_WRITE_VALIDATION_RETRY_MAX_DELAY_MS = 5_000;
 export const WRITE_VALIDATION_FEED_URL = "https://www.linkedin.com/feed/";
 
 export type WriteValidationRiskClass = "private" | "network" | "public";
@@ -36,6 +39,13 @@ export type LinkedInWriteValidationActionType =
 
 export type WriteValidationResultStatus = "pass" | "fail" | "cancelled";
 export type WriteValidationOutcome = WriteValidationResultStatus;
+export type WriteValidationActionStage =
+  | "prepare"
+  | "prompt"
+  | "before_screenshot"
+  | "confirm"
+  | "after_screenshot"
+  | "verify";
 
 export interface LinkedInWriteValidationActionDefinition {
   actionType: LinkedInWriteValidationActionType;
@@ -70,8 +80,10 @@ export interface WriteValidationActionResult {
   completed_at: string;
   confirm_artifacts: string[];
   error_code?: LinkedInAssistantErrorCode;
+  error_details?: Record<string, unknown>;
   error_message?: string;
   expected_outcome: string;
+  failure_stage?: WriteValidationActionStage;
   linkedin_response?: Record<string, unknown>;
   prepared_action_id?: string;
   preview?: WriteValidationActionPreview;
@@ -86,6 +98,7 @@ export interface WriteValidationActionResult {
     source: string;
     verified: boolean;
   };
+  warnings?: string[];
 }
 
 export interface WriteValidationReport {
@@ -118,9 +131,12 @@ export interface RunLinkedInWriteValidationOptions {
   baseDir?: string;
   cooldownMs?: number;
   interactive?: boolean;
+  maxRetries?: number;
   onBeforeAction?: (
     preview: WriteValidationActionPreview
   ) => Promise<boolean> | boolean;
+  retryBaseDelayMs?: number;
+  retryMaxDelayMs?: number;
   timeoutMs?: number;
 }
 
@@ -142,6 +158,7 @@ export interface WriteValidationScenarioDefinition
     prepared: ScenarioPrepareResult,
     confirmed: ConfirmByTokenResult
   ) => string | null;
+  validateConfig?: (account: WriteValidationAccount) => void;
   verify: (
     runtime: CoreRuntime,
     account: WriteValidationAccount,
@@ -271,7 +288,7 @@ export function buildWriteValidationSummary(
 }
 
 export function buildRecommendedActions(
-  report: Pick<WriteValidationReport, "actions" | "report_path" | "audit_log_path">
+  report: Pick<WriteValidationReport, "actions" | "report_path" | "audit_log_path" | "account">
 ): string[] {
   const actions: string[] = [
     `Review ${report.report_path} for the full per-action report and screenshots.`,
@@ -280,6 +297,30 @@ export function buildRecommendedActions(
 
   for (const action of report.actions) {
     actions.push(...action.cleanup_guidance);
+
+    if (action.error_code === "AUTH_REQUIRED" || action.error_code === "CAPTCHA_OR_CHALLENGE") {
+      actions.push(
+        `Capture a fresh stored session with "owa auth:session --session ${report.account.session_name}" before rerunning write validation.`
+      );
+    }
+
+    if (action.error_code === "RATE_LIMITED") {
+      actions.push(
+        `Wait for LinkedIn to lift rate limiting on session "${report.account.session_name}" before rerunning write validation.`
+      );
+    }
+
+    if (action.error_code === "TARGET_NOT_FOUND") {
+      actions.push(
+        `Confirm the approved ${action.action_type} target in the write-validation account config still exists before rerunning.`
+      );
+    }
+
+    if (action.error_code === "UI_CHANGED_SELECTOR_FAILED") {
+      actions.push(
+        `Review the failed ${action.action_type} screenshots and update the validator selectors before rerunning.`
+      );
+    }
 
     if (action.status === "fail") {
       actions.push(


### PR DESCRIPTION
## Summary
- add startup validation, transient retry/backoff, and account-scoped run locking to the Tier 3 harness
- degrade gracefully on non-fatal screenshot/report failures while preserving partial action results and structured context
- stop early on stale-session/rate-limit failures, surface clearer recommendations, and cover the new edge cases with tests

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #152