### PR TITLE
docs: add human-like typing implementation plan

### DIFF
--- a/docs/.plan-issue-166.md
+++ b/docs/.plan-issue-166.md
@@ -1,0 +1,755 @@
+# Execution plan — issue #166 human-like typing simulation implementation
+
+## Intent
+
+Implement issue #166 as a **focused core-only typing-engine refactor** that
+turns `docs/human-typing-architecture.md` into a concrete delivery plan for
+parent issue #131.
+
+The architecture document already settles the major design choices:
+
+- keep the existing `HumanizedPage` API stable
+- split typing into profile resolution, deterministic planning, and Playwright
+  execution
+- use a repo-owned US QWERTY map keyed by `KeyboardEvent.code`
+- model bursty cadence first, then add typo simulation behind safe defaults
+- keep sensitive flows, especially auth, typo-free and rollout-safe
+
+This plan translates those choices into:
+
+- a file-by-file implementation order
+- concrete module boundaries and interfaces
+- an additive public API surface
+- a configuration schema for typing behavior
+- timing-model defaults for cadence, pauses, and corrections
+- rollout guidance that keeps issue #132 (anti-bot evasion) decoupled from the
+  first human-typing implementation
+
+The goal is to land the typing engine **without widening scope into broader
+anti-bot heuristics, runtime config plumbing, or LinkedIn feature-module
+refactors**.
+
+## Recommended approach
+
+### 1) Keep typing behind `HumanizedPage`, but add per-call overrides
+
+The architecture doc is right to keep `humanize(page, options?)` and
+`HumanizedPage` as the public entrypoint. That preserves the current repo
+surface and avoids churn in existing call sites.
+
+However, the implementation should go one step further than the architecture
+doc’s “optional phase-2 enhancement” and add an additive third parameter to
+`type()` early:
+
+- keep `type(selector, text)` working exactly as it does today
+- add `type(selector, text, options?)` for per-field overrides
+
+This matters immediately for `packages/core/src/auth/session.ts`, where the
+same helper types both the email and password fields. Per-call options let the
+password field resolve as sensitive without forcing a separate `HumanizedPage`
+wrapper or a global auth-only mode.
+
+### 2) Split planner, executor, and profile resolution into separate modules
+
+Follow the architecture doc’s “Recommended architecture” section and keep the
+typing engine in three layers:
+
+1. profile resolution
+2. deterministic plan building
+3. Playwright execution
+
+That separation is the right fit for this repo because it keeps the risky
+browser side effects small and makes the cadence/error model unit-testable.
+
+The implementation should introduce these modules in `packages/core/src`:
+
+- `typingProfiles.ts`
+- `typingPlan.ts`
+- `typingExecutor.ts`
+- `keyboardLayouts/usQwerty.ts`
+
+`humanize.ts` should stay the public façade and orchestration point.
+
+### 3) Ship cadence and explicit shift handling before typo injection
+
+The architecture doc’s delivery order is also the safest implementation order:
+
+- first replace flat per-character jitter with seeded, profile-based cadence
+- then add explicit `Shift` handling for mapped uppercase/symbol characters
+- only after that, add typo planning and correction sequences
+
+This sequence gives issue #131 a meaningful human-typing upgrade even before
+the typo engine lands, and it limits the blast radius if auth or write flows
+surface regressions.
+
+Phase 1 should therefore include:
+
+- WPM-based inter-key timing
+- contextual pauses at word and punctuation boundaries
+- explicit `Shift` + key execution for mapped shifted characters
+- no visible wrong characters unless `simulateTypos` is enabled
+
+### 4) Keep configuration local to typing options, not global runtime config
+
+Do **not** start by adding environment variables, CLI flags, or new entries in
+`packages/core/src/config.ts`.
+
+The first implementation should keep all human-typing configuration scoped to
+`HumanizeOptions` and per-call `HumanizedTypeOptions`. That matches how the
+repo already uses `HumanizedPage`, keeps the rollout additive, and avoids
+colliding with issue #132’s broader anti-bot work.
+
+If future operator-facing controls become necessary, they can be added after
+the core contracts are stable.
+
+### 5) Use a repo-owned US QWERTY map keyed by physical key code
+
+The architecture doc makes the correct call here: typo planning and modifier
+simulation should be driven by physical-key identity, not character-only maps.
+
+The first implementation should ship one first-party layout:
+
+- `us-qwerty`
+
+Each key record should include:
+
+- `code`
+- `unshifted`
+- `shifted`
+- `row`
+- `column`
+- `hand`
+- `finger`
+- weighted `neighbors`
+
+The initial adjacency weights from the architecture doc are sufficient:
+
+- same-row horizontal: `1.0`
+- diagonal: `0.8`
+- vertical reach: `0.6`
+- same-finger stretch: `0.4`
+
+This is enough to support realistic typo sampling without adding a dependency
+or overfitting the model.
+
+### 6) Resolve auth safety through profile resolution, not scattered checks
+
+The architecture doc recommends an internal `auth` profile. That is the right
+behavioral target, but it does **not** need to become a broad public API.
+
+The cleaner implementation is:
+
+- keep public typing profiles to `careful`, `casual`, and `fast`
+- allow `sensitive: true` at the instance or per-call level
+- have profile resolution internally map sensitive typing to auth-safe values
+  when typo simulation would otherwise be possible
+
+That keeps the public API lean while still giving auth and other sensitive
+flows the stronger pauses and zero-typo guarantees recommended by the research.
+
+### 7) Validate with deterministic unit tests and one local event harness
+
+The architecture doc’s test guidance is strong and should be followed closely:
+
+- deterministic unit tests for profile resolution and plan generation
+- event-sequence validation for mapped key presses, `Shift`, fallback text, and
+  correction flows
+- envelope-style tests for seeded timing distributions
+
+The implementation should prefer one local HTML fixture or page-content harness
+that records `keydown`, `keyup`, `beforeinput`, and `input` events. That gives
+the team confidence in keyboard semantics without tying the assertions to live
+LinkedIn DOM behavior.
+
+## Proposed public API and config surface
+
+### Public exports to keep or add
+
+The public surface should remain intentionally small:
+
+- `humanize(page, options?)`
+- `HumanizedPage`
+- `HumanizeOptions`
+- `HumanizedTypeOptions`
+- `HumanTypingProfileName`
+- `KeyboardLayoutName`
+- `TypingProfileOverrides`
+
+These should be re-exported via `packages/core/src/index.ts`.
+
+### Internal-only modules and types
+
+The following types should stay internal to `packages/core` unless another
+consumer emerges later:
+
+- `ResolvedTypingProfile`
+- `TypingPlan`
+- `TypingAction`
+- `TypingPlanStats`
+- `KeyboardKeyDefinition`
+- `KeyboardAdjacencyEdge`
+- `TypingPlanBuilderInput`
+
+This is important because the planner and layout model are likely to evolve
+while issue #131 and issue #132 are still settling.
+
+### Recommended TypeScript shapes
+
+The concrete API should look roughly like this:
+
+```ts
+export type HumanTypingProfileName = "careful" | "casual" | "fast";
+
+export type KeyboardLayoutName = "us-qwerty";
+
+export interface TypingProfileOverrides {
+  wpmMin?: number;
+  wpmMax?: number;
+  sameHandDelayMinMs?: number;
+  sameHandDelayMaxMs?: number;
+  sameFingerDelayMinMs?: number;
+  sameFingerDelayMaxMs?: number;
+  shiftDelayMinMs?: number;
+  shiftDelayMaxMs?: number;
+  symbolDelayMinMs?: number;
+  symbolDelayMaxMs?: number;
+  wordBoundaryPauseMinMs?: number;
+  wordBoundaryPauseMaxMs?: number;
+  punctuationPauseMinMs?: number;
+  punctuationPauseMaxMs?: number;
+  sentencePauseMinMs?: number;
+  sentencePauseMaxMs?: number;
+  thinkPauseEveryCharsMin?: number;
+  thinkPauseEveryCharsMax?: number;
+  thinkPauseMinMs?: number;
+  thinkPauseMaxMs?: number;
+  typoRateMin?: number;
+  typoRateMax?: number;
+  immediateCorrectionRate?: number;
+  recognitionPauseMedianMs?: number;
+  recognitionPauseP95Ms?: number;
+  backspaceDelayMinMs?: number;
+  backspaceDelayMaxMs?: number;
+  recoveryPauseMinMs?: number;
+  recoveryPauseMaxMs?: number;
+}
+
+export interface HumanizeOptions {
+  baseDelay?: number;
+  jitterRange?: number;
+  fast?: boolean;
+  typingDelay?: number;
+  typingJitter?: number;
+  typingProfile?: HumanTypingProfileName;
+  simulateTypos?: boolean;
+  sensitive?: boolean;
+  typingSeed?: number;
+  keyboardLayout?: KeyboardLayoutName;
+  typingOverrides?: Partial<TypingProfileOverrides>;
+}
+
+export interface HumanizedTypeOptions {
+  typingProfile?: HumanTypingProfileName;
+  simulateTypos?: boolean;
+  sensitive?: boolean;
+  typingSeed?: number;
+  keyboardLayout?: KeyboardLayoutName;
+  typingOverrides?: Partial<TypingProfileOverrides>;
+}
+```
+
+### Option precedence rules
+
+The implementation should document and test this precedence order:
+
+1. per-call `HumanizedTypeOptions`
+2. instance-level `HumanizeOptions`
+3. legacy `fast` typing mapping
+4. profile defaults
+
+Compatibility rules:
+
+- `fast: true` should continue to shorten non-typing actions exactly as it does
+  today
+- for typing only, `fast: true` should map to the `fast` typing profile when no
+  explicit `typingProfile` is set
+- explicit `typingProfile` should win over `fast`
+- legacy `typingDelay` and `typingJitter` should remain accepted and map into
+  resolved cadence overrides instead of being dropped abruptly
+- `sensitive: true` should force typo suppression even if
+  `simulateTypos: true` was requested higher in the merge chain
+
+## Timing model defaults
+
+### Base cadence
+
+Use the architecture doc’s WPM-based abstraction and convert internally with:
+
+- `interKeyMs = 60000 / (wpm * 5)`
+
+Initial profile ranges:
+
+- `careful`: `35-50 WPM`
+- `casual`: `45-65 WPM`
+- `fast`: `70-90 WPM`
+
+The planner should use a seeded **log-normal** sampler for primary cadence so
+the distribution stays right-skewed and realistic while remaining
+deterministic.
+
+### Contextual delay adjustments
+
+Add these ranges on top of the base inter-key interval:
+
+- same-hand transition: `+10-30ms`
+- same-finger stretch: `+25-70ms`
+- shifted character: `+20-50ms`
+- digit or symbol: `+15-45ms`
+- word boundary: `+50-140ms`
+- comma or semicolon: `+120-260ms`
+- sentence-final punctuation: `+220-600ms`
+
+Think pauses should be scheduled after burst lengths, not sampled after every
+character. Start with:
+
+- one think pause every `20-60` characters on average
+- bias longer think pauses toward punctuation and word boundaries
+
+### Typo rates and budgets
+
+Only inject typos when:
+
+- `simulateTypos` resolves true
+- the field is not sensitive
+- the character has a known layout mapping
+- the word is long enough for a natural correction
+- the message-level typo budget is not exhausted
+
+Initial profile typo rates from the architecture doc:
+
+- `careful`: `0.1-0.3%` per eligible character
+- `casual`: `0.3-0.8%` per eligible character
+- `fast`: `0.8-1.5%` per eligible character
+
+Cap short strings aggressively so that a normal LinkedIn message usually
+produces zero or one correction.
+
+### Typo classes and weights
+
+Start with the four typo classes from the architecture doc:
+
+1. adjacent substitution — `0.65`
+2. missing shift — `0.15`
+3. duplicated character — `0.10`
+4. short transposition — `0.10`
+
+Phase 1 of the engine should support all four, but the rollout can still ship
+cadence first with typo simulation disabled by default.
+
+### Correction timing
+
+Recognition pause after a mistake:
+
+- `careful`: median `220ms`, p95 `450ms`
+- `casual`: median `160ms`, p95 `320ms`
+- `fast`: median `120ms`, p95 `240ms`
+
+Backspace interval:
+
+- `careful`: `70-120ms`
+- `casual`: `55-95ms`
+- `fast`: `45-80ms`
+
+Recovery pause before resuming forward typing:
+
+- `careful`: `100-220ms`
+- `casual`: `80-180ms`
+- `fast`: `60-140ms`
+
+Immediate correction probability:
+
+- `careful`: `95%`
+- `casual`: `90%`
+- `fast`: `80%`
+
+Delayed correction should be limited to the current word boundary and should
+never cross sentence-final punctuation, field blur, or submit actions.
+
+## Proposed module boundaries and interfaces
+
+### `packages/core/src/typingProfiles.ts`
+
+Purpose:
+
+- define profile presets
+- validate additive overrides
+- resolve merged options into one internal profile object
+- map legacy `fast`, `typingDelay`, and `typingJitter` into the new model
+
+Recommended interface surface:
+
+- `export type HumanTypingProfileName = "careful" | "casual" | "fast"`
+- `export type KeyboardLayoutName = "us-qwerty"`
+- `export interface TypingProfileOverrides`
+- `resolveTypingProfile(instanceOptions, callOptions): ResolvedTypingProfile`
+
+Keep `ResolvedTypingProfile` internal.
+
+### `packages/core/src/keyboardLayouts/usQwerty.ts`
+
+Purpose:
+
+- define printable key metadata for letters, digits, space, and punctuation
+- provide lookup by character and by physical key code
+- provide weighted adjacency candidates for typo planning
+
+Recommended interface surface:
+
+- `getUsQwertyKeyByChar(char)`
+- `getUsQwertyKeyByCode(code)`
+- `hasUsQwertyMapping(char)`
+
+Keep the raw layout tables internal to the module.
+
+### `packages/core/src/typingPlan.ts`
+
+Purpose:
+
+- turn text plus a resolved profile into a deterministic action plan
+- compute pause timing, typo budgets, correction sequences, and final-plan stats
+- remain completely free of Playwright side effects
+
+Recommended internal types:
+
+- `TypingPlan`
+- `TypingAction`
+- `TypingPlanStats`
+- `TypingPlanBuilderInput`
+
+Recommended action families:
+
+- mapped key press
+- explicit `Shift` key down/up
+- wait/pause
+- fallback text insertion
+- backspace
+
+Recommended top-level function:
+
+- `buildTypingPlan(input): TypingPlan`
+
+### `packages/core/src/typingExecutor.ts`
+
+Purpose:
+
+- execute a `TypingPlan` through Playwright’s keyboard surface
+- keep all browser-specific mechanics in one place
+- handle fallback insertion for unmapped characters
+
+Recommended top-level function:
+
+- `executeTypingPlan(page, plan): Promise<void>`
+
+Execution rules:
+
+- mapped lowercase: press the physical key
+- mapped shifted character: `keyboard.down("Shift")`, press key,
+  `keyboard.up("Shift")`
+- typo correction: use `Backspace` events, not selection tricks
+- unmapped character fallback: use `keyboard.type(char, { delay: 0 })` or
+  `insertText`, chosen centrally inside the executor
+
+### `packages/core/src/humanize.ts`
+
+Purpose:
+
+- remain the single public entrypoint
+- resolve instance + per-call typing options
+- build and execute the plan during `type()`
+- keep non-typing methods (`delay`, `click`, `scrollDown`, `idle`) unchanged
+
+Concrete changes:
+
+- extend `HumanizeOptions`
+- add `HumanizedTypeOptions`
+- update `type(selector, text, options?)`
+- preserve `type(selector, text)` compatibility
+- keep `delay()` and `idle()` behavior stable so issue #132 can evolve
+  separately
+
+## Suggested implementation slices
+
+### Slice 1: Public option surface and profile resolution
+
+Implement the additive option types and the resolver first.
+
+This slice should settle:
+
+- public typing profile names
+- merged option precedence
+- sensitive-field semantics
+- compatibility mapping from legacy typing options
+
+Do **not** add typo planning yet.
+
+### Slice 2: Seeded cadence-only plan builder
+
+Introduce the pure planner with:
+
+- WPM-to-delay conversion
+- contextual pause rules
+- explicit `Shift` planning for mapped characters
+- plan stats suitable for deterministic tests
+
+This slice should already improve `HumanizedPage.type()` behavior while keeping
+visible text exact.
+
+### Slice 3: Playwright executor and event-order validation
+
+Add the executor and prove its behavior with a local event-recording harness.
+
+Validate at least:
+
+- lowercase typing
+- uppercase typing with `Shift`
+- shifted symbols such as `@`
+- fallback insertion for unmapped characters
+
+This slice is where browser semantics become trustworthy.
+
+### Slice 4: Typo planning and correction sequences
+
+Once cadence and execution are stable, add:
+
+- typo budgeting
+- adjacent substitution, missing shift, duplicate, and transposition planning
+- recognition pauses
+- backspace timing
+- recovery pauses
+- immediate vs delayed correction rules
+
+Keep typo simulation disabled by default even after this slice lands.
+
+### Slice 5: Auth adoption, tests, and docs
+
+Update the auth typing path to use the new API safely and document the final
+surface.
+
+This slice should include:
+
+- `auth/session.ts` adoption
+- regression tests proving sensitive fields never emit typos
+- README or doc notes if the new options need public discoverability
+
+## Suggested files to touch, in order
+
+1. `packages/core/src/humanize.ts`
+   - Extend the public option types.
+   - Make `type()` accept additive per-call overrides.
+   - Delegate typing to the resolver, plan builder, and executor.
+
+2. `packages/core/src/typingProfiles.ts`
+   - Define profile presets and override validation.
+   - Centralize precedence and compatibility rules.
+
+3. `packages/core/src/typingPlan.ts`
+   - Add pure plan-building types and logic.
+   - Keep the planner deterministic and side-effect free.
+
+4. `packages/core/src/typingExecutor.ts`
+   - Translate plan actions into Playwright keyboard calls.
+   - Keep mapped-key and fallback behavior centralized.
+
+5. `packages/core/src/keyboardLayouts/usQwerty.ts`
+   - Add the printable-key map and weighted adjacency data.
+   - Limit phase-1 scope to characters used in auth and LinkedIn messaging.
+
+6. `packages/core/src/index.ts`
+   - Re-export the additive public typing option types.
+   - Avoid re-exporting unstable planner internals.
+
+7. `packages/core/src/auth/session.ts`
+   - Update auth typing to use sensitive-field overrides.
+   - Keep login behavior typo-free.
+
+8. `packages/core/src/__tests__/humanize.test.ts`
+   - Expand coverage for option merging and backward compatibility.
+
+9. `packages/core/src/__tests__/typingProfiles.test.ts`
+   - Add resolver and validation coverage.
+
+10. `packages/core/src/__tests__/typingPlan.test.ts`
+    - Add deterministic cadence, typo-budget, and correction-plan coverage.
+
+11. `packages/core/src/__tests__/typingExecutor.test.ts`
+    - Add keyboard event sequencing coverage using page/keyboard doubles.
+
+12. `packages/core/src/__tests__/sessionAuth.test.ts`
+    - Assert auth typing resolves as sensitive and typo-free.
+
+13. `packages/core/test/fixtures/human-typing/typing-events.html`
+    - Add a small local event-capture fixture if the executor tests need a real
+      browser-event harness.
+
+14. `packages/core/README.md`
+    - Only if the new typing options need user-facing documentation after the
+      core API settles.
+
+## Existing utilities and patterns to reuse
+
+### Reuse directly
+
+- `packages/core/src/humanize.ts`
+  - keep the public entrypoint here instead of inventing a second façade
+- `packages/core/src/index.ts`
+  - follow the repo’s core re-export rule for any new public types
+- `packages/core/src/__tests__/humanize.test.ts`
+  - use the existing page-mock style for lightweight unit coverage
+- `packages/core/src/__tests__/sessionAuth.test.ts`
+  - extend the existing auth test area instead of creating a second auth test
+    harness
+- `packages/core/src/auth/session.ts`
+  - use the current login flow as the first integration point
+
+### Reuse conceptually, but keep the extraction small
+
+- option-resolution patterns used elsewhere in core config modules
+- focused helper modules instead of broad framework abstractions
+- deterministic unit tests over pure functions before browser-coupled tests
+
+This does **not** mean the typing engine should be folded into
+`packages/core/src/config.ts` or `packages/core/src/runtime.ts`.
+
+## New code that is justified
+
+The first implementation legitimately needs:
+
+- one profile-resolution module
+- one keyboard-layout data module
+- one pure plan-builder module
+- one Playwright executor module
+- additive typing option types on the existing humanize surface
+- focused deterministic tests
+- one small event-capture fixture if mocked keyboard assertions are not enough
+
+That is enough for issue #131.
+Anything larger should clear a high scope bar.
+
+## Main risks to watch
+
+### 1) Auth safety regresses if typo simulation arrives too early
+
+This is the highest-risk integration point because the existing login flow
+already depends on `hp.type()`.
+
+Planning response:
+
+- cadence lands before typos
+- `sensitive: true` forces typo suppression
+- auth gets regression tests before typo rollout expands
+
+### 2) Legacy option compatibility becomes ambiguous
+
+`fast`, `typingDelay`, and `typingJitter` already exist today.
+If the new resolver treats them inconsistently, users will get surprising
+behavior.
+
+Planning response:
+
+- keep one resolver as the single source of truth
+- document precedence explicitly
+- add unit tests for every merge path
+
+### 3) Planner and executor leak into the public API too soon
+
+If `TypingPlan` and layout internals are exported broadly now, future tuning
+work will create avoidable churn.
+
+Planning response:
+
+- export only stable option types and entrypoints
+- keep planner/layout internals inside core modules
+
+### 4) Browser event realism diverges between mapped and fallback characters
+
+Mapped keys and unmapped text insertion do not emit the same event sequences.
+
+Planning response:
+
+- keep fallback behavior centralized in the executor
+- cover both paths in event-order tests
+- keep unmapped-character fallback explicit in plan stats and test fixtures
+
+### 5) Issue #132 pressure expands this work into broad anti-bot heuristics
+
+Typing cadence is adjacent to anti-bot behavior, but it is not the whole
+anti-bot story.
+
+Planning response:
+
+- keep the typing engine scoped to `HumanizedPage.type()`
+- do not add global evasion settings yet
+- keep `delay`, `scroll`, and broader pacing behavior stable unless the typing
+  engine truly needs a shared primitive later
+
+### 6) Timing tests become flaky if randomness is not fully seeded
+
+Using `Math.random()` across the planner will make the test suite brittle.
+
+Planning response:
+
+- inject or derive one seed per plan
+- keep all cadence/typo sampling inside the pure planner
+- assert envelopes and exact seeded outputs separately where appropriate
+
+## Guardrails
+
+### Do touch
+
+- `packages/core/src/humanize.ts`
+- new typing modules under `packages/core/src/`
+- `packages/core/src/index.ts`
+- `packages/core/src/auth/session.ts`
+- focused tests and local fixtures
+
+### Do not touch unless the implementation proves it is necessary
+
+- `packages/core/src/runtime.ts`
+- `packages/core/src/twoPhaseCommit.ts`
+- `packages/core/src/db/`
+- `packages/core/src/linkedin*.ts` read/write feature modules
+- `packages/cli/src/bin/linkedin.ts`
+- `packages/mcp/src/bin/linkedin-mcp.ts`
+- `packages/core/src/config.ts`
+
+### Avoid these traps
+
+- do not add process-wide env config for typing in phase 1
+- do not use CDP `Input.dispatchKeyEvent` as the primary implementation path
+- do not enable typo simulation by default in auth or other sensitive fields
+- do not simulate cursor movement, selections, or mouse-based corrections in
+  phase 1
+- do not collapse planning and execution back into one random side-effecting
+  loop inside `humanize.ts`
+
+## Conventions to follow
+
+- keep TypeScript strict and additive
+- use ESM imports with `.js` extensions
+- use `node:` imports for built-ins
+- use type-only imports where appropriate
+- avoid `any`; use `unknown` plus guards if needed
+- keep the public API backward-compatible
+- keep seeded planning deterministic and browser execution isolated
+- keep timing defaults conservative enough for auth and early write rollout
+
+## Implementation compass
+
+If the final implementation lands as a small set of new core typing modules,
+keeps `HumanizedPage` stable, resolves sensitive typing safely for auth, and
+proves the plan with deterministic tests plus one event-order harness, the work
+is on track.
+
+If the implementation starts adding global config knobs, exporting planner
+internals broadly, or mixing issue #132 anti-bot work into unrelated runtime
+paths, the work has drifted out of scope.


### PR DESCRIPTION
## Summary
- add `docs/.plan-issue-166.md` to translate `docs/human-typing-architecture.md` into a concrete implementation plan for the human-like typing engine
- define the proposed module structure, public API/config surface, timing model defaults, rollout slices, and file-by-file implementation order
- document auth-safe guardrails for #131 and keep the work decoupled from queued anti-bot follow-up work in #132

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #166
Related to #131
