### PR TITLE
Polish Tier 3 write-validation UX and reporting

### DIFF
--- a/docs/write-validation.md
+++ b/docs/write-validation.md
@@ -27,6 +27,7 @@ npm exec -w @linkedin-assistant/cli -- linkedin accounts add secondary \
   --session secondary-session \
   --profile secondary \
   --message-thread /messaging/thread/abc123/ \
+  --message-participant-pattern "Simon Miller" \
   --invite-profile https://www.linkedin.com/in/test-target/ \
   --followup-profile https://www.linkedin.com/in/test-target/ \
   --reaction-post https://www.linkedin.com/feed/update/urn:li:activity:123/ \
@@ -46,6 +47,12 @@ Change the cooldown between real actions when needed:
 npm exec -w @linkedin-assistant/cli -- linkedin test live --write-validation --account secondary --cooldown-seconds 20
 ```
 
+Use JSON output while keeping prompts interactive:
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin test live --write-validation --account secondary --json
+```
+
 ## Operator model
 
 The harness always runs the same fixed suite, one action at a time, in this
@@ -59,7 +66,8 @@ order:
 
 Before each action, the CLI prints a preview containing:
 
-- action type
+- action number and action type
+- one-line summary
 - risk class
 - target
 - outbound payload
@@ -74,7 +82,23 @@ Important behavior:
 - Actions are never parallelized or batched.
 - The default cooldown is 10 seconds between actions.
 - `--cooldown-seconds <n>` changes the inter-action delay.
-- `--timeout-seconds <n>` still controls navigation and selector timeouts.
+- `--timeout-seconds <n>` controls navigation and selector timeouts.
+- `--no-progress` hides the live stderr progress stream in human mode.
+- `--json` writes the structured result to stdout while prompts stay on stderr.
+
+## CLI output and progress
+
+Human-readable mode now shows three layers of feedback:
+
+1. **Startup notices** — account, docs path, and preflight activity
+2. **Live progress** — per-action stage updates such as prepare, screenshot,
+   confirm, verify, retry, and cooldown
+3. **Final summary** — color-coded pass/fail/cancelled sections with timing,
+   report paths, action details, warnings, and next steps
+
+The progress stream is designed for long-running scenarios such as invitation
+sends and message validation. It mirrors the structured write-validation log
+lifecycle without changing the underlying harness behavior.
 
 ## Account registry
 
@@ -110,6 +134,7 @@ The write-validation flow is intentionally stricter than Tier 2:
 - It requires `--account <id>` and ignores ad hoc session selection.
 - It rejects `--session` overrides; the stored session comes from the account
   registry.
+- It rejects `--yes`; every real action requires an explicit typed `yes`.
 - It refuses to run in CI.
 - It refuses to run in non-interactive or headless-style workflows.
 - It rejects external browser attachment via `--cdp-url`.
@@ -138,22 +163,71 @@ when appropriate.
 
 Each run writes:
 
-- a run-scoped report at `artifacts/<run-id>/live-write-validation/report.json`
+- a run-scoped JSON report at `artifacts/<run-id>/live-write-validation/report.json`
+- a run-scoped HTML report at `artifacts/<run-id>/live-write-validation/report.html`
 - the structured audit log for that run at `artifacts/<run-id>/events.jsonl`
 - a stable latest snapshot at `live-write-validation/<account>/latest-report.json`
 
+The HTML report is meant for review in a browser. It includes:
+
+- outcome cards with action, artifact, cleanup, and timing totals
+- color-coded action cards
+- filters by status and risk class
+- direct links to JSON, latest snapshot, audit log, and captured artifacts
+
 Each action result records:
 
-- the preview metadata that was shown before execution
-- the LinkedIn/executor response payload
+- preview metadata shown before execution
+- executor or LinkedIn response payload
 - verification outcome and source
 - before and after screenshot paths
 - related artifact paths
+- per-action duration
 - cleanup guidance
 
 The harness captures screenshots before and after every action. When the
 underlying prepare/confirm flow does not already produce screenshot artifacts,
 it captures fallback browser screenshots itself.
