### PR TITLE
docs: document Tier 3 write-validation harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,46 @@ Post safety lint configuration:
   - `LINKEDIN_ASSISTANT_POST_SAFETY_VALIDATE_LINK_PREVIEWS`
   - `LINKEDIN_ASSISTANT_POST_SAFETY_LINK_TIMEOUT_MS`
 
+Live write-validation account registry:
+
+- Optional config file: `~/.linkedin-assistant/linkedin-owa-agentools/config.json`
+- JSON shape:
+
+```json
+{
+  "writeValidation": {
+    "accounts": {
+      "secondary": {
+        "designation": "secondary",
+        "profileName": "secondary",
+        "sessionName": "secondary-session",
+        "targets": {
+          "send_message": {
+            "thread": "https://www.linkedin.com/messaging/thread/abc123/"
+          },
+          "connections.send_invitation": {
+            "targetProfile": "https://www.linkedin.com/in/test-target/"
+          },
+          "network.followup_after_accept": {
+            "profileUrlKey": "https://www.linkedin.com/in/test-target/"
+          },
+          "feed.like_post": {
+            "postUrl": "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+            "reaction": "like"
+          },
+          "post.create": {
+            "visibility": "connections"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+- Use `linkedin accounts add` or `linkedin accounts:add` to create and update
+  these entries instead of editing JSON manually when possible.
+
 ## Selector Locale Support
 
 Locale-aware selectors let the runtime prefer localized LinkedIn UI phrases
@@ -314,7 +354,8 @@ npm exec -w @linkedin-assistant/cli -- linkedin test live --read-only --session 
 Live write validation is the Tier 3 human-in-the-loop harness for confirming
 that real LinkedIn write operations still work against an approved secondary
 account. It uses the same stored-session capture flow as Tier 2, but it never
-runs unattended and never targets a primary account.
+runs unattended, never targets a primary account, and always requires typed
+confirmation before each write.
 
 Examples below use the `linkedin` binary; `owa` is an equivalent alias.
 See `docs/write-validation.md` for the full operator guide.
@@ -324,15 +365,20 @@ See `docs/write-validation.md` for the full operator guide.
 npm exec -w @linkedin-assistant/cli -- linkedin auth session --session secondary-session
 
 # Register the secondary account and approved write-validation targets
-npm exec -w @linkedin-assistant/cli -- linkedin accounts add secondary --designation secondary --session secondary-session --profile secondary --message-thread /messaging/thread/abc123/ --invite-profile https://www.linkedin.com/in/test-target/ --followup-profile https://www.linkedin.com/in/test-target/ --reaction-post https://www.linkedin.com/feed/update/urn:li:activity:123/
+npm exec -w @linkedin-assistant/cli -- linkedin accounts add secondary --designation secondary --session secondary-session --profile secondary --message-thread /messaging/thread/abc123/ --message-participant-pattern "Simon Miller" --invite-profile https://www.linkedin.com/in/test-target/ --invite-note "Quick validation hello" --followup-profile https://www.linkedin.com/in/test-target/ --reaction-post https://www.linkedin.com/feed/update/urn:li:activity:123/ --reaction like --post-visibility connections
 
 # Run the real-action harness
 npm exec -w @linkedin-assistant/cli -- linkedin test live --write-validation --account secondary
+
+# Emit the final structured report as JSON while prompts stay interactive
+npm exec -w @linkedin-assistant/cli -- linkedin test live --write-validation --account secondary --json | jq '.actions[] | {action_type, status}'
 ```
 
 - The CLI prints `This will perform REAL actions on LinkedIn` at startup.
 - Every action is previewed individually and requires typing `yes` to proceed.
 - `--yes` is rejected for this workflow; there is no batch mode.
+- There is no Tier 3 `--dry-run`; rehearse safely with
+  `linkedin test live --read-only --session secondary-session --yes` first.
 - The harness runs the fixed five-action suite: `post.create`,
   `connections.send_invitation`, `send_message`,
   `network.followup_after_accept`, and `feed.like_post`.
@@ -341,10 +387,24 @@ npm exec -w @linkedin-assistant/cli -- linkedin test live --write-validation --a
   `linkedin accounts:add` to manage them.
 - The selected account must be marked `secondary`; accounts marked `primary`
   are hard-blocked.
-- The default cooldown is 10 seconds between real actions; override it with
-  `--cooldown-seconds <n>`.
+- `linkedin accounts add` also supports `--force`, `--invite-note`,
+  `--message-participant-pattern`, `--reaction`, and `--post-visibility`.
+- `--reaction` accepts `like`, `celebrate`, `support`, `love`, `insightful`,
+  or `funny`; `--post-visibility` accepts `public` or `connections`
+  (default `connections`).
+- Tier 3 run-time flags are `--account <id>`, `--cooldown-seconds <n>`,
+  `--timeout-seconds <n>`, `--json`, and `--no-progress`.
 - Reports include per-action verification, audit-log paths, cleanup guidance,
-  and before/after screenshot paths.
+  before/after screenshot paths, and a standalone HTML review artifact.
+- Blocking auth, challenge, or rate-limit failures stop the run early and the
+  remaining actions are marked `cancelled` in the partial report.
+- Exit codes: `0` when every action passes, `1` when one or more actions fail
+  or are cancelled, and `2` when preflight, session, or runtime errors prevent
+  the run from completing.
+- If the stored session is stale, refresh it with
+  `linkedin auth session --session secondary-session` and rerun.
+- Tier 3 is CLI-only; it is intentionally not exposed as an MCP tool because it
+  requires typed confirmations and a visible browser window.
 
 ### Draft quality evaluation
 
@@ -410,6 +470,10 @@ npm exec -w @linkedin-assistant/cli -- linkedin actions confirm --profile defaul
 - Use `--yes` to skip prompt in automation/non-interactive runs.
 
 ## MCP Usage
+
+Tier 3 live write validation is intentionally **not** exposed as an MCP tool.
+Use the CLI for that workflow so the operator can review each preview, type
+`yes`, and watch the visible browser window.
 
 Start MCP server:
 

