### PR TITLE
refactor: simplify typing simulation internals

### DIFF
--- a/packages/core/src/__tests__/humanize.test.ts
+++ b/packages/core/src/__tests__/humanize.test.ts
@@ -49,11 +49,9 @@ function createPageMock() {
   } as unknown as Page;
 
   return {
-    click,
     keyboard,
     operations,
     page,
-    scrollIntoViewIfNeeded,
     waitForTimeout
   };
 }
@@ -70,6 +68,18 @@ function getWaitCalls(waitForTimeout: ReturnType<typeof vi.fn>): number[] {
   return waitForTimeout.mock.calls.flatMap(([value]) =>
     typeof value === "number" ? [value] : []
   );
+}
+
+function getInternalOptions(humanizedPage: HumanizedPage) {
+  return Reflect.get(humanizedPage, "options") as {
+    baseDelay: number;
+    fast: boolean;
+    jitterRange: number;
+    typingDelayOverride: number | null;
+    typingJitterOverride: number | null;
+    typingProfile: string;
+    typingProfileOverrides: Partial<TypingProfile>;
+  };
 }
 
 function createStableTypingOptions(overrides: Partial<TypingProfile> = {}) {
@@ -148,19 +158,8 @@ describe("HumanizedPage options", () => {
   it("merges provided options with defaults", () => {
     const { page } = createPageMock();
     const humanizedPage = new HumanizedPage(page, { baseDelay: 950 });
-    const internal = humanizedPage as unknown as {
-      options: {
-        baseDelay: number;
-        fast: boolean;
-        jitterRange: number;
-        typingDelayOverride: number | null;
-        typingJitterOverride: number | null;
-        typingProfile: string;
-        typingProfileOverrides: Partial<TypingProfile>;
-      };
-    };
 
-    expect(internal.options).toEqual({
+    expect(getInternalOptions(humanizedPage)).toEqual({
       baseDelay: 950,
       fast: false,
       jitterRange: 1500,

--- a/packages/core/src/auth/session.ts
+++ b/packages/core/src/auth/session.ts
@@ -81,10 +81,6 @@ async function getPage(context: BrowserContext): Promise<Page> {
   return context.newPage();
 }
 
-function isRateLimited(url: string): boolean {
-  return isRateLimitedChallengeUrl(url);
-}
-
 async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -100,8 +96,6 @@ export class LinkedInAuthService {
   ) {}
 
   async status(options: SessionOptions = {}): Promise<SessionStatus> {
-    const cooldown = await isInRateLimitCooldown();
-
     const profileName = options.profileName ?? "default";
     const cdpUrl = options.cdpUrl ?? this.cdpUrl;
 
@@ -126,7 +120,12 @@ export class LinkedInAuthService {
       }
     );
 
-    if (!status.authenticated && cooldown.active && cooldown.state) {
+    if (status.authenticated) {
+      return status;
+    }
+
+    const cooldown = await isInRateLimitCooldown();
+    if (cooldown.active && cooldown.state) {
       return {
         ...status,
         reason: `${status.reason} Rate-limit cooldown is active until ${cooldown.state.rateLimitedUntil}.`,
@@ -187,29 +186,22 @@ export class LinkedInAuthService {
     const maxRetries = options.maxRetries ?? 3;
     const retryBaseDelayMs = options.retryBaseDelayMs ?? 30_000;
 
-    let lastResult: HeadlessLoginResult | undefined;
+    let result = await this.performHeadlessLogin(options);
+    if (!retryOnRateLimit || result.checkpointType !== "rate_limited") {
+      return result;
+    }
 
-    const attempts = retryOnRateLimit ? maxRetries + 1 : 1;
+    for (let attempt = 1; attempt <= maxRetries; attempt += 1) {
+      const backoffMs = retryBaseDelayMs * 2 ** (attempt - 1) + Math.random() * 5_000;
+      await sleep(backoffMs);
 
-    for (let attempt = 0; attempt < attempts; attempt++) {
-      if (attempt > 0 && lastResult?.checkpointType === "rate_limited") {
-        const backoffMs =
-          retryBaseDelayMs * Math.pow(2, attempt - 1) +
-          Math.random() * 5_000;
-        await sleep(backoffMs);
-      }
-
-      lastResult = await this.performHeadlessLogin(options);
-
-      if (
-        lastResult.checkpointType !== "rate_limited" ||
-        !retryOnRateLimit
-      ) {
-        return lastResult;
+      result = await this.performHeadlessLogin(options);
+      if (result.checkpointType !== "rate_limited") {
+        return result;
       }
     }
 
-    return lastResult!;
+    return result;
   }
 
   private async performHeadlessLogin(
@@ -248,17 +240,9 @@ export class LinkedInAuthService {
         }
 
         // Human-like typing for credentials
-        const hp = humanize(page, { fast: false });
-        await hp.type(
-          "input[name='session_key'], input#username",
-          options.email,
-          { profile: "careful" }
-        );
-        await hp.type(
-          "input[name='session_password'], input#password",
-          options.password,
-          { profile: "careful" }
-        );
+        const hp = humanize(page);
+        await hp.type("input[name='session_key'], input#username", options.email);
+        await hp.type("input[name='session_password'], input#password", options.password);
 
         const signInButton = page.locator(
           "button[type='submit'][data-litms-control-urn='login-submit'], button[type='submit']:has-text('Sign in')"
@@ -290,7 +274,7 @@ export class LinkedInAuthService {
 
           if (isCheckpoint) {
             // Rate limit detection — check before other checkpoint types
-            if (isRateLimited(page.url())) {
+            if (isRateLimitedChallengeUrl(page.url())) {
               const rateLimitState = await recordRateLimit();
               return {
                 authenticated: false,

--- a/packages/core/src/humanize.ts
+++ b/packages/core/src/humanize.ts
@@ -107,10 +107,6 @@ interface ResolvedHumanizeOptions {
   typingProfileOverrides: Partial<TypingProfile>;
 }
 
-interface ResolvedTypingProfile extends TypingProfile {
-  name: TypingProfileName;
-}
-
 interface KeyboardKeyGeometry {
   key: string;
   x: number;
@@ -120,10 +116,7 @@ interface KeyboardKeyGeometry {
 }
 
 interface TypingContext {
-  current: string;
-  previous: string | null;
   previousMeaningful: string | null;
-  next: string | null;
   isBurstWord: boolean;
   isRepeatedCharacter: boolean;
   isSentenceRestart: boolean;
@@ -236,6 +229,7 @@ export const TYPING_PROFILES = {
 } satisfies Record<TypingProfileName, TypingProfile>;
 
 const KEYBOARD_GEOMETRY = createKeyboardGeometry();
+const KEYBOARD_KEYS = Object.values(KEYBOARD_GEOMETRY);
 
 export const QWERTY_KEY_ADJACENCY_MAP = createQwertyAdjacencyMap();
 
@@ -269,21 +263,24 @@ function getKeyDistance(source: KeyboardKeyGeometry, target: KeyboardKeyGeometry
   return Math.hypot(source.x - target.x, source.y - target.y);
 }
 
+function getAdjacentKeyboardKeys(source: KeyboardKeyGeometry): KeyboardKeyGeometry[] {
+  return KEYBOARD_KEYS
+    .filter(
+      (target) =>
+        target.key !== source.key &&
+        Math.abs(source.x - target.x) <= ADJACENCY_HORIZONTAL_THRESHOLD &&
+        Math.abs(source.y - target.y) <= ADJACENCY_VERTICAL_THRESHOLD
+    )
+    .sort(
+      (left, right) =>
+        getKeyDistance(source, left) - getKeyDistance(source, right) ||
+        left.key.localeCompare(right.key)
+    );
+}
+
 function createQwertyAdjacencyMap(): Readonly<Record<string, readonly string[]>> {
   const entries = Object.values(KEYBOARD_GEOMETRY).map((source) => {
-    const adjacent = Object.values(KEYBOARD_GEOMETRY)
-      .filter(
-        (target) =>
-          target.key !== source.key &&
-          Math.abs(source.x - target.x) <= ADJACENCY_HORIZONTAL_THRESHOLD &&
-          Math.abs(source.y - target.y) <= ADJACENCY_VERTICAL_THRESHOLD
-      )
-      .sort(
-        (left, right) =>
-          getKeyDistance(source, left) - getKeyDistance(source, right) ||
-          left.key.localeCompare(right.key)
-      )
-      .map((target) => target.key);
+    const adjacent = getAdjacentKeyboardKeys(source).map((target) => target.key);
 
     return [source.key, Object.freeze(adjacent)] as const;
   });
@@ -312,24 +309,16 @@ function createWeightedCandidate(
 function createWeightedQwertyAdjacencyMap(): Readonly<
   Record<string, readonly AdjacentTypoCandidate[]>
 > {
-  const entries = Object.entries(QWERTY_KEY_ADJACENCY_MAP).map(([key, adjacent]) => {
-    const source = KEYBOARD_GEOMETRY[key];
-    if (!source) {
-      return [key, Object.freeze([])] as const;
-    }
-
-    const weighted = adjacent
-      .flatMap((adjacentKey) => {
-        const target = KEYBOARD_GEOMETRY[adjacentKey];
-        return target ? [createWeightedCandidate(source, target)] : [];
-      })
+  const entries = Object.values(KEYBOARD_GEOMETRY).map((source) => {
+    const weighted = getAdjacentKeyboardKeys(source)
+      .map((target) => createWeightedCandidate(source, target))
       .sort(
         (left, right) =>
           right.weight - left.weight ||
           left.key.localeCompare(right.key)
       );
 
-    return [key, Object.freeze(weighted)] as const;
+    return [source.key, Object.freeze(weighted)] as const;
   });
 
   return Object.freeze(
@@ -390,12 +379,7 @@ export function pickAdjacentTypoCharacter(
     }
   }
 
-  const fallbackCandidate = candidates[candidates.length - 1];
-  if (!fallbackCandidate) {
-    return null;
-  }
-
-  return applyCharacterCase(fallbackCandidate.key, character);
+  return applyCharacterCase(candidates[candidates.length - 1]!.key, character);
 }
 
 export class HumanizedPage {
@@ -509,23 +493,21 @@ export class HumanizedPage {
         continue;
       }
 
-      await this.maybePauseBeforeCharacter(characters.length, context, profile);
+      await this.maybePauseBeforeCharacter(characters.length, index, context, profile);
 
-      if (this.shouldMissShift(character, profile)) {
-        await this.typeLiteralCharacter(character.toLowerCase(), profile);
-        await this.correctCharacter(character, previousCommittedCharacter, profile, {
-          allowDoubleBackspace: false
-        });
+      const missedShift =
+        isUppercaseLetter(character) && this.shouldTrigger(profile.shiftMissRate);
+      const mistypedCharacter = missedShift
+        ? character.toLowerCase()
+        : this.chooseTypoCharacter(character, profile);
+
+      if (mistypedCharacter === null) {
+        await this.typeLiteralCharacter(character, profile);
       } else {
-        const typoCharacter = this.chooseTypoCharacter(character, profile);
-        if (typoCharacter !== null) {
-          await this.typeLiteralCharacter(typoCharacter, profile);
-          await this.correctCharacter(character, previousCommittedCharacter, profile, {
-            allowDoubleBackspace: true
-          });
-        } else {
-          await this.typeLiteralCharacter(character, profile);
-        }
+        await this.typeLiteralCharacter(mistypedCharacter, profile);
+        await this.correctCharacter(character, previousCommittedCharacter, profile, {
+          allowDoubleBackspace: !missedShift
+        });
       }
 
       previousCommittedCharacter = character;
@@ -543,21 +525,17 @@ export class HumanizedPage {
 
   /** Randomly idle — used between major operations */
   async idle(): Promise<void> {
-    const idleTime = 1000 + Math.random() * 3000;
-    if (this.options.fast) {
-      await this.page.waitForTimeout(200 + Math.random() * 300);
-      return;
-    }
-
+    const idleTime = this.options.fast
+      ? 200 + Math.random() * 300
+      : 1000 + Math.random() * 3000;
     await this.page.waitForTimeout(idleTime);
   }
 
-  private resolveTypingProfile(options?: HumanizedTypingOptions): ResolvedTypingProfile {
+  private resolveTypingProfile(options?: HumanizedTypingOptions): TypingProfile {
     const name = options?.profile ?? this.options.typingProfile;
     const baseProfile = TYPING_PROFILES[name];
 
     return {
-      name,
       ...baseProfile,
       ...(this.options.typingDelayOverride === null
         ? {}
@@ -582,15 +560,9 @@ export class HumanizedPage {
       const currentIsWordCharacter = normalizedCurrent !== null;
 
       return {
-        current,
-        previous,
         previousMeaningful,
-        next,
         isBurstWord: burstWordIndexes.has(index),
-        isRepeatedCharacter:
-          currentIsWordCharacter &&
-          normalizedCurrent !== null &&
-          normalizedCurrent === normalizedPrevious,
+        isRepeatedCharacter: currentIsWordCharacter && normalizedCurrent === normalizedPrevious,
         isSentenceRestart:
           previousMeaningful !== null && /[.!?]/u.test(previousMeaningful),
         isWhitespace: isWhitespaceCharacter(current),
@@ -649,7 +621,7 @@ export class HumanizedPage {
 
   private computeCharacterDelay(
     context: TypingContext,
-    profile: ResolvedTypingProfile
+    profile: TypingProfile
   ): number {
     const jitter = profile.charDelayJitterMs > 0 ? Math.random() * profile.charDelayJitterMs : 0;
     let delay = profile.baseCharDelayMs + jitter;
@@ -679,13 +651,9 @@ export class HumanizedPage {
     return Math.max(0, delay);
   }
 
-  private shouldMissShift(character: string, profile: ResolvedTypingProfile): boolean {
-    return isUppercaseLetter(character) && this.shouldTrigger(profile.shiftMissRate);
-  }
-
   private chooseTypoCharacter(
     character: string,
-    profile: ResolvedTypingProfile
+    profile: TypingProfile
   ): string | null {
     if (normalizeTypingCharacter(character) === null || !this.shouldTrigger(profile.typoRate)) {
       return null;
@@ -696,10 +664,11 @@ export class HumanizedPage {
 
   private async maybePauseBeforeCharacter(
     totalCharacters: number,
+    characterIndex: number,
     context: TypingContext,
-    profile: ResolvedTypingProfile
+    profile: TypingProfile
   ): Promise<void> {
-    if (totalCharacters < 5 || !context.isWordStart || context.previous === null) {
+    if (totalCharacters < 5 || characterIndex === 0 || !context.isWordStart) {
       return;
     }
 
@@ -720,7 +689,7 @@ export class HumanizedPage {
   private async correctCharacter(
     intendedCharacter: string,
     previousCommittedCharacter: string | null,
-    profile: ResolvedTypingProfile,
+    profile: TypingProfile,
     options: { allowDoubleBackspace: boolean }
   ): Promise<void> {
     await this.page.waitForTimeout(this.sampleRange(profile.correctionPauseRange));
@@ -747,7 +716,7 @@ export class HumanizedPage {
 
   private async typeLiteralCharacter(
     character: string,
-    profile: ResolvedTypingProfile
+    profile: TypingProfile
   ): Promise<void> {
     if (character.length === 0) {
       return;


### PR DESCRIPTION
## Summary
- simplify the `HumanizedPage` typing flow by flattening typo and shift correction handling
- reuse adjacency lookup logic and remove dead internal state in `humanize.ts`
- drop redundant auth typing overrides and clean up the humanize unit test internals

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #172
