### PR TITLE
feat: harden keepalive session recovery

### DIFF
--- a/packages/core/src/__tests__/connectionPool.test.ts
+++ b/packages/core/src/__tests__/connectionPool.test.ts
@@ -120,4 +120,54 @@ describe("CDPConnectionPool", () => {
     expect(first.close).toHaveBeenCalledTimes(1);
     expect(second.close).toHaveBeenCalledTimes(1);
   });
+
+  it("preemptively reconnects stale connections before they age out", async () => {
+    vi.useFakeTimers();
+
+    const pool = new CDPConnectionPool({
+      idleTimeoutMs: 60_000,
+      maxConnectionAgeMs: 1_000
+    });
+    const first = createMockBrowser(true);
+    const second = createMockBrowser(true);
+
+    playwrightMocks.connectOverCDP
+      .mockResolvedValueOnce(first.mockBrowser)
+      .mockResolvedValueOnce(second.mockBrowser);
+
+    const firstLease = await pool.acquire("http://127.0.0.1:18800");
+    firstLease.release();
+
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    const secondLease = await pool.acquire("http://127.0.0.1:18800");
+
+    expect(playwrightMocks.connectOverCDP).toHaveBeenCalledTimes(2);
+    expect(first.close).toHaveBeenCalledTimes(1);
+    expect(secondLease.context).toBe(second.mockContext);
+
+    secondLease.release();
+    await pool.dispose();
+  });
+
+  it("exposes connection stats for monitoring", async () => {
+    const pool = new CDPConnectionPool({ idleTimeoutMs: 10 });
+    const { mockBrowser } = createMockBrowser();
+    playwrightMocks.connectOverCDP.mockResolvedValue(mockBrowser);
+
+    const lease = await pool.acquire("http://127.0.0.1:18800");
+    const [stats] = pool.getStats();
+
+    expect(stats).toMatchObject({
+      cdpUrl: "http://127.0.0.1:18800",
+      connected: true,
+      idleScheduled: false,
+      refCount: 1
+    });
+    expect(stats?.connectedAt).toContain("T");
+    expect(stats?.lastAcquiredAt).toContain("T");
+
+    lease.release();
+    await pool.dispose();
+  });
 });