--- a/docs/write-validation.md
+++ b/docs/write-validation.md
@@ -6,14 +6,17 @@ an approved secondary account.
 
 Examples below use the `linkedin` binary; `owa` is an equivalent alias.
 
-Unlike Tier 2 live validation, this workflow performs real outbound actions.
-The CLI prints a prominent warning at startup, runs only in an interactive
-terminal with a visible browser window, and requires the operator to type
-`yes` before every action.
+The feature is also exported from `@linkedin-assistant/core` through
+`packages/core/src/writeValidation.ts` for custom harnesses.
+
+For the Tier 2 read-only rehearsal lane, see `docs/live-validation.md`.
+For broader E2E safety rules and fixture-replay context, see
+`docs/e2e-testing.md`.
 
 ## Quick start
 
-Capture or refresh a stored session for the secondary account:
+Capture or refresh an encrypted stored session for the dedicated secondary
+account:
 
 ```bash
 npm exec -w @linkedin-assistant/cli -- linkedin auth session --session secondary-session
@@ -26,79 +29,88 @@ npm exec -w @linkedin-assistant/cli -- linkedin accounts add secondary \
   --designation secondary \
   --session secondary-session \
   --profile secondary \
+  --label "Secondary validation account" \
   --message-thread /messaging/thread/abc123/ \
   --message-participant-pattern "Simon Miller" \
   --invite-profile https://www.linkedin.com/in/test-target/ \
+  --invite-note "Quick validation hello" \
   --followup-profile https://www.linkedin.com/in/test-target/ \
   --reaction-post https://www.linkedin.com/feed/update/urn:li:activity:123/ \
   --reaction like \
   --post-visibility connections
 ```
 
-Run the write-validation harness:
+Run the Tier 3 harness:
 
 ```bash
 npm exec -w @linkedin-assistant/cli -- linkedin test live --write-validation --account secondary
 ```
 
-Change the cooldown between real actions when needed:
+## Safety model
 
-```bash
-npm exec -w @linkedin-assistant/cli -- linkedin test live --write-validation --account secondary --cooldown-seconds 20
-```
+Write validation is intentionally stricter than the other validation lanes:
 
-Use JSON output while keeping prompts interactive:
+- it performs **real LinkedIn writes** and prints a startup warning before the
+  browser begins sending them
+- it validates the configured account and all required approved targets before
+  any real action is sent
+- it runs only against accounts registered as `secondary`
+- it requires `--account <id>` and resolves the stored session through the
+  account registry
+- it rejects `--session`, `--yes`, and `--cdp-url`
+- it requires an interactive terminal and a visible browser window
+- it prompts before every action and requires the operator to type `yes`
+- it serializes runs per account with a lock file so two write-validation runs
+  cannot overlap on the same account
 
-```bash
-npm exec -w @linkedin-assistant/cli -- linkedin test live --write-validation --account secondary --json
-```
+Blocking auth, challenge, or rate-limit failures stop the run early. The
+remaining actions are recorded as `cancelled`, and the harness still writes a
+partial report so the operator can review what already happened.
 
-## Operator model
+There is currently **no** Tier 3 `--dry-run` or `--action` flag. The CLI always
+runs the same fixed five-action suite in order. If you want a no-write rehearsal,
+use Tier 2 read-only validation first.
 
-The harness always runs the same fixed suite, one action at a time, in this
-order:
+## Tier 1, Tier 2, and Tier 3
 
-- `post.create`
-- `connections.send_invitation`
-- `send_message`
-- `network.followup_after_accept`
-- `feed.like_post`
+The three lanes are related, but they do different jobs:
 
-Before each action, the CLI prints a preview containing:
+- **Tier 1 fixture replay**: deterministic, CI-safe, and no live LinkedIn side
+  effects. Use this for repeatable regression coverage.
+- **Tier 2 live read-only validation**: loads real LinkedIn pages with a stored
+  session but blocks writes. Treat this as the closest live “dry-run” for Tier 3.
+- **Tier 3 live write validation**: confirms that real outbound actions still
+  work, verifies the resulting side effect, and records cleanup guidance.
+
+A practical operator flow is:
+
+1. Refresh the stored session with `linkedin auth session`.
+2. Rehearse with `linkedin test live --read-only --session <session>`.
+3. Run `linkedin test live --write-validation --account <id>` only after the
+   approved targets and account config look correct.
+
+## What the harness runs
+
+The harness always executes the same five scenarios, in this order:
+
+1. `post.create`
+2. `connections.send_invitation`
+3. `send_message`
+4. `network.followup_after_accept`
+5. `feed.like_post`
+
+Before each action, the CLI prints a preview with:
 
 - action number and action type
 - one-line summary
-- risk class
-- target
+- risk class (`private`, `network`, or `public`)
+- target payload
 - outbound payload
 - expected outcome
 
-The operator must then type `yes` to proceed. Any other response cancels that
-single action and the harness continues to the next one.
-
-Important behavior:
-
-- `--yes` is rejected for write validation; there is no batch-confirm mode.
-- Actions are never parallelized or batched.
-- The default cooldown is 10 seconds between actions.
-- `--cooldown-seconds <n>` changes the inter-action delay.
-- `--timeout-seconds <n>` controls navigation and selector timeouts.
-- `--no-progress` hides the live stderr progress stream in human mode.
-- `--json` writes the structured result to stdout while prompts stay on stderr.
-
-## CLI output and progress
-
-Human-readable mode now shows three layers of feedback:
-
-1. **Startup notices** — account, docs path, and preflight activity
-2. **Live progress** — per-action stage updates such as prepare, screenshot,
-   confirm, verify, retry, and cooldown
-3. **Final summary** — color-coded pass/fail/cancelled sections with timing,
-   report paths, action details, warnings, and next steps
-
-The progress stream is designed for long-running scenarios such as invitation
-sends and message validation. It mirrors the structured write-validation log
-lifecycle without changing the underlying harness behavior.
+Any response other than `yes` cancels that one action and the harness continues
+to the next scenario. If you cancel some actions, the overall run outcome becomes
+`cancelled` even when the action you did execute passed.
 
 ## Account registry
 