+
+## Common setup fixes
+
+If the harness fails during startup validation, use the message together with
+these shortcuts:
+
+- Missing `targets.send_message`:
+
+  ```bash
+  linkedin accounts add secondary --designation secondary --session secondary-session \
+    --message-thread /messaging/thread/<id>/ --force
+  ```
+
+- Missing `targets.connections.send_invitation`:
+
+  ```bash
+  linkedin accounts add secondary --designation secondary --session secondary-session \
+    --invite-profile https://www.linkedin.com/in/<slug>/ --force
+  ```
+
+- Missing `targets.network.followup_after_accept`:
+
+  ```bash
+  linkedin accounts add secondary --designation secondary --session secondary-session \
+    --followup-profile https://www.linkedin.com/in/<slug>/ --force
+  ```
+
+- Missing `targets.feed.like_post`:
+
+  ```bash
+  linkedin accounts add secondary --designation secondary --session secondary-session \
+    --reaction-post https://www.linkedin.com/feed/update/urn:li:activity:<id>/ \
+    --reaction like --force
+  ```
+
+- Missing or stale stored session:
+
+  ```bash
+  linkedin auth session --session secondary-session
+  ```
 
 ## Exit codes
 

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -37,6 +37,7 @@ import {
   LINKEDIN_FIXTURE_MANIFEST_FORMAT_VERSION,
   LINKEDIN_POST_VISIBILITY_TYPES,
   LINKEDIN_SELECTOR_LOCALES,
+  LINKEDIN_WRITE_VALIDATION_ACTIONS,
   LinkedInAssistantError,
   LinkedInSchedulerService,
   DEFAULT_FIXTURE_STALENESS_DAYS,
@@ -107,6 +108,7 @@ import {
   formatWriteValidationError,
   formatWriteValidationReport,
   resolveWriteValidationOutputMode,
+  WriteValidationProgressReporter,
   type WriteValidationOutputMode
 } from "../writeValidationOutput.js";
 import {
@@ -135,6 +137,7 @@ const LIVE_VALIDATION_FAIL_EXIT_CODE = 1;
 const LIVE_VALIDATION_ERROR_EXIT_CODE = 2;
 const WRITE_VALIDATION_DOC_PATH = "docs/write-validation.md";
 const WRITE_VALIDATION_WARNING = "This will perform REAL actions on LinkedIn";
+const TOTAL_WRITE_VALIDATION_ACTIONS = LINKEDIN_WRITE_VALIDATION_ACTIONS.length;
 let cliSelectorLocale: string | undefined;
 
 function writeCliWarning(message: string): void {
@@ -4208,7 +4211,7 @@ export function createCliProgram(): Command {
           "",
           "Examples:",
           "  owa accounts add secondary --designation secondary --session secondary-session --profile secondary",
-          "  owa accounts:add secondary --designation secondary --session secondary-session --message-thread /messaging/thread/abc/ --invite-profile https://www.linkedin.com/in/test-user/",
+          "  linkedin accounts add secondary --designation secondary --session secondary-session --message-thread /messaging/thread/abc/ --invite-profile https://www.linkedin.com/in/test-user/",
           "",
           "Notes:",
           "  - write validation refuses to run against accounts marked primary",
@@ -4337,19 +4340,27 @@ export function createCliProgram(): Command {
         "after",
         [
           "",
-          "Workflow:",
+          "Read-only workflow:",
           "  - capture or refresh a stored session first with linkedin auth session --session <name>",
           "  - the validator always runs this fixed suite in order: feed, profile, notifications, inbox, connections",
           "",
           "Output:",
           "  - interactive terminals default to a human-readable summary with per-step progress",
           "  - non-interactive terminals default to JSON",
-          "  - --json prints the structured report to stdout; prompts and progress stay on stderr",
+          "  - --json prints the structured report to stdout; progress stays on stderr",
           "  - there is no separate --verbose flag; human mode is already the most detailed built-in view",
+          "  - --no-progress hides the live progress stream for either validation mode",
           "",
           "Configuration:",
           "  - LINKEDIN_ASSISTANT_HOME stores the encrypted session, reports, and latest-report.json",
           "  - PLAYWRIGHT_EXECUTABLE_PATH overrides Chromium if Playwright cannot find one",
+          "",
+          "Write validation workflow:",
+          "  - requires --write-validation --account <id> and a registered secondary account",
+          "  - validates approved targets before the browser starts sending real actions",
+          "  - prompts before every action; --yes is rejected on purpose",
+          "  - human mode shows live progress on stderr while prompts stay interactive",
+          "  - --json keeps the structured report on stdout while prompts stay on stderr",
           "",
           "Exit codes:",
           "  - 0 all validation steps passed",
@@ -4363,12 +4374,23 @@ export function createCliProgram(): Command {
           "  - prompts before every step unless --yes is set",
           "  - returns partial results if a later step hits a blocking failure",
           "",
-          "Examples:",
+          "Write validation guardrails:",
+          "  - runs only against registered secondary accounts and approved targets",
+          "  - rejects --session overrides, --yes, and --cdp-url",
+          "  - requires an interactive terminal and a visible browser window",
+          "",
+          "Read-only examples:",
           "  linkedin auth session --session smoke",
           "  linkedin test live --read-only --session smoke",
           "  linkedin test live --read-only --session smoke --yes",
           "  linkedin test live --read-only --session smoke --yes --json",
           "  linkedin test live --read-only --session smoke --yes --json | jq '.operations[] | select(.operation == \"notifications\")'",
+          "",
+          "Write validation examples:",
+          "  linkedin accounts add secondary --designation secondary --session secondary-session --profile secondary --message-thread /messaging/thread/abc123/",
+          "  linkedin test live --write-validation --account secondary",
+          "  linkedin test live --write-validation --account secondary --cooldown-seconds 20",
+          "  linkedin test live --write-validation --account secondary --json",
           "",
           "Docs:",
           "  - docs/live-validation.md",
@@ -4402,6 +4424,7 @@ export function createCliProgram(): Command {
                   "cooldown-seconds"
                 ),
                 json: options.json,
+                progress: options.progress,
                 readOnly: options.readOnly,
                 session: options.session,
                 timeoutSeconds: coercePositiveInt(
@@ -5612,10 +5635,12 @@ function resolveLiveWriteValidationAccountId(input: {
 }
 
 function formatWriteValidationPrompt(
-  preview: WriteValidationActionPreview
+  preview: WriteValidationActionPreview,
+  actionIndex: number
 ): string[] {
   return [
-    `Action: ${preview.action_type}`,
+    `Action ${actionIndex}/${TOTAL_WRITE_VALIDATION_ACTIONS}: ${preview.action_type}`,
+    `Summary: ${preview.summary}`,
     `Risk: ${preview.risk_class}`,
     `Target: ${JSON.stringify(preview.target)}`,
     `Payload: ${JSON.stringify(preview.outbound)}`,
@@ -5626,10 +5651,19 @@ function formatWriteValidationPrompt(
 function createWriteValidationPrompter(
   output: typeof stdout | typeof process.stderr
 ): (preview: WriteValidationActionPreview) => Promise<boolean> {
+  let nextActionIndex = 1;
+  let firstPrompt = true;
+
   return async (preview) => {
-    for (const line of formatWriteValidationPrompt(preview)) {
+    if (!firstPrompt) {
+      output.write("\n");
+    }
+    firstPrompt = false;
+
+    for (const line of formatWriteValidationPrompt(preview, nextActionIndex)) {
       output.write(`${line}\n`);
     }
+    nextActionIndex += 1;
 
     return promptYesNo("Execute this action?", output);
   };
@@ -5697,6 +5731,7 @@ async function runLiveWriteValidation(input: {
   accountId?: string | undefined;
   cooldownSeconds: number;
   json: boolean;
+  progress: boolean;
   readOnly: boolean;
   session: string;
   timeoutSeconds: number;
@@ -5707,6 +5742,11 @@ async function runLiveWriteValidation(input: {
     Boolean(stdout.isTTY)
   );
   const promptOutput = outputMode === "json" ? process.stderr : stdout;
+  const progressEnabled =
+    outputMode === "human" && input.progress && Boolean(process.stderr.isTTY);
+  const progressReporter = new WriteValidationProgressReporter({
+    enabled: progressEnabled
+  });
 
   try {
     const accountId = resolveLiveWriteValidationAccountId({
@@ -5721,11 +5761,21 @@ async function runLiveWriteValidation(input: {
     writeCliNotice(
       `Running write validation against account "${accountId}". See ${WRITE_VALIDATION_DOC_PATH} for account setup and approved targets.`
     );
+    writeCliNotice(
+      "Preparing the stored session, validating approved targets, and opening the interactive harness."
+    );
 
     const report = await runLinkedInWriteValidation({
       accountId: coerceProfileName(accountId, "account"),
       cooldownMs: input.cooldownSeconds * 1_000,
       interactive: Boolean(stdin.isTTY && stdout.isTTY),
+      ...(progressEnabled
+        ? {
+            onLog: (entry) => {
+              progressReporter.handleLog(entry);
+            }
+          }
+        : {}),
       onBeforeAction: createWriteValidationPrompter(promptOutput),
       timeoutMs: input.timeoutSeconds * 1_000
     });

--- a/packages/cli/src/writeValidationOutput.ts
+++ b/packages/cli/src/writeValidationOutput.ts
@@ -1,4 +1,6 @@
 import {
+  LINKEDIN_WRITE_VALIDATION_ACTIONS,
+  type JsonLogEntry,
   type LinkedInAssistantErrorPayload,
   type WriteValidationActionResult,
   type WriteValidationReport,
@@ -16,8 +18,28 @@ export interface FormatWriteValidationErrorOptions {
   helpCommand?: string;
 }
 
-type TerminalStyle = "bold" | "cyan" | "green" | "red" | "yellow";
+export interface WriteValidationProgressReporterOptions {
+  enabled?: boolean;
+  writeLine?: (line: string) => void;
+}
 
+type TerminalStyle = "bold" | "cyan" | "dim" | "green" | "red" | "yellow";
+type WriteValidationProgressLogEntry = Pick<JsonLogEntry, "event" | "payload">;
+type WriteValidationActionStage =
+  | "prepare"
+  | "prompt"
+  | "before_screenshot"
+  | "confirm"
+  | "after_screenshot"
+  | "verify";
+
+const TOTAL_WRITE_VALIDATION_ACTIONS = LINKEDIN_WRITE_VALIDATION_ACTIONS.length;
+const ACTION_INDEX_BY_TYPE = new Map<string, number>(
+  LINKEDIN_WRITE_VALIDATION_ACTIONS.map((action, index) => [action.actionType, index + 1])
+);
+const ACTION_SUMMARY_BY_TYPE = new Map<string, string>(
+  LINKEDIN_WRITE_VALIDATION_ACTIONS.map((action) => [action.actionType, action.summary])
+);
 const CONTROL_CHARACTER_PATTERN = new RegExp(
   `[${String.fromCharCode(0)}-${String.fromCharCode(31)}${String.fromCharCode(127)}-${String.fromCharCode(159)}]+`,
   "g"
@@ -29,6 +51,7 @@ const ANSI_ESCAPE_PATTERN = new RegExp(
 const TERMINAL_STYLE_CODES: Record<TerminalStyle, string> = {
   bold: "\u001B[1m",
   cyan: "\u001B[36m",
+  dim: "\u001B[2m",
   green: "\u001B[32m",
   red: "\u001B[31m",
   yellow: "\u001B[33m"
@@ -42,6 +65,10 @@ function sanitizeConsoleText(value: string): string {
     .trim();
 
   return sanitized.length > 0 ? sanitized : "[sanitized]";
+}
+
+function truncateForDisplay(value: string, maxLength: number = 180): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
 }
 
 function formatValueForDisplay(value: unknown): string {
@@ -81,6 +108,78 @@ function formatSectionTitle(title: string, color: boolean): string {
   return applyTextStyle(title, color, "bold", "cyan");
 }
 
+function formatCountLabel(
+  count: number,
+  singular: string,
+  plural: string = `${singular}s`
+): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function formatDurationMs(value: number | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return "0ms";
+  }
+
+  if (value < 1_000) {
+    return `${Math.round(value)}ms`;
+  }
+
+  if (value < 10_000) {
+    return `${(value / 1_000).toFixed(1)}s`;
+  }
+
+  return `${Math.round(value / 1_000)}s`;
+}
+
+function calculateDurationMs(startedAt: string, completedAt: string): number {
+  const startedAtMs = Date.parse(startedAt);
+  const completedAtMs = Date.parse(completedAt);
+
+  if (!Number.isFinite(startedAtMs) || !Number.isFinite(completedAtMs)) {
+    return 0;
+  }
+
+  return Math.max(0, completedAtMs - startedAtMs);
+}
+
+function readString(payload: Record<string, unknown>, key: string): string | null {
+  const value = payload[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function readNumber(payload: Record<string, unknown>, key: string): number | null {
+  const value = payload[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function readBoolean(payload: Record<string, unknown>, key: string): boolean | null {
+  const value = payload[key];
+  return typeof value === "boolean" ? value : null;
+}
+
+function readWarningCount(payload: Record<string, unknown>): number {
+  const warnings = payload.warnings;
+  return Array.isArray(warnings)
+    ? warnings.filter((warning) => typeof warning === "string").length
+    : 0;
+}
+
+function formatRunStatusLabel(
+  outcome: WriteValidationReport["outcome"],
+  color: boolean
+): string {
+  if (outcome === "pass") {
+    return applyTextStyle("PASS", color, "bold", "green");
+  }
+
+  if (outcome === "cancelled") {
+    return applyTextStyle("CANCELLED", color, "bold", "yellow");
+  }
+
+  return applyTextStyle("FAIL", color, "bold", "red");
+}
+
 function formatActionStatusLabel(
   status: WriteValidationResultStatus,
   color: boolean
@@ -96,26 +195,16 @@ function formatActionStatusLabel(
   return applyTextStyle("FAIL", color, "bold", "red");
 }
 
-function appendSection(lines: string[], title: string, entries: string[]): void {
-  if (entries.length === 0) {
-    return;
+function formatProgressStatusLabel(status: WriteValidationResultStatus): string {
+  if (status === "pass") {
+    return "PASS";
   }
 
-  lines.push("");
-  lines.push(title);
-  lines.push(...entries);
-}
+  if (status === "cancelled") {
+    return "CANCELLED";
+  }
 
-function formatActionSummary(
-  action: WriteValidationActionResult,
-  color: boolean
-): string {
-  const verification = action.verification?.verified === true ? "verified" : "unverified";
-  const sync = formatStateSyncLabel(action.state_synced);
-  const artifactCount = action.artifact_paths.length;
-  const errorSuffix = action.error_code ? ` | ${sanitizeConsoleText(action.error_code)}` : "";
-
-  return `- ${formatActionStatusLabel(action.status, color)} ${sanitizeConsoleText(action.action_type)} | ${verification} | ${sync} | ${artifactCount} artifact${artifactCount === 1 ? "" : "s"}${errorSuffix}`;
+  return "FAIL";
 }
 
 function formatStateSyncLabel(stateSynced: boolean | null): string {
@@ -126,24 +215,69 @@ function formatStateSyncLabel(stateSynced: boolean | null): string {
   return stateSynced ? "state=ok" : "state=failed";
 }
 
+function formatVerificationLabel(action: WriteValidationActionResult): string {
+  return action.verification?.verified === true ? "verified" : "unverified";
+}
+
+function appendSection(lines: string[], title: string, entries: string[]): void {
+  if (entries.length === 0) {
+    return;
+  }
+
+  lines.push("");
+  lines.push(title);
+  lines.push(...entries);
+}
+
 function formatArtifactPathList(
   label: string,
   artifactPaths: readonly string[]
-): string | null {
+): string[] {
   if (artifactPaths.length === 0) {
-    return null;
+    return [];
   }
 
-  return `  ${label}: ${artifactPaths.map(sanitizeConsoleText).join(", ")}`;
+  return [`  ${label}: ${artifactPaths.map(sanitizeConsoleText).join(", ")}`];
+}
+
+function formatActionSummary(
+  action: WriteValidationActionResult,
+  color: boolean,
+  index: number,
+  total: number
+): string {
+  const warnings = action.warnings?.length ?? 0;
+  const durationMs =
+    typeof action.duration_ms === "number"
+      ? action.duration_ms
+      : calculateDurationMs(action.started_at, action.completed_at);
+  const detailParts = [
+    action.risk_class,
+    formatVerificationLabel(action),
+    formatStateSyncLabel(action.state_synced),
+    formatDurationMs(durationMs),
+    formatCountLabel(action.artifact_paths.length, "artifact")
+  ];
+
+  if (warnings > 0) {
+    detailParts.push(formatCountLabel(warnings, "warning"));
+  }
+
+  if (action.error_code) {
+    detailParts.push(sanitizeConsoleText(action.error_code));
+  }
+
+  return `- ${index}/${total} ${formatActionStatusLabel(action.status, color)} ${sanitizeConsoleText(action.action_type)} | ${detailParts.join(" | ")}`;
 }
 
 function formatActionDetails(action: WriteValidationActionResult): string[] {
-  const target = action.preview?.target ?? {};
-  const outbound = action.preview?.outbound ?? {};
   const detailLines = [
-    `  target: ${formatValueForDisplay(target)}`,
-    `  outbound: ${formatValueForDisplay(outbound)}`,
-    `  expected: ${sanitizeConsoleText(action.expected_outcome)}`
+    `  summary: ${sanitizeConsoleText(action.summary)}`,
+    `  expected: ${sanitizeConsoleText(action.expected_outcome)}`,
+    `  target: ${formatValueForDisplay(action.preview?.target ?? {})}`,
+    `  outbound: ${formatValueForDisplay(action.preview?.outbound ?? {})}`,
+    `  started: ${sanitizeConsoleText(action.started_at)}`,
+    `  completed: ${sanitizeConsoleText(action.completed_at)}`
   ];
 
   if (action.verification) {
@@ -164,21 +298,368 @@ function formatActionDetails(action: WriteValidationActionResult): string[] {
     detailLines.push(`  warning: ${sanitizeConsoleText(warning)}`);
   }
 
-  const beforePaths = formatArtifactPathList("before", action.before_screenshot_paths);
-  if (beforePaths) {
-    detailLines.push(beforePaths);
+  for (const guidance of action.cleanup_guidance) {
+    detailLines.push(`  cleanup: ${sanitizeConsoleText(guidance)}`);
   }
 
-  const afterPaths = formatArtifactPathList("after", action.after_screenshot_paths);
-  if (afterPaths) {
-    detailLines.push(afterPaths);
-  }
+  detailLines.push(...formatArtifactPathList("artifacts", action.artifact_paths));
+  detailLines.push(...formatArtifactPathList("before", action.before_screenshot_paths));
+  detailLines.push(...formatArtifactPathList("after", action.after_screenshot_paths));
+  detailLines.push(...formatArtifactPathList("confirm", action.confirm_artifacts));
 
   return detailLines;
 }
 
+function formatOverviewEntries(report: WriteValidationReport): string[] {
+  const cleanupActionCount = report.actions.filter((action) => action.cleanup_guidance.length > 0)
+    .length;
+  const warningCount = report.actions.reduce((count, action) => {
+    return count + (action.warnings?.length ?? 0);
+  }, 0);
+  const artifactCount = report.actions.reduce((count, action) => {
+    return count + action.artifact_paths.length;
+  }, 0);
+  const durationMs =
+    typeof report.duration_ms === "number"
+      ? report.duration_ms
+      : calculateDurationMs(report.started_at, report.checked_at);
+
+  return [
+    `- Actions: ${formatCountLabel(report.pass_count, "passed action")} | ${formatCountLabel(report.fail_count, "failed action")} | ${formatCountLabel(report.cancelled_count, "cancelled action")}`,
+    `- Timing: ${formatDurationMs(durationMs)} total | cooldown ${formatDurationMs(report.cooldown_ms)}`,
+    `- Side effects: ${formatCountLabel(cleanupActionCount, "action needs cleanup", "actions need cleanup")} | ${formatCountLabel(artifactCount, "artifact")} | ${formatCountLabel(warningCount, "warning")}`,
+    `- Snapshot: latest ${sanitizeConsoleText(report.latest_report_path)}`
+  ];
+}
+
 function formatRecommendations(report: WriteValidationReport): string[] {
   return report.recommended_actions.map((action) => `- ${sanitizeConsoleText(action)}`);
+}
+
+function formatReportPaths(report: WriteValidationReport): string[] {
+  const entries = [
+    `- Report JSON: ${sanitizeConsoleText(report.report_path)}`,
+    `- Audit log: ${sanitizeConsoleText(report.audit_log_path)}`,
+    `- Latest snapshot: ${sanitizeConsoleText(report.latest_report_path)}`
+  ];
+
+  if (report.html_report_path) {
+    entries.splice(1, 0, `- Report HTML: ${sanitizeConsoleText(report.html_report_path)}`);
+  }
+
+  return entries;
+}
+
+function formatErrorDetailEntries(details: Record<string, unknown>): string[] {
+  return Object.entries(details)
+    .filter(([key]) => key !== "raw_error" && key !== "startup_validation")
+    .map(([key, value]) => `- ${sanitizeConsoleText(key)}: ${formatValueForDisplay(value)}`);
+}
+
+function readAccountId(details: Record<string, unknown>): string | null {
+  const accountId = details.account_id ?? details.account;
+  return typeof accountId === "string" && accountId.trim().length > 0
+    ? sanitizeConsoleText(accountId)
+    : null;
+}
+
+function readConfigPath(details: Record<string, unknown>): string | null {
+  const configPath = details.config_path;
+  return typeof configPath === "string" && configPath.trim().length > 0
+    ? sanitizeConsoleText(configPath)
+    : null;
+}
+
+function readSessionName(details: Record<string, unknown>): string | null {
+  const sessionName = details.session_name;
+  return typeof sessionName === "string" && sessionName.trim().length > 0
+    ? sanitizeConsoleText(sessionName)
+    : null;
+}
+
+function readMissingTargetKey(details: Record<string, unknown>): string | null {
+  const missingTargetKey = details.missing_target_key;
+  return typeof missingTargetKey === "string" && missingTargetKey.trim().length > 0
+    ? sanitizeConsoleText(missingTargetKey)
+    : null;
+}
+
+function buildMissingTargetSuggestion(
+  missingTargetKey: string,
+  accountId: string,
+  sessionName: string,
+  configPath: string | null
+): string {
+  const configSuffix = configPath ? ` or update ${configPath} manually.` : ".";
+
+  switch (missingTargetKey) {
+    case "send_message":
+      return `Add an approved message thread with "linkedin accounts add ${accountId} --designation secondary --session ${sessionName} --message-thread /messaging/thread/<id>/ --force"${configSuffix}`;
+    case "connections.send_invitation":
+      return `Add an approved invitation target with "linkedin accounts add ${accountId} --designation secondary --session ${sessionName} --invite-profile https://www.linkedin.com/in/<slug>/ --force"${configSuffix}`;
+    case "network.followup_after_accept":
+      return `Add an approved follow-up target with "linkedin accounts add ${accountId} --designation secondary --session ${sessionName} --followup-profile https://www.linkedin.com/in/<slug>/ --force"${configSuffix}`;
+    case "feed.like_post":
+      return `Add an approved reaction target with "linkedin accounts add ${accountId} --designation secondary --session ${sessionName} --reaction-post https://www.linkedin.com/feed/update/urn:li:activity:<id>/ --reaction like --force"${configSuffix}`;
+    case "post.create":
+      return `Set post visibility with "linkedin accounts add ${accountId} --designation secondary --session ${sessionName} --post-visibility connections --force" or rely on the default "connections" visibility${configSuffix}`;
+    default:
+      return `Add the missing approved target to the write-validation account config for ${accountId}${configSuffix}`;
+  }
+}
+
+function formatWriteValidationSuggestion(
+  error: LinkedInAssistantErrorPayload
+): string {
+  const sessionName = readSessionName(error.details) ?? "secondary-session";
+  const accountId = readAccountId(error.details) ?? "secondary";
+  const configPath = readConfigPath(error.details);
+  const missingTargetKey = readMissingTargetKey(error.details);
+
+  switch (error.code) {
+    case "ACTION_PRECONDITION_FAILED": {
+      if (missingTargetKey) {
+        return buildMissingTargetSuggestion(
+          missingTargetKey,
+          accountId,
+          sessionName,
+          configPath
+        );
+      }
+
+      if (error.message.includes('requires "--account <id>"')) {
+        return "Choose a registered secondary account and rerun with --write-validation --account <id>.";
+      }
+
+      if (error.message.includes('Remove "--session"')) {
+        return "Rerun without --session. Write validation always uses the stored session from the account registry.";
+      }
+
+      if (error.message.includes('typing "yes"')) {
+        return "Keep per-action confirmations enabled. The harness intentionally requires typing yes for each real action.";
+      }
+
+      if (error.message.includes("interactive terminal") || error.message.includes("visible browser")) {
+        return "Run the harness locally from an interactive terminal with a visible browser window.";
+      }
+
+      if (error.message.includes("cannot run in CI")) {
+        return "Run the harness manually outside CI from a local interactive terminal.";
+      }
+
+      if (error.message.includes("No write-validation account named")) {
+        return `Register the account with "linkedin accounts add ${accountId} --designation secondary --session ${sessionName}" or update ${configPath ?? "config.json"}.`;
+      }
+
+      return "Review the command flags, approved targets, and stored session configuration, then rerun the harness.";
+    }
+    case "AUTH_REQUIRED":
+      return `Capture a fresh stored session with "linkedin auth session --session ${sessionName}" and rerun.`;
+    case "CAPTCHA_OR_CHALLENGE":
+      return "Complete the LinkedIn challenge in a manual browser session, capture a fresh stored session, and rerun.";
+    case "RATE_LIMITED":
+      return "Wait for the session to cool down, then rerun. If this happens often, increase --cooldown-seconds or reduce how frequently you run the harness.";
+    case "NETWORK_ERROR":
+      return "Check browser and network connectivity, then rerun. If LinkedIn is flaky, keep retries enabled and try again later.";
+    case "TIMEOUT":
+      return "Rerun with a larger --timeout-seconds value after confirming the stored session still loads LinkedIn normally.";
+    case "TARGET_NOT_FOUND":
+      return "Confirm the approved LinkedIn target still exists, update the account registry if needed, and rerun.";
+    case "UI_CHANGED_SELECTOR_FAILED":
+      return "Open the HTML report or screenshots, update the validator selectors, and rerun the harness.";
+    default:
+      return "Rerun the command. If it keeps failing, review the audit log or rerun with --json for the structured payload.";
+  }
+}
+
+function describeActionStage(stage: WriteValidationActionStage): string {
+  switch (stage) {
+    case "prepare":
+      return "preparing the approved action";
+    case "prompt":
+      return "waiting for operator confirmation";
+    case "before_screenshot":
+      return "capturing the before screenshot";
+    case "confirm":
+      return "executing the live action";
+    case "after_screenshot":
+      return "capturing the after screenshot";
+    case "verify":
+      return "verifying the LinkedIn outcome";
+  }
+
+  return "processing the action";
+}
+
+function formatProgressIndex(actionType: string): string {
+  const index = ACTION_INDEX_BY_TYPE.get(actionType);
+  return typeof index === "number"
+    ? `${index}/${TOTAL_WRITE_VALIDATION_ACTIONS}`
+    : `?/${TOTAL_WRITE_VALIDATION_ACTIONS}`;
+}
+
+export class WriteValidationProgressReporter {
+  private readonly enabled: boolean;
+  private readonly writeLine: (line: string) => void;
+  private readonly lastStageByAction = new Map<string, WriteValidationActionStage>();
+
+  constructor(options: WriteValidationProgressReporterOptions = {}) {
+    this.enabled = options.enabled ?? true;
+    this.writeLine = options.writeLine ?? ((line: string) => process.stderr.write(`${line}\n`));
+  }
+
+  handleLog(entry: WriteValidationProgressLogEntry): void {
+    if (!this.enabled) {
+      return;
+    }
+
+    if (entry.event === "write_validation.start") {
+      const accountId = readString(entry.payload, "account_id") ?? "secondary";
+      const cooldownMs = readNumber(entry.payload, "cooldown_ms");
+      const timeoutMs = readNumber(entry.payload, "timeout_ms");
+      const summaryParts = [formatCountLabel(TOTAL_WRITE_VALIDATION_ACTIONS, "action")];
+
+      if (cooldownMs !== null) {
+        summaryParts.push(`cooldown ${formatDurationMs(cooldownMs)}`);
+      }
+
+      if (timeoutMs !== null) {
+        summaryParts.push(`timeout ${formatDurationMs(timeoutMs)}`);
+      }
+
+      this.writeLine(
+        `Starting write validation for account ${sanitizeConsoleText(accountId)} (${summaryParts.join(", ")}).`
+      );
+      return;
+    }
+
+    if (entry.event === "write_validation.action.start") {
+      const actionType = readString(entry.payload, "action_type") ?? "unknown";
+      const summary = ACTION_SUMMARY_BY_TYPE.get(actionType);
+      this.writeLine(
+        `Running ${formatProgressIndex(actionType)}: ${sanitizeConsoleText(actionType)}${summary ? ` — ${truncateForDisplay(sanitizeConsoleText(summary), 110)}` : ""}`
+      );
+      return;
+    }
+
+    if (entry.event === "write_validation.action.attempt") {
+      const actionType = readString(entry.payload, "action_type") ?? "unknown";
+      const stage = readString(entry.payload, "stage");
+      const attempt = readNumber(entry.payload, "attempt") ?? 1;
+
+      if (!stage || attempt !== 1) {
+        return;
+      }
+
+      const normalizedStage = stage as WriteValidationActionStage;
+      if (this.lastStageByAction.get(actionType) === normalizedStage) {
+        return;
+      }
+
+      this.lastStageByAction.set(actionType, normalizedStage);
+      this.writeLine(
+        `${formatProgressIndex(actionType)} ${sanitizeConsoleText(actionType)} — ${describeActionStage(normalizedStage)}...`
+      );
+      return;
+    }
+
+    if (entry.event === "write_validation.action.prepared") {
+      const actionType = readString(entry.payload, "action_type") ?? "unknown";
+      const retryCount = readNumber(entry.payload, "retry_count") ?? 0;
+      this.writeLine(
+        `Ready ${formatProgressIndex(actionType)}: ${sanitizeConsoleText(actionType)} — preview shown${retryCount > 0 ? ` after ${formatCountLabel(retryCount, "retry")}` : ""}; waiting for yes.`
+      );
+      return;
+    }
+
+    if (entry.event === "write_validation.action.retry") {
+      const actionType = readString(entry.payload, "action_type") ?? "unknown";
+      const attempt = readNumber(entry.payload, "attempt") ?? 1;
+      const maxAttempts = readNumber(entry.payload, "max_attempts") ?? attempt + 1;
+      const backoffMs = readNumber(entry.payload, "backoff_ms");
+      const code = readString(entry.payload, "code") ?? "UNKNOWN";
+      const nextAttempt = Math.min(maxAttempts, attempt + 1);
+      this.writeLine(
+        `Retrying ${formatProgressIndex(actionType)}: ${sanitizeConsoleText(actionType)} — ${sanitizeConsoleText(code)}; waiting ${formatDurationMs(backoffMs ?? 0)} before attempt ${nextAttempt}/${maxAttempts}.`
+      );
+      return;
+    }
+
+    if (entry.event === "write_validation.action.degraded") {
+      const actionType = readString(entry.payload, "action_type") ?? "unknown";
+      const stage = readString(entry.payload, "stage");
+      const errorMessage = readString(entry.payload, "error_message") ?? "degraded but continuing";
+      this.writeLine(
+        `Warning ${formatProgressIndex(actionType)}: ${sanitizeConsoleText(actionType)}${stage ? ` (${sanitizeConsoleText(stage)})` : ""} — ${truncateForDisplay(sanitizeConsoleText(errorMessage), 140)}.`
+      );
+      return;
+    }
+
+    if (entry.event === "write_validation.action.cancelled") {
+      const actionType = readString(entry.payload, "action_type") ?? "unknown";
+      this.writeLine(
+        `Cancelled ${formatProgressIndex(actionType)}: ${sanitizeConsoleText(actionType)} by operator.`
+      );
+      return;
+    }
+
+    if (entry.event === "write_validation.action.completed") {
+      const actionType = readString(entry.payload, "action_type") ?? "unknown";
+      const status = readString(entry.payload, "status") as WriteValidationResultStatus | null;
+      const verified = readBoolean(entry.payload, "verified");
+      const warningCount = readWarningCount(entry.payload);
+      const detailParts = [
+        verified === true ? "verified" : "needs review"
+      ];
+      if (warningCount > 0) {
+        detailParts.push(formatCountLabel(warningCount, "warning"));
+      }
+      this.writeLine(
+        `Finished ${formatProgressIndex(actionType)}: ${sanitizeConsoleText(actionType)} — ${formatProgressStatusLabel(status ?? "pass")}${detailParts.length > 0 ? ` | ${detailParts.join(" | ")}` : ""}`
+      );
+      return;
+    }
+
+    if (entry.event === "write_validation.action.failed") {
+      const actionType = readString(entry.payload, "action_type") ?? "unknown";
+      const code = readString(entry.payload, "code");
+      const failureStage = readString(entry.payload, "failure_stage");
+      const detailParts = [
+        ...(failureStage ? [sanitizeConsoleText(failureStage)] : []),
+        ...(code ? [sanitizeConsoleText(code)] : [])
+      ];
+      this.writeLine(
+        `Finished ${formatProgressIndex(actionType)}: ${sanitizeConsoleText(actionType)} — FAIL${detailParts.length > 0 ? ` | ${detailParts.join(" | ")}` : ""}`
+      );
+      return;
+    }
+
+    if (entry.event === "write_validation.cooldown.start") {
+      const cooldownMs = readNumber(entry.payload, "cooldown_ms") ?? 0;
+      this.writeLine(`Cooling down for ${formatDurationMs(cooldownMs)} before the next action...`);
+      return;
+    }
+
+    if (entry.event === "write_validation.stopped_early") {
+      const actionType = readString(entry.payload, "action_type") ?? "unknown";
+      const code = readString(entry.payload, "code") ?? "UNKNOWN";
+      const remainingActions = readNumber(entry.payload, "remaining_actions") ?? 0;
+      this.writeLine(
+        `Stopping early after ${formatProgressIndex(actionType)}: ${sanitizeConsoleText(actionType)} [${sanitizeConsoleText(code)}]; ${formatCountLabel(remainingActions, "remaining action")} marked cancelled.`
+      );
+      return;
+    }
+
+    if (entry.event === "write_validation.completed") {
+      const passCount = readNumber(entry.payload, "pass_count") ?? 0;
+      const failCount = readNumber(entry.payload, "fail_count") ?? 0;
+      const cancelledCount = readNumber(entry.payload, "cancelled_count") ?? 0;
+      const reportPath = readString(entry.payload, "report_path");
+      this.writeLine(
+        `Write validation finished — ${passCount} passed, ${failCount} failed, ${cancelledCount} cancelled${reportPath ? `. Report: ${sanitizeConsoleText(reportPath)}` : "."}`
+      );
+    }
+  }
 }
 
 export function resolveWriteValidationOutputMode(
@@ -197,20 +678,28 @@ export function formatWriteValidationReport(
   options: FormatWriteValidationReportOptions = {}
 ): string {
   const color = options.color === true;
+  const durationMs =
+    typeof report.duration_ms === "number"
+      ? report.duration_ms
+      : calculateDurationMs(report.started_at, report.checked_at);
   const lines = [
-    `${formatSectionTitle("Write Validation", color)} ${formatActionStatusLabel(report.outcome, color)}`,
-    `- Account: ${sanitizeConsoleText(report.account.id)} (${sanitizeConsoleText(report.account.designation)})`,
-    `- Warning: ${sanitizeConsoleText(report.warning)}`,
-    `- Summary: ${sanitizeConsoleText(report.summary)}`,
-    `- Audit log: ${sanitizeConsoleText(report.audit_log_path)}`,
-    `- Report: ${sanitizeConsoleText(report.report_path)}`
+    `${formatSectionTitle("Write Validation", color)} ${formatRunStatusLabel(report.outcome, color)}`,
+    `Account: ${sanitizeConsoleText(report.account.label)} [${sanitizeConsoleText(report.account.id)} / ${sanitizeConsoleText(report.account.designation)}]`,
+    `Summary: ${sanitizeConsoleText(report.summary)}`,
+    `Run: ${sanitizeConsoleText(report.run_id)} | Started ${sanitizeConsoleText(report.started_at)} | Finished ${sanitizeConsoleText(report.checked_at)} | Duration ${formatDurationMs(durationMs)}`,
+    `Warning: ${sanitizeConsoleText(report.warning)}`
   ];
 
-  const actionEntries = report.actions.flatMap((action) => [
-    formatActionSummary(action, color),
-    ...formatActionDetails(action)
-  ]);
-  appendSection(lines, formatSectionTitle("Actions", color), actionEntries);
+  appendSection(lines, formatSectionTitle("Overview", color), formatOverviewEntries(report));
+  appendSection(lines, formatSectionTitle("Reports", color), formatReportPaths(report));
+  appendSection(
+    lines,
+    formatSectionTitle("Actions", color),
+    report.actions.flatMap((action, index) => [
+      formatActionSummary(action, color, index + 1, report.actions.length),
+      ...formatActionDetails(action)
+    ])
+  );
   appendSection(
     lines,
     formatSectionTitle("Recommendations", color),
@@ -228,15 +717,15 @@ export function formatWriteValidationError(
   const helpCommand = options.helpCommand ?? "linkedin test live --help";
   const lines = [
     `${applyTextStyle("Write validation failed", color, "bold", "red")} [${sanitizeConsoleText(error.code)}]`,
-    sanitizeConsoleText(error.message)
+    sanitizeConsoleText(error.message),
+    `Suggested fix: ${formatWriteValidationSuggestion(error)}`
   ];
 
-  const detailEntries = Object.entries(error.details).map(([key, value]) => {
-    return `- ${sanitizeConsoleText(key)}: ${formatValueForDisplay(value)}`;
-  });
-  appendSection(lines, formatSectionTitle("Details", color), detailEntries);
+  appendSection(lines, formatSectionTitle("Details", color), formatErrorDetailEntries(error.details));
   appendSection(lines, formatSectionTitle("Help", color), [
-    `- Re-run ${sanitizeConsoleText(helpCommand)} for usage and safety guidance.`
+    `- Re-run ${sanitizeConsoleText(helpCommand)} for usage, safety guidance, and examples.`,
+    "- Review docs/write-validation.md for account setup, approved-target examples, and report details.",
+    "- Rerun with --json if you need the structured error payload for automation or debugging."
   ]);
 
   return lines.join("\n");

--- a/packages/cli/test/liveValidationCli.test.ts
+++ b/packages/cli/test/liveValidationCli.test.ts
@@ -469,6 +469,12 @@ describe("linkedin live validation CLI", () => {
     expect(liveHelp).toContain(
       "interactive terminals default to a human-readable summary with per-step progress"
     );
+    expect(liveHelp).toContain("Write validation workflow:");
+    expect(liveHelp).toContain("requires --write-validation --account <id>");
+    expect(liveHelp).toContain("Write validation examples:");
+    expect(liveHelp).toContain("linkedin test live --write-validation --account secondary");
+    expect(liveHelp).toContain("--cooldown-seconds 20");
+    expect(liveHelp).toContain("docs/write-validation.md");
     expect(liveHelp).toContain("-s, --session <session>");
     expect(liveHelp).toMatch(/Stored session name captured by linkedin auth\s+session/);
     expect(liveHelp).toContain("LINKEDIN_ASSISTANT_HOME");

--- a/packages/cli/test/writeValidationCli.test.ts
+++ b/packages/cli/test/writeValidationCli.test.ts
@@ -74,6 +74,7 @@ function createWriteValidationReport(
         cleanup_guidance: [],
         completed_at: "2026-03-09T10:00:05.000Z",
         confirm_artifacts: ["live-write-validation/send-message-after.png"],
+        duration_ms: 5_000,
         expected_outcome: "The outbound message is echoed in the approved conversation thread.",
         linkedin_response: {
           sent: true
@@ -110,13 +111,16 @@ function createWriteValidationReport(
     cancelled_count: outcome === "cancelled" ? 1 : 0,
     checked_at: "2026-03-09T10:00:06.000Z",
     cooldown_ms: 10_000,
+    duration_ms: 6_000,
     fail_count: outcome === "fail" ? 1 : 0,
+    html_report_path: "/tmp/report.html",
     latest_report_path: "/tmp/latest-report.json",
     outcome,
     pass_count: outcome === "pass" ? 1 : 0,
     recommended_actions: ["Review /tmp/report.json"],
     report_path: "/tmp/report.json",
     run_id: "run_write_validation_test",
+    started_at: "2026-03-09T10:00:00.000Z",
     summary: "Checked 1 write-validation actions. 1 passed. 0 failed. 0 cancelled. Overall outcome: pass.",
     warning: "This will perform REAL actions on LinkedIn."
   };
@@ -410,9 +414,113 @@ describe("write validation CLI", () => {
 
     expect(writeValidationCliMocks.runLinkedInWriteValidation).toHaveBeenCalledTimes(1);
     expect(stderrChunks.join("")).toContain("This will perform REAL actions on LinkedIn.");
-    expect(stdoutChunks.join("")).toContain("Action: send_message");
+    expect(stdoutChunks.join("")).toContain("Action 1/5: send_message");
     expect(stdoutChunks.join("")).toContain("Execute this action?");
     expect(String(consoleLogSpy.mock.calls.at(-1)?.[0] ?? "")).toContain("Write Validation");
+  });
+
+  it("streams write-validation progress to stderr in human mode", async () => {
+    writeValidationCliMocks.answers = ["yes"];
+    writeValidationCliMocks.runLinkedInWriteValidation.mockImplementation(
+      async (input: {
+        onBeforeAction?: (preview: {
+          action_type: string;
+          expected_outcome: string;
+          outbound: Record<string, unknown>;
+          risk_class: string;
+          summary: string;
+          target: Record<string, unknown>;
+        }) => Promise<boolean>;
+        onLog?: (entry: { event: string; payload: Record<string, unknown> }) => void;
+      }) => {
+        input.onLog?.({
+          event: "write_validation.start",
+          payload: {
+            account_id: "secondary",
+            cooldown_ms: 10_000,
+            timeout_ms: 30_000
+          }
+        });
+        input.onLog?.({
+          event: "write_validation.action.start",
+          payload: {
+            action_type: "send_message"
+          }
+        });
+        input.onLog?.({
+          event: "write_validation.action.attempt",
+          payload: {
+            action_type: "send_message",
+            attempt: 1,
+            stage: "prepare"
+          }
+        });
+        input.onLog?.({
+          event: "write_validation.action.prepared",
+          payload: {
+            action_type: "send_message",
+            retry_count: 0
+          }
+        });
+
+        await input.onBeforeAction?.({
+          action_type: "send_message",
+          expected_outcome:
+            "The outbound message is echoed in the approved conversation thread.",
+          outbound: {
+            text: "Quick validation ping • 2026-03-09T10:00:00.000Z"
+          },
+          risk_class: "private",
+          summary:
+            "Send a message in the approved thread and verify the outbound message appears.",
+          target: {
+            thread_id: "abc123"
+          }
+        });
+
+        input.onLog?.({
+          event: "write_validation.action.completed",
+          payload: {
+            action_type: "send_message",
+            status: "pass",
+            verified: true,
+            warnings: []
+          }
+        });
+        input.onLog?.({
+          event: "write_validation.completed",
+          payload: {
+            cancelled_count: 0,
+            fail_count: 0,
+            pass_count: 1,
+            report_path: "/tmp/report.json"
+          }
+        });
+
+        return createWriteValidationReport("pass");
+      }
+    );
+
+    await runCli([
+      "node",
+      "linkedin",
+      "test:live",
+      "--write-validation",
+      "--account",
+      "secondary"
+    ]);
+
+    const stderrOutput = stripVTControlCharacters(stderrChunks.join(""));
+
+    expect(stderrOutput).toContain(
+      "Starting write validation for account secondary (5 actions, cooldown 10s, timeout 30s)."
+    );
+    expect(stderrOutput).toContain(
+      "Running 3/5: send_message — Send a message in the approved thread and verify the outbound message appears."
+    );
+    expect(stderrOutput).toContain(
+      "Write validation finished — 1 passed, 0 failed, 0 cancelled. Report: /tmp/report.json"
+    );
   });
 
   it("writes prompts to stderr and emits JSON when --json is selected", async () => {
@@ -458,7 +566,7 @@ describe("write validation CLI", () => {
       "--json"
     ]);
 
-    expect(stderrChunks.join(" ")).toContain("Action: send_message");
+    expect(stderrChunks.join(" ")).toContain("Action 1/5: send_message");
     expect(stderrChunks.join(" ")).toContain("Execute this action?");
     expect(stdoutChunks).toEqual([]);
     expect(

--- a/packages/cli/test/writeValidationOutput.test.ts
+++ b/packages/cli/test/writeValidationOutput.test.ts
@@ -4,6 +4,7 @@ import type {
 } from "@linkedin-assistant/core";
 import { describe, expect, it } from "vitest";
 import {
+  WriteValidationProgressReporter,
   formatWriteValidationError,
   formatWriteValidationReport,
   resolveWriteValidationOutputMode
@@ -36,6 +37,7 @@ function createReportFixture(
         cleanup_guidance: [],
         completed_at: "2026-03-09T10:00:05.000Z",
         confirm_artifacts: [],
+        duration_ms: 5_000,
         ...(status === "fail"
           ? {
               error_code: "ACTION_PRECONDITION_FAILED",
@@ -84,13 +86,19 @@ function createReportFixture(
     cancelled_count: cancelledCount,
     checked_at: "2026-03-09T10:00:06.000Z",
     cooldown_ms: 10_000,
+    duration_ms: 6_000,
     fail_count: failCount,
+    html_report_path: "/tmp/report.html",
     latest_report_path: "/tmp/latest-report.json",
     outcome,
     pass_count: passCount,
-    recommended_actions: ["Review /tmp/report.json"],
+    recommended_actions: [
+      "Open /tmp/report.html in a browser for the color-coded validation report.",
+      "Review /tmp/report.json"
+    ],
     report_path: "/tmp/report.json",
     run_id: "run_write_validation_test",
+    started_at: "2026-03-09T10:00:00.000Z",
     summary:
       `Checked 1 write-validation actions. ${passCount} passed. ${failCount} failed. ${cancelledCount} cancelled. Overall outcome: ${outcome}.`,
     warning: "This will perform REAL actions on LinkedIn."
@@ -102,30 +110,49 @@ describe("write validation output", () => {
     const output = formatWriteValidationReport(createReportFixture("fail"));
 
     expect(output).toContain("Write Validation FAIL");
+    expect(output).toContain("Overview");
+    expect(output).toContain("Reports");
     expect(output).toContain("Actions");
     expect(output).toContain("send_message");
     expect(output).toContain("error: The approved thread could not be verified.");
+    expect(output).toContain("Report HTML: /tmp/report.html");
     expect(output).toContain("Recommendations");
   });
 
   it("matches the full human-readable write-validation report snapshot", () => {
     expect(formatWriteValidationReport(createReportFixture("fail"))).toMatchInlineSnapshot(`
       "Write Validation FAIL
-      - Account: secondary (secondary)
-      - Warning: This will perform REAL actions on LinkedIn.
-      - Summary: Checked 1 write-validation actions. 0 passed. 1 failed. 0 cancelled. Overall outcome: fail.
+      Account: Secondary [secondary / secondary]
+      Summary: Checked 1 write-validation actions. 0 passed. 1 failed. 0 cancelled. Overall outcome: fail.
+      Run: run_write_validation_test | Started 2026-03-09T10:00:00.000Z | Finished 2026-03-09T10:00:06.000Z | Duration 6.0s
+      Warning: This will perform REAL actions on LinkedIn.
+      
+      Overview
+      - Actions: 0 passed actions | 1 failed action | 0 cancelled actions
+      - Timing: 6.0s total | cooldown 10s
+      - Side effects: 0 actions need cleanup | 1 artifact | 0 warnings
+      - Snapshot: latest /tmp/latest-report.json
+      
+      Reports
+      - Report JSON: /tmp/report.json
+      - Report HTML: /tmp/report.html
       - Audit log: /tmp/events.jsonl
-      - Report: /tmp/report.json
-
+      - Latest snapshot: /tmp/latest-report.json
+      
       Actions
-      - FAIL send_message | unverified | state=n/a | 1 artifact | ACTION_PRECONDITION_FAILED
+      - 1/1 FAIL send_message | private | unverified | state=n/a | 5.0s | 1 artifact | ACTION_PRECONDITION_FAILED
+        summary: Send a message in the approved thread and verify the outbound message appears.
+        expected: The outbound message is echoed in the approved conversation thread.
         target: {"thread_id":"abc123"}
         outbound: {"text":"Quick validation ping • 2026-03-09T10:00:00.000Z"}
-        expected: The outbound message is echoed in the approved conversation thread.
+        started: 2026-03-09T10:00:00.000Z
+        completed: 2026-03-09T10:00:05.000Z
         error: The approved thread could not be verified.
+        artifacts: live-write-validation/send-message-before.png
         before: live-write-validation/send-message-before.png
-
+      
       Recommendations
+      - Open /tmp/report.html in a browser for the color-coded validation report.
       - Review /tmp/report.json"
     `);
   });
@@ -148,7 +175,7 @@ describe("write validation output", () => {
     );
   });
 
-  it("formats validation errors with details and help guidance", () => {
+  it("formats validation errors with details, suggestions, and help guidance", () => {
     const error: LinkedInAssistantErrorPayload = {
       code: "ACTION_PRECONDITION_FAILED",
       details: {
@@ -164,7 +191,9 @@ describe("write validation output", () => {
     expect(output).toContain(
       "Write validation failed [ACTION_PRECONDITION_FAILED]"
     );
+    expect(output).toContain("Suggested fix:");
     expect(output).toContain("account: secondary");
+    expect(output).toContain("docs/write-validation.md");
     expect(output).toContain("linkedin test live --help");
   });
 
@@ -186,15 +215,84 @@ describe("write validation output", () => {
     ).toMatchInlineSnapshot(`
       "Write validation failed [ACTION_PRECONDITION_FAILED]
       Write validation requires typing "yes" for every action.
-
+      Suggested fix: Keep per-action confirmations enabled. The harness intentionally requires typing yes for each real action.
+      
       Details
       - account: secondary
       - prompt: yes
       - reason: operator-declined
-
+      
       Help
-      - Re-run linkedin test live --help for usage and safety guidance."
+      - Re-run linkedin test live --help for usage, safety guidance, and examples.
+      - Review docs/write-validation.md for account setup, approved-target examples, and report details.
+      - Rerun with --json if you need the structured error payload for automation or debugging."
     `);
+  });
+
+  it("renders stable progress updates for long-running write scenarios", () => {
+    const lines: string[] = [];
+    const reporter = new WriteValidationProgressReporter({
+      writeLine(line) {
+        lines.push(line);
+      }
+    });
+
+    reporter.handleLog({
+      event: "write_validation.start",
+      payload: {
+        account_id: "secondary",
+        cooldown_ms: 10_000,
+        timeout_ms: 30_000
+      }
+    });
+    reporter.handleLog({
+      event: "write_validation.action.start",
+      payload: {
+        action_type: "send_message"
+      }
+    });
+    reporter.handleLog({
+      event: "write_validation.action.attempt",
+      payload: {
+        action_type: "send_message",
+        attempt: 1,
+        stage: "prepare"
+      }
+    });
+    reporter.handleLog({
+      event: "write_validation.action.prepared",
+      payload: {
+        action_type: "send_message",
+        retry_count: 0
+      }
+    });
+    reporter.handleLog({
+      event: "write_validation.action.completed",
+      payload: {
+        action_type: "send_message",
+        status: "pass",
+        verified: true,
+        warnings: []
+      }
+    });
+    reporter.handleLog({
+      event: "write_validation.completed",
+      payload: {
+        cancelled_count: 0,
+        fail_count: 0,
+        pass_count: 1,
+        report_path: "/tmp/report.json"
+      }
+    });
+
+    expect(lines).toEqual([
+      "Starting write validation for account secondary (5 actions, cooldown 10s, timeout 30s).",
+      "Running 3/5: send_message — Send a message in the approved thread and verify the outbound message appears.",
+      "3/5 send_message — preparing the approved action...",
+      "Ready 3/5: send_message — preview shown; waiting for yes.",
+      "Finished 3/5: send_message — PASS | verified",
+      "Write validation finished — 1 passed, 0 failed, 0 cancelled. Report: /tmp/report.json"
+    ]);
   });
 
   it("resolves json mode for explicit json and non-tty stdout", () => {

--- a/packages/core/src/__tests__/writeValidationExecution.test.ts
+++ b/packages/core/src/__tests__/writeValidationExecution.test.ts
@@ -51,6 +51,7 @@ interface MockRuntimeBundle {
   runtime: {
     artifacts: {
       resolve: (relativePath: string) => string;
+      writeText: ReturnType<typeof vi.fn>;
       writeJson: ReturnType<typeof vi.fn>;
     };
     close: ReturnType<typeof vi.fn>;
@@ -133,6 +134,7 @@ function createRuntimeBundle(baseDir: string): MockRuntimeBundle {
   const runtime: MockRuntimeBundle["runtime"] = {
     artifacts: {
       resolve: (relativePath) => path.join(baseDir, relativePath),
+      writeText: vi.fn(),
       writeJson: vi.fn()
     },
     close: vi.fn(),
@@ -281,10 +283,21 @@ describe("runLinkedInWriteValidation execution flow", () => {
     });
     expect(bundle.runtime.twoPhaseCommit.confirmByToken).toHaveBeenCalledTimes(1);
     expect(bundle.profileManager.capturePageScreenshot).toHaveBeenCalledTimes(2);
+    expect(bundle.runtime.artifacts.writeText).toHaveBeenCalledWith(
+      "live-write-validation/report.html",
+      expect.stringContaining("<!doctype html>"),
+      "text/html",
+      expect.objectContaining({
+        account_id: "secondary",
+        action_count: 2,
+        outcome: "fail"
+      })
+    );
     expect(bundle.runtime.artifacts.writeJson).toHaveBeenCalledWith(
       "live-write-validation/report.json",
       expect.objectContaining({
         action_count: 2,
+        html_report_path: path.join(baseDir, "live-write-validation", "report.html"),
         outcome: "fail"
       }),
       expect.objectContaining({

--- a/packages/core/src/__tests__/writeValidationReportHtml.test.ts
+++ b/packages/core/src/__tests__/writeValidationReportHtml.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import type { WriteValidationReport } from "../writeValidationShared.js";
+import { renderWriteValidationReportHtml } from "../writeValidationReportHtml.js";
+
+function createReportFixture(): WriteValidationReport {
+  return {
+    account: {
+      designation: "secondary",
+      id: "secondary",
+      label: "Secondary Account",
+      profile_name: "secondary-profile",
+      session_name: "secondary-session"
+    },
+    action_count: 1,
+    actions: [
+      {
+        action_type: "send_message",
+        after_screenshot_paths: ["live-write-validation/send-message-after.png"],
+        artifact_paths: ["live-write-validation/send-message-before.png"],
+        before_screenshot_paths: ["live-write-validation/send-message-before.png"],
+        cleanup_guidance: ["Delete the test message if you do not want it to remain visible."],
+        completed_at: "2026-03-09T10:00:05.000Z",
+        confirm_artifacts: [],
+        duration_ms: 5_000,
+        expected_outcome: "The outbound message is echoed in the approved conversation thread.",
+        linkedin_response: {
+          sent: true
+        },
+        prepared_action_id: "prepared_123",
+        preview: {
+          action_type: "send_message",
+          expected_outcome: "The outbound message is echoed in the approved conversation thread.",
+          outbound: {
+            text: "Quick validation ping • 2026-03-09T10:00:00.000Z"
+          },
+          risk_class: "private",
+          summary: "Send a message in the approved thread and verify the outbound message appears.",
+          target: {
+            thread_id: "abc123"
+          }
+        },
+        risk_class: "private",
+        started_at: "2026-03-09T10:00:00.000Z",
+        state_synced: null,
+        status: "pass",
+        summary: "Send a message in the approved thread and verify the outbound message appears.",
+        verification: {
+          details: {
+            thread_id: "abc123"
+          },
+          message: "Sent message was re-observed in the approved conversation thread.",
+          source: "inbox.getThread",
+          verified: true
+        },
+        warnings: []
+      }
+    ],
+    audit_log_path: "/tmp/run/events.jsonl",
+    cancelled_count: 0,
+    checked_at: "2026-03-09T10:00:06.000Z",
+    cooldown_ms: 10_000,
+    duration_ms: 6_000,
+    fail_count: 0,
+    html_report_path: "/tmp/run/live-write-validation/report.html",
+    latest_report_path: "/tmp/live-write-validation/secondary/latest-report.json",
+    outcome: "pass",
+    pass_count: 1,
+    recommended_actions: [
+      "Open /tmp/run/live-write-validation/report.html in a browser for the color-coded validation report."
+    ],
+    report_path: "/tmp/run/live-write-validation/report.json",
+    run_id: "run_write_validation_html_test",
+    started_at: "2026-03-09T10:00:00.000Z",
+    summary: "Checked 1 write-validation actions. 1 passed. 0 failed. 0 cancelled. Overall outcome: pass.",
+    warning: "This will perform REAL actions on LinkedIn."
+  };
+}
+
+describe("writeValidationReportHtml", () => {
+  it("renders a filterable standalone HTML report", () => {
+    const html = renderWriteValidationReportHtml(createReportFixture());
+
+    expect(html).toContain("<!doctype html>");
+    expect(html).toContain('data-filter-group="status"');
+    expect(html).toContain('data-filter-group="risk"');
+    expect(html).toContain("Secondary Account");
+    expect(html).toContain("send_message");
+    expect(html).toContain("color-coded validation report");
+    expect(html).toContain("file:///tmp/run/live-write-validation/report.json");
+  });
+});

--- a/packages/core/src/__tests__/writeValidationShared.test.ts
+++ b/packages/core/src/__tests__/writeValidationShared.test.ts
@@ -74,6 +74,7 @@ function createActionResult(
     cleanup_guidance: [],
     completed_at: "2026-03-09T10:00:05.000Z",
     confirm_artifacts: [],
+    duration_ms: 5_000,
     expected_outcome: "The outbound message is echoed in the approved conversation thread.",
     preview: {
       action_type: SEND_MESSAGE_ACTION_TYPE,

--- a/packages/core/src/writeValidation.ts
+++ b/packages/core/src/writeValidation.ts
@@ -13,6 +13,7 @@ import {
 } from "./errors.js";
 import type { PreparedActionResult } from "./twoPhaseCommit.js";
 import { resolveWriteValidationAccount } from "./writeValidationAccounts.js";
+import { renderWriteValidationReportHtml } from "./writeValidationReportHtml.js";
 import type { WriteValidationProfileManager } from "./writeValidationRuntime.js";
 import { createWriteValidationRuntime } from "./writeValidationRuntime.js";
 import {
@@ -112,6 +113,7 @@ interface ValidatedWriteValidationOptions {
   baseDir?: string;
   cooldownMs: number;
   maxRetries: number;
+  onLog?: RunLinkedInWriteValidationOptions["onLog"];
   onBeforeAction?: RunLinkedInWriteValidationOptions["onBeforeAction"];
   retryBaseDelayMs: number;
   retryMaxDelayMs: number;
@@ -143,6 +145,43 @@ function readPreparedArtifacts(prepared: PreparedActionResult): PreparedArtifact
   return {
     previewArtifacts,
     beforeScreenshotPaths: previewArtifacts.filter(isScreenshotPath)
+  };
+}
+
+function calculateIsoDurationMs(startedAt: string, completedAt: string): number {
+  const startedAtMs = Date.parse(startedAt);
+  const completedAtMs = Date.parse(completedAt);
+
+  if (!Number.isFinite(startedAtMs) || !Number.isFinite(completedAtMs)) {
+    return 0;
+  }
+
+  return Math.max(0, completedAtMs - startedAtMs);
+}
+
+function createCompletedTiming(startedAt: string): {
+  completedAt: string;
+  durationMs: number;
+} {
+  const completedAt = new Date().toISOString();
+  return {
+    completedAt,
+    durationMs: calculateIsoDurationMs(startedAt, completedAt)
+  };
+}
+
+function attachWriteValidationLogObserver(
+  logger: WriteValidationLogger,
+  onLog: NonNullable<RunLinkedInWriteValidationOptions["onLog"]>
+): void {
+  const originalLog = logger.log.bind(logger) as (
+    ...args: Parameters<WriteValidationLogger["log"]>
+  ) => ReturnType<WriteValidationLogger["log"]>;
+
+  logger.log = (...args: Parameters<WriteValidationLogger["log"]>) => {
+    const entry = originalLog(...args);
+    onLog(entry);
+    return entry;
   };
 }
 
@@ -352,8 +391,8 @@ function normalizeWriteValidationError(input: {
     return new LinkedInAssistantError(
       authCode,
       authCode === "CAPTCHA_OR_CHALLENGE"
-        ? `Stored session "${input.sessionName}" triggered a LinkedIn challenge while ${describeActionStage(input.stage)} for ${input.actionType}. Capture a fresh session with "owa auth:session --session ${input.sessionName}" and rerun the harness.`
-        : `Stored session "${input.sessionName}" is no longer authenticated while ${describeActionStage(input.stage)} for ${input.actionType}. Capture a fresh session with "owa auth:session --session ${input.sessionName}" and rerun the harness.`,
+        ? `Stored session "${input.sessionName}" triggered a LinkedIn challenge while ${describeActionStage(input.stage)} for ${input.actionType}. Capture a fresh session with "linkedin auth session --session ${input.sessionName}" and rerun the harness.`
+        : `Stored session "${input.sessionName}" is no longer authenticated while ${describeActionStage(input.stage)} for ${input.actionType}. Capture a fresh session with "linkedin auth session --session ${input.sessionName}" and rerun the harness.`,
       {
         ...details,
         raw_error: rawMessage
@@ -495,6 +534,13 @@ export function validateWriteValidationOptions(
     );
   }
 
+  if (typeof options.onLog !== "undefined" && typeof options.onLog !== "function") {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "onLog must be a function when provided."
+    );
+  }
+
   if (typeof options.interactive !== "undefined" && typeof options.interactive !== "boolean") {
     throw new LinkedInAssistantError(
       "ACTION_PRECONDITION_FAILED",
@@ -552,6 +598,7 @@ export function validateWriteValidationOptions(
     ...(typeof options.baseDir === "string" ? { baseDir: options.baseDir } : {}),
     cooldownMs,
     maxRetries,
+    ...(options.onLog ? { onLog: options.onLog } : {}),
     ...(options.onBeforeAction ? { onBeforeAction: options.onBeforeAction } : {}),
     retryBaseDelayMs,
     retryMaxDelayMs,
@@ -1026,6 +1073,8 @@ function buildCancelledActionResult(input: {
   errorMessage?: string;
   warnings?: string[];
 }): WriteValidationActionResult {
+  const timing = createCompletedTiming(input.startedAt);
+
   return {
     action_type: input.scenario.actionType,
     after_screenshot_paths: [],
@@ -1035,8 +1084,9 @@ function buildCancelledActionResult(input: {
     }),
     before_screenshot_paths: input.preparedArtifacts.beforeScreenshotPaths,
     cleanup_guidance: input.cleanupGuidance,
-    completed_at: new Date().toISOString(),
+    completed_at: timing.completedAt,
     confirm_artifacts: [],
+    duration_ms: timing.durationMs,
     ...(input.errorCode ? { error_code: input.errorCode } : {}),
     ...(input.errorDetails ? { error_details: input.errorDetails } : {}),
     ...(input.errorMessage ? { error_message: input.errorMessage } : {}),
@@ -1069,6 +1119,8 @@ function buildCompletedActionResult(input: {
   verification: WriteValidationVerificationResult;
   warnings?: string[];
 }): WriteValidationActionResult {
+  const timing = createCompletedTiming(input.startedAt);
+
   return {
     action_type: input.scenario.actionType,
     after_screenshot_paths: input.afterScreenshotPaths,
@@ -1080,8 +1132,9 @@ function buildCompletedActionResult(input: {
     }),
     before_screenshot_paths: input.beforeScreenshotPaths,
     cleanup_guidance: input.cleanupGuidance,
-    completed_at: new Date().toISOString(),
+    completed_at: timing.completedAt,
     confirm_artifacts: input.confirmArtifacts,
+    duration_ms: timing.durationMs,
     expected_outcome: input.scenario.expectedOutcome,
     linkedin_response: input.linkedinResponse,
     prepared_action_id: input.prepared.preparedActionId,
@@ -1119,6 +1172,8 @@ function buildFailedActionResult(input: {
     warnings.unshift(retryWarning);
   }
 
+  const timing = createCompletedTiming(input.startedAt);
+
   return {
     action_type: input.scenario.actionType,
     after_screenshot_paths: input.partial.afterScreenshotPaths,
@@ -1132,8 +1187,9 @@ function buildFailedActionResult(input: {
     }),
     before_screenshot_paths: input.partial.beforeScreenshotPaths,
     cleanup_guidance: input.partial.cleanupGuidance,
-    completed_at: new Date().toISOString(),
+    completed_at: timing.completedAt,
     confirm_artifacts: input.partial.confirmArtifacts,
+    duration_ms: timing.durationMs,
     error_code: input.error.code,
     error_details: input.error.details,
     error_message: input.error.message,
@@ -1162,7 +1218,7 @@ function buildRemainingScenarioSkipMessage(input: {
 }): string {
   switch (input.blockingCode) {
     case "AUTH_REQUIRED":
-      return `Skipped because the stored session expired during ${input.blockedByActionType}. Capture a fresh session with "owa auth:session --session ${input.sessionName}" before rerunning the remaining write-validation actions.`;
+      return `Skipped because the stored session expired during ${input.blockedByActionType}. Capture a fresh session with "linkedin auth session --session ${input.sessionName}" before rerunning the remaining write-validation actions.`;
     case "CAPTCHA_OR_CHALLENGE":
       return `Skipped because LinkedIn triggered a checkpoint challenge during ${input.blockedByActionType}. Resolve the challenge and capture a fresh session before rerunning the remaining write-validation actions.`;
     case "RATE_LIMITED":
@@ -1178,14 +1234,18 @@ function buildSkippedActionResult(input: {
   scenario: WriteValidationScenarioDefinition;
   sessionName: string;
 }): WriteValidationActionResult {
+  const startedAt = new Date().toISOString();
+  const timing = createCompletedTiming(startedAt);
+
   return {
     action_type: input.scenario.actionType,
     after_screenshot_paths: [],
     artifact_paths: [],
     before_screenshot_paths: [],
     cleanup_guidance: [],
-    completed_at: new Date().toISOString(),
+    completed_at: timing.completedAt,
     confirm_artifacts: [],
+    duration_ms: timing.durationMs,
     error_code: input.blockingCode,
     error_details: {
       blocked_by_action_type: input.blockedByActionType,
@@ -1198,7 +1258,7 @@ function buildSkippedActionResult(input: {
     }),
     expected_outcome: input.scenario.expectedOutcome,
     risk_class: input.scenario.riskClass,
-    started_at: new Date().toISOString(),
+    started_at: startedAt,
     state_synced: null,
     status: "cancelled",
     summary: input.scenario.summary
@@ -1507,6 +1567,7 @@ function buildWriteValidationReport(input: {
   actions: WriteValidationActionResult[];
   cooldownMs: number;
   latestReportPath: string;
+  startedAt: string;
   runtime: WriteValidationRuntime;
 }): WriteValidationReport {
   const counts = countActionStatuses(input.actions);
@@ -1530,6 +1591,7 @@ function buildWriteValidationReport(input: {
     audit_log_path: input.runtime.logger.getEventsPath(),
     checked_at: checkedAt,
     cooldown_ms: input.cooldownMs,
+    duration_ms: calculateIsoDurationMs(input.startedAt, checkedAt),
     fail_count: counts.failCount,
     latest_report_path: input.latestReportPath,
     outcome,
@@ -1538,6 +1600,7 @@ function buildWriteValidationReport(input: {
     recommended_actions: [],
     report_path: reportPath,
     run_id: input.runtime.runId,
+    started_at: input.startedAt,
     summary,
     warning: WRITE_VALIDATION_WARNING
   };
@@ -1639,6 +1702,7 @@ export async function runLinkedInWriteValidation(
   options: RunLinkedInWriteValidationOptions
 ): Promise<WriteValidationReport> {
   const validatedOptions = validateWriteValidationOptions(options);
+  const startedAt = new Date().toISOString();
   assertInteractiveWriteValidation(options);
 
   const account = resolveWriteValidationAccount(
@@ -1662,6 +1726,10 @@ export async function runLinkedInWriteValidation(
       ...(validatedOptions.baseDir ? { baseDir: validatedOptions.baseDir } : {}),
       timeoutMs: validatedOptions.timeoutMs
     });
+
+    if (validatedOptions.onLog) {
+      attachWriteValidationLogObserver(runtimeHandle.runtime.logger, validatedOptions.onLog);
+    }
 
     const { runtime, profileManager } = runtimeHandle;
     const latestReportPath = path.join(
@@ -1744,8 +1812,39 @@ export async function runLinkedInWriteValidation(
       actions,
       cooldownMs: validatedOptions.cooldownMs,
       latestReportPath,
+      startedAt,
       runtime
     });
+
+    const htmlReportPath = runtime.artifacts.resolve(
+      `${WRITE_VALIDATION_REPORT_DIR}/report.html`
+    );
+
+    try {
+      runtime.artifacts.writeText(
+        `${WRITE_VALIDATION_REPORT_DIR}/report.html`,
+        renderWriteValidationReportHtml({
+          ...report,
+          html_report_path: htmlReportPath
+        }),
+        "text/html",
+        {
+          account_id: account.id,
+          action_count: actions.length,
+          outcome: report.outcome
+        }
+      );
+      report.html_report_path = htmlReportPath;
+      report.recommended_actions.unshift(
+        `Open ${htmlReportPath} in a browser for the color-coded validation report.`
+      );
+    } catch (error) {
+      runtime.logger.log("warn", "write_validation.html_report_persist.failed", {
+        account_id: account.id,
+        error: getErrorMessage(error),
+        html_report_path: htmlReportPath
+      });
+    }
 
     try {
       runtime.artifacts.writeJson(`${WRITE_VALIDATION_REPORT_DIR}/report.json`, report, {

--- a/packages/core/src/writeValidationAccounts.ts
+++ b/packages/core/src/writeValidationAccounts.ts
@@ -604,7 +604,7 @@ export function resolveWriteValidationAccount(
 
   throw new LinkedInAssistantError(
     "ACTION_PRECONDITION_FAILED",
-    `No write-validation account named "${normalizedAccountId}" was found. Register it with "owa accounts:add ${normalizedAccountId} --designation secondary --session ${normalizedAccountId}" or update ${registry.configPath}.`,
+    `No write-validation account named "${normalizedAccountId}" was found. Register it with "linkedin accounts add ${normalizedAccountId} --designation secondary --session ${normalizedAccountId}" or update ${registry.configPath}.`,
     {
       account_id: normalizedAccountId,
       config_path: registry.configPath

--- a/packages/core/src/writeValidationReportHtml.ts
+++ b/packages/core/src/writeValidationReportHtml.ts
@@ -1,0 +1,386 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import type {
+  WriteValidationActionResult,
+  WriteValidationReport
+} from "./writeValidationShared.js";
+
+const STATUS_LABELS: Record<WriteValidationActionResult["status"], string> = {
+  cancelled: "Cancelled",
+  fail: "Fail",
+  pass: "Pass"
+};
+
+const RISK_LABELS: Record<WriteValidationActionResult["risk_class"], string> = {
+  network: "Network",
+  private: "Private",
+  public: "Public"
+};
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/gu, "&amp;")
+    .replace(/</gu, "&lt;")
+    .replace(/>/gu, "&gt;")
+    .replace(/"/gu, "&quot;")
+    .replace(/'/gu, "&#39;");
+}
+
+function formatDurationMs(value: number | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return "0ms";
+  }
+
+  if (value < 1_000) {
+    return `${Math.round(value)}ms`;
+  }
+
+  if (value < 10_000) {
+    return `${(value / 1_000).toFixed(1)}s`;
+  }
+
+  return `${Math.round(value / 1_000)}s`;
+}
+
+function formatJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2) ?? "null";
+  } catch {
+    return String(value);
+  }
+}
+
+function formatCountLabel(count: number, singular: string, plural: string = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function buildFileLink(filePath: string, label?: string): string {
+  const href = escapeHtml(pathToFileURL(filePath).href);
+  const text = escapeHtml(label ?? filePath);
+  return `<a href="${href}"><code>${text}</code></a>`;
+}
+
+function resolveRunDir(report: WriteValidationReport): string {
+  return path.dirname(report.audit_log_path);
+}
+
+function resolveArtifactPath(runDir: string, artifactPath: string): string {
+  return path.isAbsolute(artifactPath) ? artifactPath : path.resolve(runDir, artifactPath);
+}
+
+function renderPathList(title: string, paths: readonly string[], runDir: string): string {
+  if (paths.length === 0) {
+    return "";
+  }
+
+  const items = paths.map((artifactPath) => {
+    const resolvedPath = resolveArtifactPath(runDir, artifactPath);
+    return `<li>${buildFileLink(resolvedPath, artifactPath)}</li>`;
+  });
+
+  return [
+    '<section class="card-subsection">',
+    `<h3>${escapeHtml(title)}</h3>`,
+    `<ul class="path-list">${items.join("")}</ul>`,
+    "</section>"
+  ].join("");
+}
+
+function renderTextList(title: string, values: readonly string[]): string {
+  if (values.length === 0) {
+    return "";
+  }
+
+  const items = values.map((value) => `<li>${escapeHtml(value)}</li>`);
+  return [
+    '<section class="card-subsection">',
+    `<h3>${escapeHtml(title)}</h3>`,
+    `<ul class="text-list">${items.join("")}</ul>`,
+    "</section>"
+  ].join("");
+}
+
+function renderJsonDetails(title: string, value: unknown, open: boolean = false): string {
+  return [
+    `<details class="json-details"${open ? " open" : ""}>`,
+    `<summary>${escapeHtml(title)}</summary>`,
+    `<pre>${escapeHtml(formatJson(value))}</pre>`,
+    "</details>"
+  ].join("");
+}
+
+function renderActionCard(
+  action: WriteValidationActionResult,
+  index: number,
+  totalActions: number,
+  runDir: string
+): string {
+  const statusClass = `status-${action.status}`;
+  const riskClass = `risk-${action.risk_class}`;
+  const verificationLabel = action.verification?.verified === true ? "Verified" : "Unverified";
+  const stateLabel =
+    action.state_synced === null ? "State n/a" : action.state_synced ? "State ok" : "State mismatch";
+  const warnings = action.warnings ?? [];
+  const actionMeta = [
+    `<span>${escapeHtml(`${index + 1}/${totalActions}`)}</span>`,
+    `<span>${escapeHtml(formatDurationMs(action.duration_ms))}</span>`,
+    `<span>${escapeHtml(verificationLabel)}</span>`,
+    `<span>${escapeHtml(stateLabel)}</span>`,
+    `<span>${escapeHtml(formatCountLabel(action.artifact_paths.length, "artifact"))}</span>`
+  ];
+
+  if (warnings.length > 0) {
+    actionMeta.push(`<span>${escapeHtml(formatCountLabel(warnings.length, "warning"))}</span>`);
+  }
+
+  if (action.error_code) {
+    actionMeta.push(`<span>${escapeHtml(action.error_code)}</span>`);
+  }
+
+  const verificationBlock = action.verification
+    ? [
+        '<section class="card-subsection">',
+        "<h3>Verification</h3>",
+        `<p>${escapeHtml(action.verification.message)}</p>`,
+        `<p class="muted">Source: ${escapeHtml(action.verification.source)}</p>`,
+        "</section>"
+      ].join("")
+    : "";
+
+  const errorBlock = action.error_message
+    ? [
+        '<section class="card-subsection">',
+        "<h3>Error</h3>",
+        `<p>${escapeHtml(action.error_message)}</p>`,
+        action.failure_stage
+          ? `<p class="muted">Stage: ${escapeHtml(action.failure_stage)}</p>`
+          : "",
+        "</section>"
+      ].join("")
+    : "";
+
+  return [
+    `<article class="action-card ${statusClass}" data-action-card data-status="${escapeHtml(action.status)}" data-risk="${escapeHtml(action.risk_class)}">`,
+    '<header class="action-header">',
+    '<div class="action-badges">',
+    `<span class="badge ${statusClass}">${escapeHtml(STATUS_LABELS[action.status])}</span>`,
+    `<span class="badge ${riskClass}">${escapeHtml(RISK_LABELS[action.risk_class])}</span>`,
+    "</div>",
+    `<h2>${escapeHtml(action.action_type)}</h2>`,
+    `<p class="action-summary">${escapeHtml(action.summary)}</p>`,
+    `<div class="action-meta">${actionMeta.join("")}</div>`,
+    "</header>",
+    '<section class="card-subsection">',
+    "<h3>Expected outcome</h3>",
+    `<p>${escapeHtml(action.expected_outcome)}</p>`,
+    "</section>",
+    verificationBlock,
+    errorBlock,
+    renderTextList("Warnings", warnings),
+    renderTextList("Cleanup guidance", action.cleanup_guidance),
+    renderPathList("Artifacts", action.artifact_paths, runDir),
+    renderPathList("Before screenshots", action.before_screenshot_paths, runDir),
+    renderPathList("After screenshots", action.after_screenshot_paths, runDir),
+    renderPathList("Confirm artifacts", action.confirm_artifacts, runDir),
+    renderJsonDetails("Target preview", action.preview?.target ?? {}, false),
+    renderJsonDetails("Outbound payload", action.preview?.outbound ?? {}, false),
+    action.linkedin_response
+      ? renderJsonDetails("LinkedIn response", action.linkedin_response, false)
+      : "",
+    action.error_details
+      ? renderJsonDetails("Error details", action.error_details, false)
+      : "",
+    action.verification?.details
+      ? renderJsonDetails("Verification details", action.verification.details, false)
+      : "",
+    "</article>"
+  ].join("");
+}
+
+export function renderWriteValidationReportHtml(report: WriteValidationReport): string {
+  const runDir = resolveRunDir(report);
+  const htmlReportPath = report.html_report_path ?? path.join(path.dirname(report.report_path), "report.html");
+  const reportLinks = [
+    `<li>JSON report: ${buildFileLink(report.report_path)}</li>`,
+    `<li>HTML report: ${buildFileLink(htmlReportPath)}</li>`,
+    `<li>Audit log: ${buildFileLink(report.audit_log_path)}</li>`,
+    `<li>Latest snapshot: ${buildFileLink(report.latest_report_path)}</li>`
+  ];
+  const outcomeLabel = STATUS_LABELS[report.outcome];
+  const cleanupActionCount = report.actions.filter((action) => action.cleanup_guidance.length > 0).length;
+  const totalArtifactCount = report.actions.reduce((count, action) => count + action.artifact_paths.length, 0);
+  const actionCards = report.actions.map((action, index) => {
+    return renderActionCard(action, index, report.actions.length, runDir);
+  });
+
+  return [
+    "<!doctype html>",
+    '<html lang="en">',
+    "<head>",
+    '  <meta charset="utf-8">',
+    '  <meta name="viewport" content="width=device-width, initial-scale=1">',
+    `  <title>${escapeHtml(`Write validation — ${report.account.label}`)}</title>`,
+    "  <style>",
+    "    :root { color-scheme: light dark; --bg: #0b1020; --panel: #121a2b; --panel-alt: #172238; --text: #eef3ff; --muted: #a6b3cf; --border: rgba(255,255,255,0.12); --green: #3fb950; --yellow: #d29922; --red: #f85149; --blue: #58a6ff; }",
+    "    * { box-sizing: border-box; }",
+    "    body { margin: 0; font: 14px/1.5 system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: linear-gradient(180deg, #0b1020 0%, #10192f 100%); color: var(--text); }",
+    "    a { color: var(--blue); }",
+    "    code, pre { font-family: ui-monospace, SFMono-Regular, SFMono-Regular, Menlo, monospace; }",
+    "    .page { max-width: 1200px; margin: 0 auto; padding: 32px 20px 64px; }",
+    "    .hero, .panel, .action-card { background: rgba(18, 26, 43, 0.94); border: 1px solid var(--border); border-radius: 16px; box-shadow: 0 20px 48px rgba(0,0,0,0.28); }",
+    "    .hero { padding: 24px; margin-bottom: 20px; }",
+    "    .hero-header { display: flex; flex-wrap: wrap; justify-content: space-between; gap: 16px; align-items: flex-start; }",
+    "    .hero h1 { margin: 0 0 8px; font-size: 28px; line-height: 1.2; }",
+    "    .hero p { margin: 0; color: var(--muted); }",
+    "    .hero-meta { display: grid; gap: 6px; justify-items: end; text-align: right; color: var(--muted); }",
+    "    .badge { display: inline-flex; align-items: center; gap: 6px; border-radius: 999px; padding: 4px 10px; font-weight: 700; letter-spacing: 0.02em; text-transform: uppercase; font-size: 12px; }",
+    "    .status-pass { background: rgba(63,185,80,0.18); color: #7ee787; }",
+    "    .status-fail { background: rgba(248,81,73,0.18); color: #ff9b97; }",
+    "    .status-cancelled { background: rgba(210,153,34,0.18); color: #f2cc60; }",
+    "    .risk-private, .risk-network, .risk-public { background: rgba(88,166,255,0.14); color: #9cc8ff; }",
+    "    .summary-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: 12px; margin: 20px 0; }",
+    "    .summary-card { background: rgba(255,255,255,0.04); border: 1px solid var(--border); border-radius: 12px; padding: 14px 16px; }",
+    "    .summary-card h2 { margin: 0; font-size: 12px; letter-spacing: 0.04em; text-transform: uppercase; color: var(--muted); }",
+    "    .summary-card p { margin: 6px 0 0; font-size: 28px; font-weight: 700; }",
+    "    .summary-card small { display: block; margin-top: 6px; color: var(--muted); }",
+    "    .panel { padding: 20px; margin-bottom: 20px; }",
+    "    .panel h2 { margin: 0 0 12px; font-size: 18px; }",
+    "    .link-list, .path-list, .text-list { margin: 0; padding-left: 18px; }",
+    "    .filters { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; margin-bottom: 18px; }",
+    "    .filter-group { display: inline-flex; flex-wrap: wrap; gap: 8px; align-items: center; }",
+    "    .filter-label { color: var(--muted); font-weight: 600; }",
+    "    .filter-button { background: rgba(255,255,255,0.05); border: 1px solid var(--border); border-radius: 999px; color: var(--text); cursor: pointer; padding: 8px 12px; }",
+    "    .filter-button.is-active { border-color: rgba(88,166,255,0.7); background: rgba(88,166,255,0.18); }",
+    "    .actions-header { display: flex; flex-wrap: wrap; justify-content: space-between; gap: 12px; margin-bottom: 16px; align-items: center; }",
+    "    .actions-grid { display: grid; gap: 16px; }",
+    "    .action-card { padding: 20px; }",
+    "    .action-header h2 { margin: 10px 0 6px; font-size: 22px; }",
+    "    .action-summary { margin: 0 0 12px; color: var(--muted); }",
+    "    .action-badges, .action-meta { display: flex; flex-wrap: wrap; gap: 8px; }",
+    "    .action-meta span { background: rgba(255,255,255,0.04); border-radius: 999px; padding: 4px 10px; color: var(--muted); }",
+    "    .card-subsection { margin-top: 14px; }",
+    "    .card-subsection h3 { margin: 0 0 6px; font-size: 14px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }",
+    "    .card-subsection p { margin: 0; }",
+    "    .json-details { margin-top: 14px; border-top: 1px solid var(--border); padding-top: 14px; }",
+    "    .json-details summary { cursor: pointer; color: var(--blue); font-weight: 600; }",
+    "    .json-details pre { margin: 10px 0 0; padding: 12px; border-radius: 12px; background: rgba(0,0,0,0.28); overflow: auto; white-space: pre-wrap; word-break: break-word; }",
+    "    .muted { color: var(--muted); }",
+    "    [hidden] { display: none !important; }",
+    "    @media (max-width: 720px) { .hero-meta { justify-items: start; text-align: left; } .hero-header { flex-direction: column; } }",
+    "  </style>",
+    "</head>",
+    "<body>",
+    '  <main class="page">',
+    '    <section class="hero">',
+    '      <div class="hero-header">',
+    '        <div>',
+    `          <span class="badge status-${escapeHtml(report.outcome)}">${escapeHtml(outcomeLabel)}</span>`,
+    `          <h1>${escapeHtml(report.account.label)}</h1>`,
+    `          <p>${escapeHtml(report.summary)}</p>`,
+    '        </div>',
+    '        <div class="hero-meta">',
+    `          <div>Account: <strong>${escapeHtml(report.account.id)}</strong> (${escapeHtml(report.account.designation)})</div>`,
+    `          <div>Run: <code>${escapeHtml(report.run_id)}</code></div>`,
+    `          <div>Started: ${escapeHtml(report.started_at)}</div>`,
+    `          <div>Finished: ${escapeHtml(report.checked_at)}</div>`,
+    '        </div>',
+    '      </div>',
+    '      <div class="summary-grid">',
+    '        <div class="summary-card"><h2>Total actions</h2><p>' + escapeHtml(String(report.action_count)) + '</p><small>' + escapeHtml(formatCountLabel(cleanupActionCount, "action needs cleanup", "actions need cleanup")) + '</small></div>',
+    '        <div class="summary-card"><h2>Passed</h2><p>' + escapeHtml(String(report.pass_count)) + '</p><small>' + escapeHtml(formatCountLabel(report.pass_count, "verified action")) + '</small></div>',
+    '        <div class="summary-card"><h2>Failed</h2><p>' + escapeHtml(String(report.fail_count)) + '</p><small>' + escapeHtml(formatCountLabel(report.fail_count, "action needs review")) + '</small></div>',
+    '        <div class="summary-card"><h2>Cancelled</h2><p>' + escapeHtml(String(report.cancelled_count)) + '</p><small>' + escapeHtml(formatCountLabel(report.cancelled_count, "action skipped")) + '</small></div>',
+    '        <div class="summary-card"><h2>Total duration</h2><p>' + escapeHtml(formatDurationMs(report.duration_ms)) + '</p><small>' + escapeHtml(`Cooldown ${formatDurationMs(report.cooldown_ms)} between actions`) + '</small></div>',
+    '        <div class="summary-card"><h2>Artifacts</h2><p>' + escapeHtml(String(totalArtifactCount)) + '</p><small>' + escapeHtml(formatCountLabel(totalArtifactCount, "artifact")) + '</small></div>',
+    '      </div>',
+    '    </section>',
+    '    <section class="panel">',
+    '      <h2>Reports</h2>',
+    `      <p class="muted">${escapeHtml(report.warning)}</p>`,
+    `      <ul class="link-list">${reportLinks.join("")}</ul>`,
+    '    </section>',
+    '    <section class="panel">',
+    '      <div class="actions-header">',
+    '        <div>',
+    '          <h2>Actions</h2>',
+    '          <p class="muted">Showing <span data-visible-count>0</span> of ' + escapeHtml(String(report.actions.length)) + ' actions.</p>',
+    '        </div>',
+    '        <div class="filters">',
+    '          <div class="filter-group">',
+    '            <span class="filter-label">Status</span>',
+    '            <button class="filter-button is-active" type="button" data-filter-group="status" data-filter-value="all">All</button>',
+    '            <button class="filter-button" type="button" data-filter-group="status" data-filter-value="pass">Pass</button>',
+    '            <button class="filter-button" type="button" data-filter-group="status" data-filter-value="fail">Fail</button>',
+    '            <button class="filter-button" type="button" data-filter-group="status" data-filter-value="cancelled">Cancelled</button>',
+    '          </div>',
+    '          <div class="filter-group">',
+    '            <span class="filter-label">Risk</span>',
+    '            <button class="filter-button is-active" type="button" data-filter-group="risk" data-filter-value="all">All</button>',
+    '            <button class="filter-button" type="button" data-filter-group="risk" data-filter-value="private">Private</button>',
+    '            <button class="filter-button" type="button" data-filter-group="risk" data-filter-value="network">Network</button>',
+    '            <button class="filter-button" type="button" data-filter-group="risk" data-filter-value="public">Public</button>',
+    '          </div>',
+    '        </div>',
+    '      </div>',
+    `      <div class="actions-grid">${actionCards.join("")}</div>`,
+    '    </section>',
+    report.recommended_actions.length > 0
+      ? [
+          '    <section class="panel">',
+          '      <h2>Recommended next steps</h2>',
+          `      <ul class="text-list">${report.recommended_actions.map((action) => `<li>${escapeHtml(action)}</li>`).join("")}</ul>`,
+          '    </section>'
+        ].join("\n")
+      : "",
+    '  </main>',
+    '  <script>',
+    '    (() => {',
+    '      const state = { status: "all", risk: "all" };',
+    '      const cards = Array.from(document.querySelectorAll("[data-action-card]"));',
+    '      const visibleCount = document.querySelector("[data-visible-count]");',
+    '      const buttons = Array.from(document.querySelectorAll("[data-filter-group]"));',
+    '      const applyFilters = () => {',
+    '        let visible = 0;',
+    '        for (const card of cards) {',
+    '          const status = card.getAttribute("data-status") || "all";',
+    '          const risk = card.getAttribute("data-risk") || "all";',
+    '          const matchesStatus = state.status === "all" || state.status === status;',
+    '          const matchesRisk = state.risk === "all" || state.risk === risk;',
+    '          const isVisible = matchesStatus && matchesRisk;',
+    '          card.hidden = !isVisible;',
+    '          if (isVisible) {',
+    '            visible += 1;',
+    '          }',
+    '        }',
+    '        if (visibleCount) {',
+    '          visibleCount.textContent = String(visible);',
+    '        }',
+    '      };',
+    '      const syncButtons = () => {',
+    '        for (const button of buttons) {',
+    '          const group = button.getAttribute("data-filter-group");',
+    '          const value = button.getAttribute("data-filter-value");',
+    '          const active = Boolean(group && value && state[group] === value);',
+    '          button.classList.toggle("is-active", active);',
+    '        }',
+    '      };',
+    '      for (const button of buttons) {',
+    '        button.addEventListener("click", () => {',
+    '          const group = button.getAttribute("data-filter-group");',
+    '          const value = button.getAttribute("data-filter-value");',
+    '          if (!group || !value) {',
+    '            return;',
+    '          }',
+    '          state[group] = value;',
+    '          syncButtons();',
+    '          applyFilters();',
+    '        });',
+    '      }',
+    '      syncButtons();',
+    '      applyFilters();',
+    '    })();',
+    '  </script>',
+    "</body>",
+    "</html>"
+  ].join("\n");
+}

--- a/packages/core/src/writeValidationShared.ts
+++ b/packages/core/src/writeValidationShared.ts
@@ -9,6 +9,7 @@ import {
 import { FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE } from "./linkedinFollowups.js";
 import { CREATE_POST_ACTION_TYPE } from "./linkedinPosts.js";
 import type { LinkedInAssistantErrorCode } from "./errors.js";
+import type { JsonLogEntry } from "./logging.js";
 import type { CoreRuntime } from "./runtime.js";
 import type {
   ConfirmByTokenResult,
@@ -79,6 +80,7 @@ export interface WriteValidationActionResult {
   cleanup_guidance: string[];
   completed_at: string;
   confirm_artifacts: string[];
+  duration_ms: number;
   error_code?: LinkedInAssistantErrorCode;
   error_details?: Record<string, unknown>;
   error_message?: string;
@@ -114,7 +116,9 @@ export interface WriteValidationReport {
   audit_log_path: string;
   checked_at: string;
   cooldown_ms: number;
+  duration_ms: number;
   fail_count: number;
+  html_report_path?: string;
   latest_report_path: string;
   outcome: WriteValidationOutcome;
   pass_count: number;
@@ -122,6 +126,7 @@ export interface WriteValidationReport {
   recommended_actions: string[];
   report_path: string;
   run_id: string;
+  started_at: string;
   summary: string;
   warning: string;
 }
@@ -132,6 +137,7 @@ export interface RunLinkedInWriteValidationOptions {
   cooldownMs?: number;
   interactive?: boolean;
   maxRetries?: number;
+  onLog?: (entry: JsonLogEntry) => void;
   onBeforeAction?: (
     preview: WriteValidationActionPreview
   ) => Promise<boolean> | boolean;
@@ -300,7 +306,7 @@ export function buildRecommendedActions(
 
     if (action.error_code === "AUTH_REQUIRED" || action.error_code === "CAPTCHA_OR_CHALLENGE") {
       actions.push(
-        `Capture a fresh stored session with "owa auth:session --session ${report.account.session_name}" before rerunning write validation.`
+        `Capture a fresh stored session with "linkedin auth session --session ${report.account.session_name}" before rerunning write validation.`
       );
     }
 


### PR DESCRIPTION
## Summary
- upgrade Tier 3 write-validation terminal output with clearer summaries, timings, progress, and actionable errors
- generate a filterable HTML companion report alongside the JSON report for easier review
- expand CLI help and docs with write-validation workflows, examples, and setup fixes

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #154
