### PR TITLE
feat: add realistic humanized typing behavior

### DIFF
--- a/packages/core/src/__tests__/humanize.test.ts
+++ b/packages/core/src/__tests__/humanize.test.ts
@@ -1,14 +1,61 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Page } from "playwright-core";
-import type { HumanizeOptions } from "../humanize.js";
-import { HumanizedPage, humanize } from "../humanize.js";
+import type { TypingProfile } from "../humanize.js";
+import {
+  HumanizedPage,
+  QWERTY_KEY_ADJACENCY_MAP,
+  getAdjacentTypoCandidates,
+  humanize
+} from "../humanize.js";
 
 function createPageMock() {
-  const waitForTimeout = vi.fn(async () => undefined);
+  const operations: string[] = [];
+  const waitForTimeout = vi.fn(async (delay: number) => {
+    operations.push(`wait:${delay}`);
+  });
+  const scrollIntoViewIfNeeded = vi.fn(async () => {
+    operations.push("scroll");
+  });
+  const click = vi.fn(async () => {
+    operations.push("click");
+  });
+
+  const locator = {
+    click,
+    first: vi.fn(),
+    scrollIntoViewIfNeeded
+  };
+  locator.first.mockReturnValue(locator);
+
+  const keyboard = {
+    down: vi.fn(async (key: string) => {
+      operations.push(`down:${key}`);
+    }),
+    press: vi.fn(async (key: string) => {
+      operations.push(`press:${key}`);
+    }),
+    type: vi.fn(async (text: string) => {
+      operations.push(`type:${text}`);
+    }),
+    up: vi.fn(async (key: string) => {
+      operations.push(`up:${key}`);
+    })
+  };
+
   const page = {
+    keyboard,
+    locator: vi.fn(() => locator),
     waitForTimeout
   } as unknown as Page;
-  return { page, waitForTimeout };
+
+  return {
+    click,
+    keyboard,
+    operations,
+    page,
+    scrollIntoViewIfNeeded,
+    waitForTimeout
+  };
 }
 
 function getCalledDelay(waitForTimeout: ReturnType<typeof vi.fn>): number {
@@ -17,6 +64,37 @@ function getCalledDelay(waitForTimeout: ReturnType<typeof vi.fn>): number {
     throw new Error("waitForTimeout was not called with a numeric delay");
   }
   return value;
+}
+
+function getWaitCalls(waitForTimeout: ReturnType<typeof vi.fn>): number[] {
+  return waitForTimeout.mock.calls.flatMap(([value]) =>
+    typeof value === "number" ? [value] : []
+  );
+}
+
+function createStableTypingOptions(overrides: Partial<TypingProfile> = {}) {
+  return {
+    profile: "careful" as const,
+    profileOverrides: {
+      baseCharDelayMs: 100,
+      burstWordMultiplier: 0.82,
+      charDelayJitterMs: 0,
+      correctionPauseRange: { minMs: 50, maxMs: 50 },
+      correctionResumeRange: { minMs: 30, maxMs: 30 },
+      doubleBackspaceRate: 0,
+      longPauseChance: 0,
+      midWordMultiplier: 0.9,
+      punctuationMultiplier: 1.35,
+      repeatedCharacterMultiplier: 0.9,
+      shiftLeadRange: { minMs: 0, maxMs: 0 },
+      shiftMissRate: 0,
+      thinkingPauseChance: 0,
+      typoRate: 0,
+      whitespaceMultiplier: 1.25,
+      wordBoundaryMultiplier: 1.18,
+      ...overrides
+    }
+  };
 }
 
 afterEach(() => {
@@ -70,15 +148,117 @@ describe("HumanizedPage options", () => {
   it("merges provided options with defaults", () => {
     const { page } = createPageMock();
     const humanizedPage = new HumanizedPage(page, { baseDelay: 950 });
-    const internal = humanizedPage as unknown as { options: Required<HumanizeOptions> };
+    const internal = humanizedPage as unknown as {
+      options: {
+        baseDelay: number;
+        fast: boolean;
+        jitterRange: number;
+        typingDelayOverride: number | null;
+        typingJitterOverride: number | null;
+        typingProfile: string;
+        typingProfileOverrides: Partial<TypingProfile>;
+      };
+    };
 
     expect(internal.options).toEqual({
       baseDelay: 950,
-      jitterRange: 1500,
       fast: false,
-      typingDelay: 80,
-      typingJitter: 60
+      jitterRange: 1500,
+      typingDelayOverride: null,
+      typingJitterOverride: null,
+      typingProfile: "careful",
+      typingProfileOverrides: {}
     });
+  });
+});
+
+describe("QWERTY adjacency", () => {
+  it("covers every alphanumeric key on the keyboard", () => {
+    const expectedKeys = Array.from("1234567890qwertyuiopasdfghjklzxcvbnm").sort();
+    const actualKeys = Object.keys(QWERTY_KEY_ADJACENCY_MAP).sort();
+
+    expect(actualKeys).toEqual(expectedKeys);
+    for (const key of actualKeys) {
+      expect(QWERTY_KEY_ADJACENCY_MAP[key]).toBeDefined();
+      expect(QWERTY_KEY_ADJACENCY_MAP[key]?.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("weights same-finger neighbors higher than cross-hand neighbors", () => {
+    const candidates = getAdjacentTypoCandidates("t");
+    const sameFinger = candidates.find((candidate) => candidate.key === "r");
+    const crossHand = candidates.find((candidate) => candidate.key === "y");
+
+    expect(sameFinger?.weight).toBeGreaterThan(0);
+    expect(crossHand?.weight).toBeGreaterThan(0);
+    expect(sameFinger?.weight).toBeGreaterThan(crossHand?.weight ?? 0);
+  });
+});
+
+describe("HumanizedPage.type", () => {
+  it("inserts and corrects adjacent typos naturally", async () => {
+    const { keyboard, page, operations, waitForTimeout } = createPageMock();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const humanizedPage = new HumanizedPage(page, { baseDelay: 200, jitterRange: 0 });
+
+    await humanizedPage.type("#composer", "t", createStableTypingOptions({ typoRate: 1 }));
+
+    const mistypedCharacter = keyboard.type.mock.calls[0]?.[0];
+    expect(mistypedCharacter).toBeTruthy();
+    expect(mistypedCharacter).not.toBe("t");
+    expect(operations.indexOf(`type:${mistypedCharacter}`)).toBeLessThan(
+      operations.indexOf("press:Backspace")
+    );
+    expect(keyboard.press).toHaveBeenCalledWith("Backspace");
+    expect(keyboard.type).toHaveBeenLastCalledWith("t", { delay: 0 });
+    expect(getWaitCalls(waitForTimeout)).toContain(50);
+    expect(getWaitCalls(waitForTimeout)).toContain(30);
+  });
+
+  it("can double-backspace and retype the previous character", async () => {
+    const { page, operations } = createPageMock();
+    const randomValues = [0.9, 0, 0];
+    let randomIndex = 0;
+    vi.spyOn(Math, "random").mockImplementation(() => randomValues[randomIndex++] ?? 0);
+    const humanizedPage = new HumanizedPage(page, { baseDelay: 200, jitterRange: 0 });
+
+    await humanizedPage.type(
+      "#composer",
+      "at",
+      createStableTypingOptions({ doubleBackspaceRate: 1, typoRate: 0.5 })
+    );
+
+    expect(operations.filter((operation) => operation === "press:Backspace")).toHaveLength(2);
+    const typeOperations = operations.filter((operation) => operation.startsWith("type:"));
+    expect(typeOperations[0]).toBe("type:a");
+    expect(typeOperations.at(-2)).toBe("type:a");
+    expect(typeOperations.at(-1)).toBe("type:t");
+  });
+
+  it("varies cadence across burst words and word boundaries", async () => {
+    const { page, waitForTimeout } = createPageMock();
+    const humanizedPage = new HumanizedPage(page, { baseDelay: 200, jitterRange: 0 });
+
+    await humanizedPage.type("#composer", "the test", createStableTypingOptions());
+
+    const charDelays = getWaitCalls(waitForTimeout).slice(2, 10);
+    expect(charDelays).toHaveLength(8);
+    expect(charDelays[0]).toBeGreaterThan(charDelays[1] ?? 0);
+    expect(charDelays[3]).toBeGreaterThan(charDelays[1] ?? 0);
+    expect(charDelays[1]).toBeLessThan(charDelays[5] ?? Number.POSITIVE_INFINITY);
+  });
+
+  it("corrects missed shift capitalization mistakes", async () => {
+    const { page, operations } = createPageMock();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const humanizedPage = new HumanizedPage(page, { baseDelay: 200, jitterRange: 0 });
+
+    await humanizedPage.type("#composer", "A", createStableTypingOptions({ shiftMissRate: 1 }));
+
+    expect(operations.indexOf("type:a")).toBeLessThan(operations.indexOf("press:Backspace"));
+    expect(operations).toContain("down:Shift");
+    expect(operations).toContain("press:a");
+    expect(operations).toContain("up:Shift");
   });
 });
 

--- a/packages/core/src/auth/session.ts
+++ b/packages/core/src/auth/session.ts
@@ -251,11 +251,13 @@ export class LinkedInAuthService {
         const hp = humanize(page, { fast: false });
         await hp.type(
           "input[name='session_key'], input#username",
-          options.email
+          options.email,
+          { profile: "careful" }
         );
         await hp.type(
           "input[name='session_password'], input#password",
-          options.password
+          options.password,
+          { profile: "careful" }
         );
 
         const signInButton = page.locator(

--- a/packages/core/src/humanize.ts
+++ b/packages/core/src/humanize.ts
@@ -1,5 +1,73 @@
 import type { Page } from "playwright-core";
 
+const QWERTY_KEYBOARD_ROWS = ["1234567890", "qwertyuiop", "asdfghjkl", "zxcvbnm"] as const;
+const QWERTY_ROW_OFFSETS = [0, 0.5, 0.85, 1.35] as const;
+const ADJACENCY_HORIZONTAL_THRESHOLD = 1.1;
+const ADJACENCY_VERTICAL_THRESHOLD = 1.05;
+const COMMON_BURST_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "by",
+  "for",
+  "from",
+  "i",
+  "in",
+  "is",
+  "it",
+  "of",
+  "on",
+  "or",
+  "so",
+  "the",
+  "to",
+  "we",
+  "you"
+]);
+
+export type KeyboardHand = "left" | "right";
+export type KeyboardFinger =
+  | "left-pinky"
+  | "left-ring"
+  | "left-middle"
+  | "left-index"
+  | "right-index"
+  | "right-middle"
+  | "right-ring"
+  | "right-pinky";
+
+export interface DelayRange {
+  minMs: number;
+  maxMs: number;
+}
+
+export type TypingProfileName = "casual" | "careful" | "fast";
+
+export interface TypingProfile {
+  typoRate: number;
+  doubleBackspaceRate: number;
+  shiftMissRate: number;
+  baseCharDelayMs: number;
+  charDelayJitterMs: number;
+  midWordMultiplier: number;
+  wordBoundaryMultiplier: number;
+  whitespaceMultiplier: number;
+  punctuationMultiplier: number;
+  burstWordMultiplier: number;
+  repeatedCharacterMultiplier: number;
+  thinkingPauseChance: number;
+  thinkingPauseRange: DelayRange;
+  longPauseChance: number;
+  longPauseRange: DelayRange;
+  correctionPauseRange: DelayRange;
+  correctionResumeRange: DelayRange;
+  shiftLeadRange: DelayRange;
+}
+
 export interface HumanizeOptions {
   /** Base delay between actions in ms (default: 800) */
   baseDelay?: number;
@@ -7,15 +75,332 @@ export interface HumanizeOptions {
   jitterRange?: number;
   /** Whether running in fast/development mode (shorter delays) */
   fast?: boolean;
-  /** Per-character typing delay in ms (default: 80) */
+  /** Legacy base per-character typing delay override in ms */
   typingDelay?: number;
-  /** Typing jitter per character in ms (default: 60) */
+  /** Legacy typing jitter override per character in ms */
   typingJitter?: number;
+  /** Default typing profile used by HumanizedPage.type() */
+  typingProfile?: TypingProfileName;
+  /** Default per-profile overrides applied by HumanizedPage.type() */
+  typingProfileOverrides?: Partial<TypingProfile>;
+}
+
+export interface HumanizedTypingOptions {
+  profile?: TypingProfileName;
+  profileOverrides?: Partial<TypingProfile>;
+}
+
+export interface AdjacentTypoCandidate {
+  key: string;
+  weight: number;
+  hand: KeyboardHand;
+  finger: KeyboardFinger;
+}
+
+interface ResolvedHumanizeOptions {
+  baseDelay: number;
+  jitterRange: number;
+  fast: boolean;
+  typingProfile: TypingProfileName;
+  typingDelayOverride: number | null;
+  typingJitterOverride: number | null;
+  typingProfileOverrides: Partial<TypingProfile>;
+}
+
+interface ResolvedTypingProfile extends TypingProfile {
+  name: TypingProfileName;
+}
+
+interface KeyboardKeyGeometry {
+  key: string;
+  x: number;
+  y: number;
+  hand: KeyboardHand;
+  finger: KeyboardFinger;
+}
+
+interface TypingContext {
+  current: string;
+  previous: string | null;
+  previousMeaningful: string | null;
+  next: string | null;
+  isBurstWord: boolean;
+  isRepeatedCharacter: boolean;
+  isSentenceRestart: boolean;
+  isWhitespace: boolean;
+  isWordCharacter: boolean;
+  isWordEnd: boolean;
+  isWordStart: boolean;
+}
+
+const KEY_FINGER_BY_CHARACTER = {
+  "1": "left-pinky",
+  "2": "left-ring",
+  "3": "left-middle",
+  "4": "left-index",
+  "5": "left-index",
+  "6": "right-index",
+  "7": "right-index",
+  "8": "right-middle",
+  "9": "right-ring",
+  "0": "right-pinky",
+  q: "left-pinky",
+  w: "left-ring",
+  e: "left-middle",
+  r: "left-index",
+  t: "left-index",
+  y: "right-index",
+  u: "right-index",
+  i: "right-middle",
+  o: "right-ring",
+  p: "right-pinky",
+  a: "left-pinky",
+  s: "left-ring",
+  d: "left-middle",
+  f: "left-index",
+  g: "left-index",
+  h: "right-index",
+  j: "right-index",
+  k: "right-middle",
+  l: "right-ring",
+  z: "left-pinky",
+  x: "left-ring",
+  c: "left-middle",
+  v: "left-index",
+  b: "left-index",
+  n: "right-index",
+  m: "right-index"
+} as const satisfies Record<string, KeyboardFinger>;
+
+export const TYPING_PROFILES = {
+  casual: {
+    typoRate: 0.04,
+    doubleBackspaceRate: 0.08,
+    shiftMissRate: 0.02,
+    baseCharDelayMs: 85,
+    charDelayJitterMs: 95,
+    midWordMultiplier: 0.82,
+    wordBoundaryMultiplier: 1.35,
+    whitespaceMultiplier: 1.4,
+    punctuationMultiplier: 1.5,
+    burstWordMultiplier: 0.72,
+    repeatedCharacterMultiplier: 0.78,
+    thinkingPauseChance: 0.18,
+    thinkingPauseRange: { minMs: 300, maxMs: 1500 },
+    longPauseChance: 0.03,
+    longPauseRange: { minMs: 2000, maxMs: 5000 },
+    correctionPauseRange: { minMs: 60, maxMs: 220 },
+    correctionResumeRange: { minMs: 40, maxMs: 160 },
+    shiftLeadRange: { minMs: 20, maxMs: 70 }
+  },
+  careful: {
+    typoRate: 0.018,
+    doubleBackspaceRate: 0.03,
+    shiftMissRate: 0.005,
+    baseCharDelayMs: 95,
+    charDelayJitterMs: 55,
+    midWordMultiplier: 0.9,
+    wordBoundaryMultiplier: 1.18,
+    whitespaceMultiplier: 1.25,
+    punctuationMultiplier: 1.35,
+    burstWordMultiplier: 0.82,
+    repeatedCharacterMultiplier: 0.9,
+    thinkingPauseChance: 0.08,
+    thinkingPauseRange: { minMs: 250, maxMs: 900 },
+    longPauseChance: 0.01,
+    longPauseRange: { minMs: 1800, maxMs: 3200 },
+    correctionPauseRange: { minMs: 70, maxMs: 170 },
+    correctionResumeRange: { minMs: 50, maxMs: 120 },
+    shiftLeadRange: { minMs: 25, maxMs: 60 }
+  },
+  fast: {
+    typoRate: 0.025,
+    doubleBackspaceRate: 0.05,
+    shiftMissRate: 0.01,
+    baseCharDelayMs: 45,
+    charDelayJitterMs: 25,
+    midWordMultiplier: 0.74,
+    wordBoundaryMultiplier: 1.1,
+    whitespaceMultiplier: 1.12,
+    punctuationMultiplier: 1.2,
+    burstWordMultiplier: 0.58,
+    repeatedCharacterMultiplier: 0.7,
+    thinkingPauseChance: 0.04,
+    thinkingPauseRange: { minMs: 180, maxMs: 450 },
+    longPauseChance: 0.004,
+    longPauseRange: { minMs: 2000, maxMs: 3500 },
+    correctionPauseRange: { minMs: 50, maxMs: 120 },
+    correctionResumeRange: { minMs: 30, maxMs: 100 },
+    shiftLeadRange: { minMs: 15, maxMs: 40 }
+  }
+} satisfies Record<TypingProfileName, TypingProfile>;
+
+const KEYBOARD_GEOMETRY = createKeyboardGeometry();
+
+export const QWERTY_KEY_ADJACENCY_MAP = createQwertyAdjacencyMap();
+
+const WEIGHTED_QWERTY_KEY_ADJACENCY_MAP = createWeightedQwertyAdjacencyMap();
+
+function createKeyboardGeometry(): Readonly<Record<string, KeyboardKeyGeometry>> {
+  const entries = QWERTY_KEYBOARD_ROWS.flatMap((row, rowIndex) =>
+    Array.from(row).map((key, keyIndex) => {
+      const mappedKey = key as keyof typeof KEY_FINGER_BY_CHARACTER;
+      const finger = KEY_FINGER_BY_CHARACTER[mappedKey];
+      const hand: KeyboardHand = finger.startsWith("left") ? "left" : "right";
+      return [
+        key,
+        {
+          key,
+          x: keyIndex + (QWERTY_ROW_OFFSETS[rowIndex] ?? 0),
+          y: rowIndex,
+          hand,
+          finger
+        }
+      ] as const;
+    })
+  );
+
+  return Object.freeze(
+    Object.fromEntries(entries) as Record<string, KeyboardKeyGeometry>
+  );
+}
+
+function getKeyDistance(source: KeyboardKeyGeometry, target: KeyboardKeyGeometry): number {
+  return Math.hypot(source.x - target.x, source.y - target.y);
+}
+
+function createQwertyAdjacencyMap(): Readonly<Record<string, readonly string[]>> {
+  const entries = Object.values(KEYBOARD_GEOMETRY).map((source) => {
+    const adjacent = Object.values(KEYBOARD_GEOMETRY)
+      .filter(
+        (target) =>
+          target.key !== source.key &&
+          Math.abs(source.x - target.x) <= ADJACENCY_HORIZONTAL_THRESHOLD &&
+          Math.abs(source.y - target.y) <= ADJACENCY_VERTICAL_THRESHOLD
+      )
+      .sort(
+        (left, right) =>
+          getKeyDistance(source, left) - getKeyDistance(source, right) ||
+          left.key.localeCompare(right.key)
+      )
+      .map((target) => target.key);
+
+    return [source.key, Object.freeze(adjacent)] as const;
+  });
+
+  return Object.freeze(Object.fromEntries(entries) as Record<string, readonly string[]>);
+}
+
+function createWeightedCandidate(
+  source: KeyboardKeyGeometry,
+  target: KeyboardKeyGeometry
+): AdjacentTypoCandidate {
+  const sameFinger = source.finger === target.finger;
+  const sameHand = source.hand === target.hand;
+  const distance = getKeyDistance(source, target);
+  const baseWeight = sameFinger ? 6 : sameHand ? 3 : 1.5;
+  const distanceBonus = distance < 1 ? 1.25 : 1;
+
+  return {
+    key: target.key,
+    weight: baseWeight * distanceBonus,
+    hand: target.hand,
+    finger: target.finger
+  };
+}
+
+function createWeightedQwertyAdjacencyMap(): Readonly<
+  Record<string, readonly AdjacentTypoCandidate[]>
+> {
+  const entries = Object.entries(QWERTY_KEY_ADJACENCY_MAP).map(([key, adjacent]) => {
+    const source = KEYBOARD_GEOMETRY[key];
+    if (!source) {
+      return [key, Object.freeze([])] as const;
+    }
+
+    const weighted = adjacent
+      .flatMap((adjacentKey) => {
+        const target = KEYBOARD_GEOMETRY[adjacentKey];
+        return target ? [createWeightedCandidate(source, target)] : [];
+      })
+      .sort(
+        (left, right) =>
+          right.weight - left.weight ||
+          left.key.localeCompare(right.key)
+      );
+
+    return [key, Object.freeze(weighted)] as const;
+  });
+
+  return Object.freeze(
+    Object.fromEntries(entries) as Record<string, readonly AdjacentTypoCandidate[]>
+  );
+}
+
+function isUppercaseLetter(character: string): boolean {
+  return /^[A-Z]$/.test(character);
+}
+
+function isWhitespaceCharacter(character: string | null): boolean {
+  return character !== null && /^\s$/u.test(character);
+}
+
+function normalizeTypingCharacter(character: string | null): string | null {
+  if (character === null || !/^[A-Za-z0-9]$/u.test(character)) {
+    return null;
+  }
+
+  return character.toLowerCase();
+}
+
+function isWordCharacter(character: string | null): boolean {
+  return normalizeTypingCharacter(character) !== null;
+}
+
+function applyCharacterCase(candidate: string, intendedCharacter: string): string {
+  return isUppercaseLetter(intendedCharacter) ? candidate.toUpperCase() : candidate;
+}
+
+export function getAdjacentTypoCandidates(character: string): readonly AdjacentTypoCandidate[] {
+  const normalizedCharacter = normalizeTypingCharacter(character);
+  if (normalizedCharacter === null) {
+    return [];
+  }
+
+  return WEIGHTED_QWERTY_KEY_ADJACENCY_MAP[normalizedCharacter] ?? [];
+}
+
+export function pickAdjacentTypoCharacter(
+  character: string,
+  randomValue = Math.random()
+): string | null {
+  const candidates = getAdjacentTypoCandidates(character);
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const totalWeight = candidates.reduce((sum, candidate) => sum + candidate.weight, 0);
+  const clampedRandom = Math.max(0, Math.min(randomValue, 0.999999));
+  let remainingWeight = clampedRandom * totalWeight;
+
+  for (const candidate of candidates) {
+    remainingWeight -= candidate.weight;
+    if (remainingWeight < 0) {
+      return applyCharacterCase(candidate.key, character);
+    }
+  }
+
+  const fallbackCandidate = candidates[candidates.length - 1];
+  if (!fallbackCandidate) {
+    return null;
+  }
+
+  return applyCharacterCase(fallbackCandidate.key, character);
 }
 
 export class HumanizedPage {
   private readonly page: Page;
-  private readonly options: Required<HumanizeOptions>;
+  private readonly options: ResolvedHumanizeOptions;
 
   constructor(page: Page, options?: HumanizeOptions) {
     const fast = options?.fast ?? false;
@@ -24,8 +409,10 @@ export class HumanizedPage {
       baseDelay: options?.baseDelay ?? (fast ? 200 : 800),
       jitterRange: options?.jitterRange ?? (fast ? 400 : 1500),
       fast,
-      typingDelay: options?.typingDelay ?? (fast ? 30 : 80),
-      typingJitter: options?.typingJitter ?? (fast ? 20 : 60)
+      typingProfile: options?.typingProfile ?? (fast ? "fast" : "careful"),
+      typingDelayOverride: options?.typingDelay ?? null,
+      typingJitterOverride: options?.typingJitter ?? null,
+      typingProfileOverrides: options?.typingProfileOverrides ?? {}
     };
   }
 
@@ -37,7 +424,7 @@ export class HumanizedPage {
   /** Random delay with jitter */
   async delay(baseMs?: number): Promise<void> {
     const base = baseMs ?? this.options.baseDelay;
-    const jitter = Math.random() * this.options.jitterRange;
+    const jitter = this.options.jitterRange > 0 ? Math.random() * this.options.jitterRange : 0;
     await this.page.waitForTimeout(base + jitter);
   }
 
@@ -99,19 +486,50 @@ export class HumanizedPage {
     await this.delay(300);
   }
 
-  /** Type text with realistic per-character delays */
-  async type(selector: string, text: string): Promise<void> {
+  /** Type text with human-like cadence, typos, and corrections. */
+  async type(
+    selector: string,
+    text: string,
+    options?: HumanizedTypingOptions
+  ): Promise<void> {
     const element = this.page.locator(selector).first();
     await element.scrollIntoViewIfNeeded();
     await this.delay(200);
     await element.click();
     await this.delay(150);
 
-    for (const char of text) {
-      await this.page.keyboard.type(char, { delay: 0 });
-      const charDelay = this.options.typingDelay + Math.random() * this.options.typingJitter;
-      const thinkPause = Math.random() < 0.05 ? 200 + Math.random() * 400 : 0;
-      await this.page.waitForTimeout(charDelay + thinkPause);
+    const characters = Array.from(text);
+    const contexts = this.buildTypingContexts(characters);
+    const profile = this.resolveTypingProfile(options);
+    let previousCommittedCharacter: string | null = null;
+
+    for (const [index, character] of characters.entries()) {
+      const context = contexts[index];
+      if (!context) {
+        continue;
+      }
+
+      await this.maybePauseBeforeCharacter(characters.length, context, profile);
+
+      if (this.shouldMissShift(character, profile)) {
+        await this.typeLiteralCharacter(character.toLowerCase(), profile);
+        await this.correctCharacter(character, previousCommittedCharacter, profile, {
+          allowDoubleBackspace: false
+        });
+      } else {
+        const typoCharacter = this.chooseTypoCharacter(character, profile);
+        if (typoCharacter !== null) {
+          await this.typeLiteralCharacter(typoCharacter, profile);
+          await this.correctCharacter(character, previousCommittedCharacter, profile, {
+            allowDoubleBackspace: true
+          });
+        } else {
+          await this.typeLiteralCharacter(character, profile);
+        }
+      }
+
+      previousCommittedCharacter = character;
+      await this.page.waitForTimeout(this.computeCharacterDelay(context, profile));
     }
 
     await this.delay(200);
@@ -132,6 +550,242 @@ export class HumanizedPage {
     }
 
     await this.page.waitForTimeout(idleTime);
+  }
+
+  private resolveTypingProfile(options?: HumanizedTypingOptions): ResolvedTypingProfile {
+    const name = options?.profile ?? this.options.typingProfile;
+    const baseProfile = TYPING_PROFILES[name];
+
+    return {
+      name,
+      ...baseProfile,
+      ...(this.options.typingDelayOverride === null
+        ? {}
+        : { baseCharDelayMs: this.options.typingDelayOverride }),
+      ...(this.options.typingJitterOverride === null
+        ? {}
+        : { charDelayJitterMs: this.options.typingJitterOverride }),
+      ...this.options.typingProfileOverrides,
+      ...options?.profileOverrides
+    };
+  }
+
+  private buildTypingContexts(characters: readonly string[]): TypingContext[] {
+    const burstWordIndexes = this.findBurstWordIndexes(characters);
+
+    return characters.map((current, index) => {
+      const previous = index > 0 ? characters[index - 1] ?? null : null;
+      const previousMeaningful = this.findPreviousMeaningfulCharacter(characters, index - 1);
+      const next = index < characters.length - 1 ? characters[index + 1] ?? null : null;
+      const normalizedCurrent = normalizeTypingCharacter(current);
+      const normalizedPrevious = normalizeTypingCharacter(previous);
+      const currentIsWordCharacter = normalizedCurrent !== null;
+
+      return {
+        current,
+        previous,
+        previousMeaningful,
+        next,
+        isBurstWord: burstWordIndexes.has(index),
+        isRepeatedCharacter:
+          currentIsWordCharacter &&
+          normalizedCurrent !== null &&
+          normalizedCurrent === normalizedPrevious,
+        isSentenceRestart:
+          previousMeaningful !== null && /[.!?]/u.test(previousMeaningful),
+        isWhitespace: isWhitespaceCharacter(current),
+        isWordCharacter: currentIsWordCharacter,
+        isWordEnd: currentIsWordCharacter && !isWordCharacter(next),
+        isWordStart: currentIsWordCharacter && !isWordCharacter(previous)
+      };
+    });
+  }
+
+  private findPreviousMeaningfulCharacter(
+    characters: readonly string[],
+    startIndex: number
+  ): string | null {
+    for (let index = startIndex; index >= 0; index -= 1) {
+      const character = characters[index] ?? null;
+      if (!isWhitespaceCharacter(character)) {
+        return character;
+      }
+    }
+
+    return null;
+  }
+
+  private findBurstWordIndexes(characters: readonly string[]): Set<number> {
+    const burstWordIndexes = new Set<number>();
+    let wordStartIndex: number | null = null;
+
+    for (let index = 0; index <= characters.length; index += 1) {
+      const character = characters[index] ?? null;
+      const isLetter = character !== null && /^[A-Za-z]$/u.test(character);
+
+      if (isLetter) {
+        if (wordStartIndex === null) {
+          wordStartIndex = index;
+        }
+        continue;
+      }
+
+      if (wordStartIndex === null) {
+        continue;
+      }
+
+      const word = characters.slice(wordStartIndex, index).join("").toLowerCase();
+      if (COMMON_BURST_WORDS.has(word)) {
+        for (let burstIndex = wordStartIndex; burstIndex < index; burstIndex += 1) {
+          burstWordIndexes.add(burstIndex);
+        }
+      }
+
+      wordStartIndex = null;
+    }
+
+    return burstWordIndexes;
+  }
+
+  private computeCharacterDelay(
+    context: TypingContext,
+    profile: ResolvedTypingProfile
+  ): number {
+    const jitter = profile.charDelayJitterMs > 0 ? Math.random() * profile.charDelayJitterMs : 0;
+    let delay = profile.baseCharDelayMs + jitter;
+
+    if (context.isWordCharacter) {
+      delay *= context.isWordStart || context.isWordEnd
+        ? profile.wordBoundaryMultiplier
+        : profile.midWordMultiplier;
+
+      if (context.isBurstWord) {
+        delay *= profile.burstWordMultiplier;
+      }
+
+      if (context.isRepeatedCharacter) {
+        delay *= profile.repeatedCharacterMultiplier;
+      }
+    } else if (context.isWhitespace) {
+      delay *= profile.whitespaceMultiplier;
+    } else {
+      delay *= profile.punctuationMultiplier;
+    }
+
+    if (context.isSentenceRestart) {
+      delay *= 1.08;
+    }
+
+    return Math.max(0, delay);
+  }
+
+  private shouldMissShift(character: string, profile: ResolvedTypingProfile): boolean {
+    return isUppercaseLetter(character) && this.shouldTrigger(profile.shiftMissRate);
+  }
+
+  private chooseTypoCharacter(
+    character: string,
+    profile: ResolvedTypingProfile
+  ): string | null {
+    if (normalizeTypingCharacter(character) === null || !this.shouldTrigger(profile.typoRate)) {
+      return null;
+    }
+
+    return pickAdjacentTypoCharacter(character);
+  }
+
+  private async maybePauseBeforeCharacter(
+    totalCharacters: number,
+    context: TypingContext,
+    profile: ResolvedTypingProfile
+  ): Promise<void> {
+    if (totalCharacters < 5 || !context.isWordStart || context.previous === null) {
+      return;
+    }
+
+    const longPauseEligible = totalCharacters >= 15 && context.isSentenceRestart;
+    if (longPauseEligible && this.shouldTrigger(profile.longPauseChance)) {
+      await this.page.waitForTimeout(this.sampleRange(profile.longPauseRange));
+      return;
+    }
+
+    const previousCharacter = context.previousMeaningful;
+    const chanceBoost = previousCharacter !== null && /[,;:]/u.test(previousCharacter) ? 1.35 : 1;
+    const pauseChance = Math.min(1, profile.thinkingPauseChance * chanceBoost);
+    if (this.shouldTrigger(pauseChance)) {
+      await this.page.waitForTimeout(this.sampleRange(profile.thinkingPauseRange));
+    }
+  }
+
+  private async correctCharacter(
+    intendedCharacter: string,
+    previousCommittedCharacter: string | null,
+    profile: ResolvedTypingProfile,
+    options: { allowDoubleBackspace: boolean }
+  ): Promise<void> {
+    await this.page.waitForTimeout(this.sampleRange(profile.correctionPauseRange));
+    await this.page.keyboard.press("Backspace");
+
+    const shouldDoubleBackspace =
+      options.allowDoubleBackspace &&
+      previousCommittedCharacter !== null &&
+      isWordCharacter(previousCommittedCharacter) &&
+      this.shouldTrigger(profile.doubleBackspaceRate);
+
+    if (shouldDoubleBackspace) {
+      await this.page.keyboard.press("Backspace");
+    }
+
+    await this.page.waitForTimeout(this.sampleRange(profile.correctionResumeRange));
+
+    if (shouldDoubleBackspace && previousCommittedCharacter !== null) {
+      await this.typeLiteralCharacter(previousCommittedCharacter, profile);
+    }
+
+    await this.typeLiteralCharacter(intendedCharacter, profile);
+  }
+
+  private async typeLiteralCharacter(
+    character: string,
+    profile: ResolvedTypingProfile
+  ): Promise<void> {
+    if (character.length === 0) {
+      return;
+    }
+
+    if (isUppercaseLetter(character)) {
+      const shiftLeadDelay = this.sampleRange(profile.shiftLeadRange);
+      if (shiftLeadDelay > 0) {
+        await this.page.waitForTimeout(shiftLeadDelay);
+      }
+
+      await this.page.keyboard.down("Shift");
+      await this.page.keyboard.press(character.toLowerCase());
+      await this.page.keyboard.up("Shift");
+      return;
+    }
+
+    await this.page.keyboard.type(character, { delay: 0 });
+  }
+
+  private sampleRange(range: DelayRange): number {
+    if (range.minMs >= range.maxMs) {
+      return range.minMs;
+    }
+
+    return range.minMs + Math.random() * (range.maxMs - range.minMs);
+  }
+
+  private shouldTrigger(chance: number): boolean {
+    if (chance <= 0) {
+      return false;
+    }
+
+    if (chance >= 1) {
+      return true;
+    }
+
+    return Math.random() < chance;
   }
 }
 


### PR DESCRIPTION
## Summary
- add weighted QWERTY-adjacent typo generation and realistic correction flows to `HumanizedPage.type()`
- add profile-driven typing cadence with per-call overrides for `casual`, `careful`, and `fast` behavior
- use the careful profile for credential fields and expand unit coverage for typos, double-backspace, cadence, and shift correction

Closes #131

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build