@@ -107,87 +119,389 @@ Write validation resolves account metadata from
 Register or update entries with `linkedin accounts add` or the hidden
 `linkedin accounts:add` alias.
 
-Each account entry stores:
+If you omit `--profile` or `--session`, both default to the normalized account id.
 
-- designation: `primary` or `secondary`
-- stored session name
-- local profile name
-- optional human label
-- approved targets for every supported write action
+A persisted entry looks like this after normalization:
 
-Supported target options:
+```json
+{
+  "writeValidation": {
+    "accounts": {
+      "secondary": {
+        "designation": "secondary",
+        "label": "Secondary validation account",
+        "profileName": "secondary",
+        "sessionName": "secondary-session",
+        "targets": {
+          "send_message": {
+            "thread": "https://www.linkedin.com/messaging/thread/abc123/",
+            "participantPattern": "Simon Miller"
+          },
+          "connections.send_invitation": {
+            "targetProfile": "https://www.linkedin.com/in/test-target/",
+            "note": "Quick validation hello"
+          },
+          "network.followup_after_accept": {
+            "profileUrlKey": "https://www.linkedin.com/in/test-target/"
+          },
+          "feed.like_post": {
+            "postUrl": "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+            "reaction": "like"
+          },
+          "post.create": {
+            "visibility": "connections"
+          }
+        }
+      }
+    }
+  }
+}
+```
 
-- `--message-thread <thread>` and optional `--message-participant-pattern <regex>`
-- `--invite-profile <profile>` and optional `--invite-note <text>`
-- `--followup-profile <profile>`
-- `--reaction-post <post-url>` and optional `--reaction <reaction>`
-- `--post-visibility <visibility>`
+### `linkedin accounts add` flags
 
-Use `--force` when you want to replace an existing account definition.
+Required:
 
-## Safety guardrails
+- `<account>`: logical account id
+- `--designation <designation>`: `primary` or `secondary`
 
-The write-validation flow is intentionally stricter than Tier 2:
+Identity fields:
 
-- It runs only against accounts registered as `secondary`.
-- It hard-blocks accounts registered as `primary`.
-- It requires `--account <id>` and ignores ad hoc session selection.
-- It rejects `--session` overrides; the stored session comes from the account
-  registry.
-- It rejects `--yes`; every real action requires an explicit typed `yes`.
-- It refuses to run in CI.
-- It refuses to run in non-interactive or headless-style workflows.
-- It rejects external browser attachment via `--cdp-url`.
-- It cannot be combined with `--read-only`.
+- `--label <label>`: human-friendly label stored with the account
+- `--profile <profile>`: local profile name used for DB-backed write state
+- `--session <session>`: stored encrypted session captured with
+  `linkedin auth session`
 
-Use a dedicated secondary LinkedIn account and only approved test targets.
+Approved target fields:
 
-## What each action verifies
+- `--message-thread <thread>`: approved thread id or URL for `send_message`
+- `--message-participant-pattern <pattern>`: optional regex for checking the
+  approved thread participant
+- `--invite-profile <profile>`: approved profile URL or slug for
+  `connections.send_invitation`
+- `--invite-note <note>`: optional invitation note for the approved profile
+- `--followup-profile <profile>`: accepted-connection profile URL or slug for
+  `network.followup_after_accept`
+- `--reaction-post <post>`: approved post URL for `feed.like_post`
+- `--reaction <reaction>`: reaction to use for `feed.like_post`
+  (`like`, `celebrate`, `support`, `love`, `insightful`, `funny`; defaults to
+  `like`)
+- `--post-visibility <visibility>`: visibility for `post.create` (`public` or
+  `connections`; defaults to `connections`)
+- `--force`: replace an existing account definition with the same id
 
-- `post.create`: creates a connections-only post and re-reads the published
-  post from LinkedIn to confirm the content appears.
-- `connections.send_invitation`: sends an invitation to the approved target and
-  re-checks the sent invitations list.
-- `send_message`: sends a message in the approved thread and re-reads the
-  thread to confirm the latest message text.
-- `network.followup_after_accept`: prepares and confirms the follow-up for an
-  accepted connection, then checks the local follow-up state.
-- `feed.like_post`: applies the configured reaction to the approved post and
-  verifies the executor reported the reaction as active.
+Successful account registration prints JSON that includes `saved`,
+`config_path`, and the normalized `account` payload. A typical response looks
+like:
 
-Some actions leave real side effects behind. The report includes
-`cleanup_guidance[]` per action so the operator can remove test data afterward
-when appropriate.
+```json
+{
+  "saved": true,
+  "config_path": "/tmp/linkedin-assistant/config.json",
+  "account": {
+    "id": "secondary",
+    "designation": "secondary",
+    "sessionName": "secondary-session"
+  }
+}
+```
 
-## Reports and artifacts
+## Approved target examples by action
 
-Each run writes:
+Use `--force` when you are updating an existing account entry.
 
-- a run-scoped JSON report at `artifacts/<run-id>/live-write-validation/report.json`
-- a run-scoped HTML report at `artifacts/<run-id>/live-write-validation/report.html`
-- the structured audit log for that run at `artifacts/<run-id>/events.jsonl`
-- a stable latest snapshot at `live-write-validation/<account>/latest-report.json`
+### `send_message`
 
