### PR TITLE
fix: polish keepalive CLI UX and guidance

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -138,6 +138,18 @@ import {
   type SchedulerStatusReport,
   type SchedulerStopReport
 } from "../schedulerOutput.js";
+import {
+  formatKeepAliveError,
+  formatKeepAliveStartReport,
+  formatKeepAliveStatusReport,
+  formatKeepAliveStopReport,
+  resolveKeepAliveOutputMode,
+  type KeepAliveOutputMode,
+  type KeepAliveRecentEvent,
+  type KeepAliveStartReport,
+  type KeepAliveStatusReport,
+  type KeepAliveStopReport
+} from "../keepAliveOutput.js";
 
 const cliPrivacyConfig = resolvePrivacyConfig();
 const SELECTOR_AUDIT_DOC_PATH = "docs/selector-audit.md";
@@ -741,6 +753,7 @@ interface KeepAliveState {
   maxConsecutiveFailures: number;
   consecutiveFailures: number;
   lastTickAt?: string;
+  lastCheckStartedAt?: string;
   lastHealthyAt?: string;
   authenticated?: boolean;
   browserHealthy?: boolean;
@@ -748,6 +761,7 @@ interface KeepAliveState {
   reason?: string;
   lastError?: string;
   cdpUrl?: string;
+  healthCheckInProgress?: boolean;
   stoppedAt?: string;
 }
 
@@ -1023,6 +1037,69 @@ async function appendKeepAliveEvent(
   const files = getKeepAliveFiles(profileName);
   await ensureKeepAliveDir(files);
   await appendFile(files.logPath, `${JSON.stringify(event)}\n`, "utf8");
+}
+
+function isRecordValue(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asKeepAliveRecentEvent(value: unknown): KeepAliveRecentEvent | null {
+  if (!isRecordValue(value)) {
+    return null;
+  }
+
+  const ts = value.ts;
+  const event = value.event;
+  if (
+    typeof ts !== "string" ||
+    ts.trim().length === 0 ||
+    typeof event !== "string" ||
+    event.trim().length === 0
+  ) {
+    return null;
+  }
+
+  return {
+    ...value,
+    ts,
+    event
+  } as KeepAliveRecentEvent;
+}
+
+async function readKeepAliveRecentEvents(
+  profileName: string,
+  limit: number = 5
+): Promise<KeepAliveRecentEvent[]> {
+  const files = getKeepAliveFiles(profileName);
+
+  try {
+    const raw = await readFile(files.logPath, "utf8");
+    const events = raw
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .slice(-limit)
+      .map((line) => {
+        try {
+          return asKeepAliveRecentEvent(JSON.parse(line) as unknown);
+        } catch {
+          return null;
+        }
+      })
+      .filter((event): event is KeepAliveRecentEvent => event !== null);
+
+    return events;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return [];
+    }
+
+    throw error;
+  }
 }
 
 async function readSchedulerPid(profileName: string): Promise<number | null> {
@@ -1662,6 +1739,9 @@ async function captureStoredSession(input: {
   writeCliNotice(
     "Sign in manually. The browser closes automatically after the authenticated session is stored."
   );
+  writeCliNotice(
+    "Leave the LinkedIn window open after sign-in until the CLI confirms the session was captured. Press Ctrl+C if you need to cancel."
+  );
 
   return captureLinkedInSession({
     sessionName: input.sessionName,
@@ -1915,31 +1995,185 @@ async function runRateLimitStatus(clear: boolean): Promise<void> {
   printJson(status);
 }
 
+interface KeepAliveCliOutputOptions {
+  outputMode: KeepAliveOutputMode;
+  quiet: boolean;
+  verbose: boolean;
+}
+
+function emitKeepAliveStartReport(
+  report: KeepAliveStartReport,
+  options: KeepAliveCliOutputOptions
+): void {
+  if (options.outputMode === "json") {
+    printJson(report);
+    return;
+  }
+
+  console.log(
+    formatKeepAliveStartReport(
+      redactStructuredValue(report, cliPrivacyConfig, "cli") as KeepAliveStartReport,
+      {
+        quiet: options.quiet,
+        verbose: options.verbose
+      }
+    )
+  );
+}
+
+function emitKeepAliveStatusReport(
+  report: KeepAliveStatusReport,
+  options: KeepAliveCliOutputOptions
+): void {
+  if (options.outputMode === "json") {
+    printJson(report);
+    return;
+  }
+
+  console.log(
+    formatKeepAliveStatusReport(
+      redactStructuredValue(report, cliPrivacyConfig, "cli") as KeepAliveStatusReport,
+      {
+        quiet: options.quiet,
+        verbose: options.verbose
+      }
+    )
+  );
+}
+
+function emitKeepAliveStopReport(
+  report: KeepAliveStopReport,
+  options: KeepAliveCliOutputOptions
+): void {
+  if (options.outputMode === "json") {
+    printJson(report);
+    return;
+  }
+
+  console.log(
+    formatKeepAliveStopReport(
+      redactStructuredValue(report, cliPrivacyConfig, "cli") as KeepAliveStopReport,
+      {
+        quiet: options.quiet,
+        verbose: options.verbose
+      }
+    )
+  );
+}
+
+function writeKeepAliveProgressNotice(
+  outputMode: KeepAliveOutputMode,
+  quiet: boolean,
+  message: string
+): void {
+  if (outputMode === "human" && !quiet) {
+    writeCliNotice(message);
+  }
+}
+
+function warnAboutExternalCdpDaemonSession(): void {
+  writeCliWarning("--cdp-url attaches keepalive to an existing browser session.");
+  writeCliNotice("The daemon will share cookies and session state with that browser until you stop it.");
+  writeCliNotice("For an isolated tool-owned profile, omit --cdp-url.");
+}
+
+function assertKeepAliveVerbosityOptions(input: {
+  quiet?: boolean;
+  verbose?: boolean;
+}): void {
+  if (input.quiet && input.verbose) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      'Choose either "--quiet" or "--verbose", not both.'
+    );
+  }
+}
+
+async function runKeepAliveCliAction(
+  input: { json?: boolean; quiet?: boolean; verbose?: boolean },
+  action: (options: KeepAliveCliOutputOptions) => Promise<void>
+): Promise<void> {
+  const options: KeepAliveCliOutputOptions = {
+    outputMode: resolveKeepAliveOutputMode(input, Boolean(stdout.isTTY)),
+    quiet: Boolean(input.quiet),
+    verbose: Boolean(input.verbose)
+  };
+
+  try {
+    assertKeepAliveVerbosityOptions(input);
+    await action(options);
+  } catch (error) {
+    if (options.outputMode === "json") {
+      throw error;
+    }
+
+    process.stderr.write(
+      `${formatKeepAliveError(toLinkedInAssistantErrorPayload(error, cliPrivacyConfig), {
+        quiet: options.quiet
+      })}\n`
+    );
+    process.exitCode = 1;
+  }
+}
+
+async function buildKeepAliveStatusReport(
+  profileName: string
+): Promise<KeepAliveStatusReport> {
+  const normalizedProfileName = coerceProfileName(profileName);
+  const pid = await readKeepAlivePid(normalizedProfileName);
+  const state = await readKeepAliveState(normalizedProfileName);
+  const running = typeof pid === "number" ? isProcessRunning(pid) : false;
+  const files = getKeepAliveFiles(normalizedProfileName);
+
+  return {
+    profile_name: normalizedProfileName,
+    running,
+    pid: typeof pid === "number" ? pid : null,
+    state,
+    stale_pid_file: Boolean(pid && !running),
+    state_path: files.statePath,
+    log_path: files.logPath,
+    recent_events: await readKeepAliveRecentEvents(normalizedProfileName)
+  };
+}
+
 async function runKeepAliveStart(input: {
   profileName: string;
   intervalSeconds: number;
   jitterSeconds: number;
   maxConsecutiveFailures: number;
-}, cdpUrl?: string): Promise<void> {
+}, options: KeepAliveCliOutputOptions, cdpUrl?: string): Promise<void> {
   const profileName = coerceProfileName(input.profileName);
+  const files = getKeepAliveFiles(profileName);
   const existingPid = await readKeepAlivePid(profileName);
   if (existingPid && isProcessRunning(existingPid)) {
     const currentState = await readKeepAliveState(profileName);
-    printJson({
+    emitKeepAliveStartReport({
       started: false,
       reason: "Keepalive daemon is already running for this profile.",
       profile_name: profileName,
       pid: existingPid,
-      state: currentState
-    });
+      state: currentState,
+      state_path: files.statePath,
+      log_path: files.logPath
+    }, options);
     return;
   }
 
+  const recoveredStalePid = Boolean(existingPid && !isProcessRunning(existingPid));
   if (existingPid && !isProcessRunning(existingPid)) {
     await removeKeepAlivePid(profileName);
   }
 
   maybeWarnAboutSelectorLocaleConfig(cliSelectorLocale);
+  if (cdpUrl) {
+    warnAboutExternalCdpDaemonSession();
+  }
+  writeKeepAliveProgressNotice(
+    options.outputMode,
+    options.quiet,
+    `Starting keepalive daemon for profile ${profileName}.`
+  );
 
   const cliEntrypoint = resolveKeepAliveCliEntrypoint();
   if (!cliEntrypoint) {
@@ -1994,18 +2228,28 @@ async function runKeepAliveStart(input: {
     jitterMs: input.jitterSeconds * 1_000,
     maxConsecutiveFailures: input.maxConsecutiveFailures,
     consecutiveFailures: 0,
+    healthCheckInProgress: false,
     ...(cdpUrl ? { cdpUrl } : {})
   };
 
   await writeKeepAlivePid(profileName, daemon.pid);
   await writeKeepAliveState(profileName, initialState);
 
-  printJson({
+  writeKeepAliveProgressNotice(
+    options.outputMode,
+    options.quiet,
+    "The first session health check will continue in the background; use `linkedin keepalive status` to inspect it."
+  );
+
+  emitKeepAliveStartReport({
     started: true,
     profile_name: profileName,
     pid: daemon.pid,
-    state_path: getKeepAliveFiles(profileName).statePath
-  });
+    state: initialState,
+    state_path: files.statePath,
+    log_path: files.logPath,
+    ...(recoveredStalePid ? { recovered_stale_pid: true } : {})
+  }, options);
 }
 
 function resolveKeepAliveCliEntrypoint(): string | undefined {
@@ -2025,32 +2269,31 @@ function resolveKeepAliveCliEntrypoint(): string | undefined {
   return process.argv[1];
 }
 
-async function runKeepAliveStatus(profileName: string): Promise<void> {
-  const normalizedProfileName = coerceProfileName(profileName);
-  const pid = await readKeepAlivePid(normalizedProfileName);
-  const state = await readKeepAliveState(normalizedProfileName);
-  const running = typeof pid === "number" ? isProcessRunning(pid) : false;
-
-  printJson({
-    profile_name: normalizedProfileName,
-    running,
-    pid,
-    state,
-    stale_pid_file: Boolean(pid && !running)
-  });
+async function runKeepAliveStatus(
+  profileName: string,
+  options: KeepAliveCliOutputOptions
+): Promise<void> {
+  emitKeepAliveStatusReport(await buildKeepAliveStatusReport(profileName), options);
 }
 
-async function runKeepAliveStop(profileName: string): Promise<void> {
+async function runKeepAliveStop(
+  profileName: string,
+  options: KeepAliveCliOutputOptions
+): Promise<void> {
   const normalizedProfileName = coerceProfileName(profileName);
+  const files = getKeepAliveFiles(normalizedProfileName);
   const pid = await readKeepAlivePid(normalizedProfileName);
   const previousState = await readKeepAliveState(normalizedProfileName);
 
   if (!pid) {
-    printJson({
+    emitKeepAliveStopReport({
       stopped: false,
       profile_name: normalizedProfileName,
-      reason: "No keepalive daemon pid file found."
-    });
+      reason: "No keepalive daemon is currently running for this profile.",
+      state: previousState,
+      state_path: files.statePath,
+      log_path: files.logPath
+    }, options);
     return;
   }
 
@@ -2066,14 +2309,23 @@ async function runKeepAliveStop(profileName: string): Promise<void> {
         lastError: "Recovered from stale pid file."
       });
     }
-    printJson({
+    emitKeepAliveStopReport({
       stopped: true,
       profile_name: normalizedProfileName,
       pid,
-      reason: "Recovered stale keepalive pid file."
-    });
+      reason: "Removed a stale keepalive PID file for this profile.",
+      state: await readKeepAliveState(normalizedProfileName),
+      state_path: files.statePath,
+      log_path: files.logPath
+    }, options);
     return;
   }
+
+  writeKeepAliveProgressNotice(
+    options.outputMode,
+    options.quiet,
+    `Stopping keepalive daemon for profile ${normalizedProfileName}.`
+  );
 
   try {
     process.kill(pid, "SIGTERM");
@@ -2117,12 +2369,19 @@ async function runKeepAliveStop(profileName: string): Promise<void> {
     });
   }
 
-  printJson({
+  const nextState = await readKeepAliveState(normalizedProfileName);
+  emitKeepAliveStopReport({
     stopped: true,
     profile_name: normalizedProfileName,
     pid,
-    forced: running
-  });
+    forced: running,
+    reason: running
+      ? "Keepalive daemon did not exit after SIGTERM, so it was force-stopped."
+      : "Keepalive daemon exited cleanly.",
+    state: nextState,
+    state_path: files.statePath,
+    log_path: files.logPath
+  }, options);
 }
 
 async function runKeepAliveDaemon(input: {
@@ -2152,6 +2411,7 @@ async function runKeepAliveDaemon(input: {
     jitterMs: input.jitterSeconds * 1_000,
     maxConsecutiveFailures: input.maxConsecutiveFailures,
     consecutiveFailures: 0,
+    healthCheckInProgress: false,
     ...(cdpUrl ? { cdpUrl } : {})
   };
 
@@ -2171,15 +2431,35 @@ async function runKeepAliveDaemon(input: {
   try {
     while (!stopRequested) {
       const tickAt = new Date().toISOString();
+      const currentState = (await readKeepAliveState(profileName)) ?? initialState;
+      const inProgressState: KeepAliveState = {
+        ...currentState,
+        pid: process.pid,
+        profileName,
+        updatedAt: tickAt,
+        intervalMs: input.intervalSeconds * 1_000,
+        jitterMs: input.jitterSeconds * 1_000,
+        maxConsecutiveFailures: input.maxConsecutiveFailures,
+        lastCheckStartedAt: tickAt,
+        healthCheckInProgress: true
+      };
+
+      await writeKeepAliveState(profileName, inProgressState);
+      await appendKeepAliveEvent(profileName, {
+        ts: tickAt,
+        event: "keepalive.tick.started",
+        profile_name: profileName,
+        interval_ms: input.intervalSeconds * 1_000,
+        jitter_ms: input.jitterSeconds * 1_000
+      });
 
       try {
         const health = await runtime.healthCheck({ profileName });
         const healthy = health.browser.healthy && health.session.authenticated;
         consecutiveFailures = healthy ? 0 : consecutiveFailures + 1;
 
-        const priorState = (await readKeepAliveState(profileName)) ?? initialState;
         const nextState: KeepAliveState = {
-          ...priorState,
+          ...inProgressState,
           pid: process.pid,
           profileName,
           updatedAt: tickAt,
@@ -2195,7 +2475,8 @@ async function runKeepAliveDaemon(input: {
           authenticated: health.session.authenticated,
           browserHealthy: health.browser.healthy,
           currentUrl: health.session.currentUrl,
-          reason: health.session.reason
+          reason: health.session.reason,
+          healthCheckInProgress: false
         };
         if (healthy) {
           nextState.lastHealthyAt = tickAt;
@@ -2223,7 +2504,7 @@ async function runKeepAliveDaemon(input: {
         }
 
         const nextState: KeepAliveState = {
-          ...(await readKeepAliveState(profileName) ?? initialState),
+          ...inProgressState,
           pid: process.pid,
           profileName,
           updatedAt: tickAt,
@@ -2236,7 +2517,8 @@ async function runKeepAliveDaemon(input: {
           maxConsecutiveFailures: input.maxConsecutiveFailures,
           consecutiveFailures,
           lastTickAt: tickAt,
-          lastError: message
+          lastError: message,
+          healthCheckInProgress: false
         };
         await writeKeepAliveState(profileName, nextState);
         await appendKeepAliveEvent(profileName, {
@@ -2278,6 +2560,7 @@ async function runKeepAliveDaemon(input: {
       profileName,
       status: "stopped",
       updatedAt: now,
+      healthCheckInProgress: false,
       stoppedAt: now
     });
     await appendKeepAliveEvent(profileName, {
@@ -5096,6 +5379,7 @@ export function createCliProgram(): Command {
           "  - opens a dedicated browser window for manual login only",
           "  - stores Playwright session state encrypted at rest",
           "  - never prints cookies or storage contents",
+          "  - keep the LinkedIn window open until the CLI confirms capture",
           "",
           "Examples:",
           "  linkedin auth session",
@@ -5497,11 +5781,31 @@ export function createCliProgram(): Command {
 
   const keepAliveCommand = program
     .command("keepalive")
-    .description("Run and manage a background session keepalive daemon");
+    .description(
+      "Manage the local session keepalive daemon that records background LinkedIn health checks"
+    )
+    .addHelpText(
+      "after",
+      [
+        "",
+        "Interactive terminals default to human-readable keepalive summaries.",
+        "Use --json for automation or to inspect the structured daemon state directly.",
+        "Use --verbose for recent daemon events and extra session diagnostics.",
+        "Use --quiet for a concise human summary and to suppress progress notices.",
+        "",
+        "Examples:",
+        "  linkedin keepalive start --profile default",
+        "  linkedin keepalive status --profile default --verbose",
+        "  linkedin keepalive stop --profile default",
+        "  linkedin keepalive status --profile smoke --json"
+      ].join("\n")
+    );
 
   keepAliveCommand
     .command("start")
-    .description("Start keepalive daemon for a profile")
+    .description(
+      "Start the local keepalive daemon for a profile and begin background session health checks"
+    )
     .option("-p, --profile <profile>", "Profile name", "default")
     .option(
       "--interval-seconds <seconds>",
@@ -5518,49 +5822,110 @@ export function createCliProgram(): Command {
       "Mark daemon degraded after this many consecutive failures",
       "5"
     )
+    .option("--json", "Print the structured keepalive payload", false)
+    .option("--verbose", "Show extra diagnostics in human-readable output", false)
+    .option("--quiet", "Print a concise human-readable summary", false)
+    .addHelpText(
+      "after",
+      [
+        "",
+        "The daemon writes PID, state, and event-log files under the keepalive directory.",
+        "Human output shows a startup summary and reminds you how to inspect the first background health checks.",
+        "Use --quiet if you only need a compact confirmation message."
+      ].join("\n")
+    )
     .action(
       async (options: {
         profile: string;
         intervalSeconds: string;
         jitterSeconds: string;
         maxConsecutiveFailures: string;
+        json: boolean;
+        quiet: boolean;
+        verbose: boolean;
       }) => {
-        await runKeepAliveStart(
-          {
-            profileName: options.profile,
-            intervalSeconds: coercePositiveInt(
-              options.intervalSeconds,
-              "interval-seconds"
-            ),
-            jitterSeconds: coerceNonNegativeInt(
-              options.jitterSeconds,
-              "jitter-seconds"
-            ),
-            maxConsecutiveFailures: coercePositiveInt(
-              options.maxConsecutiveFailures,
-              "max-consecutive-failures"
-            )
-          },
-          readCdpUrl()
-        );
+        await runKeepAliveCliAction(options, async (outputOptions) => {
+          await runKeepAliveStart(
+            {
+              profileName: options.profile,
+              intervalSeconds: coercePositiveInt(
+                options.intervalSeconds,
+                "interval-seconds"
+              ),
+              jitterSeconds: coerceNonNegativeInt(
+                options.jitterSeconds,
+                "jitter-seconds"
+              ),
+              maxConsecutiveFailures: coercePositiveInt(
+                options.maxConsecutiveFailures,
+                "max-consecutive-failures"
+              )
+            },
+            outputOptions,
+            readCdpUrl()
+          );
+        });
       }
     );
 
   keepAliveCommand
     .command("status")
-    .description("Show keepalive daemon status for a profile")
+    .description("Show daemon health, the latest saved session check, and recovery guidance")
     .option("-p, --profile <profile>", "Profile name", "default")
-    .action(async (options: { profile: string }) => {
-      await runKeepAliveStatus(options.profile);
-    });
+    .option("--json", "Print the structured keepalive payload", false)
+    .option("--verbose", "Show recent daemon events and extra diagnostics", false)
+    .option("--quiet", "Print a concise human-readable summary", false)
+    .addHelpText(
+      "after",
+      [
+        "",
+        "Status reads the daemon state and recent keepalive events saved for the selected profile.",
+        "Use --verbose to include recent daemon events, timestamps, and extra session detail.",
+        "Use --json for automation or to inspect the raw saved state."
+      ].join("\n")
+    )
+    .action(
+      async (options: {
+        profile: string;
+        json: boolean;
+        quiet: boolean;
+        verbose: boolean;
+      }) => {
+        await runKeepAliveCliAction(options, async (outputOptions) => {
+          await runKeepAliveStatus(options.profile, outputOptions);
+        });
+      }
+    );
 
   keepAliveCommand
     .command("stop")
-    .description("Stop keepalive daemon for a profile")
+    .description(
+      "Stop the local keepalive daemon and preserve the last saved health state"
+    )
     .option("-p, --profile <profile>", "Profile name", "default")
-    .action(async (options: { profile: string }) => {
-      await runKeepAliveStop(options.profile);
-    });
+    .option("--json", "Print the structured keepalive payload", false)
+    .option("--verbose", "Show extra diagnostics in human-readable output", false)
+    .option("--quiet", "Print a concise human-readable summary", false)
+    .addHelpText(
+      "after",
+      [
+        "",
+        "Stopping the daemon preserves the last saved state file and event log for later inspection.",
+        "Use status after stopping if you want to confirm the daemon is idle or review the last recorded failure."
+      ].join("\n")
+    )
+    .action(
+      async (options: {
+        profile: string;
+        json: boolean;
+        quiet: boolean;
+        verbose: boolean;
+      }) => {
+        await runKeepAliveCliAction(options, async (outputOptions) => {
+          await runKeepAliveStop(options.profile, outputOptions);
+        });
+      }
+    );
 
   keepAliveCommand
     .command("__run", { hidden: true })

--- a/packages/cli/src/keepAliveOutput.ts
+++ b/packages/cli/src/keepAliveOutput.ts
@@ -1,0 +1,678 @@
+import type { LinkedInAssistantErrorPayload } from "@linkedin-assistant/core";
+
+export type KeepAliveOutputMode = "human" | "json";
+
+export interface KeepAliveStateView {
+  pid: number;
+  profileName: string;
+  startedAt: string;
+  updatedAt: string;
+  status: "starting" | "running" | "degraded" | "stopped";
+  intervalMs: number;
+  jitterMs: number;
+  maxConsecutiveFailures: number;
+  consecutiveFailures: number;
+  lastTickAt?: string;
+  lastCheckStartedAt?: string;
+  lastHealthyAt?: string;
+  authenticated?: boolean;
+  browserHealthy?: boolean;
+  currentUrl?: string;
+  reason?: string;
+  lastError?: string;
+  cdpUrl?: string;
+  healthCheckInProgress?: boolean;
+  stoppedAt?: string;
+}
+
+export interface KeepAliveRecentEvent extends Record<string, unknown> {
+  ts: string;
+  event: string;
+}
+
+export interface KeepAliveStatusReport {
+  profile_name: string;
+  running: boolean;
+  pid: number | null;
+  state: KeepAliveStateView | null;
+  stale_pid_file: boolean;
+  state_path: string;
+  log_path: string;
+  recent_events: KeepAliveRecentEvent[];
+}
+
+export interface KeepAliveStartReport {
+  started: boolean;
+  reason?: string;
+  profile_name: string;
+  pid?: number;
+  state?: KeepAliveStateView | null;
+  state_path: string;
+  log_path: string;
+  recovered_stale_pid?: boolean;
+}
+
+export interface KeepAliveStopReport {
+  stopped: boolean;
+  profile_name: string;
+  pid?: number;
+  forced?: boolean;
+  reason?: string;
+  state?: KeepAliveStateView | null;
+  state_path: string;
+  log_path: string;
+}
+
+export interface KeepAliveFormatOptions {
+  quiet?: boolean;
+  verbose?: boolean;
+}
+
+const CONTROL_CHARACTER_PATTERN = new RegExp(
+  `[${String.fromCharCode(0)}-${String.fromCharCode(31)}${String.fromCharCode(127)}-${String.fromCharCode(159)}]+`,
+  "g"
+);
+const ANSI_ESCAPE_PATTERN = new RegExp(
+  `${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`,
+  "g"
+);
+
+function sanitizeConsoleText(value: string): string {
+  const sanitized = value
+    .replace(ANSI_ESCAPE_PATTERN, " ")
+    .replace(CONTROL_CHARACTER_PATTERN, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return sanitized.length > 0 ? sanitized : "[sanitized]";
+}
+
+function appendSection(lines: string[], title: string, entries: string[]): void {
+  if (entries.length === 0) {
+    return;
+  }
+
+  lines.push("");
+  lines.push(title);
+  lines.push(...entries);
+}
+
+function formatDurationMs(value: number): string {
+  if (!Number.isFinite(value) || value < 1_000) {
+    return `${Math.max(0, Math.round(value))}ms`;
+  }
+
+  const seconds = Math.round(value / 1_000);
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+
+  const hours = Math.round((minutes / 60) * 10) / 10;
+  return `${hours}h`;
+}
+
+function formatStatusLabel(status: string): string {
+  return sanitizeConsoleText(status.replace(/_/g, " ").toUpperCase());
+}
+
+function formatTimestamp(value?: string | null): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return "not recorded";
+  }
+
+  return sanitizeConsoleText(value);
+}
+
+function formatHealthLabel(value: boolean | undefined, positive: string, negative: string): string {
+  if (typeof value !== "boolean") {
+    return "unknown";
+  }
+
+  return value ? positive : negative;
+}
+
+function readString(payload: Record<string, unknown>, key: string): string | null {
+  const value = payload[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function stateConditionSummary(state: KeepAliveStateView | null): string {
+  if (!state) {
+    return "no saved daemon state";
+  }
+
+  return [
+    formatStatusLabel(state.status).toLowerCase(),
+    `browser ${formatHealthLabel(state.browserHealthy, "healthy", "unhealthy")}`,
+    `session ${formatHealthLabel(state.authenticated, "authenticated", "not authenticated")}`
+  ].join(" | ");
+}
+
+function formatCadenceSummary(state: KeepAliveStateView): string {
+  return `every ${formatDurationMs(state.intervalMs)} with ±${formatDurationMs(state.jitterMs)} jitter`;
+}
+
+function inferOperatorGuidance(state: KeepAliveStateView | null): string | null {
+  if (!state) {
+    return null;
+  }
+
+  const reason = state.reason?.toLowerCase() ?? "";
+  const currentUrl = state.currentUrl?.toLowerCase() ?? "";
+  const lastError = state.lastError?.toLowerCase() ?? "";
+
+  if (
+    reason.includes("challenge") ||
+    reason.includes("checkpoint") ||
+    currentUrl.includes("/checkpoint")
+  ) {
+    return "Complete the LinkedIn checkpoint or verification manually in the same browser session, then rerun the daemon or status check.";
+  }
+
+  if (
+    reason.includes("login wall") ||
+    reason.includes("login form") ||
+    currentUrl.includes("/login") ||
+    currentUrl.includes("/authwall")
+  ) {
+    return "Open LinkedIn in the same browser session, sign in again until the feed loads normally, then rerun keepalive.";
+  }
+
+  if (reason.includes("rate-limit") || lastError.includes("rate-limit")) {
+    return "LinkedIn is throttling session checks right now. Wait a bit before retrying or restarting the daemon.";
+  }
+
+  if (
+    lastError.includes("profile lock") ||
+    lastError.includes("lock") ||
+    lastError.includes("busy")
+  ) {
+    return "Another CLI, MCP, or daemon task is using this profile. Let that work finish before retrying keepalive.";
+  }
+
+  if (
+    lastError.includes("network") ||
+    lastError.includes("timeout") ||
+    lastError.includes("cdp") ||
+    lastError.includes("browser")
+  ) {
+    return "Check browser connectivity and any --cdp-url endpoint, then rerun status or restart the daemon if the issue persists.";
+  }
+
+  return null;
+}
+
+function formatEventSummary(event: KeepAliveRecentEvent): string {
+  const reason = readString(event, "reason");
+  const error = readString(event, "error");
+  const healthy = event.healthy;
+
+  switch (event.event) {
+    case "keepalive.daemon.started":
+      return "Daemon started";
+    case "keepalive.tick.started":
+      return "Health check started";
+    case "keepalive.tick":
+      if (healthy === true) {
+        return "Health check passed";
+      }
+      if (healthy === false) {
+        return reason ? `Health check completed with warning: ${sanitizeConsoleText(reason)}` : "Health check completed with warnings";
+      }
+      return "Health check finished";
+    case "keepalive.tick.skipped":
+      return reason ? `Health check skipped: ${sanitizeConsoleText(reason)}` : "Health check skipped";
+    case "keepalive.tick.error":
+      return error ? `Health check failed: ${sanitizeConsoleText(error)}` : "Health check failed";
+    case "keepalive.daemon.stopped":
+      return "Daemon stopped";
+    default:
+      return sanitizeConsoleText(event.event);
+  }
+}
+
+function formatRecentEventLine(event: KeepAliveRecentEvent): string {
+  return `- ${formatTimestamp(event.ts)} — ${formatEventSummary(event)}`;
+}
+
+function formatStateHeadline(report: KeepAliveStatusReport): string {
+  if (report.stale_pid_file) {
+    return "STALE PID FILE";
+  }
+
+  if (report.running) {
+    return report.state ? formatStatusLabel(report.state.status) : "RUNNING";
+  }
+
+  if (report.state) {
+    return formatStatusLabel(report.state.status);
+  }
+
+  return "STOPPED";
+}
+
+function formatStartNextSteps(report: KeepAliveStartReport, verbose: boolean): string[] {
+  const profile = sanitizeConsoleText(report.profile_name);
+
+  if (!report.started) {
+    const steps = [
+      `Run \`linkedin keepalive status --profile ${profile}\` to inspect the existing daemon state.`,
+      `Run \`linkedin keepalive stop --profile ${profile}\` if you need to restart it cleanly.`
+    ];
+    if (!verbose) {
+      steps.push("Rerun with `--verbose` to include recent daemon-event context in human-readable output.");
+    }
+    steps.push("Use `--json` if you need the structured payload for automation.");
+    return steps;
+  }
+
+  const steps = [
+    `Run \`linkedin keepalive status --profile ${profile}\` to inspect health, daemon state, and recovery guidance.`,
+    `Run \`linkedin keepalive stop --profile ${profile}\` when you want to stop background health checks.`
+  ];
+  if (!verbose) {
+    steps.push("Rerun status with `--verbose` to include recent daemon events and extra diagnostics.");
+  }
+  steps.push("Use `--json` if you need the structured payload for automation.");
+  return steps;
+}
+
+function formatStatusNextSteps(
+  report: KeepAliveStatusReport,
+  verbose: boolean
+): string[] {
+  const profile = sanitizeConsoleText(report.profile_name);
+  const steps: string[] = [];
+  const guidance = inferOperatorGuidance(report.state);
+
+  if (report.stale_pid_file) {
+    steps.push(
+      `Run \`linkedin keepalive stop --profile ${profile}\` to clear the stale PID file safely.`
+    );
+  } else if (report.running) {
+    steps.push(
+      `Run \`linkedin keepalive stop --profile ${profile}\` to stop background health checks.`
+    );
+  } else {
+    steps.push(
+      `Run \`linkedin keepalive start --profile ${profile}\` to resume background health checks.`
+    );
+  }
+
+  if (guidance) {
+    steps.push(guidance);
+  }
+
+  if (report.state?.healthCheckInProgress) {
+    steps.push(
+      `Rerun \`linkedin keepalive status --profile ${profile}\` after the current health check completes for the latest saved result.`
+    );
+  }
+
+  if (!verbose) {
+    steps.push("Rerun with `--verbose` to inspect recent daemon events and raw session diagnostics.");
+  }
+  steps.push("Use `--json` if you need the structured payload for automation.");
+  return steps;
+}
+
+function formatStopNextSteps(report: KeepAliveStopReport, verbose: boolean): string[] {
+  const profile = sanitizeConsoleText(report.profile_name);
+
+  if (report.stopped) {
+    const steps = [
+      `Run \`linkedin keepalive status --profile ${profile}\` to confirm the daemon is idle.`,
+      `Run \`linkedin keepalive start --profile ${profile}\` when you want background health checks again.`
+    ];
+    if (!verbose) {
+      steps.push("Rerun status with `--verbose` if you want recent daemon-event context before restarting.");
+    }
+    steps.push("Use `--json` if you need the structured payload for automation.");
+    return steps;
+  }
+
+  return [
+    `Run \`linkedin keepalive start --profile ${profile}\` to launch the daemon.`,
+    "Use `--json` if you need the structured payload for automation."
+  ];
+}
+
+function formatErrorLines(error: LinkedInAssistantErrorPayload): string[] {
+  const lines = [
+    `Keepalive command failed [${sanitizeConsoleText(error.code)}]`,
+    sanitizeConsoleText(error.message)
+  ];
+
+  const profileName = readString(error.details, "profile_name");
+  const path = readString(error.details, "path");
+  const env = readString(error.details, "env");
+  const cause = readString(error.details, "cause");
+
+  if (profileName) {
+    lines.push(`Profile: ${sanitizeConsoleText(profileName)}`);
+  }
+  if (path) {
+    lines.push(`Path: ${sanitizeConsoleText(path)}`);
+  }
+  if (env) {
+    lines.push(`Setting: ${sanitizeConsoleText(env)}`);
+  }
+  if (cause) {
+    lines.push(`Cause: ${sanitizeConsoleText(cause)}`);
+  }
+
+  return lines;
+}
+
+function formatErrorNextSteps(error: LinkedInAssistantErrorPayload): string[] {
+  switch (error.code) {
+    case "AUTH_REQUIRED":
+      return [
+        "Open LinkedIn in the same browser session and sign back in until the feed loads normally.",
+        "After the session is healthy again, rerun the keepalive command that failed.",
+        "If you are using a stored-session workflow elsewhere, refresh it with `linkedin auth session --session <name>` after reauth."
+      ];
+    case "CAPTCHA_OR_CHALLENGE":
+      return [
+        "Complete the LinkedIn checkpoint or challenge manually in the same browser session.",
+        "After LinkedIn returns you to the feed, rerun the keepalive command that failed.",
+        "Avoid restarting the daemon until manual verification is complete."
+      ];
+    case "RATE_LIMITED":
+      return [
+        "Wait for LinkedIn's temporary throttle or cooldown window to pass before retrying.",
+        "Use `linkedin keepalive status --profile <profile>` to inspect the last saved daemon state before restarting.",
+        "Reduce other browser activity on the same profile if the throttle keeps recurring."
+      ];
+    case "NETWORK_ERROR":
+    case "TIMEOUT":
+      return [
+        "Confirm the browser is reachable and any `--cdp-url` endpoint is still listening.",
+        "Retry after the browser or network stabilizes.",
+        "Check the keepalive event log for recent failures if the problem persists."
+      ];
+    case "ACTION_PRECONDITION_FAILED": {
+      const message = error.message.toLowerCase();
+      if (message.includes("path separators") || message.includes("relative path segments")) {
+        return [
+          "Use a simple profile name such as `default` or `sales`, not a filesystem path.",
+          "Rerun the keepalive command with `--profile <name>` using that label.",
+          "Run `linkedin keepalive --help` to review the supported flags."
+        ];
+      }
+
+      return [
+        "Review the message above, correct the input or environment setting, and rerun the command.",
+        "Run `linkedin keepalive --help` to review command usage and examples."
+      ];
+    }
+    default: {
+      if (error.message.toLowerCase().includes("resolve cli entrypoint")) {
+        return [
+          "Ensure the CLI was built correctly before starting background daemons.",
+          "Run `npm run build` and then retry the keepalive command.",
+          "Run `linkedin keepalive --help` if you want to verify the supported startup flags first."
+        ];
+      }
+
+      return [
+        "Retry the command after checking the browser session, keepalive state file, and event log.",
+        "Run `linkedin keepalive --help` to review supported usage and recovery options."
+      ];
+    }
+  }
+}
+
+export function resolveKeepAliveOutputMode(
+  input: { json?: boolean },
+  interactiveTerminal: boolean
+): KeepAliveOutputMode {
+  if (input.json) {
+    return "json";
+  }
+
+  return interactiveTerminal ? "human" : "json";
+}
+
+export function formatKeepAliveStatusReport(
+  report: KeepAliveStatusReport,
+  options: KeepAliveFormatOptions = {}
+): string {
+  if (options.quiet) {
+    const parts = [
+      `Keepalive Status: ${formatStateHeadline(report)}`,
+      `profile ${sanitizeConsoleText(report.profile_name)}`
+    ];
+    if (typeof report.pid === "number") {
+      parts.push(`PID ${report.pid}`);
+    }
+    parts.push(stateConditionSummary(report.state));
+    if (report.state?.healthCheckInProgress) {
+      parts.push("health check in progress");
+    }
+    if (report.state?.reason) {
+      parts.push(sanitizeConsoleText(report.state.reason));
+    }
+    return parts.join(" — ");
+  }
+
+  const lines = [`Keepalive Status: ${formatStateHeadline(report)}`];
+
+  lines.push(`Profile: ${sanitizeConsoleText(report.profile_name)}`);
+  if (typeof report.pid === "number") {
+    lines.push(`PID: ${report.pid}`);
+  }
+  lines.push(`State file: ${sanitizeConsoleText(report.state_path)}`);
+  lines.push(`Event log: ${sanitizeConsoleText(report.log_path)}`);
+
+  if (!report.state) {
+    appendSection(lines, "Summary", [
+      "- No saved keepalive state was found for this profile.",
+      `- Running now: ${report.running ? "yes" : "no"}`
+    ]);
+  } else {
+    const summaryEntries = [
+      `- Daemon state: ${formatStatusLabel(report.state.status)}`,
+      `- Browser health: ${formatHealthLabel(report.state.browserHealthy, "healthy", "unhealthy")}`,
+      `- Session health: ${formatHealthLabel(report.state.authenticated, "authenticated", "not authenticated")}`,
+      `- Consecutive failures: ${report.state.consecutiveFailures}/${report.state.maxConsecutiveFailures}`,
+      `- Health-check cadence: ${formatCadenceSummary(report.state)}`,
+      `- Last tick: ${formatTimestamp(report.state.lastTickAt)}`
+    ];
+
+    if (report.state.healthCheckInProgress) {
+      summaryEntries.push(
+        `- Health check progress: running since ${formatTimestamp(report.state.lastCheckStartedAt)}`
+      );
+    } else {
+      summaryEntries.push(
+        `- Last healthy tick: ${formatTimestamp(report.state.lastHealthyAt)}`
+      );
+    }
+
+    if (report.stale_pid_file) {
+      summaryEntries.push("- PID file is stale: the recorded process is no longer running.");
+    }
+
+    appendSection(lines, "Summary", summaryEntries);
+
+    const sessionEntries = [
+      `- Current URL: ${formatTimestamp(report.state.currentUrl)}`,
+      `- LinkedIn reason: ${formatTimestamp(report.state.reason)}`
+    ];
+
+    if (report.state.lastError) {
+      sessionEntries.push(`- Last error: ${sanitizeConsoleText(report.state.lastError)}`);
+    }
+    if (options.verbose && report.state.cdpUrl) {
+      sessionEntries.push(`- External CDP session: ${sanitizeConsoleText(report.state.cdpUrl)}`);
+    }
+    if (options.verbose) {
+      sessionEntries.push(`- Started at: ${formatTimestamp(report.state.startedAt)}`);
+      sessionEntries.push(`- Updated at: ${formatTimestamp(report.state.updatedAt)}`);
+      if (report.state.stoppedAt) {
+        sessionEntries.push(`- Stopped at: ${formatTimestamp(report.state.stoppedAt)}`);
+      }
+    }
+    appendSection(lines, "Session", sessionEntries);
+
+    const guidance = inferOperatorGuidance(report.state);
+    if (guidance) {
+      appendSection(lines, "Action Needed", [`- ${sanitizeConsoleText(guidance)}`]);
+    }
+  }
+
+  if (options.verbose) {
+    appendSection(
+      lines,
+      "Recent Events",
+      report.recent_events.length > 0
+        ? report.recent_events.map((event) => formatRecentEventLine(event))
+        : ["- No keepalive events have been recorded yet."]
+    );
+  }
+
+  appendSection(
+    lines,
+    "Next Steps",
+    formatStatusNextSteps(report, Boolean(options.verbose)).map((step) => `- ${sanitizeConsoleText(step)}`)
+  );
+
+  return lines.join("\n");
+}
+
+export function formatKeepAliveStartReport(
+  report: KeepAliveStartReport,
+  options: KeepAliveFormatOptions = {}
+): string {
+  const title = report.started
+    ? "Keepalive Start: STARTED"
+    : "Keepalive Start: ALREADY RUNNING";
+
+  if (options.quiet) {
+    const parts = [title, `profile ${sanitizeConsoleText(report.profile_name)}`];
+    if (typeof report.pid === "number") {
+      parts.push(`PID ${report.pid}`);
+    }
+    if (report.reason) {
+      parts.push(sanitizeConsoleText(report.reason));
+    }
+    return parts.join(" — ");
+  }
+
+  const lines = [title];
+
+  lines.push(`Profile: ${sanitizeConsoleText(report.profile_name)}`);
+  if (typeof report.pid === "number") {
+    lines.push(`PID: ${report.pid}`);
+  }
+  lines.push(`State file: ${sanitizeConsoleText(report.state_path)}`);
+  lines.push(`Event log: ${sanitizeConsoleText(report.log_path)}`);
+
+  const statusEntries: string[] = [];
+  if (report.reason) {
+    statusEntries.push(`- ${sanitizeConsoleText(report.reason)}`);
+  }
+  if (report.recovered_stale_pid) {
+    statusEntries.push("- Removed a stale keepalive PID file before starting the new daemon.");
+  }
+  if (report.started) {
+    statusEntries.push(
+      "- The daemon starts a session health check in the background right away; use status to inspect live progress and saved results."
+    );
+  }
+  if (report.state?.healthCheckInProgress) {
+    statusEntries.push(
+      `- Health check progress: running since ${formatTimestamp(report.state.lastCheckStartedAt)}`
+    );
+  }
+  appendSection(lines, "Status", statusEntries);
+
+  if (options.verbose && report.state) {
+    appendSection(lines, "State", [
+      `- Daemon state: ${formatStatusLabel(report.state.status)}`,
+      `- Health-check cadence: ${formatCadenceSummary(report.state)}`,
+      `- Consecutive failures: ${report.state.consecutiveFailures}/${report.state.maxConsecutiveFailures}`,
+      `- Current URL: ${formatTimestamp(report.state.currentUrl)}`,
+      `- LinkedIn reason: ${formatTimestamp(report.state.reason)}`
+    ]);
+  }
+
+  appendSection(
+    lines,
+    "Next Steps",
+    formatStartNextSteps(report, Boolean(options.verbose)).map((step) => `- ${sanitizeConsoleText(step)}`)
+  );
+
+  return lines.join("\n");
+}
+
+export function formatKeepAliveStopReport(
+  report: KeepAliveStopReport,
+  options: KeepAliveFormatOptions = {}
+): string {
+  const title = report.stopped ? "Keepalive Stop: STOPPED" : "Keepalive Stop: NOT RUNNING";
+
+  if (options.quiet) {
+    const parts = [title, `profile ${sanitizeConsoleText(report.profile_name)}`];
+    if (typeof report.pid === "number") {
+      parts.push(`PID ${report.pid}`);
+    }
+    if (report.reason) {
+      parts.push(sanitizeConsoleText(report.reason));
+    }
+    return parts.join(" — ");
+  }
+
+  const lines = [title];
+
+  lines.push(`Profile: ${sanitizeConsoleText(report.profile_name)}`);
+  if (typeof report.pid === "number") {
+    lines.push(`PID: ${report.pid}`);
+  }
+  lines.push(`State file: ${sanitizeConsoleText(report.state_path)}`);
+  lines.push(`Event log: ${sanitizeConsoleText(report.log_path)}`);
+
+  const statusEntries: string[] = [];
+  if (report.reason) {
+    statusEntries.push(`- ${sanitizeConsoleText(report.reason)}`);
+  }
+  if (report.forced) {
+    statusEntries.push("- Stop required SIGKILL after the daemon ignored SIGTERM for 5 seconds.");
+  }
+  if (options.verbose && report.state?.lastError) {
+    statusEntries.push(`- Last recorded error: ${sanitizeConsoleText(report.state.lastError)}`);
+  }
+  appendSection(lines, "Status", statusEntries);
+
+  appendSection(
+    lines,
+    "Next Steps",
+    formatStopNextSteps(report, Boolean(options.verbose)).map((step) => `- ${sanitizeConsoleText(step)}`)
+  );
+
+  return lines.join("\n");
+}
+
+export function formatKeepAliveError(
+  error: LinkedInAssistantErrorPayload,
+  options: Pick<KeepAliveFormatOptions, "quiet"> = {}
+): string {
+  const lines = formatErrorLines(error);
+
+  if (options.quiet) {
+    return lines.join(" — ");
+  }
+
+  appendSection(
+    lines,
+    "What To Do",
+    formatErrorNextSteps(error).map((step) => `- ${sanitizeConsoleText(step)}`)
+  );
+  return lines.join("\n");
+}

--- a/packages/cli/test/keepAliveCli.test.ts
+++ b/packages/cli/test/keepAliveCli.test.ts
@@ -1,0 +1,365 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { stdin, stdout } from "node:process";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const keepAliveCliMocks = vi.hoisted(() => ({
+  spawn: vi.fn(() => ({
+    pid: 12_345,
+    unref: vi.fn()
+  }))
+}));
+
+vi.mock("@linkedin-assistant/core", async () => await import("../../core/src/index.js"));
+
+vi.mock("node:child_process", () => ({
+  spawn: keepAliveCliMocks.spawn
+}));
+
+import { resolveConfigPaths } from "@linkedin-assistant/core";
+import { createCliProgram, runCli } from "../src/bin/linkedin.js";
+
+interface KeepAliveStateFile {
+  pid: number;
+  profileName: string;
+  startedAt: string;
+  updatedAt: string;
+  status: "starting" | "running" | "degraded" | "stopped";
+  intervalMs: number;
+  jitterMs: number;
+  maxConsecutiveFailures: number;
+  consecutiveFailures: number;
+  lastTickAt?: string;
+  lastCheckStartedAt?: string;
+  lastHealthyAt?: string;
+  authenticated?: boolean;
+  browserHealthy?: boolean;
+  currentUrl?: string;
+  reason?: string;
+  lastError?: string;
+  cdpUrl?: string;
+  healthCheckInProgress?: boolean;
+  stoppedAt?: string;
+}
+
+function setInteractiveMode(inputIsTty: boolean, outputIsTty: boolean): void {
+  Object.defineProperty(stdin, "isTTY", {
+    configurable: true,
+    value: inputIsTty
+  });
+  Object.defineProperty(stdout, "isTTY", {
+    configurable: true,
+    value: outputIsTty
+  });
+  Object.defineProperty(process.stderr, "isTTY", {
+    configurable: true,
+    value: outputIsTty
+  });
+}
+
+function keepAliveDir(): string {
+  return path.join(resolveConfigPaths().baseDir, "keepalive");
+}
+
+async function seedKeepAliveState(
+  profileName: string,
+  state: KeepAliveStateFile
+): Promise<void> {
+  const dir = keepAliveDir();
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    path.join(dir, `${profileName}.state.json`),
+    `${JSON.stringify(state, null, 2)}\n`,
+    "utf8"
+  );
+}
+
+async function seedKeepAlivePid(profileName: string, pid: number): Promise<void> {
+  const dir = keepAliveDir();
+  await mkdir(dir, { recursive: true });
+  await writeFile(path.join(dir, `${profileName}.pid`), `${pid}\n`, "utf8");
+}
+
+async function seedKeepAliveEvents(
+  profileName: string,
+  events: Array<Record<string, unknown>>
+): Promise<void> {
+  const dir = keepAliveDir();
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    path.join(dir, `${profileName}.events.jsonl`),
+    `${events.map((event) => JSON.stringify(event)).join("\n")}\n`,
+    "utf8"
+  );
+}
+
+describe("linkedin keepalive CLI UX", () => {
+  let tempDir = "";
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let stderrWriteSpy: ReturnType<typeof vi.spyOn>;
+  let stderrChunks: string[] = [];
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-cli-keepalive-"));
+    process.env.LINKEDIN_ASSISTANT_HOME = path.join(tempDir, "assistant-home");
+    process.exitCode = undefined;
+    stderrChunks = [];
+    setInteractiveMode(true, true);
+    vi.clearAllMocks();
+    keepAliveCliMocks.spawn.mockImplementation(() => ({
+      pid: 12_345,
+      unref: vi.fn()
+    }));
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    stderrWriteSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((...args: Parameters<typeof process.stderr.write>) => {
+        const [chunk] = args;
+        stderrChunks.push(String(chunk));
+        return true;
+      });
+  });
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore();
+    stderrWriteSpy.mockRestore();
+    process.exitCode = undefined;
+    delete process.env.LINKEDIN_ASSISTANT_HOME;
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("prints a human-readable keepalive status summary by default on TTYs", async () => {
+    await seedKeepAlivePid("default", process.pid);
+    await seedKeepAliveState("default", {
+      pid: process.pid,
+      profileName: "default",
+      startedAt: "2026-03-09T08:00:00.000Z",
+      updatedAt: "2026-03-09T08:05:00.000Z",
+      status: "running",
+      intervalMs: 300_000,
+      jitterMs: 30_000,
+      maxConsecutiveFailures: 5,
+      consecutiveFailures: 0,
+      lastTickAt: "2026-03-09T08:05:00.000Z",
+      lastHealthyAt: "2026-03-09T08:05:00.000Z",
+      authenticated: true,
+      browserHealthy: true,
+      currentUrl: "https://www.linkedin.com/feed/",
+      reason: "LinkedIn session appears authenticated.",
+      healthCheckInProgress: false
+    });
+    await seedKeepAliveEvents("default", [
+      {
+        ts: "2026-03-09T08:05:00.000Z",
+        event: "keepalive.tick.started",
+        profile_name: "default"
+      },
+      {
+        ts: "2026-03-09T08:05:01.000Z",
+        event: "keepalive.tick",
+        profile_name: "default",
+        healthy: true,
+        reason: "LinkedIn session appears authenticated."
+      }
+    ]);
+
+    await runCli(["node", "linkedin", "keepalive", "status"]);
+
+    const output = String(consoleLogSpy.mock.calls.at(-1)?.[0] ?? "");
+
+    expect(output).toContain("Keepalive Status:");
+    expect(output).toContain("Browser health: healthy");
+    expect(output).toContain("Session health: authenticated");
+    expect(output).toContain("State file:");
+    expect(output).toContain("Next Steps");
+    expect(output).not.toContain("Recent Events");
+  });
+
+  it("shows recent events and extra diagnostics in verbose human mode", async () => {
+    await seedKeepAlivePid("default", process.pid);
+    await seedKeepAliveState("default", {
+      pid: process.pid,
+      profileName: "default",
+      startedAt: "2026-03-09T08:00:00.000Z",
+      updatedAt: "2026-03-09T08:05:00.000Z",
+      status: "degraded",
+      intervalMs: 300_000,
+      jitterMs: 30_000,
+      maxConsecutiveFailures: 5,
+      consecutiveFailures: 3,
+      lastTickAt: "2026-03-09T08:05:00.000Z",
+      lastCheckStartedAt: "2026-03-09T08:05:00.000Z",
+      authenticated: false,
+      browserHealthy: true,
+      currentUrl: "https://www.linkedin.com/checkpoint/challenge/",
+      reason: "LinkedIn checkpoint detected. Manual verification is required.",
+      lastError: "Checkpoint still active.",
+      cdpUrl: "http://127.0.0.1:18800",
+      healthCheckInProgress: true
+    });
+    await seedKeepAliveEvents("default", [
+      {
+        ts: "2026-03-09T08:05:00.000Z",
+        event: "keepalive.tick.started",
+        profile_name: "default"
+      },
+      {
+        ts: "2026-03-09T08:05:02.000Z",
+        event: "keepalive.tick.error",
+        profile_name: "default",
+        error: "Checkpoint still active."
+      }
+    ]);
+
+    await runCli(["node", "linkedin", "keepalive", "status", "--verbose"]);
+
+    const output = String(consoleLogSpy.mock.calls.at(-1)?.[0] ?? "");
+
+    expect(output).toContain("Keepalive Status: DEGRADED");
+    expect(output).toContain("Recent Events");
+    expect(output).toContain("Health check started");
+    expect(output).toContain("External CDP session:");
+    expect(output).toContain("Action Needed");
+  });
+
+  it("prints a human-readable start summary and progress notices", async () => {
+    await runCli(["node", "linkedin", "keepalive", "start"]);
+
+    const output = String(consoleLogSpy.mock.calls.at(-1)?.[0] ?? "");
+    const state = JSON.parse(
+      await readFile(path.join(keepAliveDir(), "default.state.json"), "utf8")
+    ) as KeepAliveStateFile;
+
+    expect(output).toContain("Keepalive Start: STARTED");
+    expect(output).toContain("Event log:");
+    expect(output).toContain("linkedin keepalive status --profile default");
+    expect(stderrChunks.join("")).toContain(
+      "[linkedin] Starting keepalive daemon for profile default."
+    );
+    expect(stderrChunks.join("")).toContain(
+      "first session health check will continue in the background"
+    );
+    expect(state.status).toBe("starting");
+    expect(state.healthCheckInProgress).toBe(false);
+    expect(keepAliveCliMocks.spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports quiet mode for concise keepalive output", async () => {
+    await runCli(["node", "linkedin", "keepalive", "start", "--quiet"]);
+
+    const output = String(consoleLogSpy.mock.calls.at(-1)?.[0] ?? "");
+
+    expect(output).toContain("Keepalive Start: STARTED");
+    expect(stderrChunks).toEqual([]);
+  });
+
+  it("formats keepalive input errors with actionable guidance in human mode", async () => {
+    await runCli(["node", "linkedin", "keepalive", "status", "--profile", "../bad"]);
+
+    expect(process.exitCode).toBe(1);
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+    expect(stderrChunks.join("")).toContain(
+      "Keepalive command failed [ACTION_PRECONDITION_FAILED]"
+    );
+    expect(stderrChunks.join("")).toContain(
+      "Use a simple profile name such as `default` or `sales`, not a filesystem path."
+    );
+    expect(stderrChunks.join("")).toContain("linkedin keepalive --help");
+  });
+
+  it("rejects combining quiet and verbose keepalive flags", async () => {
+    await runCli([
+      "node",
+      "linkedin",
+      "keepalive",
+      "status",
+      "--quiet",
+      "--verbose"
+    ]);
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrChunks.join("")).toContain(
+      'Choose either "--quiet" or "--verbose", not both.'
+    );
+  });
+
+  it("defaults to JSON keepalive output outside TTYs", async () => {
+    setInteractiveMode(false, false);
+    await seedKeepAlivePid("default", process.pid);
+    await seedKeepAliveState("default", {
+      pid: process.pid,
+      profileName: "default",
+      startedAt: "2026-03-09T08:00:00.000Z",
+      updatedAt: "2026-03-09T08:05:00.000Z",
+      status: "running",
+      intervalMs: 300_000,
+      jitterMs: 30_000,
+      maxConsecutiveFailures: 5,
+      consecutiveFailures: 0,
+      authenticated: true,
+      browserHealthy: true,
+      currentUrl: "https://www.linkedin.com/feed/",
+      reason: "LinkedIn session appears authenticated.",
+      healthCheckInProgress: false
+    });
+    await seedKeepAliveEvents("default", [
+      {
+        ts: "2026-03-09T08:05:01.000Z",
+        event: "keepalive.tick",
+        profile_name: "default",
+        healthy: true
+      }
+    ]);
+
+    await runCli(["node", "linkedin", "keepalive", "status"]);
+
+    const payload = JSON.parse(
+      String(consoleLogSpy.mock.calls.at(-1)?.[0] ?? "{}")
+    ) as Record<string, unknown>;
+
+    expect(payload.profile_name).toBe("default");
+    expect(payload.state).toMatchObject({
+      status: "running",
+      authenticated: true,
+      browserHealthy: true
+    });
+    expect(payload.recent_events).toEqual([
+      expect.objectContaining({
+        event: "keepalive.tick"
+      })
+    ]);
+  });
+
+  it("documents keepalive human and JSON usage in help output", () => {
+    const program = createCliProgram();
+    const keepAliveCommand = program.commands.find(
+      (command) => command.name() === "keepalive"
+    );
+    const startCommand = keepAliveCommand?.commands.find(
+      (command) => command.name() === "start"
+    );
+    const statusCommand = keepAliveCommand?.commands.find(
+      (command) => command.name() === "status"
+    );
+    const stopCommand = keepAliveCommand?.commands.find(
+      (command) => command.name() === "stop"
+    );
+
+    expect(keepAliveCommand?.description()).toContain(
+      "records background LinkedIn health checks"
+    );
+    expect(startCommand?.helpInformation() ?? "").toContain("--json");
+    expect(startCommand?.helpInformation() ?? "").toContain("--verbose");
+    expect(statusCommand?.helpInformation() ?? "").toContain("--quiet");
+    expect(startCommand?.description() ?? "").toContain(
+      "background session health checks"
+    );
+    expect(statusCommand?.helpInformation() ?? "").toContain(
+      "recent daemon events"
+    );
+    expect(stopCommand?.description() ?? "").toContain(
+      "preserve the last saved health state"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add human-friendly keepalive start/status/stop output with consistent `--json`, `--verbose`, and `--quiet` behavior
- surface recent keepalive events, in-progress health-check state, and actionable recovery guidance for common session failures
- add focused CLI tests for keepalive UX, help text, error handling, and JSON fallback

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #191
