### PR TITLE
docs: add anti-bot evasion implementation plan

### DIFF
--- a/docs/.plan-issue-202.md
+++ b/docs/.plan-issue-202.md
@@ -1,0 +1,1022 @@
+# Execution plan — issue #202 anti-bot evasion implementation plan
+
+Related issues: #202, #199, #132
+
+This planning document turns the Phase 0 research brief in
+`docs/.research-brief-issue-199.md` into a concrete Build-phase implementation
+plan for the `packages/core` runtime.
+
+## Intent
+
+Produce a repo-specific implementation plan that improves LinkedIn session
+believability without expanding into fragile or hard-to-verify spoofing.
+
+The plan follows the research brief’s recommended order:
+
+1. enrich mouse movement and scroll behavior first
+2. add a session-rhythm layer around warmup, dwell, and pacing
+3. harden browser-context consistency before deeper fingerprint work
+4. centralize challenge and honeypot detection as a fail-closed guardrail
+
+The guiding principle for every slice is:
+
+> prefer consistency over randomness
+
+For this codebase, stable, coherent signals are more valuable than aggressive
+randomization. The plan therefore favors deterministic planners, reusable
+profiles, and small public APIs over one-off heuristics embedded in each
+LinkedIn service.
+
+## Current repo findings that shape the plan
+
+The Phase 0 brief and current codebase point to a clear split between what is
+already strong and what is still lightweight:
+
+- `packages/core/src/humanize.ts`
+  - already has a mature typing layer with profiles, typo correction,
+    contextual pauses, and safe degradation
+  - still treats mouse, scroll, and idle as thin helpers built around a single
+    `mouse.move()`, `scrollBy()`, or short timeout
+- `packages/core/src/keepAlive.ts`
+  - already uses `humanize(page, { fast: true })` for warmup and activity, but
+    only for a basic idle or one downward scroll
+- `packages/core/src/profileManager.ts`
+  - is the right place to apply persistent-context launch consistency and to
+    inspect attached CDP contexts
+- `packages/core/src/auth/sessionInspection.ts`
+  - already classifies login walls, checkpoints, and the
+    `challenge_global_internal_error` rate-limit flow
+- `packages/core/src/healthCheck.ts`
+  - already gathers cookie metadata and session status, making it a natural
+    place to surface hardening diagnostics later
+
+The result is that the next implementation wave should not start with deep
+fingerprint spoofing. It should start by giving `humanize.ts` richer movement
+and scrolling primitives, then add session-level pacing, then add context
+coherence checks at the profile/runtime boundary.
+
+## Scope boundaries and non-goals
+
+These constraints should shape the Build phase:
+
+- keep this phase planning-only; no runtime changes are proposed here
+- keep `packages/core/src/humanize.ts` as the primary public interaction entry
+  point
+- prefer pure, seedable planners behind public helpers so unit tests stay
+  deterministic
+- keep CLI and MCP changes out of the first implementation slice unless the
+  core runtime proves a stable operator-facing need
+- do not attempt TLS, JA3/JA4, proxy, ASN, or IP-reputation shaping in this
+  phase; those are partly outside the repo and harder to validate safely
+- do not start with broad `navigator.*`, canvas, WebGL, audio, or plugin
+  spoofing; only add context-consistency measures that can stay coherent across
+  persistent and CDP-attached sessions
+- do not add automatic challenge bypass or captcha-solving behavior; challenge
+  handling remains fail-closed
+- validate primarily with unit tests, fixture replay, local DOM harnesses, and
+  read-only live flows; do not rely on public actions to “see if detection
+  happens”
+
+## Priority ranking — detection risk versus implementation effort
+
+| Rank | Technique | Detection risk addressed | Implementation effort | Why it lands here |
+| --- | --- | --- | --- | --- |
+| 1 | Mouse movement enrichment | High | Medium | Current cursor movement is visibly lightweight and affects nearly every click path |
+| 2 | Scroll rhythm enrichment | High | Medium | Feed, search, jobs, inbox, and notifications all generate scroll-heavy sessions |
+| 3 | Session-rhythm layer | High | Medium-high | Even better pointer primitives still look robotic if every page follows the same short delay pattern |
+| 4 | Browser-context consistency | Medium-high | Medium-high | Coherent locale/timezone/viewport surfaces matter, but broad spoofing is riskier than behavior work |
+| 5 | Challenge and honeypot detection | Medium | Low-medium | The repo already fails closed on obvious challenge URLs, so this is valuable guardrail work rather than the biggest realism gap |
+| Defer | Network-level shaping | High in theory | Very high / partly out of scope | Important, but not the best first implementation target in a Playwright-only repo |
+
+The Build phase should therefore ship in this order:
+
+1. mouse trajectory + click hover realism
+2. scroll chunking + read dwell behavior
+3. session rhythm and mutation warmup rules
+4. browser-context consistency profiles and diagnostics
+5. challenge/honeypot guards for selectors and unexpected interstitials
+
+## Recommended architecture decisions
+
+### 1) Keep `humanize.ts` public, but move richer planners into focused modules
+
+`HumanizedPage` is already the repo’s natural abstraction for human-like
+interaction. The Build phase should preserve that surface and factor new logic
+into small internal modules rather than turning `humanize.ts` into one giant
+file.
+
+### 2) Treat mouse and scroll as planner/executor pairs, like typing
+
+The typing work already proved the value of separating profile resolution from
+execution. Mouse and scroll should follow the same pattern:
+
+- a pure planner decides waypoints, pauses, and corrections
+- `humanize.ts` executes the plan with Playwright primitives
+- tests validate the plan without a real browser session
+
+### 3) Put session rhythm in runtime state, not inside each LinkedIn service
+
+Warmup, dwell, and burst control are session-level concerns. They should live in
+one shared runtime service that can be consulted by `auth`, `keepAlive`, and
+read/write services instead of duplicating ad hoc delays throughout the repo.
+
+### 4) Apply browser-context consistency at the profile boundary
+
+`ProfileManager` is the right place to shape persistent launch options and to
+inspect CDP-attached contexts. Hardening should not be scattered across
+`linkedinFeed.ts`, `linkedinSearch.ts`, or individual action executors.
+
+### 5) Centralize challenge and honeypot checks in shared interaction guards
+
+Challenge detection should stay fail-closed and become easier to reuse. Hidden
+or suspicious targets should be screened through one module that is shared by
+`humanize.ts`, `auth/sessionInspection.ts`, `healthCheck.ts`, and later write
+executors.
+
+### 6) Roll out read-only first, then auth, then write flows
+
+The order inside the Build phase should be:
+
+1. pure planners + `humanize.ts` execution
+2. `keepAlive` and read-only browsing services
+3. auth flows
+4. prepare/confirm write executors
+
+That minimizes the risk of introducing fragile behavior into mutations before
+low-risk browsing paths are validated.
+
+## Ordered implementation steps
+
+### 1) Build mouse trajectory and click-hover enrichment
+
+#### Goals
+
+- replace single straight-line pointer moves with planned trajectories
+- support hover hesitation, slight overshoot, and corrective motion before a
+  click
+- keep the public entry point centered on `HumanizedPage`
+- preserve `fast` mode for tests and validation flows without bypassing the new
+  module boundaries
+
+#### File-level changes
+
+- new `packages/core/src/interactionProfiles.ts`
+  - mouse, scroll, and rhythm profile presets
+  - shared validation helpers for numeric ranges and per-profile overrides
+- new `packages/core/src/mousePath.ts`
+  - pure mouse trajectory planning
+  - overshoot/correction, waypoint generation, and hover timing
+- modify `packages/core/src/humanize.ts`
+  - keep `humanize(page)` and `HumanizedPage`
+  - replace `moveMouseNear()` and click pointer setup with a planner/executor
+    path
+  - add selector-based hover/move helpers instead of exposing only raw x/y
+    movement
+- modify `packages/core/src/index.ts`
+  - re-export any new public types that should be available from the core
+    package
+
+#### Planned API surface
+
+Recommended new public types in `packages/core/src/humanize.ts`:
+
+```ts
+export type MouseProfileName = "subtle" | "balanced" | "careful";
+
+export interface MouseMoveOptions {
+  profile?: MouseProfileName;
+  hoverBeforeMs?: DelayRange;
+  allowOvershoot?: boolean;
+  targetPaddingPx?: number;
+}
+
+export interface HumanizedClickOptions extends MouseMoveOptions {
+  settleBeforeClickMs?: DelayRange;
+}
+
+export class HumanizedPage {
+  moveMouseToSelector(
+    selector: string,
+    options?: MouseMoveOptions
+  ): Promise<void>;
+
+  hover(
+    selector: string,
+    options?: MouseMoveOptions
+  ): Promise<void>;
+
+  click(
+    selector: string,
+    options?: HumanizedClickOptions
+  ): Promise<void>;
+}
+```
+
+Recommended new internal planner API in `packages/core/src/mousePath.ts`:
+
+```ts
+export interface MouseWaypoint {
+  x: number;
+  y: number;
+  dwellMs: number;
+}
+
+export interface MousePathPlan {
+  hoverMs: number;
+  overshoot: boolean;
+  waypoints: MouseWaypoint[];
+}
+
+export interface BuildMousePathPlanInput {
+  from: { x: number; y: number };
+  profile: MouseProfileName;
+  random?: () => number;
+  target: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+}
+
+export function buildMousePathPlan(
+  input: BuildMousePathPlanInput
+): MousePathPlan;
+```
+
+#### Test strategy for this step
+
+- add `packages/core/src/__tests__/mousePath.test.ts`
+  - deterministic seeded coverage for path curvature, overshoot, correction,
+    bounds clamping, and short-distance moves
+- modify `packages/core/src/__tests__/humanize.test.ts`
+  - verify multi-step `page.mouse.move()` execution instead of a single move
+  - verify hover pauses and click-settle behavior
+- modify `packages/core/src/__tests__/humanizeHardening.test.ts`
+  - validate argument checking and degraded behavior when an element lacks a
+    bounding box
+- keep browser-free tests as the main validation path; no live actions are
+  needed for this slice
+
+#### Dependencies
+
+- no upstream implementation dependency
+- unlocks richer scroll behavior and is the first realism primitive to ship
+
+### 2) Build scroll rhythm and read-dwell behavior on top of the mouse layer
+
+#### Goals
+
+- replace one-shot `scrollBy({ behavior: "smooth" })` usage with planned scroll
+  segments
+- support variable chunk sizes, end-of-scroll dwell, and occasional light
+  reverse scrolls
+- connect scroll behavior to reading pauses rather than treating scroll as a
+  stand-alone animation
+- make feed/search/jobs/inbox flows able to consume the same primitive without
+  copy-pasting logic
+
+#### File-level changes
+
+- new `packages/core/src/scrollPlan.ts`
+  - pure planning for wheel/touchpad-style scroll segments and dwell windows
+- modify `packages/core/src/humanize.ts`
+  - replace `scrollDown()` with a richer planner-driven scroll executor
+  - add higher-level read/settle helper(s) instead of keeping idle separate from
+    browsing intent
+- later-read callers to adopt after the planner is stable:
+  - `packages/core/src/keepAlive.ts`
+  - `packages/core/src/linkedinFeed.ts`
+  - `packages/core/src/linkedinSearch.ts`
+  - `packages/core/src/linkedinJobs.ts`
+  - `packages/core/src/linkedinInbox.ts`
+  - `packages/core/src/linkedinNotifications.ts`
+
+#### Planned API surface
+
+Recommended public additions in `packages/core/src/humanize.ts`:
+
+```ts
+export type ScrollProfileName = "reader" | "skim" | "careful";
+
+export interface ScrollOptions {
+  profile?: ScrollProfileName;
+  direction?: "down" | "up";
+  distancePx?: number;
+  readAfter?: boolean;
+}
+
+export interface ReadDwellOptions {
+  complexity?: "short" | "medium" | "long";
+  reason?: "post-scroll" | "pre-click" | "post-navigation";
+}
+
+export class HumanizedPage {
+  scroll(options?: ScrollOptions): Promise<void>;
+  read(options?: ReadDwellOptions): Promise<void>;
+}
+```
+
+Recommended internal planner API in `packages/core/src/scrollPlan.ts`:
+
+```ts
+export interface ScrollSegment {
+  deltaY: number;
+  pauseAfterMs: number;
+}
+
+export interface ScrollPlan {
+  direction: "down" | "up";
+  finalDwellMs: number;
+  segments: ScrollSegment[];
+}
+
+export interface BuildScrollPlanInput {
+  distancePx?: number;
+  profile: ScrollProfileName;
+  random?: () => number;
+  viewportHeight: number;
+}
+
+export function buildScrollPlan(
+  input: BuildScrollPlanInput
+): ScrollPlan;
+```
+
+#### Test strategy for this step
+
+- add `packages/core/src/__tests__/scrollPlan.test.ts`
+  - deterministic segment clustering, reverse-scroll behavior, and final dwell
+    coverage
+- modify `packages/core/src/__tests__/humanize.test.ts`
+  - verify repeated scroll execution rather than a single DOM `scrollBy()`
+  - verify read dwell is invoked after scroll when requested
+- add a local DOM harness or fixture-based test for long list pages rather than
+  a real LinkedIn session
+- do not use public feed interactions as validation; read-only traversal is
+  sufficient
+
+#### Dependencies
+
+- depends on step 1 for shared profile handling and pointer/hover semantics
+- unlocks step 3 because session rhythm should orchestrate real scroll/read
+  primitives instead of raw sleeps
+
+### 3) Add a shared session-rhythm service
+
+#### Goals
+
+- make session pacing depend on session state instead of fixed per-call waits
+- add warmup and dwell rules before mutations after navigation or long idle
+- capture burstiness, short idle gaps, and longer thinking pauses as explicit
+  runtime decisions
+- keep rhythm state in memory first; do not introduce DB persistence unless it
+  proves necessary
+
+#### File-level changes
+
+- new `packages/core/src/sessionRhythm.ts`
+  - shared service for navigation cadence, idle windows, and mutation warmup
+- modify `packages/core/src/config.ts`
+  - add a minimal hardening config resolver for profile-level rhythm behavior
+- modify `packages/core/src/runtime.ts`
+  - construct the rhythm service and expose it on the runtime
+- modify `packages/core/src/keepAlive.ts`
+  - replace the current warmup/idle heuristics with rhythm-driven decisions
+- modify `packages/core/src/auth/session.ts`
+  - insert rhythm-aware warmup before login writes and post-navigation actions
+- later-read services to consult once the core service is stable:
+  - `packages/core/src/linkedinFeed.ts`
+  - `packages/core/src/linkedinSearch.ts`
+  - `packages/core/src/linkedinInbox.ts`
+  - `packages/core/src/linkedinJobs.ts`
+  - `packages/core/src/linkedinNotifications.ts`
+
+#### Planned API surface
+
+Recommended public runtime additions:
+
+```ts
+export type RhythmActionKind =
+  | "navigate"
+  | "scroll"
+  | "hover"
+  | "click"
+  | "type"
+  | "mutation";
+
+export type SessionRhythmProfileName = "conservative" | "balanced" | "fast";
+
+export interface SessionRhythmDecision {
+  beforeActionDelayMs: number;
+  requireWarmup: boolean;
+  recommendedReadDwellMs: number;
+  shouldScrollFirst: boolean;
+}
+
+export class SessionRhythmService {
+  noteNavigation(input: { pageKey: string; url: string; at?: string }): void;
+  noteAction(input: {
+    pageKey: string;
+    action: RhythmActionKind;
+    at?: string;
+    isMutation?: boolean;
+  }): void;
+  getDecision(input: {
+    pageKey: string;
+    nextAction: RhythmActionKind;
+    isMutation?: boolean;
+  }): SessionRhythmDecision;
+  reset(pageKey: string): void;
+}
+```
+
+Recommended config surface in `packages/core/src/config.ts`:
+
+```ts
+export interface AutomationHardeningConfig {
+  enabled: boolean;
+  profile: SessionRhythmProfileName;
+  warmupAfterIdleMs: number;
+  mutationWarmupMs: number;
+  readDwellMultiplier: number;
+}
+
+export function resolveAutomationHardeningConfig(): AutomationHardeningConfig;
+```
+
+#### Test strategy for this step
+
+- add `packages/core/src/__tests__/sessionRhythm.test.ts`
+  - fake-clock coverage for warmup-after-idle, post-navigation dwell, mutation
+    gating, and burst cooldown decisions
+- modify `packages/core/src/__tests__/keepAlive.test.ts`
+  - verify warmup and activity decisions come from the rhythm service instead of
+    ad hoc time checks
+- modify `packages/core/src/__tests__/headlessLogin.test.ts`
+  - verify auth flows can consume rhythm delays without changing the final
+    outcome shape
+- validate with deterministic clocks and seeded planners only; do not try to
+  “prove” success through live challenge avoidance
+
+#### Dependencies
+
+- depends on steps 1 and 2 for realistic interaction primitives
+- should land before browser-context rollout expands to broad write flows
+
+### 4) Add browser-context consistency profiles and diagnostics
+
+#### Goals
+
+- keep locale, timezone, viewport, and related context values internally
+  coherent
+- apply consistency at persistent-launch time when the repo owns the browser
+- inspect and report mismatches for CDP-attached contexts that cannot be safely
+  rewritten
+- stop short of brittle deep-fingerprint spoofing in the first implementation
+  wave
+
+#### File-level changes
+
+- new `packages/core/src/browserContextConsistency.ts`
+  - profile resolution and mismatch reporting for persistent and CDP contexts
+- modify `packages/core/src/config.ts`
+  - extend hardening config with context-consistency settings
+- modify `packages/core/src/profileManager.ts`
+  - apply consistent persistent launch options
+  - inspect attached contexts and surface mismatch reports
+- modify `packages/core/src/runtime.ts`
+  - expose the service on runtime for diagnostics and later adoption
+- modify `packages/core/src/healthCheck.ts`
+  - optionally include hardening diagnostics in the session/browser report
+- modify `packages/core/src/index.ts`
+  - re-export the new service and types
+
+#### Planned API surface
+
+Recommended public types:
+
+```ts
+export type ContextConsistencyMode =
+  | "disabled"
+  | "observe"
+  | "apply-persistent"
+  | "strict";
+
+export interface BrowserContextProfile {
+  locale: string;
+  timezoneId: string;
+  viewport: {
+    width: number;
+    height: number;
+  };
+  colorScheme: "light" | "dark" | "no-preference";
+  reducedMotion: "reduce" | "no-preference";
+}
+
+export interface BrowserContextMismatch {
+  actual: string | null;
+  expected: string;
+  severity: "info" | "warn" | "error";
+  surface: string;
+}
+
+export interface BrowserContextConsistencyReport {
+  checkedAt: string;
+  mode: ContextConsistencyMode;
+  mismatches: BrowserContextMismatch[];
+  profile: BrowserContextProfile;
+}
+
+export class BrowserContextConsistencyService {
+  resolveProfile(input: {
+    profileName: string;
+    selectorLocale?: LinkedInSelectorLocale;
+  }): BrowserContextProfile;
+
+  buildPersistentContextOptions(input: {
+    profileName: string;
+    base?: PersistentContextOptions["launchOptions"];
+    selectorLocale?: LinkedInSelectorLocale;
+  }): PersistentContextOptions["launchOptions"];
+
+  inspectContext(
+    context: BrowserContext,
+    input: { profileName: string; selectorLocale?: LinkedInSelectorLocale }
+  ): Promise<BrowserContextConsistencyReport>;
+}
+```
+
+Recommended config additions:
+
+```ts
+export interface AutomationHardeningConfig {
+  enabled: boolean;
+  profile: SessionRhythmProfileName;
+  warmupAfterIdleMs: number;
+  mutationWarmupMs: number;
+  readDwellMultiplier: number;
+  contextConsistency: {
+    enabled: boolean;
+    mode: ContextConsistencyMode;
+    locale?: string;
+    timezoneId?: string;
+    viewportWidth: number;
+    viewportHeight: number;
+    colorScheme: "light" | "dark" | "no-preference";
+    reducedMotion: "reduce" | "no-preference";
+  };
+}
+```
+
+Recommended environment variables to keep the surface intentionally small:
+
+- `LINKEDIN_ASSISTANT_HARDENING_ENABLED`
+- `LINKEDIN_ASSISTANT_HARDENING_PROFILE`
+- `LINKEDIN_ASSISTANT_HARDENING_CONTEXT_MODE`
+- `LINKEDIN_ASSISTANT_HARDENING_TIMEZONE`
+- `LINKEDIN_ASSISTANT_HARDENING_LOCALE`
+- `LINKEDIN_ASSISTANT_HARDENING_VIEWPORT_WIDTH`
+- `LINKEDIN_ASSISTANT_HARDENING_VIEWPORT_HEIGHT`
+
+#### Test strategy for this step
+
+- add `packages/core/src/__tests__/browserContextConsistency.test.ts`
+  - resolve-profile coverage and mismatch classification for persistent and CDP
+    modes
+- modify `packages/core/src/__tests__/profileManager.test.ts`
+  - verify launch options are passed through for persistent contexts
+  - verify attached contexts are inspected rather than mutated
+- modify `packages/core/src/__tests__/healthCheck.test.ts`
+  - verify diagnostics projection if health output is extended
+- avoid “deep spoofing” tests; validate profile coherence, launch wiring, and
+  mismatch reporting instead
+
+#### Dependencies
+
+- can begin once step 3 config/runtime scaffolding exists
+- should be fully in place before the behavior layer is rolled out broadly to
+  write executors
+
+### 5) Centralize challenge and honeypot detection as shared interaction guards
+
+#### Goals
+
+- preserve the repo’s fail-closed challenge handling
+- extend detection beyond URL checks to suspicious or hidden targets
+- stop accidental interaction with likely trap elements or unexpected
+  interstitials
+- keep selectors and guards generic rather than embedding brittle LinkedIn-only
+  trap assumptions
+
+#### File-level changes
+
+- new `packages/core/src/interactionGuards.ts`
+  - shared page and target inspection helpers
+- modify `packages/core/src/auth/sessionInspection.ts`
+  - reuse shared challenge/interstitial classification helpers
+- modify `packages/core/src/humanize.ts`
+  - call target-actionability guards before click/type helpers
+- modify `packages/core/src/healthCheck.ts`
+  - surface guard-state details in diagnostics where useful
+- modify `packages/core/src/liveValidation.ts`
+  - reuse the shared classification instead of duplicating page checks
+- later write-surface adopters:
+  - `packages/core/src/linkedinConnections.ts`
+  - `packages/core/src/linkedinInbox.ts`
+  - `packages/core/src/linkedinFeed.ts`
+  - `packages/core/src/linkedinPosts.ts`
+
+#### Planned API surface
+
+Recommended public types:
+
+```ts
+export type InteractionBlockReason =
+  | "checkpoint"
+  | "captcha"
+  | "login_wall"
+  | "hidden_target"
+  | "disabled_target"
+  | "offscreen_target"
+  | "suspicious_interstitial";
+
+export interface InteractionGuardReport {
+  blocked: boolean;
+  checkedAt: string;
+  currentUrl: string;
+  reasons: InteractionBlockReason[];
+}
+
+export class InteractionGuardService {
+  inspectPage(page: Page): Promise<InteractionGuardReport>;
+  assertActionableTarget(
+    locator: Locator,
+    options?: { allowDisabled?: boolean }
+  ): Promise<void>;
+}
+```
+
+Recommended config additions:
+
+```ts
+export interface AutomationHardeningConfig {
+  enabled: boolean;
+  profile: SessionRhythmProfileName;
+  warmupAfterIdleMs: number;
+  mutationWarmupMs: number;
+  readDwellMultiplier: number;
+  contextConsistency: { /* as above */ };
+  interactionGuards: {
+    enabled: boolean;
+    blockHiddenTargets: boolean;
+    failClosedOnChallenge: boolean;
+  };
+}
+```
+
+#### Test strategy for this step
+
+- add `packages/core/src/__tests__/interactionGuards.test.ts`
+  - hidden target, zero-size target, disabled target, and suspicious
+    interstitial coverage with a local DOM harness or page mock
+- modify `packages/core/src/__tests__/sessionInspection.test.ts`
+  - verify shared challenge classification still prioritizes checkpoint/login
+    wall flows correctly
+- modify `packages/core/src/__tests__/writeValidationRuntime.test.ts`
+  - verify writes stop early when guard reports a blocked page or target
+- validate against synthetic pages and fixture replay only; do not intentionally
+  trigger real LinkedIn detection
+
+#### Dependencies
+
+- depends on steps 1 through 4 so it can reuse the same runtime services and
+  guard the final adopted interaction surfaces
+- should land before public write flows adopt the new behavior stack
+
+## Proposed file-level implementation map
+
+### New files
+
+- `packages/core/src/interactionProfiles.ts`
+  - preset definitions and range validation for mouse, scroll, and rhythm
+- `packages/core/src/mousePath.ts`
+  - pure trajectory planner
+- `packages/core/src/scrollPlan.ts`
+  - pure scroll/dwell planner
+- `packages/core/src/sessionRhythm.ts`
+  - runtime pacing service
+- `packages/core/src/browserContextConsistency.ts`
+  - launch-profile resolution and mismatch inspection
+- `packages/core/src/interactionGuards.ts`
+  - shared challenge/interstitial/target guard logic
+- `packages/core/src/__tests__/mousePath.test.ts`
+- `packages/core/src/__tests__/scrollPlan.test.ts`
+- `packages/core/src/__tests__/sessionRhythm.test.ts`
+- `packages/core/src/__tests__/browserContextConsistency.test.ts`
+- `packages/core/src/__tests__/interactionGuards.test.ts`
+
+### Modified files
+
+Core infrastructure:
+
+- `packages/core/src/humanize.ts`
+- `packages/core/src/config.ts`
+- `packages/core/src/runtime.ts`
+- `packages/core/src/index.ts`
+- `packages/core/src/profileManager.ts`
+
+Health, auth, and validation surfaces:
+
+- `packages/core/src/auth/session.ts`
+- `packages/core/src/auth/sessionInspection.ts`
+- `packages/core/src/healthCheck.ts`
+- `packages/core/src/liveValidation.ts`
+- `packages/core/src/keepAlive.ts`
+
+Read-only adopters for rollout:
+
+- `packages/core/src/linkedinFeed.ts`
+- `packages/core/src/linkedinSearch.ts`
+- `packages/core/src/linkedinJobs.ts`
+- `packages/core/src/linkedinInbox.ts`
+- `packages/core/src/linkedinNotifications.ts`
+- `packages/core/src/linkedinProfile.ts`
+
+Write-side adopters after read-only validation:
+
+- `packages/core/src/linkedinConnections.ts`
+- `packages/core/src/linkedinInbox.ts`
+- `packages/core/src/linkedinFeed.ts`
+- `packages/core/src/linkedinPosts.ts`
+
+Existing tests to extend:
+
+- `packages/core/src/__tests__/humanize.test.ts`
+- `packages/core/src/__tests__/humanizeHardening.test.ts`
+- `packages/core/src/__tests__/profileManager.test.ts`
+- `packages/core/src/__tests__/sessionInspection.test.ts`
+- `packages/core/src/__tests__/healthCheck.test.ts`
+- `packages/core/src/__tests__/keepAlive.test.ts`
+- `packages/core/src/__tests__/headlessLogin.test.ts`
+- `packages/core/src/__tests__/writeValidationRuntime.test.ts`
+
+## Planned runtime and config surface
+
+### Runtime additions
+
+Recommended `CoreRuntime` additions once implementation begins:
+
+```ts
+export interface CoreRuntime {
+  // existing fields...
+  hardening: AutomationHardeningConfig;
+  sessionRhythm: SessionRhythmService;
+  browserContextConsistency: BrowserContextConsistencyService;
+  interactionGuards: InteractionGuardService;
+}
+
+export interface CreateCoreRuntimeOptions {
+  // existing fields...
+  hardening?: Partial<AutomationHardeningConfig>;
+}
+```
+
+This keeps hardening config and services in the same place as `privacy`,
+`selectorLocale`, `rateLimiter`, and the rest of the runtime graph.
+
+### Config design rules
+
+The hardening config should stay intentionally small:
+
+- one top-level enable/disable switch
+- one profile name that shifts default pacing
+- a minimal context-consistency block
+- a minimal interaction-guard block
+
+What should *not* become environment variables in phase 1:
+
+- individual mouse waypoint counts
+- per-pause jitter numbers
+- typo-style micro-probabilities for non-typing behavior
+- one-off LinkedIn page heuristics
+
+Those should live in code-owned presets so the runtime remains coherent and easy
+to test.
+
+## Dependency summary
+
+The implementation dependencies should be treated as a real graph, not as a flat
+checklist:
+
+```text
+interactionProfiles
+├─> mousePath
+│   └─> humanize click/hover helpers
+├─> scrollPlan
+│   └─> humanize scroll/read helpers
+│       └─> sessionRhythm
+│           ├─> keepAlive
+│           ├─> auth/session
+│           └─> read-only LinkedIn services
+├─> browserContextConsistency
+│   ├─> profileManager
+│   ├─> runtime
+│   └─> healthCheck
+└─> interactionGuards
+    ├─> auth/sessionInspection
+    ├─> humanize click/type guards
+    ├─> liveValidation
+    └─> write executors
+```
+
+The most important ordering rule is:
+
+- mouse movement should land before scroll behavior because the scroll layer
+  should share the same profile system and pointer-settle assumptions
+- session rhythm should land after mouse/scroll so it orchestrates real
+  primitives instead of raw sleeps
+- browser-context consistency can start once config/runtime scaffolding exists,
+  but it should be fully wired before broad write-surface rollout
+- interaction guards should land after the core interaction surfaces exist so
+  they can guard the final shape of those APIs
+
+## Recommended Build-phase rollout
+
+### Slice 1: planner primitives and `humanize.ts` upgrades
+
+- add `interactionProfiles.ts`, `mousePath.ts`, and `scrollPlan.ts`
+- extend `HumanizedPage` with richer `click`, `hover`, `scroll`, and `read`
+  behavior
+- keep adoption local to `humanize.ts` until the primitives and tests are stable
+
+### Slice 2: read-only runtime adoption
+
+- wire `sessionRhythm.ts` into `runtime.ts`
+- adopt the new behavior stack in `keepAlive.ts`, `linkedinFeed.ts`,
+  `linkedinSearch.ts`, `linkedinJobs.ts`, `linkedinInbox.ts`, and
+  `linkedinNotifications.ts`
+- validate through unit tests, fixture replay, and read-only E2Es only
+
+### Slice 3: context-consistency hardening
+
+- add `browserContextConsistency.ts`
+- wire `ProfileManager`, `runtime`, and `healthCheck`
+- keep CDP mode inspect-first and observe-first before any strict policy is
+  considered
+
+### Slice 4: auth adoption and mutation warmup
+
+- adopt session-rhythm decisions in `auth/session.ts`
+- add mutation warmup rules before write-side actions
+- validate on auth and prepare/confirm flows without introducing public actions
+  beyond existing test constraints
+
+### Slice 5: interaction guards and write-surface rollout
+
+- add `interactionGuards.ts`
+- wire shared challenge/interstitial checks into `humanize.ts`,
+  `sessionInspection.ts`, `liveValidation.ts`, and write executors
+- stop rollout if guard behavior becomes noisy in read-only paths; do not force
+  it into mutations prematurely
+
+## Verification strategy by technique
+
+### Mouse movement
+
+Use deterministic unit tests and mocked `Page.mouse.move()` calls to verify:
+
+- curved waypoint generation
+- overshoot and correction behavior
+- hover timing
+- fast-mode degradation without skipping validations
+
+### Scroll behavior
+
+Use deterministic planner tests and a local scrollable harness to verify:
+
+- variable chunk sizes
+- dwell after scrolling
+- occasional reverse micro-scrolls
+- bounded total distance and no huge jumps
+
+### Session rhythm
+
+Use fake clocks and in-memory service tests to verify:
+
+- warmup after long idle
+- post-navigation dwell
+- mutation gating
+- burst cooldown behavior
+
+### Browser-context consistency
+
+Use mocked contexts and persistent-launch option assertions to verify:
+
+- stable profile resolution
+- consistent launch options for persistent sessions
+- mismatch reporting for CDP-attached sessions
+- strict/observe mode branching without deep spoofing
+
+### Challenge and honeypot detection
+
+Use synthetic pages and page mocks to verify:
+
+- checkpoint/login wall precedence
+- hidden or zero-size target blocking
+- suspicious interstitial blocking
+- fail-closed behavior before writes continue
+
+### End-to-end confidence without provoking real detection
+
+The Build phase should avoid “test by getting challenged.” Instead it should use:
+
+- pure planner tests with seeded randomness
+- `Page`/`Locator` mocks for executor behavior
+- fixture replay where page structure is already captured
+- read-only authenticated E2Es for browsing flows
+- existing auth and live-validation suites for regression coverage
+
+No public comments, likes, posts, or uncontrolled connection requests should be
+introduced as validation mechanisms for this feature area.
+
+## Main risks and how the plan reduces them
+
+### 1) The project over-rotates into brittle fingerprint spoofing
+
+Mitigation:
+
+- keep the first context-hardening wave focused on coherence, not spoofing
+- inspect CDP-attached contexts before enforcing strict behavior
+- defer canvas/WebGL/audio/plugin work until measurement justifies it
+
+### 2) Randomness leaks into call sites and makes tests flaky
+
+Mitigation:
+
+- keep all stochastic behavior inside pure planners
+- support injected random sources for deterministic tests
+- avoid sprinkling `Math.random()` across LinkedIn service methods
+
+### 3) Read-only services and mutation services diverge
+
+Mitigation:
+
+- keep the public interaction surface concentrated in `humanize.ts`
+- put pacing decisions in `sessionRhythm.ts`, not in each service
+- gate write adoption on read-only stability first
+
+### 4) Hidden-element guard logic becomes too noisy
+
+Mitigation:
+
+- start with generic visibility/actionability checks
+- avoid brittle LinkedIn-specific “trap” selectors in the first slice
+- keep guard output observable in tests and diagnostics before broad rollout
+
+### 5) CDP-attached sessions cannot honor persistent-context hardening
+
+Mitigation:
+
+- make CDP mode inspect-first and observe-first by default
+- reserve strict mode for persistent contexts the repo launches itself
+- report mismatch diagnostics through health surfaces rather than silently
+  mutating attached browsers
+
+## Guardrails for the Build phase
+
+### Do touch
+
+- planner modules under `packages/core/src/`
+- `humanize.ts`, `runtime.ts`, `config.ts`, and `profileManager.ts`
+- read-only flows first, then auth, then write executors
+- deterministic unit and fixture-based tests
+
+### Do not touch first
+
+- CLI or MCP flags for every low-level tuning knob
+- proxy rotation, TLS shaping, or fingerprint spoofing beyond context coherence
+- captcha solving or challenge circumvention
+- LinkedIn-specific trap heuristics that are difficult to verify safely
+
+### Avoid these traps
+
+- treating “more randomness” as equivalent to realism
+- adding new hardening logic directly inside each LinkedIn service
+- using live public actions as the main validation loop
+- forcing strict consistency rules onto attached CDP sessions too early
+
+## Implementation compass
+
+If implementation pressure forces scope cuts, keep the following order intact:
+
+1. planner-backed mouse movement
+2. planner-backed scroll plus read dwell
+3. shared session rhythm
+4. context-consistency profiles and diagnostics
+5. interaction guards
+
+That order best matches both the research brief and the current repo shape:
+start where the gaps are largest, keep behavior and context coherent, and use
+fail-closed guards as the final protection layer rather than the first and only
+anti-detection strategy.


### PR DESCRIPTION
## Summary
- add `docs/.plan-issue-202.md` as the Phase 1 planning deliverable for anti-bot evasion work
- translate the Phase 0 research brief into concrete module boundaries, API signatures, config additions, dependencies, rollout order, and test strategy
- keep the plan aligned with the current `humanize.ts`, `profileManager.ts`, `runtime.ts`, `keepAlive.ts`, and session-health surfaces

## Why
Issue #202 asks for a detailed implementation plan before Build-phase coding begins so the work lands in the right order and stays coherent across behavior, context consistency, and challenge handling.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

Closes #202