-The HTML report is meant for review in a browser. It includes:
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin accounts add secondary \
+  --designation secondary \
+  --session secondary-session \
+  --message-thread /messaging/thread/abc123/ \
+  --message-participant-pattern "Simon Miller" \
+  --force
+```
 
-- outcome cards with action, artifact, cleanup, and timing totals
+The harness sends one validation reply into the approved thread and verifies that
+the newest message text matches the sent payload.
+
+### `connections.send_invitation`
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin accounts add secondary \
+  --designation secondary \
+  --session secondary-session \
+  --invite-profile https://www.linkedin.com/in/test-target/ \
+  --invite-note "Quick validation hello" \
+  --force
+```
+
+The harness sends an invitation to the approved profile and re-checks the sent
+invitations list.
+
+### `network.followup_after_accept`
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin accounts add secondary \
+  --designation secondary \
+  --session secondary-session \
+  --followup-profile https://www.linkedin.com/in/test-target/ \
+  --force
+```
+
+The harness prepares the approved accepted-connection follow-up, confirms it,
+and checks the local follow-up state for confirmation.
+
+### `feed.like_post`
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin accounts add secondary \
+  --designation secondary \
+  --session secondary-session \
+  --reaction-post https://www.linkedin.com/feed/update/urn:li:activity:123/ \
+  --reaction celebrate \
+  --force
+```
+
+The harness applies the configured reaction and verifies that the executor
+reported the target reaction as active.
+
+### `post.create`
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin accounts add secondary \
+  --designation secondary \
+  --session secondary-session \
+  --post-visibility connections \
+  --force
+```
+
+The harness creates a new post, re-reads the published post from LinkedIn, and
+checks that the validation text appears in the post content.
+
+## Common workflows
+
+### Run the full fixed suite
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin test live --write-validation --account secondary
+```
+
+Expected interactive output looks like:
+
+```text
+This will perform REAL actions on LinkedIn.
+Running write validation against account "secondary". See docs/write-validation.md for account setup and approved targets.
+Preparing the stored session, validating approved targets, and opening the interactive harness.
+Starting write validation for account secondary (5 actions, cooldown 10s, timeout 30s).
+Running 3/5: send_message — Send a message in the approved thread and verify the outbound message appears.
+Write validation finished — 5 passed, 0 failed, 0 cancelled. Report: /tmp/live-write-validation/report.json
+```
+
+### Run one action from the fixed suite
+
+There is no `--action` flag today. To exercise one scenario in practice, run the
+full harness and answer `yes` only for the action you want to validate.
+Cancel the others by answering anything else.
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin test live --write-validation --account secondary
+```
+
+Example flow when only `send_message` is approved during the prompts:
+
+```text
+Action 1/5: post.create
+Execute this action? no
+Cancelled 1/5: post.create by operator.
+
+Action 3/5: send_message
+Execute this action? yes
+Finished 3/5: send_message — PASS | verified | state=n/a | 5.0s | 2 artifacts
+Write validation finished — 1 passed, 0 failed, 4 cancelled. Report: /tmp/live-write-validation/report.json
+```
+
+### Rehearse with the Tier 2 no-write lane
+
+Tier 3 has no dedicated `--dry-run` flag. The recommended no-write rehearsal is
+Tier 2 live read-only validation against the same stored session:
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin test live --read-only --session secondary-session --yes
+```
+
+Expected progress looks like:
+
+```text
+Starting live validation for session secondary-session (5 steps, request cap 20, min interval 5.0s).
+Live validation finished — 5 passed, 0 failed. Report: /tmp/live-readonly/report.json
+```
+
+Use this lane to confirm the stored session is still healthy before starting real
+Tier 3 writes.
+
+### Emit JSON while keeping prompts interactive
+
+```bash
+mkdir -p reports
+npm exec -w @linkedin-assistant/cli -- linkedin test live --write-validation --account secondary --json > reports/write-validation.json
+```
+
+In JSON mode, prompts still go to `stderr`, while the final report goes to
+`stdout`. The saved report starts like:
+
+```json
+{
+  "outcome": "pass",
+  "action_count": 5,
+  "report_path": "/tmp/live-write-validation/report.json",
+  "html_report_path": "/tmp/live-write-validation/report.html",
+  "latest_report_path": "/tmp/live-write-validation/secondary/latest-report.json"
+}
+```
+
+### Review the HTML report
+
+Every completed run writes a standalone HTML report automatically. No extra flag
+is required.
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin test live --write-validation --account secondary --json > reports/write-validation.json
+jq -r '.html_report_path' reports/write-validation.json
+```
+
+Typical output:
+
+```text
+/tmp/live-write-validation/report.html
+```
+
+The human-readable report also includes the path directly:
+
+```text
+Report HTML: /tmp/live-write-validation/report.html
+Open /tmp/live-write-validation/report.html in a browser for the color-coded validation report.
+```
+
+### Slow the pace between real actions
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin test live --write-validation --account secondary --cooldown-seconds 20 --timeout-seconds 45
+```
+
+Use this when the account is rate-limited or the target surfaces load slowly.
+
+## CLI options
+
+### `linkedin test live --write-validation`
+
+These flags affect Tier 3 runs directly:
+
+- `--write-validation`: select the Tier 3 real-action harness
+- `--account <id>`: required write-validation account id
+- `--cooldown-seconds <seconds>`: cooldown between actions, default `10`
+- `--timeout-seconds <seconds>`: navigation and selector timeout, default `30`
+- `--no-progress`: hide the live progress stream in human mode
+- `--json`: print the structured final report to `stdout`
+
+These flags are explicitly rejected for Tier 3:
+
+- `--read-only`
+- `--session <name>`
+- `--yes`
+- `--cdp-url <url>`
+
+`linkedin test live` also exposes Tier 2-only pacing and retry flags such as
+`--max-requests`, `--min-interval-ms`, `--max-retries`,
+`--retry-base-delay-ms`, and `--retry-max-delay-ms`. They belong to the
+read-only lane and do not affect `--write-validation` runs.
+
+Use `npm exec -w @linkedin-assistant/cli -- linkedin test live --help` for the
+built-in help text. The hidden `linkedin test:live` alias accepts the same
+options.
+
+### `linkedin accounts add`
+
+Use `linkedin accounts add <account> --designation secondary ...` to create or
+update the account registry entry that Tier 3 will resolve at runtime. The
+hidden `linkedin accounts:add` alias behaves the same way.
+
+## Output formats
+
+### Human-readable text
+
+Human mode shows three layers:
+
+1. startup warnings and notices
+2. live progress on `stderr`
+3. a formatted summary with `Overview`, `Reports`, `Actions`, and
+   `Recommendations`
+
+A typical final summary contains lines such as:
+
+```text
+Write Validation FAIL
+Overview
+- Actions: 0 passed actions | 1 failed action | 0 cancelled actions
+Reports
+- Report JSON: /tmp/report.json
+- Report HTML: /tmp/report.html
+Actions
+- 1/1 FAIL send_message | private | unverified | state=n/a | 5.0s | 1 artifact | ACTION_PRECONDITION_FAILED
+Recommendations
+- Open /tmp/report.html in a browser for the color-coded validation report.
+```
+
+### JSON report
+
+The JSON report preserves the complete run contract, including:
+
+- `account`: resolved account id, designation, label, profile, and session
+- `action_count`, `pass_count`, `fail_count`, `cancelled_count`, and `outcome`
+- `actions[]`: per-action previews, verification data, artifact paths, warnings,
+  cleanup guidance, and any structured error details
+- `report_path`, `html_report_path`, `audit_log_path`, and `latest_report_path`
+- `recommended_actions[]`: operator guidance for cleanup, review, or reruns
+
+### HTML report
+
+The HTML report is a standalone browser-friendly review artifact. It includes:
+
+- outcome cards for actions, cleanup items, duration, and artifact counts
 - color-coded action cards
 - filters by status and risk class