--- a/packages/core/src/__tests__/healthCheck.test.ts
+++ b/packages/core/src/__tests__/healthCheck.test.ts
@@ -35,6 +35,16 @@ function createMockPage(opts: {
 }
 
 function createMockContext(opts: {
+  cookies?: Array<{
+    domain: string;
+    expires: number;
+    httpOnly: boolean;
+    name: string;
+    path: string;
+    sameSite: "Lax" | "None" | "Strict";
+    secure: boolean;
+    value: string;
+  }>;
   connected: boolean;
   pages: Page[];
 }): BrowserContext {
@@ -44,6 +54,7 @@ function createMockContext(opts: {
 
   return {
     browser: vi.fn(() => mockBrowser),
+    cookies: vi.fn(async () => opts.cookies ?? []),
     pages: vi.fn(() => opts.pages),
     newPage: vi.fn(async () => {
       const [firstPage] = opts.pages;
@@ -122,8 +133,12 @@ describe("checkLinkedInSession", () => {
     const status = await checkLinkedInSession(context);
 
     expect(status.authenticated).toBe(true);
+    expect(status.checkpointDetected).toBe(false);
+    expect(status.cookieExpiringSoon).toBe(false);
     expect(status.currentUrl).toContain("/feed");
+    expect(status.loginWallDetected).toBe(false);
     expect(status.reason).toContain("authenticated");
+    expect(status.sessionCookiePresent).toBe(false);
   });
 
   it("is unauthenticated when login form is visible", async () => {
@@ -139,7 +154,41 @@ describe("checkLinkedInSession", () => {
     const status = await checkLinkedInSession(context);
 
     expect(status.authenticated).toBe(false);
+    expect(status.checkpointDetected).toBe(false);
+    expect(status.loginWallDetected).toBe(true);
     expect(status.currentUrl).toContain("/login");
     expect(status.reason).toContain("Login form");
+  });
+
+  it("surfaces cookie expiry metadata for proactive refresh decisions", async () => {
+    const page = createMockPage({
+      url: "https://www.linkedin.com/feed/",
+      isVisible: (selector) => selector === "nav.global-nav"
+    });
+    const context = createMockContext({
+      connected: true,
+      cookies: [
+        {
+          name: "li_at",
+          value: "token",
+          domain: ".linkedin.com",
+          path: "/",
+          expires: Math.floor((Date.now() + 30 * 60_000) / 1_000),
+          httpOnly: true,
+          secure: true,
+          sameSite: "Lax"
+        }
+      ],
+      pages: [page]
+    });
+
+    const status = await checkLinkedInSession(context);
+
+    expect(status.authenticated).toBe(true);
+    expect(status.cookieExpiringSoon).toBe(true);
+    expect(status.nextCookieExpiryAt).toContain("T");
+    expect(status.sessionCookieFingerprint).toMatch(/^[a-f0-9]{64}$/u);
+    expect(status.sessionCookiePresent).toBe(true);
+    expect(status.sessionCookies).toHaveLength(1);
   });
 });

--- a/packages/core/src/__tests__/keepAlive.test.ts
+++ b/packages/core/src/__tests__/keepAlive.test.ts
@@ -6,49 +6,136 @@ import {
 } from "../keepAlive.js";
 import { CDPConnectionPool } from "../connectionPool.js";
 import type { FullHealthStatus } from "../healthCheck.js";
+import type {
+  LinkedInBrowserStorageState,
+  LinkedInSessionStore
+} from "../auth/sessionStore.js";
 
-vi.mock("../healthCheck.js", () => ({
-  checkFullHealth: vi.fn()
+vi.mock("../healthCheck.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../healthCheck.js")>();
+
+  return {
+    ...actual,
+    checkFullHealth: vi.fn()
+  };
+});
+
+const humanizeMocks = vi.hoisted(() => ({
+  idle: vi.fn(async () => undefined),
+  moveMouseNear: vi.fn(async () => undefined),
+  navigate: vi.fn(async () => undefined),
+  scrollDown: vi.fn(async () => undefined)
 }));
 
 vi.mock("../humanize.js", () => ({
-  humanize: vi.fn(() => ({
-    scrollDown: vi.fn(async () => undefined),
-    idle: vi.fn(async () => undefined)
-  }))
+  humanize: vi.fn(() => humanizeMocks)
 }));
 
 import { checkFullHealth } from "../healthCheck.js";
 
 const mockedCheckFullHealth = vi.mocked(checkFullHealth);
 
-interface MockPoolBundle {
-  pool: CDPConnectionPool;
-  acquire: ReturnType<typeof vi.fn>;
-  dispose: ReturnType<typeof vi.fn>;
-  release: ReturnType<typeof vi.fn>;
+function createStorageState(
+  overrides?: Partial<LinkedInBrowserStorageState>
+): LinkedInBrowserStorageState {
+  return {
+    cookies: [
+      {
+        domain: ".linkedin.com",
+        expires: 1_900_000_000,
+        httpOnly: true,
+        name: "li_at",
+        path: "/",
+        sameSite: "Lax",
+        secure: true,
+        value: "valid-cookie"
+      }
+    ],
+    origins: [
+      {
+        localStorage: [
+          {
+            name: "li_theme",
+            value: "dark"
+          }
+        ],
+        origin: "https://www.linkedin.com"
+      }
+    ],
+    ...(overrides ?? {})
+  };
 }
 
-function createMockPool(): MockPoolBundle {
+interface MockPoolBundle {
+  addCookies: ReturnType<typeof vi.fn>;
+  pool: CDPConnectionPool;
+  acquire: ReturnType<typeof vi.fn>;
+  cookies: ReturnType<typeof vi.fn>;
+  dispose: ReturnType<typeof vi.fn>;
+  mockContext: BrowserContext;
+  mockPage: Page;
+  release: ReturnType<typeof vi.fn>;
+  storageState: ReturnType<typeof vi.fn>;
+}
+
+function createMockPool(options?: {
+  cookieCalls?: LinkedInBrowserStorageState["cookies"][];
+  storageStateCalls?: LinkedInBrowserStorageState[];
+  storageState?: LinkedInBrowserStorageState;
+}): MockPoolBundle {
+  const storageStateValue = options?.storageState ?? createStorageState();
+  const queuedCookieCalls = [
+    ...(options?.cookieCalls ?? [storageStateValue.cookies])
+  ];
+  const queuedStorageStateCalls = [
+    ...(options?.storageStateCalls ?? [storageStateValue])
+  ];
   const mockPage = {
+    close: vi.fn(async () => undefined),
+    evaluate: vi.fn(async () => undefined),
     goto: vi.fn(async () => undefined),
     url: vi.fn(() => "https://www.linkedin.com/feed/")
   } as unknown as Page;
+  const cookies = vi.fn(async () => {
+    if (queuedCookieCalls.length > 1) {
+      return queuedCookieCalls.shift() ?? [];
+    }
+
+    return queuedCookieCalls[0] ?? [];
+  });
+  const storageState = vi.fn(async () => {
+    if (queuedStorageStateCalls.length > 1) {
+      return queuedStorageStateCalls.shift() ?? storageStateValue;
+    }
+
+    return queuedStorageStateCalls[0] ?? storageStateValue;
+  });
+  const addCookies = vi.fn(async () => undefined);
   const mockContext = {
-    pages: vi.fn(() => [mockPage])
+    addCookies,
+    cookies,
+    newPage: vi.fn(async () => mockPage),
+    pages: vi.fn(() => [mockPage]),
+    storageState
   } as unknown as BrowserContext;
   const release = vi.fn();
   const acquire = vi.fn(async () => ({ context: mockContext, release }));
   const dispose = vi.fn(async () => undefined);
 
   return {
+    addCookies,
     pool: {
       acquire,
-      dispose
+      dispose,
+      invalidate: vi.fn(async () => undefined)
     } as unknown as CDPConnectionPool,
     acquire,
+    cookies,
     dispose,
-    release
+    mockContext,
+    mockPage,
+    release,
+    storageState
   };
 }
 
@@ -65,9 +152,17 @@ function createHealthStatus(overrides?: {
     },
     session: {
       authenticated: true,
+      checkpointDetected: false,
+      cookieExpiringSoon: false,
       currentUrl: "https://www.linkedin.com/feed/",
+      loginWallDetected: false,
+      nextCookieExpiryAt: null,
+      rateLimited: false,
       reason: "LinkedIn session appears authenticated.",
-      checkedAt: "2026-02-22T00:00:00.000Z"
+      checkedAt: "2026-02-22T00:00:00.000Z",
+      sessionCookieFingerprint: "healthy-session-fingerprint",
+      sessionCookiePresent: true,
+      sessionCookies: []
     }
   };
 
@@ -114,7 +209,8 @@ describe("SessionKeepAliveService", () => {
     const service = new SessionKeepAliveService(pool, {
       cdpUrl: "http://127.0.0.1:18800",
       intervalMs: 1_000,
-      jitterMs: 0
+      jitterMs: 0,
+      sessionRefreshEnabled: false
     });
     const healthyStatus = createHealthStatus();
     const onHealthy = vi.fn();
@@ -138,7 +234,8 @@ describe("SessionKeepAliveService", () => {
     const service = new SessionKeepAliveService(pool, {
       cdpUrl: "http://127.0.0.1:18800",
       intervalMs: 1_000,
-      jitterMs: 0
+      jitterMs: 0,
+      sessionRefreshEnabled: false
     });
     const expiredStatus = createHealthStatus({
       session: {
@@ -164,7 +261,8 @@ describe("SessionKeepAliveService", () => {
     const service = new SessionKeepAliveService(pool, {
       cdpUrl: "http://127.0.0.1:18800",
       intervalMs: 1_000,
-      jitterMs: 0
+      jitterMs: 0,
+      networkGracePeriodMs: 0
     });
     const disconnectedStatus = createHealthStatus({
       browser: {
@@ -221,7 +319,8 @@ describe("SessionKeepAliveService", () => {
       cdpUrl: "http://127.0.0.1:18800",
       intervalMs: 1_000,
       jitterMs: 0,
-      maxConsecutiveFailures: 3
+      maxConsecutiveFailures: 3,
+      sessionRefreshEnabled: false
     });
     const expiredStatus = createHealthStatus({
       session: {
@@ -258,7 +357,8 @@ describe("SessionKeepAliveService", () => {
       cdpUrl: "http://127.0.0.1:18800",
       intervalMs: 1_000,
       jitterMs: 0,
-      maxConsecutiveFailures: 5
+      maxConsecutiveFailures: 5,
+      sessionRefreshEnabled: false
     });
     const expiredStatus = createHealthStatus({
       session: {
@@ -326,10 +426,10 @@ describe("SessionKeepAliveService", () => {
   });
 
   it("emits reconnect-failed when reconnect fails", async () => {
-    const mockContext = {} as BrowserContext;
     const release = vi.fn();
     const acquire = vi.fn();
     const dispose = vi.fn(async () => undefined);
+    const invalidate = vi.fn(async () => undefined);
 
     const disconnectedStatus = createHealthStatus({
       browser: {
@@ -345,14 +445,28 @@ describe("SessionKeepAliveService", () => {
 
     // First acquire succeeds (for health check), second acquire fails (reconnect)
     acquire
-      .mockResolvedValueOnce({ context: mockContext, release })
+      .mockResolvedValueOnce({
+        context: {
+          cookies: vi.fn(async () => createStorageState().cookies),
+          newPage: vi.fn(async () => ({ goto: vi.fn(async () => undefined) })),
+          pages: vi.fn(() => [
+            {
+              goto: vi.fn(async () => undefined),
+              url: vi.fn(() => "https://www.linkedin.com/feed/")
+            }
+          ]),
+          storageState: vi.fn(async () => createStorageState())
+        } as unknown as BrowserContext,
+        release
+      })
       .mockRejectedValueOnce(new Error("Connection refused"));
 
-    const pool = { acquire, dispose } as unknown as CDPConnectionPool;
+    const pool = { acquire, dispose, invalidate } as unknown as CDPConnectionPool;
     const service = new SessionKeepAliveService(pool, {
       cdpUrl: "http://127.0.0.1:18800",
       intervalMs: 1_000,
-      jitterMs: 0
+      jitterMs: 0,
+      networkGracePeriodMs: 0
     });
     const onHealthEvent = vi.fn();
 
@@ -404,7 +518,8 @@ describe("SessionKeepAliveService", () => {
       cdpUrl: "http://127.0.0.1:18800",
       intervalMs: 1_000,
       jitterMs: 0,
-      maxConsecutiveFailures: 2
+      maxConsecutiveFailures: 2,
+      sessionRefreshEnabled: false
     });
     const expiredStatus = createHealthStatus({
       session: {
@@ -443,5 +558,265 @@ describe("SessionKeepAliveService", () => {
     service.start(); // should not throw or create duplicate timers
     expect(service.isRunning()).toBe(true);
     service.stop();
+  });
+
+  it("proactively refreshes expiring cookies and persists the session snapshot", async () => {
+    const nowMs = Date.parse("2026-03-09T10:00:00.000Z");
+    vi.setSystemTime(nowMs);
+    const expiringCookies = [
+      {
+        ...createStorageState().cookies[0]!,
+        expires: Math.floor((nowMs + 5 * 60_000) / 1_000),
+        value: "expiring-cookie"
+      }
+    ];
+    const refreshedCookies = [
+      {
+        ...createStorageState().cookies[0]!,
+        expires: Math.floor((nowMs + 3 * 60 * 60_000) / 1_000),
+        value: "refreshed-cookie"
+      }
+    ];
+    const refreshedStorageState = createStorageState({
+      cookies: refreshedCookies
+    });
+    const { pool } = createMockPool({
+      cookieCalls: [expiringCookies, refreshedCookies],
+      storageStateCalls: [
+        createStorageState({ cookies: expiringCookies }),
+        refreshedStorageState
+      ],
+      storageState: refreshedStorageState
+    });
+    const sessionStore = {
+      saveWithBackups: vi.fn(async () => undefined)
+    } as unknown as LinkedInSessionStore;
+    const service = new SessionKeepAliveService(pool, {
+      cdpUrl: "http://127.0.0.1:18800",
+      intervalMs: 1_000,
+      jitterMs: 0,
+      cookieRefreshLeadMs: 60 * 60_000,
+      sessionName: "default",
+      sessionStore
+    });
+    const onHealthEvent = vi.fn();
+
+    mockedCheckFullHealth
+      .mockResolvedValueOnce(
+        createHealthStatus({
+          session: {
+            cookieExpiringSoon: true,
+            nextCookieExpiryAt: new Date(nowMs + 5 * 60_000).toISOString(),
+            sessionCookieFingerprint: "expiring-session-fingerprint",
+            sessionCookies: [
+              {
+                name: "li_at",
+                domain: ".linkedin.com",
+                path: "/",
+                expiresAt: new Date(nowMs + 5 * 60_000).toISOString(),
+                expiresInMs: 5 * 60_000,
+                httpOnly: true,
+                secure: true,
+                sameSite: "Lax"
+              }
+            ]
+          }
+        })
+      )
+      .mockResolvedValueOnce(
+        createHealthStatus({
+          session: {
+            nextCookieExpiryAt: new Date(nowMs + 3 * 60 * 60_000).toISOString(),
+            sessionCookieFingerprint: "refreshed-session-fingerprint",
+            sessionCookies: [
+              {
+                name: "li_at",
+                domain: ".linkedin.com",
+                path: "/",
+                expiresAt: new Date(nowMs + 3 * 60 * 60_000).toISOString(),
+                expiresInMs: 3 * 60 * 60_000,
+                httpOnly: true,
+                secure: true,
+                sameSite: "Lax"
+              }
+            ]
+          }
+        })
+      );
+    service.on("health-event", onHealthEvent);
+
+    service.start();
+    await vi.advanceTimersByTimeAsync(1_000);
+    service.stop();
+
+    const eventTypes = onHealthEvent.mock.calls.map(
+      (call) => (call[0] as KeepAliveEvent).type
+    );
+    expect(eventTypes).toContain("cookie-refresh");
+    expect(eventTypes).toContain("session-persisted");
+    expect(sessionStore.saveWithBackups).toHaveBeenCalled();
+    expect(eventTypes).toContain("session-rotated");
+  });
+
+  it("rotates activity patterns instead of repeating one keepalive action", async () => {
+    const { pool } = createMockPool();
+    const service = new SessionKeepAliveService(pool, {
+      cdpUrl: "http://127.0.0.1:18800",
+      intervalMs: 1_000,
+      jitterMs: 0
+    });
+    const onHealthEvent = vi.fn();
+
+    mockedCheckFullHealth.mockResolvedValue(createHealthStatus());
+    service.on("health-event", onHealthEvent);
+
+    service.start();
+    await vi.advanceTimersByTimeAsync(6_000);
+    service.stop();
+
+    const activityEvents = onHealthEvent.mock.calls
+      .map((call) => call[0] as KeepAliveEvent)
+      .filter((event) => event.type === "activity");
+
+    expect(activityEvents).toHaveLength(2);
+    expect(activityEvents[0]?.metadata?.pattern).toBe("feed-scroll");
+    expect(activityEvents[1]?.metadata?.pattern).toBe("notifications-peek");
+  });
+
+  it("recovers from transient network interruptions inside the grace period", async () => {
+    const { mockContext, release } = createMockPool();
+    const acquire = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+      .mockResolvedValue({ context: mockContext, release });
+    const pool = {
+      acquire,
+      dispose: vi.fn(async () => undefined),
+      invalidate: vi.fn(async () => undefined)
+    } as unknown as CDPConnectionPool;
+    const service = new SessionKeepAliveService(pool, {
+      cdpUrl: "http://127.0.0.1:18800",
+      intervalMs: 1_000,
+      jitterMs: 0,
+      networkGracePeriodMs: 60_000
+    });
+    const onHealthEvent = vi.fn();
+
+    mockedCheckFullHealth.mockResolvedValue(createHealthStatus());
+    service.on("health-event", onHealthEvent);
+
+    service.start();
+    await vi.advanceTimersByTimeAsync(1_000);
+    service.stop();
+
+    const eventTypes = onHealthEvent.mock.calls.map(
+      (call) => (call[0] as KeepAliveEvent).type
+    );
+    expect(eventTypes).toContain("network-interruption");
+    expect(eventTypes).toContain("reconnect-attempt");
+    expect(eventTypes).toContain("reconnect-success");
+    expect(eventTypes).not.toContain("dead");
+    expect(service.getConsecutiveFailures()).toBe(0);
+  });
+
+  it("emits login-required with health context when soft re-auth fails", async () => {
+    const expiredCookies = [
+      {
+        ...createStorageState().cookies[0]!,
+        expires: 1_600_000_000,
+        value: "expired-cookie"
+      }
+    ];
+    const { pool } = createMockPool({
+      cookieCalls: [expiredCookies],
+      storageState: createStorageState({ cookies: expiredCookies })
+    });
+    const service = new SessionKeepAliveService(pool, {
+      cdpUrl: "http://127.0.0.1:18800",
+      intervalMs: 1_000,
+      jitterMs: 0,
+      sessionRefreshEnabled: false
+    });
+    const expiredStatus = createHealthStatus({
+      session: {
+        authenticated: false,
+        loginWallDetected: true,
+        nextCookieExpiryAt: "2020-09-13T12:26:40.000Z",
+        reason: "LinkedIn login wall detected."
+      }
+    });
+    const onHealthEvent = vi.fn();
+
+    mockedCheckFullHealth.mockResolvedValue(expiredStatus);
+    service.on("health-event", onHealthEvent);
+
+    service.start();
+    await vi.advanceTimersByTimeAsync(1_000);
+    service.stop();
+
+    const loginRequiredEvent = onHealthEvent.mock.calls
+      .map((call) => call[0] as KeepAliveEvent)
+      .find((event) => event.type === "manual-login-required");
+
+    expect(loginRequiredEvent?.detail).toContain("Manual LinkedIn login");
+    expect(loginRequiredEvent?.metadata?.currentUrl).toBe(
+      "https://www.linkedin.com/feed/"
+    );
+    expect(loginRequiredEvent?.metadata?.nextCookieExpiryAt).toBe(
+      "2020-09-13T12:26:40.000Z"
+    );
+  });
+
+  it("restores a stored session fallback before requiring manual login", async () => {
+    const { pool } = createMockPool();
+    const sessionStore = {
+      saveWithBackups: vi.fn(async () => undefined),
+      restoreToContext: vi.fn(async () => ({
+        metadata: {
+          capturedAt: "2026-03-09T09:00:00.000Z",
+          cookieCount: 1,
+          filePath: "/tmp/default.backup-1.session.enc.json",
+          hasLinkedInAuthCookie: true,
+          liAtCookieExpiresAt: "2026-03-10T09:00:00.000Z",
+          originCount: 1,
+          sessionName: "default.backup-1"
+        },
+        restoredFromBackup: true,
+        restoredSessionName: "default.backup-1",
+        storageState: createStorageState()
+      }))
+    } as unknown as LinkedInSessionStore;
+    const service = new SessionKeepAliveService(pool, {
+      cdpUrl: "http://127.0.0.1:18800",
+      intervalMs: 1_000,
+      jitterMs: 0,
+      sessionRefreshEnabled: false,
+      sessionStore
+    });
+    const expiredStatus = createHealthStatus({
+      session: {
+        authenticated: false,
+        loginWallDetected: true,
+        reason: "LinkedIn login wall detected."
+      }
+    });
+    const healthyStatus = createHealthStatus();
+    const onHealthEvent = vi.fn();
+
+    mockedCheckFullHealth
+      .mockResolvedValueOnce(expiredStatus)
+      .mockResolvedValueOnce(healthyStatus);
+    service.on("health-event", onHealthEvent);
+
+    service.start();
+    await vi.advanceTimersByTimeAsync(1_000);
+    service.stop();
+
+    const eventTypes = onHealthEvent.mock.calls.map(
+      (call) => (call[0] as KeepAliveEvent).type
+    );
+    expect(eventTypes).toContain("soft-reauth-attempt");
+    expect(eventTypes).toContain("soft-reauth-success");
+    expect(eventTypes).not.toContain("manual-login-required");
   });
 });

--- a/packages/core/src/__tests__/sessionInspection.test.ts
+++ b/packages/core/src/__tests__/sessionInspection.test.ts
@@ -38,9 +38,11 @@ describe("inspectLinkedInSession", () => {
     const status = await inspectLinkedInSession(page);
 
     expect(status.authenticated).toBe(false);
+    expect(status.loginWallDetected).toBe(false);
     expect(status.reason).toBe(
       "Could not confirm an authenticated LinkedIn session."
     );
+    expect(status.sessionCookiePresent).toBe(false);
   });
 
   it("marks the session unauthenticated when the login form is visible", async () => {
@@ -52,7 +54,21 @@ describe("inspectLinkedInSession", () => {
     const status = await inspectLinkedInSession(page);
 
     expect(status.authenticated).toBe(false);
+    expect(status.loginWallDetected).toBe(false);
     expect(status.reason).toBe("Login form is visible.");
+  });
+
+  it("detects a login wall even when the URL still looks like feed", async () => {
+    const page = createMockPage({
+      url: "https://www.linkedin.com/feed/",
+      isVisible: (selector) => selector.includes("[data-test-id='sign-in-form']")
+    });
+
+    const status = await inspectLinkedInSession(page);
+
+    expect(status.authenticated).toBe(false);
+    expect(status.loginWallDetected).toBe(true);
+    expect(status.reason).toBe("LinkedIn login wall detected.");
   });
 
   it("detects LinkedIn rate-limit challenge URLs", async () => {
@@ -63,7 +79,21 @@ describe("inspectLinkedInSession", () => {
     const status = await inspectLinkedInSession(page);
 
     expect(status.authenticated).toBe(false);
+    expect(status.checkpointDetected).toBe(true);
+    expect(status.rateLimited).toBe(true);
     expect(status.reason).toBe("LinkedIn rate-limit challenge detected.");
+  });
+
+  it("flags LinkedIn authwall pages as login walls", async () => {
+    const page = createMockPage({
+      url: "https://www.linkedin.com/authwall?trk=public_profile"
+    });
+
+    const status = await inspectLinkedInSession(page);
+
+    expect(status.authenticated).toBe(false);
+    expect(status.loginWallDetected).toBe(true);
+    expect(status.reason).toContain("Login form");
   });
 
   it("authenticates when the localized profile-menu aria label is visible", async () => {
@@ -77,6 +107,7 @@ describe("inspectLinkedInSession", () => {
     });
 
     expect(status.authenticated).toBe(true);
+    expect(status.loginWallDetected).toBe(false);
     expect(status.reason).toContain("authenticated");
   });
 

--- a/packages/core/src/__tests__/sessionStore.test.ts
+++ b/packages/core/src/__tests__/sessionStore.test.ts
@@ -1,7 +1,8 @@
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import type { BrowserContext, Page } from "playwright-core";
+import { describe, expect, it, vi } from "vitest";
 import {
   LinkedInSessionStore,
   resolveStoredLinkedInSessionPath,
@@ -36,6 +37,33 @@ function createStorageState(): LinkedInBrowserStorageState {
   };
 }
 
+function createRestoreContext(): {
+  addCookies: ReturnType<typeof vi.fn>;
+  context: BrowserContext;
+  evaluate: ReturnType<typeof vi.fn>;
+  goto: ReturnType<typeof vi.fn>;
+} {
+  const goto = vi.fn(async () => undefined);
+  const evaluate = vi.fn(async () => undefined);
+  const page = {
+    evaluate,
+    goto
+  } as unknown as Page;
+  const addCookies = vi.fn(async () => undefined);
+  const context = {
+    addCookies,
+    newPage: vi.fn(async () => page),
+    pages: vi.fn(() => [])
+  } as unknown as BrowserContext;
+
+  return {
+    addCookies,
+    context,
+    evaluate,
+    goto
+  };
+}
+
 describe("LinkedInSessionStore", () => {
   it("encrypts stored session state and round-trips it correctly", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-session-store-"));
@@ -51,9 +79,14 @@ describe("LinkedInSessionStore", () => {
 
       expect(metadata.filePath).toBe(storedFile);
       expect(metadata.hasLinkedInAuthCookie).toBe(true);
+      expect(metadata.sessionCookieFingerprint).toMatch(/^[a-f0-9]{64}$/u);
+      expect(metadata.sessionCookies).toHaveLength(1);
       expect(rawEnvelope).not.toContain("super-secret-cookie");
       expect(rawEnvelope).not.toContain('"origins"');
       expect(loaded.metadata.sessionName).toBe("smoke");
+      expect(loaded.metadata.sessionCookieFingerprint).toBe(
+        metadata.sessionCookieFingerprint
+      );
       expect(loaded.storageState).toEqual(storageState);
     } finally {
       await rm(tempDir, { recursive: true, force: true });
@@ -70,6 +103,43 @@ describe("LinkedInSessionStore", () => {
         code: "AUTH_REQUIRED",
         message: expect.stringContaining("owa auth:session")
       });
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rotates stored backups and restores the freshest non-expired fallback", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-session-store-"));
+
+    try {
+      const store = new LinkedInSessionStore(tempDir);
+      const firstStorageState = createStorageState();
+      const expiredStorageState: LinkedInBrowserStorageState = {
+        ...createStorageState(),
+        cookies: [
+          {
+            ...createStorageState().cookies[0]!,
+            expires: 1_600_000_000,
+            value: "expired-cookie"
+          }
+        ]
+      };
+
+      await store.saveWithBackups("smoke", firstStorageState, { maxBackups: 2 });
+      await store.saveWithBackups("smoke", expiredStorageState, { maxBackups: 2 });
+
+      const restored = createRestoreContext();
+      const restoreResult = await store.restoreToContext(restored.context, "smoke", {
+        maxBackups: 2
+      });
+
+      expect(restoreResult.restoredFromBackup).toBe(true);
+      expect(restoreResult.restoredSessionName).toBe("smoke.backup-1");
+      expect(restored.addCookies).toHaveBeenCalledWith(firstStorageState.cookies);
+      expect(restored.goto).toHaveBeenCalledWith("https://www.linkedin.com", {
+        waitUntil: "domcontentloaded"
+      });
+      expect(restored.evaluate).toHaveBeenCalledTimes(1);
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }

--- a/packages/core/src/auth/session.ts
+++ b/packages/core/src/auth/session.ts
@@ -20,10 +20,14 @@ import {
 export interface SessionStatus {
   authenticated: boolean;
   checkedAt: string;
+  checkpointDetected?: boolean;
   currentUrl: string;
+  loginWallDetected?: boolean;
   reason: string;
   rateLimitActive?: boolean;
+  rateLimited?: boolean;
   rateLimitUntil?: string;
+  sessionCookiePresent?: boolean;
 }
 
 export interface SessionOptions {
@@ -144,7 +148,7 @@ export class LinkedInAuthService {
     if (!status.authenticated) {
       const code = status.rateLimitActive
         ? "RATE_LIMITED"
-        : status.currentUrl.includes("/checkpoint")
+        : status.checkpointDetected
           ? "CAPTCHA_OR_CHALLENGE"
           : "AUTH_REQUIRED";
       const guidance = status.rateLimitActive

--- a/packages/core/src/auth/sessionInspection.ts
+++ b/packages/core/src/auth/sessionInspection.ts
@@ -10,12 +10,22 @@ export interface LinkedInSessionInspection {
   checkedAt: string;
   currentUrl: string;
   reason: string;
+  checkpointDetected: boolean;
+  loginWallDetected: boolean;
+  rateLimited: boolean;
+  sessionCookiePresent: boolean;
 }
 
 const LOGIN_FORM_SELECTOR = "input[name='session_key'], input#username";
 const CHECKPOINT_FORM_SELECTOR = "form[action*='checkpoint']";
 const AUTH_NAV_SELECTOR = "nav.global-nav";
 const AUTH_PROFILE_MENU_SELECTOR = "[data-control-name='nav.settings_view_profile']";
+const LOGIN_WALL_SELECTOR = [
+  "[data-test-id='sign-in-form']",
+  ".authwall",
+  "form[action*='login-submit']",
+  "a[href*='/login'][data-tracking-control-name]"
+].join(", ");
 
 async function isVisibleSafe(page: Page, selector: string): Promise<boolean> {
   try {
@@ -71,26 +81,39 @@ export async function inspectLinkedInSession(
   const checkpointVisible =
     isCheckpointUrl(currentUrl) ||
     (await isVisibleSafe(page, CHECKPOINT_FORM_SELECTOR));
+  const sessionCookiePresent = await hasSessionCookie(page);
 
   if (checkpointVisible) {
-    const reason = isRateLimitedChallengeUrl(currentUrl)
+    const rateLimited = isRateLimitedChallengeUrl(currentUrl);
+    const reason = rateLimited
       ? "LinkedIn rate-limit challenge detected."
       : "LinkedIn checkpoint detected. Manual verification is required.";
     return {
       authenticated: false,
       checkedAt,
       currentUrl,
-      reason
+      reason,
+      checkpointDetected: true,
+      loginWallDetected: false,
+      rateLimited,
+      sessionCookiePresent
     };
   }
 
   const loginFormVisible = await isVisibleSafe(page, LOGIN_FORM_SELECTOR);
-  if (loginFormVisible || isLoginUrl(currentUrl)) {
+  const loginWallVisible = await isVisibleSafe(page, LOGIN_WALL_SELECTOR);
+  if (loginFormVisible || isLoginUrl(currentUrl) || loginWallVisible) {
     return {
       authenticated: false,
       checkedAt,
       currentUrl,
-      reason: "Login form is visible."
+      reason: loginWallVisible
+        ? "LinkedIn login wall detected."
+        : "Login form is visible.",
+      checkpointDetected: false,
+      loginWallDetected: loginWallVisible || isLoginUrl(currentUrl),
+      rateLimited: false,
+      sessionCookiePresent
     };
   }
 
@@ -103,14 +126,16 @@ export async function inspectLinkedInSession(
     page,
     profileMenuSelector
   );
-  const sessionCookiePresent = await hasSessionCookie(page);
-
   if (navVisible || profileMenuVisible || sessionCookiePresent) {
     return {
       authenticated: true,
       checkedAt,
       currentUrl,
-      reason: "LinkedIn session appears authenticated."
+      reason: "LinkedIn session appears authenticated.",
+      checkpointDetected: false,
+      loginWallDetected: false,
+      rateLimited: false,
+      sessionCookiePresent
     };
   }
 
@@ -118,6 +143,10 @@ export async function inspectLinkedInSession(
     authenticated: false,
     checkedAt,
     currentUrl,
-    reason: "Could not confirm an authenticated LinkedIn session."
+    reason: "Could not confirm an authenticated LinkedIn session.",
+    checkpointDetected: false,
+    loginWallDetected: false,
+    rateLimited: false,
+    sessionCookiePresent
   };
 }

--- a/packages/core/src/auth/sessionStore.ts
+++ b/packages/core/src/auth/sessionStore.ts
@@ -29,6 +29,124 @@ const SESSION_STORE_KEY_FILE_NAME = ".session-store.key";
 const SESSION_FILE_SUFFIX = ".session.enc.json";
 const SESSION_STORE_SCHEMA_VERSION = 1;
 const AES_GCM_IV_BYTES = 12;
+const LINKEDIN_AUTH_COOKIE_NAMES = new Set([
+  "li_at",
+  "JSESSIONID",
+  "liap",
+  "bscookie",
+  "bcookie"
+]);
+
+type StorageStateCookie = LinkedInBrowserStorageState["cookies"][number];
+
+export interface LinkedInSessionCookieMetadata {
+  name: string;
+  domain: string;
+  path: string;
+  expiresAt: string | null;
+  expiresInMs: number | null;
+  httpOnly: boolean;
+  secure: boolean;
+  sameSite: StorageStateCookie["sameSite"];
+}
+
+function isSupportedSameSite(
+  value: unknown
+): value is LinkedInSessionCookieMetadata["sameSite"] | undefined {
+  return (
+    value === undefined || value === "Lax" || value === "Strict" || value === "None"
+  );
+}
+
+function isLinkedInCookie(cookie: Pick<StorageStateCookie, "domain">): boolean {
+  return cookie.domain.toLowerCase().includes("linkedin.com");
+}
+
+function isLinkedInAuthCookie(cookie: Pick<StorageStateCookie, "name" | "domain">): boolean {
+  return isLinkedInCookie(cookie) && LINKEDIN_AUTH_COOKIE_NAMES.has(cookie.name);
+}
+
+function toCookieExpiresAt(expires: number): string | null {
+  if (!Number.isFinite(expires) || expires <= 0) {
+    return null;
+  }
+
+  return new Date(expires * 1_000).toISOString();
+}
+
+export function summarizeLinkedInSessionCookies(
+  cookies: readonly StorageStateCookie[],
+  options: { nowMs?: number } = {}
+): LinkedInSessionCookieMetadata[] {
+  const nowMs = options.nowMs ?? Date.now();
+
+  return cookies
+    .filter((cookie) => isLinkedInAuthCookie(cookie))
+    .map((cookie) => {
+      const expiresAt = toCookieExpiresAt(cookie.expires);
+      const expiresInMs =
+        expiresAt === null ? null : new Date(expiresAt).getTime() - nowMs;
+
+      return {
+        name: cookie.name,
+        domain: cookie.domain,
+        path: cookie.path,
+        expiresAt,
+        expiresInMs,
+        httpOnly: cookie.httpOnly,
+        secure: cookie.secure,
+        sameSite: cookie.sameSite
+      };
+    })
+    .sort((left, right) => {
+      const leftExpiry = left.expiresAt === null ? Number.POSITIVE_INFINITY : new Date(left.expiresAt).getTime();
+      const rightExpiry = right.expiresAt === null ? Number.POSITIVE_INFINITY : new Date(right.expiresAt).getTime();
+
+      if (leftExpiry !== rightExpiry) {
+        return leftExpiry - rightExpiry;
+      }
+
+      return left.name.localeCompare(right.name);
+    });
+}
+
+export function getLinkedInSessionFingerprint(
+  storageState: Pick<LinkedInBrowserStorageState, "cookies">
+): string {
+  const authCookiePayload = storageState.cookies
+    .filter((cookie) => isLinkedInAuthCookie(cookie))
+    .sort((left, right) => {
+      const leftKey = `${left.name}\u0000${left.domain}\u0000${left.path}`;
+      const rightKey = `${right.name}\u0000${right.domain}\u0000${right.path}`;
+      return leftKey.localeCompare(rightKey);
+    })
+    .map((cookie) => ({
+      name: cookie.name,
+      value: cookie.value,
+      domain: cookie.domain,
+      path: cookie.path,
+      expires: cookie.expires,
+      httpOnly: cookie.httpOnly,
+      secure: cookie.secure,
+      sameSite: cookie.sameSite
+    }));
+
+  return createHash("sha256")
+    .update(JSON.stringify(authCookiePayload))
+    .digest("hex");
+}
+
+export async function restoreLinkedInSessionCookies(
+  context: BrowserContext,
+  storageState: LinkedInBrowserStorageState
+): Promise<void> {
+  const cookiesToRestore = storageState.cookies.filter((cookie) => isLinkedInCookie(cookie));
+  if (cookiesToRestore.length === 0) {
+    return;
+  }
+
+  await context.addCookies(cookiesToRestore);
+}
 
 function isNotFoundError(error: unknown): boolean {
   return error instanceof Error && "code" in error && error.code === "ENOENT";
@@ -50,6 +168,8 @@ interface StoredLinkedInSessionMetadataRecord {
   liAtCookieExpiresAt: string | null;
   originCount: number;
   sessionName: string;
+  sessionCookieFingerprint?: string;
+  sessionCookies?: LinkedInSessionCookieMetadata[];
 }
 
 export interface StoredLinkedInSessionMetadata {
@@ -60,11 +180,28 @@ export interface StoredLinkedInSessionMetadata {
   liAtCookieExpiresAt: string | null;
   originCount: number;
   sessionName: string;
+  sessionCookieFingerprint?: string;
+  sessionCookies?: LinkedInSessionCookieMetadata[];
 }
 
 export interface LoadStoredLinkedInSessionResult {
   metadata: StoredLinkedInSessionMetadata;
   storageState: LinkedInBrowserStorageState;
+}
+
+export interface SaveStoredLinkedInSessionOptions {
+  maxBackups?: number;
+}
+
+export interface RestoreStoredLinkedInSessionOptions {
+  allowExpired?: boolean;
+  maxBackups?: number;
+}
+
+export interface RestoreStoredLinkedInSessionResult
+  extends LoadStoredLinkedInSessionResult {
+  restoredFromBackup: boolean;
+  restoredSessionName: string;
 }
 
 export interface CaptureLinkedInSessionOptions {
@@ -115,6 +252,47 @@ function normalizeSessionName(sessionName: string | undefined): string {
   }
 
   return normalized;
+}
+
+function getBackupSessionName(sessionName: string, index: number): string {
+  return `${normalizeSessionName(sessionName)}.backup-${index}`;
+}
+
+function getFallbackSessionNames(
+  sessionName: string,
+  maxBackups: number
+): string[] {
+  const normalizedSessionName = normalizeSessionName(sessionName);
+  return [
+    normalizedSessionName,
+    ...Array.from({ length: maxBackups }, (_, index) =>
+      getBackupSessionName(normalizedSessionName, index + 1)
+    )
+  ];
+}
+
+function getLinkedInAuthCookie(
+  storageState: LinkedInBrowserStorageState
+): LinkedInBrowserStorageState["cookies"][number] | undefined {
+  return storageState.cookies.find(
+    (cookie) => cookie.name === "li_at" && cookie.value.trim().length > 0
+  );
+}
+
+function isStoredSessionExpired(
+  storageState: LinkedInBrowserStorageState,
+  referenceTimeMs: number = Date.now()
+): boolean {
+  const authCookie = getLinkedInAuthCookie(storageState);
+  if (!authCookie) {
+    return true;
+  }
+
+  if (typeof authCookie.expires !== "number" || authCookie.expires <= 0) {
+    return false;
+  }
+
+  return authCookie.expires * 1_000 <= referenceTimeMs;
 }
 
 function createStoredSessionValidationError(
@@ -173,7 +351,7 @@ function getLinkedInAuthCookieExpiry(
     return null;
   }
 
-  return new Date(authCookie.expires * 1_000).toISOString();
+  return toCookieExpiresAt(authCookie.expires);
 }
 
 function createStoredSessionMetadata(
@@ -193,7 +371,11 @@ function createStoredSessionMetadata(
     hasLinkedInAuthCookie,
     liAtCookieExpiresAt: getLinkedInAuthCookieExpiry(storageState),
     originCount: storageState.origins.length,
-    sessionName
+    sessionName,
+    sessionCookieFingerprint: getLinkedInSessionFingerprint(storageState),
+    sessionCookies: summarizeLinkedInSessionCookies(storageState.cookies, {
+      nowMs: new Date(capturedAt).getTime()
+    })
   };
 }
 
@@ -206,7 +388,11 @@ function toStoredMetadataRecord(
     hasLinkedInAuthCookie: metadata.hasLinkedInAuthCookie,
     liAtCookieExpiresAt: metadata.liAtCookieExpiresAt,
     originCount: metadata.originCount,
-    sessionName: metadata.sessionName
+    sessionName: metadata.sessionName,
+    ...(metadata.sessionCookieFingerprint
+      ? { sessionCookieFingerprint: metadata.sessionCookieFingerprint }
+      : {}),
+    ...(metadata.sessionCookies ? { sessionCookies: metadata.sessionCookies } : {})
   };
 }
 
@@ -221,7 +407,11 @@ function toStoredMetadata(
     hasLinkedInAuthCookie: metadata.hasLinkedInAuthCookie,
     liAtCookieExpiresAt: metadata.liAtCookieExpiresAt,
     originCount: metadata.originCount,
-    sessionName: metadata.sessionName
+    sessionName: metadata.sessionName,
+    ...(metadata.sessionCookieFingerprint
+      ? { sessionCookieFingerprint: metadata.sessionCookieFingerprint }
+      : {}),
+    ...(metadata.sessionCookies ? { sessionCookies: metadata.sessionCookies } : {})
   };
 }
 
@@ -300,6 +490,27 @@ function validateEnvelope(
     typeof metadata.originCount !== "number" ||
     typeof metadata.hasLinkedInAuthCookie !== "boolean" ||
     !(
+      metadata.sessionCookieFingerprint === undefined ||
+      typeof metadata.sessionCookieFingerprint === "string"
+    ) ||
+    !(
+      metadata.sessionCookies === undefined ||
+      (Array.isArray(metadata.sessionCookies) &&
+        metadata.sessionCookies.every(
+          (cookie) =>
+            typeof cookie === "object" &&
+            cookie !== null &&
+            typeof cookie.name === "string" &&
+            typeof cookie.domain === "string" &&
+            typeof cookie.path === "string" &&
+            (cookie.expiresAt === null || typeof cookie.expiresAt === "string") &&
+            (cookie.expiresInMs === null || typeof cookie.expiresInMs === "number") &&
+            typeof cookie.httpOnly === "boolean" &&
+            typeof cookie.secure === "boolean" &&
+            isSupportedSameSite((cookie as { sameSite?: unknown }).sameSite)
+        ))
+    ) ||
+    !(
       metadata.liAtCookieExpiresAt === null ||
       typeof metadata.liAtCookieExpiresAt === "string"
     )
@@ -323,7 +534,11 @@ function validateEnvelope(
       hasLinkedInAuthCookie: metadata.hasLinkedInAuthCookie,
       liAtCookieExpiresAt: metadata.liAtCookieExpiresAt ?? null,
       originCount: metadata.originCount,
-      sessionName: metadata.sessionName
+      sessionName: metadata.sessionName,
+      ...(metadata.sessionCookieFingerprint
+        ? { sessionCookieFingerprint: metadata.sessionCookieFingerprint }
+        : {}),
+      ...(metadata.sessionCookies ? { sessionCookies: metadata.sessionCookies } : {})
     }
   };
 }
@@ -414,6 +629,44 @@ export class LinkedInSessionStore {
     return metadata;
   }
 
+  async saveWithBackups(
+    sessionName: string,
+    storageState: LinkedInBrowserStorageState,
+    options: SaveStoredLinkedInSessionOptions = {}
+  ): Promise<StoredLinkedInSessionMetadata> {
+    const normalizedSessionName = normalizeSessionName(sessionName);
+    const maxBackups = Math.max(0, options.maxBackups ?? 2);
+
+    if (maxBackups > 0) {
+      for (let backupIndex = maxBackups; backupIndex >= 2; backupIndex -= 1) {
+        const sourceBackupName = getBackupSessionName(
+          normalizedSessionName,
+          backupIndex - 1
+        );
+
+        if (!(await this.exists(sourceBackupName))) {
+          continue;
+        }
+
+        const sourceBackup = await this.load(sourceBackupName);
+        await this.save(
+          getBackupSessionName(normalizedSessionName, backupIndex),
+          sourceBackup.storageState
+        );
+      }
+
+      if (await this.exists(normalizedSessionName)) {
+        const previousPrimary = await this.load(normalizedSessionName);
+        await this.save(
+          getBackupSessionName(normalizedSessionName, 1),
+          previousPrimary.storageState
+        );
+      }
+    }
+
+    return this.save(normalizedSessionName, storageState);
+  }
+
   async exists(sessionName: string = "default"): Promise<boolean> {
     try {
       await readFile(this.getSessionPath(sessionName), "utf8");
@@ -486,12 +739,106 @@ export class LinkedInSessionStore {
       storageState
     };
   }
+
+  async loadLatestAvailable(
+    sessionName: string = "default",
+    options: RestoreStoredLinkedInSessionOptions = {}
+  ): Promise<RestoreStoredLinkedInSessionResult> {
+    const normalizedSessionName = normalizeSessionName(sessionName);
+    const maxBackups = Math.max(0, options.maxBackups ?? 2);
+    let lastValidationError: Error | undefined;
+
+    for (const candidateSessionName of getFallbackSessionNames(
+      normalizedSessionName,
+      maxBackups
+    )) {
+      try {
+        const loadedSession = await this.load(candidateSessionName);
+        if (
+          !options.allowExpired &&
+          isStoredSessionExpired(loadedSession.storageState)
+        ) {
+          continue;
+        }
+
+        return {
+          ...loadedSession,
+          restoredFromBackup: candidateSessionName !== normalizedSessionName,
+          restoredSessionName: candidateSessionName
+        };
+      } catch (error) {
+        if (
+          error instanceof LinkedInAssistantError &&
+          ["AUTH_REQUIRED", "ACTION_PRECONDITION_FAILED"].includes(error.code)
+        ) {
+          lastValidationError = error;
+          continue;
+        }
+
+        throw error;
+      }
+    }
+
+    throw new LinkedInAssistantError(
+      "AUTH_REQUIRED",
+      `No non-expired stored LinkedIn session named "${normalizedSessionName}" was found. Capture a fresh session and retry.`,
+      {
+        session_name: normalizedSessionName,
+        ...(lastValidationError instanceof Error
+          ? { cause: lastValidationError.message }
+          : {})
+      },
+      lastValidationError instanceof Error
+        ? { cause: lastValidationError }
+        : undefined
+    );
+  }
+
+  async restoreToContext(
+    context: BrowserContext,
+    sessionName: string = "default",
+    options: RestoreStoredLinkedInSessionOptions = {}
+  ): Promise<RestoreStoredLinkedInSessionResult> {
+    const restoredSession = await this.loadLatestAvailable(sessionName, options);
+
+    await context.addCookies(restoredSession.storageState.cookies);
+    await restoreOriginStorageToContext(context, restoredSession.storageState);
+
+    return restoredSession;
+  }
 }
 
 async function getOrCreatePage(context: BrowserContext) {
   const existingPage = context.pages()[0];
 
   return existingPage ?? context.newPage();
+}
+
+async function restoreOriginStorageToContext(
+  context: BrowserContext,
+  storageState: LinkedInBrowserStorageState
+): Promise<void> {
+  if (storageState.origins.length === 0) {
+    return;
+  }
+
+  const page = await getOrCreatePage(context);
+
+  for (const originState of storageState.origins) {
+    try {
+      await page.goto(originState.origin, {
+        waitUntil: "domcontentloaded"
+      });
+      await page.evaluate((localStorageEntries) => {
+        globalThis.localStorage.clear();
+        for (const entry of localStorageEntries) {
+          globalThis.localStorage.setItem(entry.name, entry.value);
+        }
+      }, originState.localStorage);
+    } catch {
+      // Restoring origin-scoped storage is best-effort; cookies are the critical part.
+    }
+  }
 }
 
 async function waitForManualLogin(

--- a/packages/core/src/connectionPool.ts
+++ b/packages/core/src/connectionPool.ts
@@ -6,8 +6,11 @@ import {
 
 interface PooledConnection {
   browser: Browser;
+  connectedAtMs: number;
   refCount: number;
   idleTimer: ReturnType<typeof setTimeout> | undefined;
+  lastAcquiredAtMs: number;
+  lastReleasedAtMs: number | undefined;
 }
 
 class AsyncLock {
@@ -28,13 +31,26 @@ export interface ConnectionLease {
   release: () => void;
 }
 
+export interface ConnectionPoolEntryStats {
+  ageMs: number;
+  cdpUrl: string;
+  connected: boolean;
+  connectedAt: string;
+  idleScheduled: boolean;
+  lastAcquiredAt: string;
+  lastReleasedAt?: string;
+  refCount: number;
+}
+
 export class CDPConnectionPool {
   private connections = new Map<string, PooledConnection>();
   private readonly idleTimeoutMs: number;
   private readonly lock = new AsyncLock();
+  private readonly maxConnectionAgeMs: number;
 
-  constructor(options?: { idleTimeoutMs?: number }) {
+  constructor(options?: { idleTimeoutMs?: number; maxConnectionAgeMs?: number }) {
     this.idleTimeoutMs = options?.idleTimeoutMs ?? 300_000;
+    this.maxConnectionAgeMs = options?.maxConnectionAgeMs ?? 30 * 60_000;
   }
 
   async acquire(cdpUrl: string): Promise<ConnectionLease> {
@@ -46,7 +62,13 @@ export class CDPConnectionPool {
         pooled.idleTimer = undefined;
       }
 
-      if (pooled && !pooled.browser.isConnected()) {
+      const nowMs = Date.now();
+
+      if (
+        pooled &&
+        (!pooled.browser.isConnected() ||
+          nowMs - pooled.connectedAtMs >= this.maxConnectionAgeMs)
+      ) {
         await this.closeConnection(cdpUrl, pooled);
         pooled = undefined;
       }
@@ -55,11 +77,16 @@ export class CDPConnectionPool {
         const browser = await chromium.connectOverCDP(cdpUrl);
         pooled = {
           browser,
+          connectedAtMs: nowMs,
           refCount: 0,
-          idleTimer: undefined
+          idleTimer: undefined,
+          lastAcquiredAtMs: nowMs,
+          lastReleasedAtMs: undefined
         };
         this.connections.set(cdpUrl, pooled);
       }
+
+      pooled.lastAcquiredAtMs = nowMs;
 
       const context = pooled.browser.contexts()[0];
       if (!context) {
@@ -83,6 +110,7 @@ export class CDPConnectionPool {
             }
 
             current.refCount = Math.max(0, current.refCount - 1);
+            current.lastReleasedAtMs = Date.now();
             if (current.refCount !== 0 || current.idleTimer) {
               return;
             }
@@ -136,6 +164,33 @@ export class CDPConnectionPool {
         })
       );
     });
+  }
+
+  async invalidate(cdpUrl: string): Promise<void> {
+    await this.lock.run(async () => {
+      const connection = this.connections.get(cdpUrl);
+      if (!connection) {
+        return;
+      }
+
+      await this.closeConnection(cdpUrl, connection);
+    });
+  }
+
+  getStats(): ConnectionPoolEntryStats[] {
+    const nowMs = Date.now();
+    return [...this.connections.entries()].map(([cdpUrl, connection]) => ({
+      ageMs: Math.max(0, nowMs - connection.connectedAtMs),
+      cdpUrl,
+      connected: connection.browser.isConnected(),
+      connectedAt: new Date(connection.connectedAtMs).toISOString(),
+      idleScheduled: connection.idleTimer !== undefined,
+      lastAcquiredAt: new Date(connection.lastAcquiredAtMs).toISOString(),
+      ...(typeof connection.lastReleasedAtMs === "number"
+        ? { lastReleasedAt: new Date(connection.lastReleasedAtMs).toISOString() }
+        : {}),
+      refCount: connection.refCount
+    }));
   }
 
   private async closeConnection(

--- a/packages/core/src/healthCheck.ts
+++ b/packages/core/src/healthCheck.ts
@@ -1,5 +1,12 @@
 import type { BrowserContext, Page } from "playwright-core";
 import { inspectLinkedInSession } from "./auth/sessionInspection.js";
+import {
+  getLinkedInSessionFingerprint,
+  summarizeLinkedInSessionCookies,
+  type LinkedInSessionCookieMetadata
+} from "./auth/sessionStore.js";
+
+export const DEFAULT_SESSION_COOKIE_EXPIRY_WARNING_MS = 60 * 60_000;
 
 export interface BrowserHealthStatus {
   healthy: boolean;
@@ -13,6 +20,14 @@ export interface SessionHealthStatus {
   currentUrl: string;
   reason: string;
   checkedAt: string;
+  checkpointDetected: boolean;
+  cookieExpiringSoon: boolean;
+  loginWallDetected: boolean;
+  nextCookieExpiryAt: string | null;
+  rateLimited: boolean;
+  sessionCookieFingerprint: string | null;
+  sessionCookiePresent: boolean;
+  sessionCookies: LinkedInSessionCookieMetadata[];
 }
 
 export interface FullHealthStatus {
@@ -63,7 +78,31 @@ export async function checkLinkedInSession(
       waitUntil: "domcontentloaded"
     });
 
-    return inspectLinkedInSession(page);
+    const inspection = await inspectLinkedInSession(page);
+    const cookies = await context.cookies("https://www.linkedin.com");
+    const sessionCookies = summarizeLinkedInSessionCookies(cookies);
+    const nextCookieExpiryAt = sessionCookies.find(
+      (cookie) => cookie.expiresAt !== null && (cookie.expiresInMs ?? 0) > 0
+    )?.expiresAt ?? null;
+    const cookieExpiringSoon = sessionCookies.some(
+      (cookie) =>
+        cookie.expiresInMs !== null &&
+        cookie.expiresInMs > 0 &&
+        cookie.expiresInMs <= DEFAULT_SESSION_COOKIE_EXPIRY_WARNING_MS
+    );
+
+    return {
+      ...inspection,
+      cookieExpiringSoon,
+      nextCookieExpiryAt,
+      sessionCookieFingerprint:
+        sessionCookies.length > 0
+          ? getLinkedInSessionFingerprint({ cookies })
+          : null,
+      sessionCookiePresent:
+        inspection.sessionCookiePresent || sessionCookies.length > 0,
+      sessionCookies
+    };
   } catch (error) {
     const checkedAt = new Date().toISOString();
     const currentUrl = context.pages()[0]?.url() ?? "";
@@ -76,7 +115,15 @@ export async function checkLinkedInSession(
       authenticated: false,
       checkedAt,
       currentUrl,
-      reason
+      reason,
+      checkpointDetected: false,
+      cookieExpiringSoon: false,
+      loginWallDetected: false,
+      nextCookieExpiryAt: null,
+      rateLimited: false,
+      sessionCookieFingerprint: null,
+      sessionCookiePresent: false,
+      sessionCookies: []
     };
   }
 }

--- a/packages/core/src/keepAlive.ts
+++ b/packages/core/src/keepAlive.ts
@@ -1,9 +1,61 @@
 import { EventEmitter } from "node:events";
-import type { FullHealthStatus } from "./healthCheck.js";
-import { checkFullHealth } from "./healthCheck.js";
+import type { BrowserContext, Page } from "playwright-core";
+import type {
+  LinkedInBrowserStorageState,
+  RestoreStoredLinkedInSessionOptions,
+  SaveStoredLinkedInSessionOptions
+} from "./auth/sessionStore.js";
+import {
+  getLinkedInSessionFingerprint,
+  restoreLinkedInSessionCookies
+} from "./auth/sessionStore.js";
+import {
+  checkFullHealth,
+  DEFAULT_SESSION_COOKIE_EXPIRY_WARNING_MS,
+  type FullHealthStatus
+} from "./healthCheck.js";
 import type { ConnectionLease } from "./connectionPool.js";
 import { CDPConnectionPool } from "./connectionPool.js";
 import { humanize } from "./humanize.js";
+
+const DEFAULT_NETWORK_GRACE_PERIOD_MS = 5 * 60_000;
+const DEFAULT_NETWORK_RETRY_INTERVAL_MS = 30_000;
+const DEFAULT_IDLE_WARMUP_THRESHOLD_MS = 4 * 60 * 60_000;
+const DEFAULT_ACTIVITY_EVERY_HEALTHY_TICKS = 3;
+const DEFAULT_NIGHT_ACTIVITY_EVERY_HEALTHY_TICKS = 6;
+const DEFAULT_MAX_HEALTH_LOG_ENTRIES = 200;
+const DEFAULT_MAX_BACKUP_SESSIONS = 3;
+
+const DEFAULT_RECONNECT_ALERT_THRESHOLD = {
+  count: 3,
+  windowMs: 10 * 60_000
+} as const;
+
+const ACTIVITY_PATTERNS = [
+  "feed-scroll",
+  "notifications-peek",
+  "network-peek"
+] as const;
+
+interface SessionSnapshot {
+  capturedAt: string;
+  fingerprint: string;
+  nextCookieExpiryAt: string | null;
+  storageState: LinkedInBrowserStorageState;
+}
+
+interface KeepAliveSessionStoreLike {
+  restoreToContext(
+    context: BrowserContext,
+    sessionName?: string,
+    options?: RestoreStoredLinkedInSessionOptions
+  ): Promise<unknown>;
+  saveWithBackups(
+    sessionName: string,
+    storageState: LinkedInBrowserStorageState,
+    options?: SaveStoredLinkedInSessionOptions
+  ): Promise<unknown>;
+}
 
 export type KeepAliveEventType =
   | "healthy"
@@ -13,7 +65,20 @@ export type KeepAliveEventType =
   | "reconnect-success"
   | "reconnect-failed"
   | "dead"
-  | "activity";
+  | "activity"
+  | "alert"
+  | "cookie-refresh"
+  | "login-wall-detected"
+  | "manual-login-required"
+  | "network-interruption"
+  | "network-recovered"
+  | "session-persisted"
+  | "session-rotated"
+  | "soft-reauth-attempt"
+  | "soft-reauth-failed"
+  | "soft-reauth-success"
+  | "tab-cleanup"
+  | "warmup";
 
 export interface KeepAliveEvent {
   type: KeepAliveEventType;
@@ -21,15 +86,120 @@ export interface KeepAliveEvent {
   health?: FullHealthStatus | undefined;
   consecutiveFailures: number;
   detail?: string | undefined;
+  metadata?: Record<string, unknown> | undefined;
+}
+
+export interface KeepAliveAlertThresholds {
+  cookieExpiringWithinMs?: number;
+  reconnectsInWindow?: {
+    count: number;
+    windowMs: number;
+  };
+}
+
+export interface KeepAliveMetrics {
+  activeAlerts: string[];
+  authenticated: boolean;
+  backupSessionCount: number;
+  browserConnected: boolean;
+  browserHealthy: boolean;
+  consecutiveFailures: number;
+  currentReason: string;
+  currentUrl: string;
+  lastActivityAt?: string;
+  lastCookieRefreshAt?: string;
+  lastHealthyAt?: string;
+  lastLoginRequiredAt?: string;
+  lastSessionFingerprint?: string;
+  lastTickAt?: string;
+  lastWarmupAt?: string;
+  networkInterruptedAt?: string;
+  nextCookieExpiryAt: string | null;
+  reconnectCount: number;
+  reconnectCountInWindow: number;
+  sessionCookiePresent: boolean;
+  sessionUptimeMs: number;
+  startedAt?: string;
 }
 
 export interface KeepAliveOptions {
-  intervalMs?: number;
-  cdpUrl: string;
-  maxConsecutiveFailures?: number;
-  jitterMs?: number;
-  sessionRefreshEnabled?: boolean;
+  activityEveryHealthyTicks?: number;
   activitySimulationEnabled?: boolean;
+  alertThresholds?: KeepAliveAlertThresholds;
+  cdpUrl: string;
+  cookieRefreshLeadMs?: number;
+  idleWarmupThresholdMs?: number;
+  intervalMs?: number;
+  jitterMs?: number;
+  maxBackupSessions?: number;
+  maxConsecutiveFailures?: number;
+  maxHealthLogEntries?: number;
+  networkGracePeriodMs?: number;
+  networkRetryIntervalMs?: number;
+  nightActivityEveryHealthyTicks?: number;
+  nightHours?: {
+    endHour: number;
+    startHour: number;
+  };
+  sessionName?: string;
+  sessionRefreshEnabled?: boolean;
+  sessionStore?: KeepAliveSessionStoreLike;
+}
+
+function isNightHour(
+  hour: number,
+  nightHours: NonNullable<KeepAliveOptions["nightHours"]>
+): boolean {
+  if (nightHours.startHour === nightHours.endHour) {
+    return false;
+  }
+
+  if (nightHours.startHour < nightHours.endHour) {
+    return hour >= nightHours.startHour && hour < nightHours.endHour;
+  }
+
+  return hour >= nightHours.startHour || hour < nightHours.endHour;
+}
+
+function isTransientConnectionError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const normalized = error.message.toLowerCase();
+  return [
+    "browser has been closed",
+    "connection refused",
+    "eai_again",
+    "econnrefused",
+    "network",
+    "socket hang up",
+    "target closed",
+    "timed out",
+    "websocket"
+  ].some((token) => normalized.includes(token));
+}
+
+function millisecondsUntil(isoTimestamp: string | null | undefined): number | null {
+  if (!isoTimestamp) {
+    return null;
+  }
+
+  const timestampMs = Date.parse(isoTimestamp);
+  if (!Number.isFinite(timestampMs)) {
+    return null;
+  }
+
+  return timestampMs - Date.now();
+}
+
+async function getOrCreatePage(context: BrowserContext): Promise<Page> {
+  const existingPage = context.pages()[0];
+  if (existingPage) {
+    return existingPage;
+  }
+
+  return context.newPage();
 }
 
 export class SessionKeepAliveService extends EventEmitter {
@@ -38,13 +208,32 @@ export class SessionKeepAliveService extends EventEmitter {
   private tickInFlight = false;
   private consecutiveFailures = 0;
   private tickCount = 0;
+  private healthyTickCount = 0;
   private declaredDead = false;
+  private networkInterruptedAtMs: number | undefined;
+  private activityPatternIndex = 0;
+  private readonly eventLog: KeepAliveEvent[] = [];
+  private readonly reconnectTimestampsMs: number[] = [];
+  private readonly activeAlerts = new Set<string>();
+  private backupSessions: SessionSnapshot[] = [];
+  private metrics: KeepAliveMetrics = this.createInitialMetrics();
 
-  private readonly intervalMs: number;
-  private readonly maxConsecutiveFailures: number;
-  private readonly jitterMs: number;
-  private readonly sessionRefreshEnabled: boolean;
+  private readonly activityEveryHealthyTicks: number;
   private readonly activitySimulationEnabled: boolean;
+  private readonly alertThresholds: Required<KeepAliveAlertThresholds>;
+  private readonly cookieRefreshLeadMs: number;
+  private readonly idleWarmupThresholdMs: number;
+  private readonly intervalMs: number;
+  private readonly jitterMs: number;
+  private readonly maxBackupSessions: number;
+  private readonly maxConsecutiveFailures: number;
+  private readonly maxHealthLogEntries: number;
+  private readonly networkGracePeriodMs: number;
+  private readonly networkRetryIntervalMs: number;
+  private readonly nightActivityEveryHealthyTicks: number;
+  private readonly nightHours: NonNullable<KeepAliveOptions["nightHours"]>;
+  private readonly sessionName: string;
+  private readonly sessionRefreshEnabled: boolean;
 
   constructor(
     private readonly pool: CDPConnectionPool,
@@ -53,11 +242,49 @@ export class SessionKeepAliveService extends EventEmitter {
     super();
     this.on("error", () => undefined);
 
-    this.intervalMs = options.intervalMs ?? 300_000;
-    this.maxConsecutiveFailures = options.maxConsecutiveFailures ?? 5;
-    this.jitterMs = options.jitterMs ?? 30_000;
-    this.sessionRefreshEnabled = options.sessionRefreshEnabled ?? true;
+    this.activityEveryHealthyTicks = Math.max(
+      1,
+      options.activityEveryHealthyTicks ?? DEFAULT_ACTIVITY_EVERY_HEALTHY_TICKS
+    );
     this.activitySimulationEnabled = options.activitySimulationEnabled ?? true;
+    this.alertThresholds = {
+      cookieExpiringWithinMs:
+        options.alertThresholds?.cookieExpiringWithinMs ??
+        DEFAULT_SESSION_COOKIE_EXPIRY_WARNING_MS,
+      reconnectsInWindow:
+        options.alertThresholds?.reconnectsInWindow ??
+        DEFAULT_RECONNECT_ALERT_THRESHOLD
+    };
+    this.cookieRefreshLeadMs =
+      options.cookieRefreshLeadMs ?? DEFAULT_SESSION_COOKIE_EXPIRY_WARNING_MS;
+    this.idleWarmupThresholdMs =
+      options.idleWarmupThresholdMs ?? DEFAULT_IDLE_WARMUP_THRESHOLD_MS;
+    this.intervalMs = options.intervalMs ?? 300_000;
+    this.jitterMs = options.jitterMs ?? 30_000;
+    this.maxBackupSessions = Math.max(
+      1,
+      options.maxBackupSessions ?? DEFAULT_MAX_BACKUP_SESSIONS
+    );
+    this.maxConsecutiveFailures = options.maxConsecutiveFailures ?? 5;
+    this.maxHealthLogEntries = Math.max(
+      10,
+      options.maxHealthLogEntries ?? DEFAULT_MAX_HEALTH_LOG_ENTRIES
+    );
+    this.networkGracePeriodMs =
+      options.networkGracePeriodMs ?? DEFAULT_NETWORK_GRACE_PERIOD_MS;
+    this.networkRetryIntervalMs =
+      options.networkRetryIntervalMs ?? DEFAULT_NETWORK_RETRY_INTERVAL_MS;
+    this.nightActivityEveryHealthyTicks = Math.max(
+      1,
+      options.nightActivityEveryHealthyTicks ??
+        DEFAULT_NIGHT_ACTIVITY_EVERY_HEALTHY_TICKS
+    );
+    this.nightHours = options.nightHours ?? {
+      startHour: 0,
+      endHour: 6
+    };
+    this.sessionName = options.sessionName ?? "default";
+    this.sessionRefreshEnabled = options.sessionRefreshEnabled ?? true;
   }
 
   start(): void {
@@ -68,7 +295,15 @@ export class SessionKeepAliveService extends EventEmitter {
     this.running = true;
     this.consecutiveFailures = 0;
     this.tickCount = 0;
+    this.healthyTickCount = 0;
     this.declaredDead = false;
+    this.networkInterruptedAtMs = undefined;
+    this.activityPatternIndex = 0;
+    this.eventLog.length = 0;
+    this.reconnectTimestampsMs.length = 0;
+    this.activeAlerts.clear();
+    this.backupSessions = [];
+    this.metrics = this.createInitialMetrics(new Date().toISOString());
     this.scheduleNextTick();
   }
 
@@ -89,13 +324,64 @@ export class SessionKeepAliveService extends EventEmitter {
     return this.consecutiveFailures;
   }
 
+  getHealthLog(): KeepAliveEvent[] {
+    return [...this.eventLog];
+  }
+
+  getMetrics(): KeepAliveMetrics {
+    return {
+      ...this.metrics,
+      activeAlerts: [...this.activeAlerts],
+      backupSessionCount: this.backupSessions.length,
+      consecutiveFailures: this.consecutiveFailures,
+      reconnectCountInWindow: this.reconnectTimestampsMs.length,
+      sessionUptimeMs: this.getSessionUptimeMs()
+    };
+  }
+
+  private createInitialMetrics(startedAt?: string): KeepAliveMetrics {
+    return {
+      activeAlerts: [],
+      authenticated: false,
+      backupSessionCount: 0,
+      browserConnected: false,
+      browserHealthy: false,
+      consecutiveFailures: 0,
+      currentReason: "",
+      currentUrl: "",
+      nextCookieExpiryAt: null,
+      reconnectCount: 0,
+      reconnectCountInWindow: 0,
+      sessionCookiePresent: false,
+      sessionUptimeMs: 0,
+      ...(startedAt ? { startedAt } : {})
+    };
+  }
+
+  private getSessionUptimeMs(): number {
+    if (!this.metrics.startedAt || !this.metrics.lastHealthyAt) {
+      return this.metrics.sessionUptimeMs;
+    }
+
+    const startedAtMs = Date.parse(this.metrics.startedAt);
+    if (!Number.isFinite(startedAtMs)) {
+      return this.metrics.sessionUptimeMs;
+    }
+
+    return Math.max(0, Date.now() - startedAtMs);
+  }
+
   private scheduleNextTick(): void {
     if (!this.running) {
       return;
     }
 
-    const jitter = (Math.random() * 2 - 1) * this.jitterMs;
-    const delay = Math.max(1_000, this.intervalMs + jitter);
+    const usingRetryCadence = this.networkInterruptedAtMs !== undefined;
+    const jitter = usingRetryCadence ? 0 : (Math.random() * 2 - 1) * this.jitterMs;
+    const baseDelay = usingRetryCadence
+      ? this.networkRetryIntervalMs
+      : this.intervalMs;
+    const delay = Math.max(1_000, baseDelay + jitter);
 
     this.timer = setTimeout(() => {
       void this.runTick().finally(() => {
@@ -111,73 +397,45 @@ export class SessionKeepAliveService extends EventEmitter {
 
     this.tickInFlight = true;
     this.tickCount += 1;
+    this.metrics.lastTickAt = new Date().toISOString();
     let lease: ConnectionLease | undefined;
 
     try {
       lease = await this.pool.acquire(this.options.cdpUrl);
       const health = await checkFullHealth(lease.context);
-      this.processHealthResult(health, lease);
+      await this.processHealthResult(health, lease);
     } catch (error) {
-      this.handleTickError(error);
+      await this.handleTickError(error);
     } finally {
       lease?.release();
       this.tickInFlight = false;
     }
   }
 
-  private processHealthResult(
+  private async processHealthResult(
     health: FullHealthStatus,
     lease: ConnectionLease
-  ): void {
+  ): Promise<void> {
+    this.updateMetricsFromHealth(health);
+
     if (health.browser.healthy && health.session.authenticated) {
-      this.consecutiveFailures = 0;
-      this.declaredDead = false;
-
-      this.emitKeepAliveEvent({
-        type: "healthy",
-        health
-      });
-      // Backward-compat
-      this.emit("healthy", health);
-
-      // Activity simulation on every 3rd healthy tick
-      if (this.activitySimulationEnabled && this.tickCount % 3 === 0) {
-        void this.simulateActivity(lease);
-      }
+      await this.handleHealthyState(health, lease);
       return;
     }
 
     if (!health.browser.browserConnected) {
-      this.recordFailure();
-
       this.emitKeepAliveEvent({
         type: "browser-disconnected",
         health,
         detail: "Browser connection lost"
       });
-      // Backward-compat
       this.emit("browser-disconnected", health);
-
-      // Auto-reconnect: release current lease and re-acquire
-      void this.attemptReconnect();
+      await this.handleNetworkInterruption("Browser connection lost");
       return;
     }
 
     if (!health.session.authenticated) {
-      this.recordFailure();
-
-      this.emitKeepAliveEvent({
-        type: "session-expired",
-        health,
-        detail: "LinkedIn session expired"
-      });
-      // Backward-compat
-      this.emit("session-expired", health);
-
-      // Session refresh: navigate to feed to refresh cookies
-      if (this.sessionRefreshEnabled) {
-        void this.refreshSession(lease);
-      }
+      await this.handleUnauthenticatedState(health, lease);
       return;
     }
 
@@ -185,8 +443,179 @@ export class SessionKeepAliveService extends EventEmitter {
     this.emitError(new Error("Health check failed."));
   }
 
+  private updateMetricsFromHealth(health: FullHealthStatus): void {
+    this.metrics.authenticated = health.session.authenticated;
+    this.metrics.browserConnected = health.browser.browserConnected;
+    this.metrics.browserHealthy = health.browser.healthy;
+    this.metrics.currentReason = health.session.reason;
+    this.metrics.currentUrl = health.session.currentUrl;
+    this.metrics.nextCookieExpiryAt = health.session.nextCookieExpiryAt;
+    this.metrics.sessionCookiePresent = health.session.sessionCookiePresent;
+    this.metrics.sessionUptimeMs = this.getSessionUptimeMs();
+  }
+
+  private async handleHealthyState(
+    health: FullHealthStatus,
+    lease: ConnectionLease
+  ): Promise<void> {
+    this.healthyTickCount += 1;
+    this.consecutiveFailures = 0;
+    this.declaredDead = false;
+    this.metrics.consecutiveFailures = 0;
+    this.metrics.lastHealthyAt = new Date().toISOString();
+    this.metrics.sessionUptimeMs = this.getSessionUptimeMs();
+
+    this.emitKeepAliveEvent({
+      type: "healthy",
+      health
+    });
+    this.emit("healthy", health);
+
+    this.recoverFromNetworkInterruption(health);
+    await this.captureSessionSnapshot(lease, health);
+    await this.cleanupOrphanPages(lease);
+
+    if (this.sessionRefreshEnabled && this.shouldRefreshCookies(health)) {
+      await this.refreshSession(lease, "proactive");
+    }
+
+    if (this.activitySimulationEnabled && this.shouldSimulateActivity()) {
+      await this.maybeWarmup(lease);
+      await this.simulateActivity(lease);
+    }
+
+    this.evaluateAlerts();
+  }
+
+  private shouldRefreshCookies(health: FullHealthStatus): boolean {
+    const expiresInMs = millisecondsUntil(health.session.nextCookieExpiryAt);
+    return (
+      expiresInMs !== null &&
+      expiresInMs > 0 &&
+      expiresInMs <= this.cookieRefreshLeadMs
+    );
+  }
+
+  private shouldSimulateActivity(): boolean {
+    const cadence = isNightHour(new Date().getHours(), this.nightHours)
+      ? this.nightActivityEveryHealthyTicks
+      : this.activityEveryHealthyTicks;
+
+    return cadence > 0 && this.healthyTickCount % cadence === 0;
+  }
+
+  private async handleUnauthenticatedState(
+    health: FullHealthStatus,
+    lease: ConnectionLease
+  ): Promise<void> {
+    this.emitKeepAliveEvent({
+      type: "session-expired",
+      health,
+      detail: "LinkedIn session expired"
+    });
+    this.emit("session-expired", health);
+
+    if (health.session.loginWallDetected) {
+      this.emitKeepAliveEvent({
+        type: "login-wall-detected",
+        health,
+        detail: "LinkedIn login wall detected mid-session",
+        metadata: {
+          currentUrl: health.session.currentUrl,
+          reason: health.session.reason
+        }
+      });
+    }
+
+    let recovered = false;
+
+    if (
+      this.sessionRefreshEnabled &&
+      (health.session.sessionCookiePresent || this.shouldRefreshCookies(health))
+    ) {
+      recovered = await this.attemptSoftRefresh(lease, health);
+    }
+
+    if (!recovered) {
+      recovered = await this.restoreBackupSession(lease);
+    }
+
+    if (recovered) {
+      this.consecutiveFailures = 0;
+      this.declaredDead = false;
+      this.metrics.consecutiveFailures = 0;
+      return;
+    }
+
+    this.recordFailure();
+    this.metrics.lastLoginRequiredAt = new Date().toISOString();
+    this.emitKeepAliveEvent({
+      type: "manual-login-required",
+      health,
+      detail: "Manual LinkedIn login is required to continue",
+      metadata: {
+        currentUrl: health.session.currentUrl,
+        reason: health.session.reason,
+        nextCookieExpiryAt: health.session.nextCookieExpiryAt,
+        sessionCookiePresent: health.session.sessionCookiePresent,
+        whatWasHappening: health.session.loginWallDetected
+          ? "soft re-auth after LinkedIn login wall"
+          : "session recovery after authentication loss"
+      }
+    });
+  }
+
+  private async handleNetworkInterruption(detail: string): Promise<void> {
+    const firstInterruption = this.networkInterruptedAtMs === undefined;
+    if (firstInterruption) {
+      this.networkInterruptedAtMs = Date.now();
+      this.metrics.networkInterruptedAt = new Date(
+        this.networkInterruptedAtMs
+      ).toISOString();
+      this.emitKeepAliveEvent({
+        type: "network-interruption",
+        detail,
+        metadata: {
+          retryIntervalMs: this.networkRetryIntervalMs,
+          gracePeriodMs: this.networkGracePeriodMs
+        }
+      });
+    }
+
+    const recovered = await this.attemptReconnect();
+    if (recovered) {
+      return;
+    }
+
+    if (!this.isWithinNetworkGracePeriod()) {
+      this.recordFailure();
+    }
+  }
+
+  private isWithinNetworkGracePeriod(): boolean {
+    return (
+      this.networkInterruptedAtMs !== undefined &&
+      Date.now() - this.networkInterruptedAtMs < this.networkGracePeriodMs
+    );
+  }
+
+  private recoverFromNetworkInterruption(health: FullHealthStatus): void {
+    if (this.networkInterruptedAtMs === undefined) {
+      return;
+    }
+
+    this.emitKeepAliveEvent({
+      type: "network-recovered",
+      health,
+      detail: "Recovered from transient network interruption"
+    });
+    this.networkInterruptedAtMs = undefined;
+    delete this.metrics.networkInterruptedAt;
+  }
+
   private recordFailure(): void {
     this.consecutiveFailures += 1;
+    this.metrics.consecutiveFailures = this.consecutiveFailures;
 
     if (
       !this.declaredDead &&
@@ -200,7 +629,7 @@ export class SessionKeepAliveService extends EventEmitter {
     }
   }
 
-  private async attemptReconnect(): Promise<void> {
+  private async attemptReconnect(): Promise<boolean> {
     this.emitKeepAliveEvent({
       type: "reconnect-attempt",
       detail: "Attempting to reconnect to browser"
@@ -208,71 +637,449 @@ export class SessionKeepAliveService extends EventEmitter {
 
     let lease: ConnectionLease | undefined;
     try {
+      await this.pool.invalidate?.(this.options.cdpUrl);
       lease = await this.pool.acquire(this.options.cdpUrl);
       const health = await checkFullHealth(lease.context);
+      this.updateMetricsFromHealth(health);
 
       if (health.browser.healthy) {
+        this.reconnectTimestampsMs.push(Date.now());
+        this.trimReconnectWindow();
+        this.metrics.reconnectCount += 1;
+        this.metrics.reconnectCountInWindow = this.reconnectTimestampsMs.length;
         this.emitKeepAliveEvent({
           type: "reconnect-success",
           health,
-          detail: "Successfully reconnected to browser"
+          detail: health.session.authenticated
+            ? "Successfully reconnected to browser"
+            : "Reconnected to browser, but session still needs recovery"
         });
-      } else {
-        this.emitKeepAliveEvent({
-          type: "reconnect-failed",
-          health,
-          detail: "Reconnected but browser not healthy"
-        });
+
+        if (health.session.authenticated) {
+          this.consecutiveFailures = 0;
+          this.declaredDead = false;
+          this.metrics.lastHealthyAt = new Date().toISOString();
+          this.metrics.sessionUptimeMs = this.getSessionUptimeMs();
+          this.recoverFromNetworkInterruption(health);
+          await this.captureSessionSnapshot(lease, health);
+        }
+
+        this.evaluateAlerts();
+        return health.session.authenticated;
       }
-    } catch (error) {
-      const detail =
-        error instanceof Error ? error.message : "Unknown reconnect error";
+
       this.emitKeepAliveEvent({
         type: "reconnect-failed",
-        detail
+        health,
+        detail: "Reconnected, but browser is still unhealthy"
+      });
+    } catch (error) {
+      this.emitKeepAliveEvent({
+        type: "reconnect-failed",
+        detail:
+          error instanceof Error ? error.message : "Unknown reconnect error"
       });
     } finally {
       lease?.release();
     }
+
+    return false;
   }
 
-  private async refreshSession(lease: ConnectionLease): Promise<void> {
-    try {
-      const page = lease.context.pages()[0];
-      if (!page) {
-        return;
-      }
+  private async attemptSoftRefresh(
+    lease: ConnectionLease,
+    health: FullHealthStatus
+  ): Promise<boolean> {
+    this.emitKeepAliveEvent({
+      type: "soft-reauth-attempt",
+      health,
+      detail: "Attempting to recover the active session without manual login"
+    });
 
+    const refreshedHealth = await this.refreshSession(lease, "soft-reauth");
+    if (refreshedHealth?.session.authenticated) {
+      this.emitKeepAliveEvent({
+        type: "soft-reauth-success",
+        health: refreshedHealth,
+        detail: "Recovered the LinkedIn session without manual login"
+      });
+      return true;
+    }
+
+    this.emitKeepAliveEvent({
+      type: "soft-reauth-failed",
+      health: refreshedHealth ?? health,
+      detail: "Soft session refresh did not restore authentication"
+    });
+    return false;
+  }
+
+  private async refreshSession(
+    lease: ConnectionLease,
+    reason: "proactive" | "soft-reauth"
+  ): Promise<FullHealthStatus | null> {
+    try {
+      const page = await getOrCreatePage(lease.context);
       await page.goto("https://www.linkedin.com/feed/", {
         waitUntil: "domcontentloaded"
       });
 
+      this.metrics.lastCookieRefreshAt = new Date().toISOString();
+      if (reason === "proactive") {
+        this.emitKeepAliveEvent({
+          type: "cookie-refresh",
+          detail: "Proactively refreshed near-expiry LinkedIn session cookies"
+        });
+      }
+
+      const refreshedHealth = await checkFullHealth(lease.context);
+      this.updateMetricsFromHealth(refreshedHealth);
+      if (refreshedHealth.session.authenticated) {
+        this.metrics.lastHealthyAt = new Date().toISOString();
+        this.metrics.sessionUptimeMs = this.getSessionUptimeMs();
+        await this.captureSessionSnapshot(lease, refreshedHealth);
+      }
+
+      return refreshedHealth;
+    } catch {
+      return null;
+    }
+  }
+
+  private async captureSessionSnapshot(
+    lease: ConnectionLease,
+    health: FullHealthStatus
+  ): Promise<void> {
+    if (typeof lease.context.storageState !== "function") {
+      return;
+    }
+
+    const knownFingerprint = health.session.sessionCookieFingerprint;
+    const shouldCapture =
+      this.backupSessions.length === 0 ||
+      knownFingerprint === null ||
+      knownFingerprint === undefined ||
+      knownFingerprint !== this.metrics.lastSessionFingerprint ||
+      this.shouldRefreshCookies(health);
+
+    if (!shouldCapture) {
+      return;
+    }
+
+    try {
+      const storageState = await lease.context.storageState();
+      const fingerprint = getLinkedInSessionFingerprint(storageState);
+      const snapshot: SessionSnapshot = {
+        capturedAt: new Date().toISOString(),
+        fingerprint,
+        nextCookieExpiryAt: health.session.nextCookieExpiryAt,
+        storageState
+      };
+
+      const fingerprintChanged =
+        this.metrics.lastSessionFingerprint !== undefined &&
+        this.metrics.lastSessionFingerprint !== fingerprint;
+      this.metrics.lastSessionFingerprint = fingerprint;
+      this.backupSessions = [
+        snapshot,
+        ...this.backupSessions.filter(
+          (candidate) => candidate.fingerprint !== fingerprint
+        )
+      ].slice(0, this.maxBackupSessions);
+      this.metrics.backupSessionCount = this.backupSessions.length;
+
+      if (fingerprintChanged) {
+        this.emitKeepAliveEvent({
+          type: "session-rotated",
+          health,
+          detail: "LinkedIn rotated session tokens; refreshed backup state",
+          metadata: {
+            backupSessionCount: this.backupSessions.length,
+            nextCookieExpiryAt: health.session.nextCookieExpiryAt
+          }
+        });
+      }
+
+      if (this.options.sessionStore) {
+        await this.options.sessionStore.saveWithBackups(
+          this.sessionName,
+          storageState,
+          {
+            maxBackups: this.maxBackupSessions
+          }
+        );
+        this.emitKeepAliveEvent({
+          type: "session-persisted",
+          detail: `Persisted session snapshot for ${this.sessionName}`,
+          metadata: {
+            backupSessionCount: this.maxBackupSessions,
+            sessionName: this.sessionName
+          }
+        });
+      }
+    } catch {
+      // Snapshot capture is best-effort; failures should not break keepalive.
+    }
+  }
+
+  private async restoreBackupSession(lease: ConnectionLease): Promise<boolean> {
+    if (this.options.sessionStore) {
       this.emitKeepAliveEvent({
-        type: "activity",
-        detail: "Session refresh: navigated to feed"
+        type: "soft-reauth-attempt",
+        detail: `Attempting stored-session restore for ${this.sessionName}`,
+        metadata: {
+          sessionName: this.sessionName,
+          source: "session-store"
+        }
+      });
+
+      try {
+        await this.options.sessionStore.restoreToContext(
+          lease.context,
+          this.sessionName,
+          {
+            allowExpired: false,
+            maxBackups: this.maxBackupSessions
+          }
+        );
+        const restoredHealth = await checkFullHealth(lease.context);
+        this.updateMetricsFromHealth(restoredHealth);
+        if (restoredHealth.session.authenticated) {
+          await this.captureSessionSnapshot(lease, restoredHealth);
+          this.emitKeepAliveEvent({
+            type: "soft-reauth-success",
+            health: restoredHealth,
+            detail: `Recovered authentication from stored session ${this.sessionName}`,
+            metadata: {
+              source: "session-store"
+            }
+          });
+          return true;
+        }
+      } catch {
+        // Fall back to in-memory snapshots below.
+      }
+    }
+
+    for (const snapshot of this.backupSessions) {
+      this.emitKeepAliveEvent({
+        type: "soft-reauth-attempt",
+        detail: "Attempting in-memory session restore",
+        metadata: {
+          capturedAt: snapshot.capturedAt,
+          nextCookieExpiryAt: snapshot.nextCookieExpiryAt,
+          source: "memory"
+        }
+      });
+
+      try {
+        await restoreLinkedInSessionCookies(lease.context, snapshot.storageState);
+        const restoredHealth = await checkFullHealth(lease.context);
+        this.updateMetricsFromHealth(restoredHealth);
+        if (restoredHealth.session.authenticated) {
+          await this.captureSessionSnapshot(lease, restoredHealth);
+          this.emitKeepAliveEvent({
+            type: "soft-reauth-success",
+            health: restoredHealth,
+            detail: "Recovered authentication from in-memory backup session",
+            metadata: {
+              source: "memory",
+              capturedAt: snapshot.capturedAt
+            }
+          });
+          return true;
+        }
+      } catch {
+        // Continue through remaining snapshots.
+      }
+    }
+
+    return false;
+  }
+
+  private async maybeWarmup(lease: ConnectionLease): Promise<void> {
+    if (!this.metrics.lastActivityAt) {
+      return;
+    }
+
+    const lastActivityAtMs = Date.parse(this.metrics.lastActivityAt);
+    if (!Number.isFinite(lastActivityAtMs)) {
+      return;
+    }
+
+    if (Date.now() - lastActivityAtMs < this.idleWarmupThresholdMs) {
+      return;
+    }
+
+    try {
+      const page = await getOrCreatePage(lease.context);
+      await page.goto("https://www.linkedin.com/feed/", {
+        waitUntil: "domcontentloaded"
+      });
+      await humanize(page, { fast: true }).idle();
+      this.metrics.lastWarmupAt = new Date().toISOString();
+      this.emitKeepAliveEvent({
+        type: "warmup",
+        detail: "Performed a gentle session warmup after extended idle time"
       });
     } catch {
-      // Session refresh is best-effort; failures are not fatal
+      // Warmup is best-effort; failures should not break keepalive.
     }
   }
 
   private async simulateActivity(lease: ConnectionLease): Promise<void> {
     try {
-      const page = lease.context.pages()[0];
-      if (!page) {
-        return;
+      const page = await getOrCreatePage(lease.context);
+      const hp = humanize(page, { fast: true });
+      const pattern = ACTIVITY_PATTERNS[
+        this.activityPatternIndex % ACTIVITY_PATTERNS.length
+      ];
+      this.activityPatternIndex += 1;
+      let detail = "";
+
+      switch (pattern) {
+        case "feed-scroll": {
+          await page.goto("https://www.linkedin.com/feed/", {
+            waitUntil: "domcontentloaded"
+          });
+          await hp.scrollDown();
+          await hp.idle();
+          detail = "Rotated keepalive activity: scrolled the LinkedIn feed";
+          break;
+        }
+        case "notifications-peek": {
+          await page.goto("https://www.linkedin.com/notifications/", {
+            waitUntil: "domcontentloaded"
+          });
+          await hp.idle();
+          detail = "Rotated keepalive activity: checked the notifications page";
+          break;
+        }
+        case "network-peek": {
+          await page.goto("https://www.linkedin.com/mynetwork/", {
+            waitUntil: "domcontentloaded"
+          });
+          await hp.idle();
+          detail = "Rotated keepalive activity: viewed the network page";
+          break;
+        }
       }
 
-      const hp = humanize(page, { fast: true });
-      await hp.scrollDown();
-      await hp.idle();
-
+      this.metrics.lastActivityAt = new Date().toISOString();
       this.emitKeepAliveEvent({
         type: "activity",
-        detail: "Simulated user scroll activity"
+        detail,
+        metadata: {
+          pattern
+        }
       });
     } catch {
-      // Activity simulation is best-effort; failures are not fatal
+      // Activity simulation is best-effort; failures are not fatal.
+    }
+  }
+
+  private async cleanupOrphanPages(lease: ConnectionLease): Promise<void> {
+    const pages = lease.context.pages();
+    if (pages.length <= 1) {
+      return;
+    }
+
+    let closedCount = 0;
+    for (const page of pages.slice(1)) {
+      const currentUrl = page.url();
+      const looksOrphaned =
+        currentUrl.length === 0 ||
+        currentUrl === "about:blank" ||
+        currentUrl.startsWith("chrome-error://");
+      if (!looksOrphaned || typeof page.close !== "function") {
+        continue;
+      }
+
+      try {
+        await page.close();
+        closedCount += 1;
+      } catch {
+        // Keepalive should continue even if tab cleanup fails.
+      }
+    }
+
+    if (closedCount > 0) {
+      this.emitKeepAliveEvent({
+        type: "tab-cleanup",
+        detail: `Closed ${closedCount} orphaned page${closedCount === 1 ? "" : "s"}`,
+        metadata: {
+          closedCount,
+          remainingPages: Math.max(0, pages.length - closedCount)
+        }
+      });
+    }
+  }
+
+  private trimReconnectWindow(): void {
+    const windowMs = this.alertThresholds.reconnectsInWindow.windowMs;
+    const cutoffMs = Date.now() - windowMs;
+    while (
+      this.reconnectTimestampsMs.length > 0 &&
+      this.reconnectTimestampsMs[0] !== undefined &&
+      this.reconnectTimestampsMs[0] < cutoffMs
+    ) {
+      this.reconnectTimestampsMs.shift();
+    }
+  }
+
+  private evaluateAlerts(): void {
+    this.trimReconnectWindow();
+    this.metrics.reconnectCountInWindow = this.reconnectTimestampsMs.length;
+
+    const cookieExpiryMs = millisecondsUntil(this.metrics.nextCookieExpiryAt);
+    const cookieAlertActive =
+      cookieExpiryMs !== null &&
+      cookieExpiryMs > 0 &&
+      cookieExpiryMs <= this.alertThresholds.cookieExpiringWithinMs;
+    this.updateAlert(
+      "cookie-expiry",
+      cookieAlertActive,
+      "LinkedIn session cookie is approaching expiry",
+      {
+        expiresInMs: cookieExpiryMs,
+        nextCookieExpiryAt: this.metrics.nextCookieExpiryAt
+      }
+    );
+
+    const reconnectAlertActive =
+      this.reconnectTimestampsMs.length >= this.alertThresholds.reconnectsInWindow.count;
+    this.updateAlert(
+      "reconnect-burst",
+      reconnectAlertActive,
+      "Keepalive has needed repeated reconnects in a short window",
+      {
+        reconnectsInWindow: this.reconnectTimestampsMs.length,
+        windowMs: this.alertThresholds.reconnectsInWindow.windowMs
+      }
+    );
+  }
+
+  private updateAlert(
+    key: string,
+    active: boolean,
+    detail: string,
+    metadata: Record<string, unknown>
+  ): void {
+    if (active && !this.activeAlerts.has(key)) {
+      this.activeAlerts.add(key);
+      this.emitKeepAliveEvent({
+        type: "alert",
+        detail,
+        metadata: {
+          alertKey: key,
+          ...metadata
+        }
+      });
+      return;
+    }
+
+    if (!active) {
+      this.activeAlerts.delete(key);
     }
   }
 
@@ -285,13 +1092,26 @@ export class SessionKeepAliveService extends EventEmitter {
       consecutiveFailures: partial.consecutiveFailures ?? this.consecutiveFailures,
       type: partial.type,
       health: partial.health,
-      detail: partial.detail
+      detail: partial.detail,
+      metadata: partial.metadata
     };
+
+    this.eventLog.push(event);
+    if (this.eventLog.length > this.maxHealthLogEntries) {
+      this.eventLog.splice(0, this.eventLog.length - this.maxHealthLogEntries);
+    }
 
     this.emit("health-event", event);
   }
 
-  private handleTickError(error: unknown): void {
+  private async handleTickError(error: unknown): Promise<void> {
+    if (isTransientConnectionError(error)) {
+      await this.handleNetworkInterruption(
+        error instanceof Error ? error.message : "Transient network interruption"
+      );
+      return;
+    }
+
     this.recordFailure();
     this.emitError(error);
   }

--- a/packages/core/src/writeValidationRuntime.ts
+++ b/packages/core/src/writeValidationRuntime.ts
@@ -231,7 +231,9 @@ function toSessionStatus(inspection: LinkedInSessionInspection): SessionStatus {
   return {
     authenticated: inspection.authenticated,
     checkedAt: inspection.checkedAt,
+    checkpointDetected: inspection.checkpointDetected,
     currentUrl: inspection.currentUrl,
+    loginWallDetected: inspection.loginWallDetected,
     reason: inspection.reason
   };
 }


### PR DESCRIPTION
## Summary\n- harden keepalive session monitoring with proactive cookie expiry signals, login-wall detection, and richer session health metadata\n- persist and rotate encrypted session snapshots so keepalive can restore fresher cookies before falling back to manual login\n- recycle stale CDP connections earlier and expand unit coverage for keepalive, session storage, health checks, and connection stats\n\n## Validation\n- npm run typecheck\n- npm run lint\n- npm test\n- npm run build\n\nCloses #133