### PR TITLE
docs: document session keep-alive hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,17 @@ Session keepalive daemon (isolated profile):
 
 ```bash
 npm exec -w @linkedin-assistant/cli -- linkedin keepalive start --profile default
-npm exec -w @linkedin-assistant/cli -- linkedin keepalive status --profile default
+npm exec -w @linkedin-assistant/cli -- linkedin keepalive status --profile default --verbose
+npm exec -w @linkedin-assistant/cli -- linkedin keepalive status --profile default --json
 npm exec -w @linkedin-assistant/cli -- linkedin keepalive stop --profile default
 ```
 
-- Keepalive state/log files are stored under `~/.linkedin-assistant/linkedin-owa-agentools/keepalive/`.
+- `start` spawns a detached daemon and returns after it writes the profile PID file plus `*.state.json` and `*.events.jsonl` files under `~/.linkedin-assistant/linkedin-owa-agentools/keepalive/`.
+- `status` reads the saved daemon state instead of attaching to the browser directly. On interactive terminals it defaults to a human summary with `Summary`, `Session`, `Action Needed`, and `Next Steps` sections. Outside a TTY it defaults to JSON. Use `--quiet` for a one-line summary or `--verbose` for recent event history and extra diagnostics.
+- Health monitoring is persisted per profile: daemon status (`starting`, `running`, `degraded`, `stopped`), browser/session health, current LinkedIn URL and reason, last healthy tick, last error, and consecutive failure count all remain inspectable after the daemon stops.
+- Failure handling is operator-visible. Failed checks are recorded in the saved state and retried on the next scheduled interval. Once failures reach `--max-consecutive-failures`, the saved state flips to `degraded` until a later healthy check resets the counter.
+- Human-readable recovery guidance points operators to the right next step for login walls, checkpoints, rate limits, profile locks, and browser or `--cdp-url` connectivity issues. `start` and `stop` also clean up stale PID files automatically; `stop` escalates from `SIGTERM` to `SIGKILL` after 5 seconds if the daemon does not exit.
+- CLI defaults: `--profile default`, `--interval-seconds 300`, `--jitter-seconds 30`, and `--max-consecutive-failures 5`. Omitting `--cdp-url` keeps keepalive on a tool-owned Playwright profile; providing it attaches keepalive to an existing browser session.
 - See `docs/session-keepalive-hardening-architecture.md` for the hardening design and rollout plan.
 
 Scheduled follow-up daemon:

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -5810,16 +5810,17 @@ export function createCliProgram(): Command {
   const keepAliveCommand = program
     .command("keepalive")
     .description(
-      "Manage the local session keepalive daemon that records background LinkedIn health checks"
+      "Manage the local session keepalive daemon that records background LinkedIn health checks to disk"
     )
     .addHelpText(
       "after",
       [
         "",
-        "Interactive terminals default to human-readable keepalive summaries.",
+        "Interactive terminals default to human-readable keepalive summaries; non-interactive runs default to JSON.",
         "Use --json for automation or to inspect the structured daemon state directly.",
-        "Use --verbose for recent daemon events and extra session diagnostics.",
+        "Use --verbose for recent daemon events, saved diagnostics, and extra recovery context.",
         "Use --quiet for a concise human summary and to suppress progress notices.",
+        "Status keeps showing the last saved state after the daemon stops, so recovery stays inspectable.",
         "",
         "Examples:",
         "  linkedin keepalive start --profile default",
@@ -5857,7 +5858,9 @@ export function createCliProgram(): Command {
       "after",
       [
         "",
-        "The daemon writes PID, state, and event-log files under the keepalive directory.",
+        "Startup returns after the detached daemon writes PID, state, and event-log files under the keepalive directory.",
+        "Checks continue on the configured interval/jitter cadence and the saved state becomes degraded after the configured failure threshold.",
+        "If a stale PID file already exists for this profile, start removes it before launching the new daemon.",
         "Human output shows a startup summary and reminds you how to inspect the first background health checks.",
         "Use --quiet if you only need a compact confirmation message."
       ].join("\n")
@@ -5908,6 +5911,7 @@ export function createCliProgram(): Command {
       [
         "",
         "Status reads the daemon state and recent keepalive events saved for the selected profile.",
+        "Interactive terminals show a human summary with Next Steps and Action Needed guidance when recovery is needed.",
         "Use --verbose to include recent daemon events, timestamps, and extra session detail.",
         "Use --json for automation or to inspect the raw saved state."
       ].join("\n")
@@ -5939,7 +5943,8 @@ export function createCliProgram(): Command {
       [
         "",
         "Stopping the daemon preserves the last saved state file and event log for later inspection.",
-        "Use status after stopping if you want to confirm the daemon is idle or review the last recorded failure."
+        "Use status after stopping if you want to confirm the daemon is idle or review the last recorded failure.",
+        "If the daemon ignores SIGTERM for 5 seconds, stop force-kills it and records that in the saved state."
       ].join("\n")
     )
     .action(

--- a/packages/cli/src/keepAliveOutput.ts
+++ b/packages/cli/src/keepAliveOutput.ts
@@ -1,7 +1,13 @@
 import type { LinkedInAssistantErrorPayload } from "@linkedin-assistant/core";
 
+/**
+ * Output mode used by the keepalive CLI formatters.
+ */
 export type KeepAliveOutputMode = "human" | "json";
 
+/**
+ * Saved keepalive daemon state as read from the profile state file.
+ */
 export interface KeepAliveStateView {
   pid: number;
   profileName: string;
@@ -25,11 +31,17 @@ export interface KeepAliveStateView {
   stoppedAt?: string;
 }
 
+/**
+ * Recent keepalive event-log entry surfaced in status output.
+ */
 export interface KeepAliveRecentEvent extends Record<string, unknown> {
   ts: string;
   event: string;
 }
 
+/**
+ * Normalized payload rendered by `linkedin keepalive status`.
+ */
 export interface KeepAliveStatusReport {
   profile_name: string;
   running: boolean;
@@ -41,6 +53,9 @@ export interface KeepAliveStatusReport {
   recent_events: KeepAliveRecentEvent[];
 }
 
+/**
+ * Normalized payload rendered by `linkedin keepalive start`.
+ */
 export interface KeepAliveStartReport {
   started: boolean;
   reason?: string;
@@ -52,6 +67,9 @@ export interface KeepAliveStartReport {
   recovered_stale_pid?: boolean;
 }
 
+/**
+ * Normalized payload rendered by `linkedin keepalive stop`.
+ */
 export interface KeepAliveStopReport {
   stopped: boolean;
   profile_name: string;
@@ -63,6 +81,9 @@ export interface KeepAliveStopReport {
   log_path: string;
 }
 
+/**
+ * Formatting toggles for human-readable keepalive output.
+ */
 export interface KeepAliveFormatOptions {
   quiet?: boolean;
   verbose?: boolean;
@@ -428,6 +449,10 @@ function formatErrorNextSteps(error: LinkedInAssistantErrorPayload): string[] {
   }
 }
 
+/**
+ * Chooses human-readable output on interactive terminals unless JSON is
+ * requested explicitly.
+ */
 export function resolveKeepAliveOutputMode(
   input: { json?: boolean },
   interactiveTerminal: boolean
@@ -439,6 +464,10 @@ export function resolveKeepAliveOutputMode(
   return interactiveTerminal ? "human" : "json";
 }
 
+/**
+ * Formats a keepalive status report for either operator-facing CLI output or
+ * structured automation output.
+ */
 export function formatKeepAliveStatusReport(
   report: KeepAliveStatusReport,
   options: KeepAliveFormatOptions = {}
@@ -546,6 +575,9 @@ export function formatKeepAliveStatusReport(
   return lines.join("\n");
 }
 
+/**
+ * Formats the result of a keepalive daemon start attempt.
+ */
 export function formatKeepAliveStartReport(
   report: KeepAliveStartReport,
   options: KeepAliveFormatOptions = {}
@@ -612,6 +644,9 @@ export function formatKeepAliveStartReport(
   return lines.join("\n");
 }
 
+/**
+ * Formats the result of a keepalive daemon stop attempt.
+ */
 export function formatKeepAliveStopReport(
   report: KeepAliveStopReport,
   options: KeepAliveFormatOptions = {}
@@ -659,6 +694,10 @@ export function formatKeepAliveStopReport(
   return lines.join("\n");
 }
 
+/**
+ * Formats a keepalive CLI error with operator guidance for human-readable
+ * output.
+ */
 export function formatKeepAliveError(
   error: LinkedInAssistantErrorPayload,
   options: Pick<KeepAliveFormatOptions, "quiet"> = {}

--- a/packages/cli/test/keepAliveCli.test.ts
+++ b/packages/cli/test/keepAliveCli.test.ts
@@ -97,13 +97,16 @@ async function seedKeepAliveEvents(
 describe("linkedin keepalive CLI UX", () => {
   let tempDir = "";
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
   let stderrWriteSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutChunks: string[] = [];
   let stderrChunks: string[] = [];
 
   beforeEach(async () => {
     tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-cli-keepalive-"));
     process.env.LINKEDIN_ASSISTANT_HOME = path.join(tempDir, "assistant-home");
     process.exitCode = undefined;
+    stdoutChunks = [];
     stderrChunks = [];
     setInteractiveMode(true, true);
     vi.clearAllMocks();
@@ -112,6 +115,13 @@ describe("linkedin keepalive CLI UX", () => {
       unref: vi.fn()
     }));
     consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    stdoutWriteSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((...args: Parameters<typeof process.stdout.write>) => {
+        const [chunk] = args;
+        stdoutChunks.push(String(chunk));
+        return true;
+      });
     stderrWriteSpy = vi
       .spyOn(process.stderr, "write")
       .mockImplementation((...args: Parameters<typeof process.stderr.write>) => {
@@ -123,6 +133,7 @@ describe("linkedin keepalive CLI UX", () => {
 
   afterEach(async () => {
     consoleLogSpy.mockRestore();
+    stdoutWriteSpy.mockRestore();
     stderrWriteSpy.mockRestore();
     process.exitCode = undefined;
     delete process.env.LINKEDIN_ASSISTANT_HOME;
@@ -347,19 +358,27 @@ describe("linkedin keepalive CLI UX", () => {
     );
 
     expect(keepAliveCommand?.description()).toContain(
-      "records background LinkedIn health checks"
+      "records background LinkedIn health checks to disk"
     );
-    expect(startCommand?.helpInformation() ?? "").toContain("--json");
-    expect(startCommand?.helpInformation() ?? "").toContain("--verbose");
-    expect(statusCommand?.helpInformation() ?? "").toContain("--quiet");
     expect(startCommand?.description() ?? "").toContain(
       "background session health checks"
     );
-    expect(statusCommand?.helpInformation() ?? "").toContain(
-      "recent daemon events"
-    );
-    expect(stopCommand?.description() ?? "").toContain(
-      "preserve the last saved health state"
-    );
+
+    startCommand?.outputHelp();
+    const startHelpOutput = stdoutChunks.join("");
+    expect(startHelpOutput).toContain("--json");
+    expect(startHelpOutput).toContain("--verbose");
+    expect(startHelpOutput).toContain("stale PID file");
+
+    stdoutChunks = [];
+    statusCommand?.outputHelp();
+    const statusHelpOutput = stdoutChunks.join("");
+    expect(statusHelpOutput).toContain("--quiet");
+    expect(statusHelpOutput).toContain("Action Needed guidance");
+
+    stdoutChunks = [];
+    stopCommand?.outputHelp();
+    const stopHelpOutput = stdoutChunks.join("");
+    expect(stopHelpOutput).toContain("force-kills it");
   });
 });

--- a/packages/core/src/auth/sessionInspection.ts
+++ b/packages/core/src/auth/sessionInspection.ts
@@ -5,6 +5,10 @@ import {
   type LinkedInSelectorLocale
 } from "../selectorLocale.js";
 
+/**
+ * Snapshot of whether a Playwright page currently appears authenticated to
+ * LinkedIn.
+ */
 export interface LinkedInSessionInspection {
   authenticated: boolean;
   checkedAt: string;
@@ -43,6 +47,9 @@ function isLoginUrl(url: string): boolean {
   );
 }
 
+/**
+ * Returns whether a LinkedIn challenge URL matches the known rate-limit flow.
+ */
 export function isRateLimitedChallengeUrl(url: string): boolean {
   return (
     url.includes("challenge_global_internal_error") ||
@@ -69,6 +76,10 @@ async function hasSessionCookie(page: Page): Promise<boolean> {
   }
 }
 
+/**
+ * Inspects the current LinkedIn page for authenticated-session, login-wall,
+ * checkpoint, and rate-limit signals.
+ */
 export async function inspectLinkedInSession(
   page: Page,
   options: { selectorLocale?: LinkedInSelectorLocale } = {}

--- a/packages/core/src/auth/sessionStore.ts
+++ b/packages/core/src/auth/sessionStore.ts
@@ -19,6 +19,9 @@ import {
   type LinkedInSessionInspection
 } from "./sessionInspection.js";
 
+/**
+ * Playwright storage-state snapshot used for LinkedIn session persistence.
+ */
 export type LinkedInBrowserStorageState = Awaited<
   ReturnType<BrowserContext["storageState"]>
 >;
@@ -39,6 +42,10 @@ const LINKEDIN_AUTH_COOKIE_NAMES = new Set([
 
 type StorageStateCookie = LinkedInBrowserStorageState["cookies"][number];
 
+/**
+ * Redacted metadata describing the LinkedIn authentication cookies present in a
+ * captured storage-state snapshot.
+ */
 export interface LinkedInSessionCookieMetadata {
   name: string;
   domain: string;
@@ -74,6 +81,10 @@ function toCookieExpiresAt(expires: number): string | null {
   return new Date(expires * 1_000).toISOString();
 }
 
+/**
+ * Extracts the LinkedIn authentication cookies from a storage-state snapshot
+ * and returns them ordered by expiry.
+ */
 export function summarizeLinkedInSessionCookies(
   cookies: readonly StorageStateCookie[],
   options: { nowMs?: number } = {}
@@ -110,6 +121,10 @@ export function summarizeLinkedInSessionCookies(
     });
 }
 
+/**
+ * Computes a stable fingerprint for the LinkedIn authentication cookies in a
+ * storage-state snapshot.
+ */
 export function getLinkedInSessionFingerprint(
   storageState: Pick<LinkedInBrowserStorageState, "cookies">
 ): string {
@@ -136,6 +151,10 @@ export function getLinkedInSessionFingerprint(
     .digest("hex");
 }
 
+/**
+ * Restores the LinkedIn cookies from a storage-state snapshot into an existing
+ * Playwright browser context.
+ */
 export async function restoreLinkedInSessionCookies(
   context: BrowserContext,
   storageState: LinkedInBrowserStorageState
@@ -172,6 +191,9 @@ interface StoredLinkedInSessionMetadataRecord {
   sessionCookies?: LinkedInSessionCookieMetadata[];
 }
 
+/**
+ * Metadata returned when a stored LinkedIn session snapshot is saved or loaded.
+ */
 export interface StoredLinkedInSessionMetadata {
   capturedAt: string;
   cookieCount: number;
@@ -184,26 +206,41 @@ export interface StoredLinkedInSessionMetadata {
   sessionCookies?: LinkedInSessionCookieMetadata[];
 }
 
+/**
+ * Result returned by `LinkedInSessionStore.load()`.
+ */
 export interface LoadStoredLinkedInSessionResult {
   metadata: StoredLinkedInSessionMetadata;
   storageState: LinkedInBrowserStorageState;
 }
 
+/**
+ * Options for snapshot rotation when saving a LinkedIn session.
+ */
 export interface SaveStoredLinkedInSessionOptions {
   maxBackups?: number;
 }
 
+/**
+ * Options controlling restore fallback behavior.
+ */
 export interface RestoreStoredLinkedInSessionOptions {
   allowExpired?: boolean;
   maxBackups?: number;
 }
 
+/**
+ * Result returned when a stored LinkedIn session snapshot is restored.
+ */
 export interface RestoreStoredLinkedInSessionResult
   extends LoadStoredLinkedInSessionResult {
   restoredFromBackup: boolean;
   restoredSessionName: string;
 }
 
+/**
+ * Options for the interactive manual-login capture helper.
+ */
 export interface CaptureLinkedInSessionOptions {
   baseDir?: string;
   pollIntervalMs?: number;
@@ -211,6 +248,10 @@ export interface CaptureLinkedInSessionOptions {
   timeoutMs?: number;
 }
 
+/**
+ * Result returned by `captureLinkedInSession()` after a successful manual login
+ * capture.
+ */
 export interface CaptureLinkedInSessionResult
   extends StoredLinkedInSessionMetadata {
   authenticated: true;
@@ -566,10 +607,16 @@ function validateStorageState(
   return value as LinkedInBrowserStorageState;
 }
 
+/**
+ * Resolves the directory that stores encrypted LinkedIn session snapshots.
+ */
 export function resolveLinkedInSessionStoreDir(baseDir?: string): string {
   return path.join(resolveConfigPaths(baseDir).profilesDir, "stored-sessions");
 }
 
+/**
+ * Resolves the encrypted on-disk file path for a named stored LinkedIn session.
+ */
 export function resolveStoredLinkedInSessionPath(
   sessionName: string = "default",
   baseDir?: string
@@ -581,13 +628,27 @@ export function resolveStoredLinkedInSessionPath(
   );
 }
 
+/**
+ * Encrypts, rotates, loads, and restores named LinkedIn session snapshots.
+ */
 export class LinkedInSessionStore {
+  /**
+   * Creates a session store rooted in the default tool home or a custom base
+   * directory.
+   */
   constructor(private readonly baseDir?: string) {}
 
+  /**
+   * Returns the encrypted session file path for the provided session name.
+   */
   getSessionPath(sessionName: string = "default"): string {
     return resolveStoredLinkedInSessionPath(sessionName, this.baseDir);
   }
 
+  /**
+   * Saves the provided storage-state snapshot as the primary encrypted session
+   * file for `sessionName`.
+   */
   async save(
     sessionName: string,
     storageState: LinkedInBrowserStorageState
@@ -629,6 +690,10 @@ export class LinkedInSessionStore {
     return metadata;
   }
 
+  /**
+   * Saves a session snapshot and rotates older copies into numbered backup
+   * slots.
+   */
   async saveWithBackups(
     sessionName: string,
     storageState: LinkedInBrowserStorageState,
@@ -667,6 +732,9 @@ export class LinkedInSessionStore {
     return this.save(normalizedSessionName, storageState);
   }
 
+  /**
+   * Returns whether an encrypted session snapshot exists for `sessionName`.
+   */
   async exists(sessionName: string = "default"): Promise<boolean> {
     try {
       await readFile(this.getSessionPath(sessionName), "utf8");
@@ -679,6 +747,9 @@ export class LinkedInSessionStore {
     }
   }
 
+  /**
+   * Loads and decrypts a named stored LinkedIn session snapshot.
+   */
   async load(sessionName: string = "default"): Promise<LoadStoredLinkedInSessionResult> {
     const normalizedSessionName = normalizeSessionName(sessionName);
     const filePath = this.getSessionPath(normalizedSessionName);
@@ -740,6 +811,10 @@ export class LinkedInSessionStore {
     };
   }
 
+  /**
+   * Loads the newest usable stored session, falling back through backups when
+   * needed.
+   */
   async loadLatestAvailable(
     sessionName: string = "default",
     options: RestoreStoredLinkedInSessionOptions = {}
@@ -794,6 +869,10 @@ export class LinkedInSessionStore {
     );
   }
 
+  /**
+   * Restores the latest usable stored session snapshot into an existing
+   * Playwright browser context.
+   */
   async restoreToContext(
     context: BrowserContext,
     sessionName: string = "default",
@@ -874,6 +953,10 @@ async function waitForManualLogin(
   return lastStatus;
 }
 
+/**
+ * Opens a visible Chromium browser, waits for a manual LinkedIn login, and
+ * persists the resulting authenticated session snapshot.
+ */
 export async function captureLinkedInSession(
   options: CaptureLinkedInSessionOptions = {}
 ): Promise<CaptureLinkedInSessionResult> {

--- a/packages/core/src/keepAlive.ts
+++ b/packages/core/src/keepAlive.ts
@@ -96,6 +96,10 @@ interface SessionRestoreAttempt {
   successMetadata: Record<string, unknown>;
 }
 
+/**
+ * Structured event kinds emitted by `SessionKeepAliveService` as it monitors
+ * and recovers a LinkedIn browser session.
+ */
 export type KeepAliveEventType =
   | "healthy"
   | "session-expired"
@@ -119,6 +123,9 @@ export type KeepAliveEventType =
   | "tab-cleanup"
   | "warmup";
 
+/**
+ * Structured keepalive event emitted on the `health-event` channel.
+ */
 export interface KeepAliveEvent {
   type: KeepAliveEventType;
   timestamp: string;
@@ -128,6 +135,9 @@ export interface KeepAliveEvent {
   metadata?: Record<string, unknown>;
 }
 
+/**
+ * Thresholds that raise operator-visible keepalive alerts.
+ */
 export interface KeepAliveAlertThresholds {
   cookieExpiringWithinMs?: number;
   reconnectsInWindow?: {
@@ -136,6 +146,9 @@ export interface KeepAliveAlertThresholds {
   };
 }
 
+/**
+ * Rolling health and recovery metrics exposed by `SessionKeepAliveService`.
+ */
 export interface KeepAliveMetrics {
   activeAlerts: string[];
   authenticated: boolean;
@@ -161,6 +174,27 @@ export interface KeepAliveMetrics {
   startedAt?: string;
 }
 
+/**
+ * Configuration for `SessionKeepAliveService`.
+ *
+ * Defaults:
+ * - `activityEveryHealthyTicks`: `3`
+ * - `activitySimulationEnabled`: `true`
+ * - `cookieRefreshLeadMs`: session-cookie warning threshold from
+ *   `checkFullHealth()`
+ * - `idleWarmupThresholdMs`: `14400000`
+ * - `intervalMs`: `300000`
+ * - `jitterMs`: `30000`
+ * - `maxBackupSessions`: `3`
+ * - `maxConsecutiveFailures`: `5`
+ * - `maxHealthLogEntries`: `200` (minimum `10`)
+ * - `networkGracePeriodMs`: `300000`
+ * - `networkRetryIntervalMs`: `30000`
+ * - `nightActivityEveryHealthyTicks`: `6`
+ * - `nightHours`: `00:00`-`06:00`
+ * - `sessionName`: `default`
+ * - `sessionRefreshEnabled`: `true`
+ */
 export interface KeepAliveOptions {
   activityEveryHealthyTicks?: number;
   activitySimulationEnabled?: boolean;
@@ -642,6 +676,14 @@ async function navigateToKeepAlivePage(page: Page, url: string): Promise<void> {
   await page.goto(url, KEEP_ALIVE_PAGE_GOTO_OPTIONS);
 }
 
+/**
+ * Coordinates periodic LinkedIn health checks, low-risk background activity,
+ * session snapshot persistence, and recovery attempts for a CDP-attached
+ * browser session.
+ *
+ * Emits high-level events such as `healthy`, `session-expired`,
+ * `browser-disconnected`, `health-event`, and `error`.
+ */
 export class SessionKeepAliveService extends EventEmitter {
   private timer: ReturnType<typeof setTimeout> | undefined;
   private running = false;
@@ -767,6 +809,9 @@ export class SessionKeepAliveService extends EventEmitter {
     this.sessionStore = normalizeSessionStore(options.sessionStore);
   }
 
+  /**
+   * Starts the keepalive loop. Calling this while already running is a no-op.
+   */
   start(): void {
     if (this.running) {
       return;
@@ -789,24 +834,39 @@ export class SessionKeepAliveService extends EventEmitter {
     this.scheduleNextTick(this.generation);
   }
 
+  /**
+   * Stops future keepalive ticks and invalidates any in-flight generation.
+   */
   stop(): void {
     this.generation += 1;
     this.clearTimer();
     this.running = false;
   }
 
+  /**
+   * Returns whether the keepalive loop is currently running.
+   */
   isRunning(): boolean {
     return this.running;
   }
 
+  /**
+   * Returns the current consecutive-failure count.
+   */
   getConsecutiveFailures(): number {
     return this.consecutiveFailures;
   }
 
+  /**
+   * Returns a defensive copy of the in-memory health-event log.
+   */
   getHealthLog(): KeepAliveEvent[] {
     return [...this.eventLog];
   }
 
+  /**
+   * Returns the latest derived keepalive metrics and active alerts.
+   */
   getMetrics(): KeepAliveMetrics {
     void this.getRateLimitDelayMs();
 


### PR DESCRIPTION
## Summary
- update the root README keepalive section with the hardened operator workflow, saved state/event files, recovery guidance, and CLI defaults
- expand keepalive CLI help coverage and add a test that exercises the rendered `--help` output
- add missing TSDoc for the keepalive, session-inspection, and session-store APIs introduced during the hardening work

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #196