-- direct links to JSON, latest snapshot, audit log, and captured artifacts
+- links to the JSON report, audit log, latest snapshot, and captured artifacts
+
+## Reports, artifacts, and snapshots
+
+Each completed run writes:
+
+- a run-scoped JSON report at
+  `artifacts/<run-id>/live-write-validation/report.json`
+- a run-scoped HTML report at
+  `artifacts/<run-id>/live-write-validation/report.html`
+- the structured audit log for that run at `artifacts/<run-id>/events.jsonl`
+- a stable latest snapshot at
+  `LINKEDIN_ASSISTANT_HOME/live-write-validation/<account>/latest-report.json`
 
 Each action result records:
 
-- preview metadata shown before execution
-- executor or LinkedIn response payload
-- verification outcome and source
+- the preview shown before confirmation
+- the executor or LinkedIn response payload
+- verification status and verification source
 - before and after screenshot paths
-- related artifact paths
+- any additional artifact paths
 - per-action duration
-- cleanup guidance
+- cleanup guidance when the action leaves a lasting side effect
 
 The harness captures screenshots before and after every action. When the
 underlying prepare/confirm flow does not already produce screenshot artifacts,
 it captures fallback browser screenshots itself.
+
+## Exit codes
+
+- `0`: every action passed verification
+- `1`: one or more actions failed verification or were cancelled
+- `2`: preflight, session, or runtime errors prevented the run from completing
 
 ## Common setup fixes
 
@@ -223,19 +537,21 @@ these shortcuts:
     --reaction like --force
   ```
 
+- Missing `targets.post.create`:
+
+  ```bash
+  linkedin accounts add secondary --designation secondary --session secondary-session \
+    --post-visibility connections --force
+  ```
+
 - Missing or stale stored session:
 
   ```bash
   linkedin auth session --session secondary-session
   ```
 
-## Exit codes
-
-- `0`: every action passed verification
-- `1`: one or more actions failed verification or were cancelled
-- `2`: preflight, session, or runtime errors prevented the run from completing
-
 ## Related docs
 
-- `docs/live-validation.md` for Tier 2 read-only validation
+- `docs/live-validation.md` for Tier 2 live read-only validation
 - `docs/live-validation-architecture.md` for the Tier 2 pipeline internals
+- `docs/e2e-testing.md` for the fixture-replay lane and live E2E safety rules

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,18 @@
+# `@linkedin-assistant/cli`
+
+Operator CLI for LinkedIn Assistant.
+
+## Tier 3 write validation
+
+Use the CLI for the Tier 3 live write-validation harness:
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin test live --write-validation --account secondary
+```
+
+This workflow performs real LinkedIn writes against approved targets on a
+registered secondary account, requires typed confirmation before every action,
+and writes JSON plus HTML reports for review.
+
+See `../../docs/write-validation.md` for the full setup guide, account-registry
+shape, safety rules, output formats, and examples.

--- a/packages/cli/src/writeValidationOutput.ts
+++ b/packages/cli/src/writeValidationOutput.ts
@@ -7,17 +7,21 @@ import {
   type WriteValidationResultStatus
 } from "@linkedin-assistant/core";
 
+/** Output modes supported by the Tier 3 CLI formatter. */
 export type WriteValidationOutputMode = "human" | "json";
 
+/** Options for rendering the human-readable write-validation report. */
 export interface FormatWriteValidationReportOptions {
   color?: boolean;
 }
 
+/** Options for rendering human-readable write-validation errors. */
 export interface FormatWriteValidationErrorOptions {
   color?: boolean;
   helpCommand?: string;
 }
 
+/** Options for the stderr progress reporter that mirrors structured run events. */
 export interface WriteValidationProgressReporterOptions {
   enabled?: boolean;
   writeLine?: (line: string) => void;
@@ -498,6 +502,7 @@ function formatProgressIndex(actionType: string): string {
     : `?/${TOTAL_WRITE_VALIDATION_ACTIONS}`;
 }
 
+/** Turns structured write-validation log events into concise operator progress lines. */
 export class WriteValidationProgressReporter {
   private readonly enabled: boolean;
   private readonly writeLine: (line: string) => void;
@@ -662,6 +667,7 @@ export class WriteValidationProgressReporter {
   }
 }
 
+/** Resolves whether Tier 3 should emit human text or JSON for the current stdout target. */
 export function resolveWriteValidationOutputMode(
   input: { json?: boolean },
   stdoutIsTty: boolean
@@ -673,6 +679,7 @@ export function resolveWriteValidationOutputMode(
   return "human";
 }
 
+/** Formats the final Tier 3 report for human-readable CLI output. */
 export function formatWriteValidationReport(
   report: WriteValidationReport,
   options: FormatWriteValidationReportOptions = {}
@@ -709,6 +716,7 @@ export function formatWriteValidationReport(
   return lines.join("\n");
 }
 
+/** Formats a structured write-validation failure into human-readable CLI guidance. */
 export function formatWriteValidationError(
   error: LinkedInAssistantErrorPayload,
   options: FormatWriteValidationErrorOptions = {}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,21 @@
+# `@linkedin-assistant/core`
+
+Core runtime and automation library for LinkedIn Assistant.
+
+## Tier 3 write validation
+
+Tier 3 live write validation is exported from the core package through
+`packages/core/src/writeValidation.ts` and `packages/core/src/writeValidationAccounts.ts`.
+The main entry points are:
+
+- `runLinkedInWriteValidation()`
+- `getWriteValidationActionDefinitions()`
+- `loadWriteValidationAccounts()`
+- `resolveWriteValidationAccount()`
+- `upsertWriteValidationAccount()`
+
+Use the CLI when you need the operator-facing prompt flow. Use the Core API when
+you need custom orchestration around the fixed Tier 3 scenario suite.
+
+See `../../docs/write-validation.md` for the complete operator and integration
+guide.

--- a/packages/core/src/writeValidation.ts
+++ b/packages/core/src/writeValidation.ts
@@ -51,7 +51,10 @@ import {
   type WriteValidationVerificationResult
 } from "./writeValidationShared.js";
 
+/** Public action metadata for the fixed Tier 3 scenario suite. */
 export { LINKEDIN_WRITE_VALIDATION_ACTIONS } from "./writeValidationScenarios.js";
+
+/** Public report and API types for custom Tier 3 harness integrations. */
 export type {
   LinkedInWriteValidationActionType,
   LinkedInWriteValidationActionDefinition,
@@ -497,6 +500,7 @@ function assertInteractiveWriteValidation(input: { interactive?: boolean }): voi
   }
 }
 
+/** Validates and normalizes core write-validation options before execution starts. */
 export function validateWriteValidationOptions(
   options: RunLinkedInWriteValidationOptions
 ): ValidatedWriteValidationOptions {
@@ -1698,6 +1702,12 @@ async function cleanupWriteValidationResources(input: {
   }
 }
 
+/**
+ * Runs the full Tier 3 write-validation harness against one registered account.
+ *
+ * The harness performs real LinkedIn actions, writes JSON and HTML reports,
+ * updates the rolling latest snapshot, and returns the structured run report.
+ */
 export async function runLinkedInWriteValidation(
   options: RunLinkedInWriteValidationOptions
 ): Promise<WriteValidationReport> {
@@ -1917,6 +1927,7 @@ export async function runLinkedInWriteValidation(
   }
 }
 
+/** Returns the public action metadata list without exposing the scenario implementations. */
 export function getWriteValidationActionDefinitions(): readonly LinkedInWriteValidationActionDefinition[] {
   return LINKEDIN_WRITE_VALIDATION_ACTIONS;
 }

--- a/packages/core/src/writeValidationAccounts.ts
+++ b/packages/core/src/writeValidationAccounts.ts
@@ -18,37 +18,45 @@ import {
 
 const LINKEDIN_ASSISTANT_CONFIG_FILENAME = "config.json";
 
+/** Allowed account designations for write-validation registry entries. */
 export const WRITE_VALIDATION_ACCOUNT_DESIGNATIONS = [
   "primary",
   "secondary"
 ] as const;
 
+/** Designation assigned to a write-validation account in persisted config. */
 export type WriteValidationAccountDesignation =
   (typeof WRITE_VALIDATION_ACCOUNT_DESIGNATIONS)[number];
 
+/** Approved target configuration for the `send_message` scenario. */
 export interface WriteValidationMessageTargetConfig {
   thread: string;
   participantPattern?: string;
 }
 
+/** Approved target configuration for the `connections.send_invitation` scenario. */
 export interface WriteValidationConnectionTargetConfig {
   note?: string;
   targetProfile: string;
 }
 
+/** Approved target configuration for the `network.followup_after_accept` scenario. */
 export interface WriteValidationFollowupTargetConfig {
   profileUrlKey: string;
 }
 
+/** Approved target configuration for the `feed.like_post` scenario. */
 export interface WriteValidationReactionTargetConfig {
   postUrl: string;
   reaction?: LinkedInFeedReaction;
 }
 
+/** Approved target configuration for the `post.create` scenario. */
 export interface WriteValidationPostTargetConfig {
   visibility?: LinkedInPostVisibility;
 }
 
+/** Per-scenario approved targets persisted for one write-validation account. */
 export interface WriteValidationAccountTargets {
   "connections.send_invitation"?: WriteValidationConnectionTargetConfig;
   "feed.like_post"?: WriteValidationReactionTargetConfig;
@@ -57,6 +65,7 @@ export interface WriteValidationAccountTargets {
   send_message?: WriteValidationMessageTargetConfig;
 }
 
+/** Resolved write-validation account record used by the Tier 3 harness. */
 export interface WriteValidationAccount {
   id: string;
   designation: WriteValidationAccountDesignation;
@@ -66,11 +75,13 @@ export interface WriteValidationAccount {
   targets: WriteValidationAccountTargets;
 }
 
+/** Loaded registry plus the config path it came from. */
 export interface WriteValidationAccountRegistry {
   accounts: Record<string, WriteValidationAccount>;
   configPath: string;
 }
 
+/** Input contract for creating or replacing a persisted write-validation account. */
 export interface UpsertWriteValidationAccountInput {
   accountId: string;
   baseDir?: string;
@@ -548,6 +559,7 @@ function serializeAccount(account: WriteValidationAccount): JsonRecord {
   };
 }
 
+/** Loads and normalizes the write-validation account registry from config.json. */
 export function loadWriteValidationAccounts(
   baseDir?: string
 ): WriteValidationAccountRegistry {
@@ -590,6 +602,7 @@ export function loadWriteValidationAccounts(
   };
 }
 
+/** Resolves one account by id or throws a structured error when it is missing. */
 export function resolveWriteValidationAccount(
   accountId: string,
   baseDir?: string
@@ -612,6 +625,7 @@ export function resolveWriteValidationAccount(
   );
 }
 
+/** Persists a write-validation account entry and returns the refreshed registry view. */
 export async function upsertWriteValidationAccount(
   input: UpsertWriteValidationAccountInput
 ): Promise<WriteValidationAccountRegistry> {

--- a/packages/core/src/writeValidationReportHtml.ts
+++ b/packages/core/src/writeValidationReportHtml.ts
@@ -197,6 +197,7 @@ function renderActionCard(
   ].join("");
 }
 
+/** Renders a standalone HTML review report for one completed write-validation run. */
 export function renderWriteValidationReportHtml(report: WriteValidationReport): string {
   const runDir = resolveRunDir(report);
   const htmlReportPath = report.html_report_path ?? path.join(path.dirname(report.report_path), "report.html");

--- a/packages/core/src/writeValidationRuntime.ts
+++ b/packages/core/src/writeValidationRuntime.ts
@@ -236,6 +236,7 @@ function toSessionStatus(inspection: LinkedInSessionInspection): SessionStatus {
   };
 }
 
+/** Screenshot and cleanup surface required by the Tier 3 execution pipeline. */
 export interface WriteValidationProfileManager {
   capturePageScreenshot(input: {
     actionType: LinkedInWriteValidationActionType;
@@ -245,11 +246,18 @@ export interface WriteValidationProfileManager {
   dispose(): Promise<void>;
 }
 
+/** Runtime resources created for one write-validation run and disposed during cleanup. */
 export interface WriteValidationRuntimeHandle {
   profileManager: WriteValidationProfileManager;
   runtime: CoreRuntime;
 }
 
+/**
+ * Creates the stored-session runtime used by Tier 3 write validation.
+ *
+ * The returned handle owns both the core runtime and the profile manager and
+ * must be cleaned up by the caller when the run completes.
+ */
 export async function createWriteValidationRuntime(input: {
   account: WriteValidationAccount;
   baseDir?: string;

--- a/packages/core/src/writeValidationScenarios.ts
+++ b/packages/core/src/writeValidationScenarios.ts
@@ -128,6 +128,7 @@ function extractRecentMessageText(messages: readonly { text: string }[]): string
   return lastMessage ? normalizeText(lastMessage.text) : null;
 }
 
+/** Fixed write-validation scenarios executed by the Tier 3 harness in order. */
 export const WRITE_VALIDATION_SCENARIOS = [
   {
     actionType: CREATE_POST_ACTION_TYPE,
@@ -532,6 +533,7 @@ export const WRITE_VALIDATION_SCENARIOS = [
   }
 ] satisfies readonly WriteValidationScenarioDefinition[];
 
+/** Public metadata projection derived from the full scenario implementations. */
 export const LINKEDIN_WRITE_VALIDATION_ACTIONS: readonly LinkedInWriteValidationActionDefinition[] =
   WRITE_VALIDATION_SCENARIOS.map(
     ({ actionType, expectedOutcome, riskClass, summary }) => ({

--- a/packages/core/src/writeValidationShared.ts
+++ b/packages/core/src/writeValidationShared.ts
@@ -17,20 +17,41 @@ import type {
 } from "./twoPhaseCommit.js";
 import type { WriteValidationAccount } from "./writeValidationAccounts.js";
 
+/** Canonical action key used for validated outbound inbox replies. */
 export const SEND_MESSAGE_ACTION_TYPE = "send_message";
+
+/** Operator-facing warning emitted before the harness performs real LinkedIn writes. */
 export const WRITE_VALIDATION_WARNING =
   "This will perform REAL actions on LinkedIn.";
+
+/** Run-relative artifact directory used for Tier 3 reports, screenshots, and report assets. */
 export const WRITE_VALIDATION_REPORT_DIR = "live-write-validation";
+
+/** Stable filename used for the account-level rolling latest snapshot. */
 export const WRITE_VALIDATION_LATEST_REPORT_NAME = "latest-report.json";
+
+/** Default safety pause inserted between consecutive write-validation actions. */
 export const DEFAULT_WRITE_VALIDATION_COOLDOWN_MS = 10_000;
+
+/** Default navigation and selector timeout for stored-session write validation. */
 export const DEFAULT_WRITE_VALIDATION_TIMEOUT_MS = 30_000;
+
+/** Default retry count for recoverable write-validation stage failures. */
 export const DEFAULT_WRITE_VALIDATION_MAX_RETRIES = 1;
+
+/** Initial exponential-backoff delay for recoverable write-validation retries. */
 export const DEFAULT_WRITE_VALIDATION_RETRY_BASE_DELAY_MS = 1_000;
+
+/** Upper bound for exponential-backoff delay during write-validation retries. */
 export const DEFAULT_WRITE_VALIDATION_RETRY_MAX_DELAY_MS = 5_000;
+
+/** Feed URL used as the authenticated landing page and default screenshot baseline. */
 export const WRITE_VALIDATION_FEED_URL = "https://www.linkedin.com/feed/";
 
+/** Visibility bucket used to communicate the operator risk of a write action. */
 export type WriteValidationRiskClass = "private" | "network" | "public";
 
+/** Union of every action type supported by the Tier 3 write-validation harness. */
 export type LinkedInWriteValidationActionType =
   | typeof CREATE_POST_ACTION_TYPE
   | typeof SEND_INVITATION_ACTION_TYPE
@@ -38,8 +59,13 @@ export type LinkedInWriteValidationActionType =
   | typeof FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE
   | typeof LIKE_POST_ACTION_TYPE;
 
+/** Per-action status recorded in the final write-validation report. */
 export type WriteValidationResultStatus = "pass" | "fail" | "cancelled";
+
+/** Overall run outcome derived from the set of per-action statuses. */
 export type WriteValidationOutcome = WriteValidationResultStatus;
+
+/** Lifecycle stage used for progress events, retries, and failure attribution. */
 export type WriteValidationActionStage =
   | "prepare"
   | "prompt"
@@ -48,6 +74,7 @@ export type WriteValidationActionStage =
   | "after_screenshot"
   | "verify";
 
+/** Public metadata advertised for one supported write-validation scenario. */
 export interface LinkedInWriteValidationActionDefinition {
   actionType: LinkedInWriteValidationActionType;
   expectedOutcome: string;
@@ -55,6 +82,7 @@ export interface LinkedInWriteValidationActionDefinition {
   summary: string;
 }
 
+/** Preview payload shown to the operator before confirming a real action. */
 export interface WriteValidationActionPreview {
   action_type: LinkedInWriteValidationActionType;
   expected_outcome: string;
@@ -64,6 +92,7 @@ export interface WriteValidationActionPreview {
   target: Record<string, unknown>;
 }
 
+/** Verification result returned after a scenario confirms the prepared action. */
 export interface WriteValidationVerificationResult {
   details: Record<string, unknown>;
   message: string;
@@ -72,6 +101,7 @@ export interface WriteValidationVerificationResult {
   verified: boolean;
 }
 
+/** Persisted report row describing one action attempt in a write-validation run. */
 export interface WriteValidationActionResult {
   action_type: LinkedInWriteValidationActionType;
   after_screenshot_paths: string[];
@@ -103,6 +133,7 @@ export interface WriteValidationActionResult {
   warnings?: string[];
 }
 
+/** Top-level report contract written to JSON, surfaced in the CLI, and rendered to HTML. */
 export interface WriteValidationReport {
   account: {
     designation: WriteValidationAccount["designation"];
@@ -131,6 +162,7 @@ export interface WriteValidationReport {
   warning: string;
 }
 
+/** Core API options for running the Tier 3 write-validation harness. */
 export interface RunLinkedInWriteValidationOptions {
   accountId: string;
   baseDir?: string;
@@ -146,6 +178,7 @@ export interface RunLinkedInWriteValidationOptions {
   timeoutMs?: number;
 }
 
+/** Data a scenario prepare step must return for confirmation, screenshots, and verification. */
 export interface ScenarioPrepareResult {
   beforeScreenshotUrl?: string;
   cleanupGuidance: string[];
@@ -153,6 +186,7 @@ export interface ScenarioPrepareResult {
   verificationContext: Record<string, unknown>;
 }
 
+/** Full contract implemented by each real-action scenario in the fixed Tier 3 suite. */
 export interface WriteValidationScenarioDefinition
   extends LinkedInWriteValidationActionDefinition {
   prepare: (
@@ -173,22 +207,27 @@ export interface WriteValidationScenarioDefinition
   ) => Promise<WriteValidationVerificationResult>;
 }
 
+/** Returns whether a value is a plain object rather than `null` or an array. */
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/** Trims text and collapses internal whitespace for stable comparisons and output. */
 export function normalizeText(value: string | null | undefined): string {
   return (value ?? "").replace(/\s+/gu, " ").trim();
 }
 
+/** Removes blank strings and duplicates while preserving the first-seen order. */
 export function dedupeStrings(values: readonly string[]): string[] {
   return [...new Set(values.filter((value) => value.trim().length > 0))];
 }
 
+/** Returns whether an artifact path points at a captured PNG screenshot. */
 export function isScreenshotPath(value: string): boolean {
   return /\.png$/iu.test(value.trim());
 }
 
+/** Extracts artifact paths from a prepared-action preview payload when available. */
 export function readPreviewArtifacts(preview: Record<string, unknown>): string[] {
   const artifacts = preview.artifacts;
   if (!Array.isArray(artifacts)) {
@@ -207,6 +246,7 @@ export function readPreviewArtifacts(preview: Record<string, unknown>): string[]
     .filter((artifactPath): artifactPath is string => typeof artifactPath === "string");
 }
 
+/** Normalizes a prepared action into the public preview payload shown to operators. */
 export function buildPreview(
   scenario: WriteValidationScenarioDefinition,
   prepared: PreparedActionResult
@@ -226,6 +266,7 @@ export function buildPreview(
   };
 }
 
+/** Maps a verification result to the final status stored for an action. */
 export function determineActionStatus(
   verification: WriteValidationVerificationResult
 ): WriteValidationResultStatus {
@@ -236,6 +277,7 @@ export function determineActionStatus(
   return "pass";
 }
 
+/** Tallies pass, fail, and cancelled counts across a set of action results. */
 export function countActionStatuses(
   actions: readonly WriteValidationActionResult[]
 ): {
@@ -263,6 +305,7 @@ export function countActionStatuses(
   );
 }
 
+/** Resolves the run outcome, with `fail` taking precedence over `cancelled` and `pass`. */
 export function determineOutcome(
   actions: readonly WriteValidationActionResult[]
 ): WriteValidationOutcome {
@@ -277,6 +320,7 @@ export function determineOutcome(
   return "pass";
 }
 
+/** Builds the one-line human-readable summary used by Tier 3 reports and CLI output. */
 export function buildWriteValidationSummary(
   report: Pick<
     WriteValidationReport,
@@ -293,6 +337,7 @@ export function buildWriteValidationSummary(
   return `${parts.join(" ")} Overall outcome: ${report.outcome}.`;
 }
 
+/** Derives follow-up guidance from report paths, cleanup steps, and common failure modes. */
 export function buildRecommendedActions(
   report: Pick<WriteValidationReport, "actions" | "report_path" | "audit_log_path" | "account">
 ): string[] {
@@ -338,11 +383,13 @@ export function buildRecommendedActions(
   return dedupeStrings(actions);
 }
 
+/** Writes pretty JSON with a trailing newline, creating parent directories as needed. */
 export async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
   await mkdir(path.dirname(filePath), { recursive: true });
   await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
 }
 
+/** Projects an internal account record into the report-safe account payload. */
 export function buildWriteValidationReportAccount(
   account: WriteValidationAccount
 ): WriteValidationReport["account"] {

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,17 @@
+# `@linkedin-assistant/mcp`
+
+MCP stdio server for LinkedIn Assistant.
+
+## Tier 3 write validation boundary
+
+Tier 3 live write validation is intentionally not exposed as an MCP surface.
+That workflow requires a visible browser window and typed per-action
+confirmations, so it stays CLI-only.
+
+Use the CLI for Tier 3:
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin test live --write-validation --account secondary
+```
+
+See `../../docs/write-validation.md` for the full Tier 3 guide.


### PR DESCRIPTION
## Summary
- expand `docs/write-validation.md` into a full Tier 3 operator guide with setup, safety, output, and workflow examples
- add JSDoc for the public write-validation exports in Core and CLI modules
- link Tier 3 docs from the root README and package READMEs, including the CLI-only/MCP boundary

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #156
Closes #90