### PR TITLE
Fix activity webhook polling UX and diagnostics

### DIFF
--- a/packages/cli/src/activityOutput.ts
+++ b/packages/cli/src/activityOutput.ts
@@ -1,0 +1,917 @@
+import type {
+  ActivityEventRecord,
+  ActivityPollTickResult,
+  ActivityWatch,
+  ActivityWebhookConfig,
+  CreatedWebhookSubscription,
+  LinkedInAssistantErrorPayload,
+  WebhookDeliveryAttemptRecord,
+  WebhookSubscription
+} from "@linkedin-assistant/core";
+
+export type ActivityOutputMode = "human" | "json";
+
+export type ActivityDaemonStateSummary = Pick<
+  ActivityPollTickResult,
+  | "claimedWatches"
+  | "polledWatches"
+  | "failedWatches"
+  | "emittedEvents"
+  | "enqueuedDeliveries"
+  | "claimedDeliveries"
+  | "deliveredAttempts"
+  | "retriedDeliveries"
+  | "failedDeliveries"
+  | "deadLetterDeliveries"
+  | "disabledSubscriptions"
+>;
+
+export interface ActivityDaemonState {
+  pid: number;
+  profileName: string;
+  startedAt: string;
+  updatedAt: string;
+  status: "starting" | "running" | "idle" | "degraded" | "stopped";
+  daemonPollIntervalMs: number;
+  maxWatchesPerTick: number;
+  maxDeliveriesPerTick: number;
+  consecutiveFailures: number;
+  maxConsecutiveFailures: number;
+  lastTickAt?: string;
+  lastSuccessfulTickAt?: string;
+  lastSummary?: ActivityDaemonStateSummary;
+  lastError?: string;
+  cdpUrl?: string;
+  stoppedAt?: string;
+}
+
+export interface ActivityWatchAddReport {
+  run_id: string;
+  profile_name: string;
+  watch: ActivityWatch;
+}
+
+export interface ActivityWatchListReport {
+  run_id: string;
+  profile_name: string;
+  count: number;
+  watches: ActivityWatch[];
+}
+
+export interface ActivityWatchMutationReport {
+  run_id: string;
+  watch: ActivityWatch;
+}
+
+export interface ActivityWatchRemovalReport {
+  run_id: string;
+  watch_id: string;
+  removed: boolean;
+}
+
+export interface ActivityWebhookAddReport {
+  run_id: string;
+  subscription: CreatedWebhookSubscription;
+}
+
+export interface ActivityWebhookListReport {
+  run_id: string;
+  profile_name: string;
+  count: number;
+  subscriptions: WebhookSubscription[];
+}
+
+export interface ActivityWebhookMutationReport {
+  run_id: string;
+  subscription: WebhookSubscription;
+}
+
+export interface ActivityWebhookRemovalReport {
+  run_id: string;
+  subscription_id: string;
+  removed: boolean;
+}
+
+export interface ActivityEventListReport {
+  run_id: string;
+  profile_name: string;
+  count: number;
+  events: ActivityEventRecord[];
+}
+
+export interface ActivityDeliveryListReport {
+  run_id: string;
+  profile_name: string;
+  count: number;
+  deliveries: WebhookDeliveryAttemptRecord[];
+}
+
+export interface ActivityStartReport {
+  started: boolean;
+  reason?: string;
+  profile_name: string;
+  pid?: number;
+  state?: ActivityDaemonState | null;
+  state_path: string;
+  log_path: string;
+  activity_config?: ActivityWebhookConfig;
+  activity_config_error?: LinkedInAssistantErrorPayload;
+}
+
+export interface ActivityStatusReport {
+  profile_name: string;
+  running: boolean;
+  pid: number | null;
+  state: ActivityDaemonState | null;
+  stale_pid_file: boolean;
+  state_path: string;
+  log_path: string;
+  watch_count: number;
+  active_watch_count: number;
+  subscription_count: number;
+  active_subscription_count: number;
+  recent_event_count: number;
+  recent_delivery_count: number;
+  activity_config?: ActivityWebhookConfig;
+  activity_config_error?: LinkedInAssistantErrorPayload;
+}
+
+export interface ActivityStopReport {
+  stopped: boolean;
+  profile_name: string;
+  pid?: number;
+  forced?: boolean;
+  reason?: string;
+  state_path: string;
+  log_path: string;
+}
+
+export interface ActivityRunOnceReport extends ActivityPollTickResult {
+  run_id: string;
+  profile_name: string;
+  activity_config: ActivityWebhookConfig;
+}
+
+const CONTROL_CHARACTER_PATTERN = new RegExp(
+  `[${String.fromCharCode(0)}-${String.fromCharCode(31)}${String.fromCharCode(127)}-${String.fromCharCode(159)}]+`,
+  "g"
+);
+const ANSI_ESCAPE_PATTERN = new RegExp(
+  `${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`,
+  "g"
+);
+
+function sanitizeConsoleText(value: string): string {
+  const sanitized = value
+    .replace(ANSI_ESCAPE_PATTERN, " ")
+    .replace(CONTROL_CHARACTER_PATTERN, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return sanitized.length > 0 ? sanitized : "[sanitized]";
+}
+
+function appendSection(lines: string[], title: string, entries: string[]): void {
+  if (entries.length === 0) {
+    return;
+  }
+
+  lines.push("");
+  lines.push(title);
+  lines.push(...entries);
+}
+
+function formatDurationMs(value: number): string {
+  if (!Number.isFinite(value) || value < 1_000) {
+    return `${Math.max(0, Math.round(value))}ms`;
+  }
+
+  const seconds = Math.round(value / 1_000);
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+
+  const hours = Math.round((minutes / 60) * 10) / 10;
+  return `${hours}h`;
+}
+
+function formatTimestamp(value: string | number | null | undefined): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value).toISOString();
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    return sanitizeConsoleText(value.trim());
+  }
+
+  return "n/a";
+}
+
+function formatCompactJson(value: unknown): string {
+  try {
+    return sanitizeConsoleText(JSON.stringify(value));
+  } catch {
+    return "{}";
+  }
+}
+
+function formatCountLabel(
+  count: number,
+  singular: string,
+  plural: string = `${singular}s`
+): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function formatWatchSchedule(watch: ActivityWatch): string {
+  if (watch.scheduleKind === "cron" && watch.cronExpression) {
+    return `cron ${sanitizeConsoleText(watch.cronExpression)}`;
+  }
+
+  if (typeof watch.pollIntervalMs === "number") {
+    return `every ${formatDurationMs(watch.pollIntervalMs)}`;
+  }
+
+  return sanitizeConsoleText(watch.scheduleKind);
+}
+
+function formatWatchTarget(watch: ActivityWatch): string {
+  return formatCompactJson(watch.target);
+}
+
+function formatWatchLine(watch: ActivityWatch): string {
+  const errorSuffix =
+    watch.lastErrorCode || watch.lastErrorMessage
+      ? `, last error ${sanitizeConsoleText(watch.lastErrorCode ?? "UNKNOWN")}: ${sanitizeConsoleText(watch.lastErrorMessage ?? "Unknown activity watch failure.")}`
+      : "";
+
+  return `- ${sanitizeConsoleText(watch.id)} — ${sanitizeConsoleText(watch.kind)}, ${sanitizeConsoleText(watch.status)}, ${formatWatchSchedule(watch)}, next poll ${formatTimestamp(watch.nextPollAtMs)}, target ${formatWatchTarget(watch)}${errorSuffix}`;
+}
+
+function formatSubscriptionLine(subscription: WebhookSubscription): string {
+  const eventTypes = subscription.eventTypes.length > 0
+    ? subscription.eventTypes.map(sanitizeConsoleText).join(", ")
+    : "all supported events";
+  const errorSuffix =
+    subscription.lastErrorCode || subscription.lastErrorMessage
+      ? `, last error ${sanitizeConsoleText(subscription.lastErrorCode ?? "UNKNOWN")}: ${sanitizeConsoleText(subscription.lastErrorMessage ?? "Unknown webhook delivery failure.")}`
+      : "";
+
+  return `- ${sanitizeConsoleText(subscription.id)} — ${sanitizeConsoleText(subscription.status)}, watch ${sanitizeConsoleText(subscription.watchId)}, events ${eventTypes}, max attempts ${subscription.maxAttempts}, endpoint ${sanitizeConsoleText(subscription.deliveryUrl)}${errorSuffix}`;
+}
+
+function formatEventLine(event: ActivityEventRecord): string {
+  return `- ${sanitizeConsoleText(event.id)} — ${sanitizeConsoleText(event.eventType)}, watch ${sanitizeConsoleText(event.watchId)}, entity ${sanitizeConsoleText(event.entityKey)}, occurred ${formatTimestamp(event.occurredAtMs)}`;
+}
+
+function formatDeliveryLine(delivery: WebhookDeliveryAttemptRecord): string {
+  const responseSuffix =
+    typeof delivery.responseStatus === "number"
+      ? `, HTTP ${delivery.responseStatus}`
+      : "";
+  const errorSuffix =
+    delivery.lastErrorCode || delivery.lastErrorMessage
+      ? `, error ${sanitizeConsoleText(delivery.lastErrorCode ?? "UNKNOWN")}: ${sanitizeConsoleText(delivery.lastErrorMessage ?? "Unknown webhook delivery failure.")}`
+      : "";
+
+  return `- ${sanitizeConsoleText(delivery.id)} — ${sanitizeConsoleText(delivery.status)}, attempt ${delivery.attemptNumber}, event ${sanitizeConsoleText(delivery.eventType)}, next attempt ${formatTimestamp(delivery.nextAttemptAtMs)}, endpoint ${sanitizeConsoleText(delivery.deliveryUrl)}${responseSuffix}${errorSuffix}`;
+}
+
+function formatActivityConfigSummary(config: ActivityWebhookConfig): string[] {
+  return [
+    `- Enabled: ${config.enabled ? "yes" : "no"}`,
+    `- Polling: daemon every ${formatDurationMs(config.daemonPollIntervalMs)}, minimum watch interval ${formatDurationMs(config.minPollIntervalMs)}`,
+    `- Capacity: ${formatCountLabel(config.maxWatchesPerTick, "watch")} per tick, ${formatCountLabel(config.maxConcurrentWatches, "active watch")} per profile, ${formatCountLabel(config.maxDeliveriesPerTick, "delivery")} per tick`,
+    `- Queueing: depth ${config.maxEventQueueDepth}, watch lease ${formatDurationMs(config.watchLeaseTtlMs)}, delivery lease ${formatDurationMs(config.deliveryLeaseTtlMs)}`,
+    `- Delivery: timeout ${formatDurationMs(config.deliveryTimeoutMs)}, clock skew ${formatDurationMs(config.clockSkewAllowanceMs)}, retry ${config.retry.maxAttempts} attempts with ${formatDurationMs(config.retry.initialBackoffMs)} → ${formatDurationMs(config.retry.maxBackoffMs)} backoff`
+  ];
+}
+
+function formatActivitySummary(summary: ActivityDaemonStateSummary): string {
+  return [
+    `${summary.claimedWatches} claimed watch${summary.claimedWatches === 1 ? "" : "es"}`,
+    `${summary.polledWatches} polled`,
+    `${summary.failedWatches} failed`,
+    `${summary.emittedEvents} event${summary.emittedEvents === 1 ? "" : "s"}`,
+    `${summary.enqueuedDeliveries} enqueued ${summary.enqueuedDeliveries === 1 ? "delivery" : "deliveries"}`,
+    `${summary.claimedDeliveries} claimed ${summary.claimedDeliveries === 1 ? "delivery" : "deliveries"}`,
+    `${summary.deliveredAttempts} delivered`,
+    `${summary.retriedDeliveries} retry`,
+    `${summary.failedDeliveries} failed ${summary.failedDeliveries === 1 ? "delivery" : "deliveries"}`,
+    `${summary.deadLetterDeliveries} dead-letter`,
+    `${summary.disabledSubscriptions} disabled subscription${summary.disabledSubscriptions === 1 ? "" : "s"}`
+  ].join(", ");
+}
+
+function readString(
+  details: LinkedInAssistantErrorPayload["details"],
+  key: string
+): string | null {
+  const value = details[key];
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function readNumber(
+  details: LinkedInAssistantErrorPayload["details"],
+  key: string
+): number | null {
+  const value = details[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function readStringArray(
+  details: LinkedInAssistantErrorPayload["details"],
+  key: string
+): string[] | null {
+  const value = details[key];
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const strings = value
+    .filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+    .map((entry) => entry.trim());
+
+  return strings.length > 0 ? strings : null;
+}
+
+function formatActivityErrorDetails(error: LinkedInAssistantErrorPayload): string[] {
+  const lines = [sanitizeConsoleText(error.message)];
+  const env = readString(error.details, "env");
+  const field = readString(error.details, "field");
+  const value = readString(error.details, "value");
+  const example = readString(error.details, "example");
+  const suggestion = readString(error.details, "suggestion");
+  const defaultValue = readString(error.details, "default_value");
+  const providedKind = readString(error.details, "provided_kind");
+  const kind = readString(error.details, "kind");
+  const profileName = readString(error.details, "profile_name");
+  const supportedKinds = readStringArray(error.details, "supported_kinds");
+  const supportedEventTypes = readStringArray(error.details, "supported_event_types");
+  const providedEventTypes = readStringArray(error.details, "provided_event_types");
+  const allowedValues = readStringArray(error.details, "allowed_values");
+  const minimum = readNumber(error.details, "minimum");
+  const maximum = readNumber(error.details, "maximum");
+  const minimumSeconds = readNumber(error.details, "minimum_seconds");
+  const activeWatchCount = readNumber(error.details, "active_watch_count");
+  const maxConcurrentWatches = readNumber(
+    error.details,
+    "max_concurrent_watches"
+  );
+
+  if (env) {
+    lines.push(`Setting: ${sanitizeConsoleText(env)}`);
+  }
+  if (field) {
+    lines.push(`Field: ${sanitizeConsoleText(field)}`);
+  }
+  if (value) {
+    lines.push(`Provided value: ${sanitizeConsoleText(value)}`);
+  }
+  if (providedKind) {
+    lines.push(`Provided kind: ${sanitizeConsoleText(providedKind)}`);
+  }
+  if (kind) {
+    lines.push(`Watch kind: ${sanitizeConsoleText(kind)}`);
+  }
+  if (profileName) {
+    lines.push(`Profile: ${sanitizeConsoleText(profileName)}`);
+  }
+  if (typeof minimum === "number" && typeof maximum === "number") {
+    lines.push(`Allowed range: ${minimum} to ${maximum}`);
+  } else if (typeof minimum === "number") {
+    lines.push(`Minimum allowed: ${minimum}`);
+  } else if (typeof maximum === "number") {
+    lines.push(`Maximum allowed: ${maximum}`);
+  }
+  if (typeof minimumSeconds === "number") {
+    lines.push(`Minimum interval: ${minimumSeconds}s`);
+  }
+  if (supportedKinds) {
+    lines.push(`Supported watch kinds: ${supportedKinds.map(sanitizeConsoleText).join(", ")}`);
+  }
+  if (supportedEventTypes) {
+    lines.push(
+      `Supported event types: ${supportedEventTypes.map(sanitizeConsoleText).join(", ")}`
+    );
+  }
+  if (providedEventTypes) {
+    lines.push(
+      `Provided event types: ${providedEventTypes.map(sanitizeConsoleText).join(", ")}`
+    );
+  }
+  if (allowedValues) {
+    lines.push(`Allowed values: ${allowedValues.map(sanitizeConsoleText).join(", ")}`);
+  }
+  if (
+    typeof activeWatchCount === "number" &&
+    typeof maxConcurrentWatches === "number"
+  ) {
+    lines.push(
+      `Active watch usage: ${activeWatchCount}/${maxConcurrentWatches} active watches already allocated.`
+    );
+  }
+  if (defaultValue) {
+    lines.push(`Default value: ${sanitizeConsoleText(defaultValue)}`);
+  }
+  if (example) {
+    lines.push(`Example: ${sanitizeConsoleText(example)}`);
+  }
+  if (suggestion) {
+    lines.push(`Suggested fix: ${sanitizeConsoleText(suggestion)}`);
+  }
+
+  return lines;
+}
+
+function formatActivityErrorNextSteps(error: LinkedInAssistantErrorPayload): string[] {
+  const env = readString(error.details, "env");
+  const field = readString(error.details, "field");
+  const steps: string[] = [];
+
+  if (env?.startsWith("LINKEDIN_ASSISTANT_ACTIVITY_")) {
+    steps.push(
+      "Fix the activity setting above, or unset it to fall back to the default value."
+    );
+  }
+
+  if (field === "deliveryUrl") {
+    steps.push(
+      "Use an absolute http(s) webhook endpoint, then rerun the subscription command."
+    );
+  }
+
+  if (error.code === "TARGET_NOT_FOUND") {
+    steps.push(
+      "List current watches or webhook subscriptions again to confirm the id you want to update."
+    );
+  }
+
+  if (error.code === "AUTH_REQUIRED") {
+    steps.push(
+      "Open LinkedIn in the same browser session, sign in until the feed loads, then rerun the activity command."
+    );
+  }
+
+  if (error.code === "CAPTCHA_OR_CHALLENGE") {
+    steps.push(
+      "Complete the LinkedIn checkpoint or verification in the same browser session before retrying."
+    );
+  }
+
+  if (error.code === "RATE_LIMITED") {
+    steps.push(
+      "Wait for LinkedIn or the webhook endpoint throttle window to cool down before retrying."
+    );
+  }
+
+  if (steps.length === 0) {
+    steps.push(
+      "Rerun the command. If it keeps failing, inspect the activity status output or rerun with --json for the structured payload."
+    );
+  }
+
+  steps.push("Run `linkedin activity --help` for activity command examples.");
+  steps.push("Rerun with --json if you need the structured error payload.");
+  return steps;
+}
+
+export function resolveActivityOutputMode(
+  input: { json?: boolean },
+  stdoutIsTty: boolean
+): ActivityOutputMode {
+  return input.json || !stdoutIsTty ? "json" : "human";
+}
+
+export function formatActivityError(error: LinkedInAssistantErrorPayload): string {
+  const lines = [
+    `Activity command failed [${sanitizeConsoleText(error.code)}]`,
+    ...formatActivityErrorDetails(error)
+  ];
+
+  lines.push(...formatActivityErrorNextSteps(error).map((step) => `Tip: ${sanitizeConsoleText(step)}`));
+  return lines.join("\n");
+}
+
+export function formatActivityWatchAddReport(
+  report: ActivityWatchAddReport
+): string {
+  const lines = [
+    `Created activity watch for profile ${sanitizeConsoleText(report.profile_name)}`,
+    `- Watch id: ${sanitizeConsoleText(report.watch.id)}`,
+    `- Kind: ${sanitizeConsoleText(report.watch.kind)}`,
+    `- Status: ${sanitizeConsoleText(report.watch.status)}`,
+    `- Schedule: ${formatWatchSchedule(report.watch)}`,
+    `- Next poll: ${formatTimestamp(report.watch.nextPollAtMs)}`,
+    `- Target: ${formatWatchTarget(report.watch)}`
+  ];
+
+  appendSection(lines, "Next Steps", [
+    `- Run \`linkedin activity webhook add --watch ${sanitizeConsoleText(report.watch.id)} --url https://example.com/hooks/linkedin\` to deliver new activity events.`,
+    `- Run \`linkedin activity watch list --profile ${sanitizeConsoleText(report.profile_name)}\` to review active watch state.`
+  ]);
+
+  return lines.join("\n");
+}
+
+export function formatActivityWatchListReport(
+  report: ActivityWatchListReport
+): string {
+  const lines = [
+    `Activity watches for profile ${sanitizeConsoleText(report.profile_name)}`,
+    `- ${formatCountLabel(report.count, "watch")} matched.`
+  ];
+
+  if (report.watches.length > 0) {
+    appendSection(lines, "Watches", report.watches.map(formatWatchLine));
+  } else {
+    lines.push("- No activity watches found for this profile and filter combination.");
+  }
+
+  lines.push("");
+  lines.push("Use `--json` if you need the structured activity payload for automation.");
+  return lines.join("\n");
+}
+
+export function formatActivityWatchMutationReport(
+  report: ActivityWatchMutationReport,
+  action: "paused" | "resumed"
+): string {
+  const lines = [
+    `Activity watch ${action} for profile ${sanitizeConsoleText(report.watch.profileName)}`,
+    `- Watch id: ${sanitizeConsoleText(report.watch.id)}`,
+    `- Kind: ${sanitizeConsoleText(report.watch.kind)}`,
+    `- Status: ${sanitizeConsoleText(report.watch.status)}`,
+    `- Next poll: ${formatTimestamp(report.watch.nextPollAtMs)}`
+  ];
+
+  appendSection(lines, "Next Steps", [
+    `- Run \`linkedin activity watch list --profile ${sanitizeConsoleText(report.watch.profileName)}\` to confirm the updated watch state.`
+  ]);
+
+  return lines.join("\n");
+}
+
+export function formatActivityWatchRemovalReport(
+  report: ActivityWatchRemovalReport
+): string {
+  const lines = [
+    `Removed activity watch ${sanitizeConsoleText(report.watch_id)}`,
+    `- Removed: ${report.removed ? "yes" : "no"}`
+  ];
+
+  appendSection(lines, "Next Steps", [
+    "- Run `linkedin activity watch list --profile <profile>` to confirm the remaining watch set.",
+    "- Removing a watch also removes its webhook subscriptions and future deliveries."
+  ]);
+
+  return lines.join("\n");
+}
+
+export function formatActivityWebhookAddReport(
+  report: ActivityWebhookAddReport
+): string {
+  const eventTypes = report.subscription.eventTypes.length > 0
+    ? report.subscription.eventTypes.map(sanitizeConsoleText).join(", ")
+    : "all supported events";
+  const lines = [
+    `Registered activity webhook subscription ${sanitizeConsoleText(report.subscription.id)}`,
+    `- Watch id: ${sanitizeConsoleText(report.subscription.watchId)}`,
+    `- Endpoint: ${sanitizeConsoleText(report.subscription.deliveryUrl)}`,
+    `- Event filters: ${eventTypes}`,
+    `- Max attempts: ${report.subscription.maxAttempts}`,
+    `- Signing secret: ${sanitizeConsoleText(report.subscription.signingSecret)}`
+  ];
+
+  appendSection(lines, "Next Steps", [
+    `- Save the signing secret now. It is only returned when the subscription is created.`,
+    `- Run \`linkedin activity deliveries --subscription ${sanitizeConsoleText(report.subscription.id)}\` after the next poll to inspect delivery attempts.`
+  ]);
+
+  return lines.join("\n");
+}
+
+export function formatActivityWebhookListReport(
+  report: ActivityWebhookListReport
+): string {
+  const lines = [
+    `Activity webhook subscriptions for profile ${sanitizeConsoleText(report.profile_name)}`,
+    `- ${formatCountLabel(report.count, "subscription")} matched.`
+  ];
+
+  if (report.subscriptions.length > 0) {
+    appendSection(lines, "Subscriptions", report.subscriptions.map(formatSubscriptionLine));
+  } else {
+    lines.push("- No webhook subscriptions found for this profile and filter combination.");
+  }
+
+  lines.push("");
+  lines.push("Use `--json` if you need the structured activity payload for automation.");
+  return lines.join("\n");
+}
+
+export function formatActivityWebhookMutationReport(
+  report: ActivityWebhookMutationReport,
+  action: "paused" | "resumed"
+): string {
+  const lines = [
+    `Webhook subscription ${action}`,
+    `- Subscription id: ${sanitizeConsoleText(report.subscription.id)}`,
+    `- Watch id: ${sanitizeConsoleText(report.subscription.watchId)}`,
+    `- Status: ${sanitizeConsoleText(report.subscription.status)}`,
+    `- Endpoint: ${sanitizeConsoleText(report.subscription.deliveryUrl)}`
+  ];
+
+  appendSection(lines, "Next Steps", [
+    "- Run `linkedin activity webhook list --profile <profile>` to review current webhook routing state."
+  ]);
+
+  return lines.join("\n");
+}
+
+export function formatActivityWebhookRemovalReport(
+  report: ActivityWebhookRemovalReport
+): string {
+  const lines = [
+    `Removed webhook subscription ${sanitizeConsoleText(report.subscription_id)}`,
+    `- Removed: ${report.removed ? "yes" : "no"}`
+  ];
+
+  appendSection(lines, "Next Steps", [
+    "- Run `linkedin activity webhook list --profile <profile>` to confirm the remaining subscriptions.",
+    "- Existing queued deliveries may still appear in history until they are processed or expire."
+  ]);
+
+  return lines.join("\n");
+}
+
+export function formatActivityEventListReport(
+  report: ActivityEventListReport
+): string {
+  const lines = [
+    `Recent activity events for profile ${sanitizeConsoleText(report.profile_name)}`,
+    `- Showing ${formatCountLabel(report.count, "event")}.`
+  ];
+
+  if (report.events.length > 0) {
+    appendSection(lines, "Events", report.events.map(formatEventLine));
+  } else {
+    lines.push("- No activity events are recorded for this profile yet.");
+  }
+
+  lines.push("");
+  lines.push("Use `--json` if you need the structured activity payload for automation.");
+  return lines.join("\n");
+}
+
+export function formatActivityDeliveryListReport(
+  report: ActivityDeliveryListReport
+): string {
+  const lines = [
+    `Recent webhook deliveries for profile ${sanitizeConsoleText(report.profile_name)}`,
+    `- Showing ${formatCountLabel(report.count, "delivery attempt")}.`
+  ];
+
+  if (report.deliveries.length > 0) {
+    appendSection(lines, "Deliveries", report.deliveries.map(formatDeliveryLine));
+  } else {
+    lines.push("- No webhook delivery attempts are recorded for this profile yet.");
+  }
+
+  lines.push("");
+  lines.push("Use `--json` if you need the structured activity payload for automation.");
+  return lines.join("\n");
+}
+
+export function formatActivityStartReport(
+  report: ActivityStartReport
+): string {
+  const lines = [
+    report.started
+      ? `Activity daemon started for profile ${sanitizeConsoleText(report.profile_name)}`
+      : `Activity daemon not started for profile ${sanitizeConsoleText(report.profile_name)}`,
+    ...(typeof report.pid === "number"
+      ? [`- PID: ${report.pid}`]
+      : []),
+    `- State path: ${sanitizeConsoleText(report.state_path)}`,
+    `- Event log: ${sanitizeConsoleText(report.log_path)}`
+  ];
+
+  if (report.reason) {
+    lines.push(`- Status: ${sanitizeConsoleText(report.reason)}`);
+  }
+
+  if (report.activity_config) {
+    appendSection(lines, "Config", formatActivityConfigSummary(report.activity_config));
+  }
+
+  if (report.activity_config_error) {
+    appendSection(
+      lines,
+      "Config Issue",
+      formatActivityErrorDetails(report.activity_config_error).map(
+        (entry) => `- ${sanitizeConsoleText(entry)}`
+      )
+    );
+  }
+
+  appendSection(lines, "Next Steps", [
+    `- Run \`linkedin activity status --profile ${sanitizeConsoleText(report.profile_name)}\` to confirm the daemon becomes running or idle.`,
+    `- Run \`linkedin activity stop --profile ${sanitizeConsoleText(report.profile_name)}\` when you want to stop background polling.`,
+    "- Use `--json` if you need the structured activity payload for automation."
+  ]);
+
+  return lines.join("\n");
+}
+
+export function formatActivityStatusReport(
+  report: ActivityStatusReport
+): string {
+  const lines = [
+    `Activity daemon status for profile ${sanitizeConsoleText(report.profile_name)}`,
+    `- Daemon: ${report.running ? "running" : "not running"}`,
+    `- PID: ${report.pid ?? "n/a"}`,
+    `- State path: ${sanitizeConsoleText(report.state_path)}`,
+    `- Event log: ${sanitizeConsoleText(report.log_path)}`
+  ];
+
+  if (report.stale_pid_file) {
+    lines.push("- Warning: a stale PID file is present for this profile.");
+  }
+
+  appendSection(lines, "Queues", [
+    `- Watches: ${report.active_watch_count}/${report.watch_count} active`,
+    `- Webhooks: ${report.active_subscription_count}/${report.subscription_count} active`,
+    `- Recent history: ${report.recent_event_count} events, ${report.recent_delivery_count} delivery attempts`
+  ]);
+
+  if (report.state) {
+    const stateEntries = [
+      `- State: ${sanitizeConsoleText(report.state.status)}`,
+      `- Started: ${formatTimestamp(report.state.startedAt)}`,
+      `- Updated: ${formatTimestamp(report.state.updatedAt)}`,
+      `- Poll interval: ${formatDurationMs(report.state.daemonPollIntervalMs)}`,
+      `- Per tick: ${report.state.maxWatchesPerTick} watches, ${report.state.maxDeliveriesPerTick} deliveries`,
+      `- Consecutive failures: ${report.state.consecutiveFailures}/${report.state.maxConsecutiveFailures}`
+    ];
+
+    if (report.state.lastTickAt) {
+      stateEntries.push(`- Last tick: ${formatTimestamp(report.state.lastTickAt)}`);
+    }
+    if (report.state.lastSuccessfulTickAt) {
+      stateEntries.push(
+        `- Last successful tick: ${formatTimestamp(report.state.lastSuccessfulTickAt)}`
+      );
+    }
+    if (report.state.lastSummary) {
+      stateEntries.push(
+        `- Last summary: ${formatActivitySummary(report.state.lastSummary)}`
+      );
+    }
+    if (report.state.lastError) {
+      stateEntries.push(
+        `- Last recorded error: ${sanitizeConsoleText(report.state.lastError)}`
+      );
+    }
+
+    appendSection(lines, "State", stateEntries);
+  }
+
+  if (report.activity_config) {
+    appendSection(lines, "Config", formatActivityConfigSummary(report.activity_config));
+  }
+
+  if (report.activity_config_error) {
+    appendSection(
+      lines,
+      "Config Issue",
+      formatActivityErrorDetails(report.activity_config_error).map(
+        (entry) => `- ${sanitizeConsoleText(entry)}`
+      )
+    );
+  }
+
+  const nextSteps = [
+    report.running
+      ? `Run \`linkedin activity stop --profile ${sanitizeConsoleText(report.profile_name)}\` to stop background polling.`
+      : `Run \`linkedin activity start --profile ${sanitizeConsoleText(report.profile_name)}\` to start background polling.`,
+    `Run \`linkedin activity run-once --profile ${sanitizeConsoleText(report.profile_name)}\` to process due work immediately without leaving the daemon running.`,
+    "Use `--json` if you need the structured activity payload for automation."
+  ];
+
+  if (report.activity_config_error) {
+    nextSteps.unshift(
+      "Fix the invalid activity configuration before relying on the daemon for webhook polling."
+    );
+  }
+  if (report.stale_pid_file) {
+    nextSteps.unshift(
+      `Run \`linkedin activity stop --profile ${sanitizeConsoleText(report.profile_name)}\` once to clean up the stale PID file safely.`
+    );
+  }
+
+  appendSection(lines, "Next Steps", nextSteps.map((step) => `- ${sanitizeConsoleText(step)}`));
+  return lines.join("\n");
+}
+
+export function formatActivityStopReport(
+  report: ActivityStopReport
+): string {
+  const lines = [
+    report.stopped
+      ? `Activity daemon stopped for profile ${sanitizeConsoleText(report.profile_name)}`
+      : `Activity daemon already stopped for profile ${sanitizeConsoleText(report.profile_name)}`,
+    ...(typeof report.pid === "number"
+      ? [`- PID: ${report.pid}`]
+      : []),
+    `- State path: ${sanitizeConsoleText(report.state_path)}`,
+    `- Event log: ${sanitizeConsoleText(report.log_path)}`
+  ];
+
+  if (report.reason) {
+    lines.push(`- Status: ${sanitizeConsoleText(report.reason)}`);
+  }
+  if (report.forced) {
+    lines.push("- Stop required SIGKILL after the daemon ignored SIGTERM for 5 seconds.");
+  }
+
+  appendSection(lines, "Next Steps", [
+    `- Run \`linkedin activity status --profile ${sanitizeConsoleText(report.profile_name)}\` to confirm the daemon is stopped and inspect queue counts.`,
+    `- Run \`linkedin activity start --profile ${sanitizeConsoleText(report.profile_name)}\` when you are ready to resume background polling.`
+  ]);
+
+  return lines.join("\n");
+}
+
+export function formatActivityRunOnceReport(
+  report: ActivityRunOnceReport
+): string {
+  const lines = [
+    `Activity poll tick completed for profile ${sanitizeConsoleText(report.profile_name)}`,
+    `- Watches: ${report.claimedWatches} claimed, ${report.polledWatches} polled, ${report.failedWatches} failed, ${report.emittedEvents} events emitted, ${report.enqueuedDeliveries} deliveries enqueued`,
+    `- Deliveries: ${report.claimedDeliveries} claimed, ${report.deliveredAttempts} delivered, ${report.retriedDeliveries} retry, ${report.failedDeliveries} failed, ${report.deadLetterDeliveries} dead-letter, ${report.disabledSubscriptions} subscriptions disabled`,
+    `- Worker: ${sanitizeConsoleText(report.workerId)}`
+  ];
+
+  if (report.watchResults.length > 0) {
+    appendSection(
+      lines,
+      "Watch Results",
+      report.watchResults.map((result) => {
+        const errorSuffix =
+          result.errorCode || result.errorMessage
+            ? `, error ${sanitizeConsoleText(result.errorCode ?? "UNKNOWN")}: ${sanitizeConsoleText(result.errorMessage ?? "Unknown poll failure.")}`
+            : "";
+        return `- ${sanitizeConsoleText(result.watchId)} — ${sanitizeConsoleText(result.kind)}, ${result.emittedEvents} events, ${result.enqueuedDeliveries} enqueued deliveries${errorSuffix}`;
+      })
+    );
+  }
+
+  if (report.deliveryResults.length > 0) {
+    appendSection(
+      lines,
+      "Delivery Results",
+      report.deliveryResults.map((result) => {
+        const statusSuffix =
+          typeof result.responseStatus === "number"
+            ? `, HTTP ${result.responseStatus}`
+            : "";
+        const errorSuffix =
+          result.errorCode || result.errorMessage
+            ? `, error ${sanitizeConsoleText(result.errorCode ?? "UNKNOWN")}: ${sanitizeConsoleText(result.errorMessage ?? "Unknown delivery failure.")}`
+            : "";
+        return `- ${sanitizeConsoleText(result.deliveryId)} — ${sanitizeConsoleText(result.outcome)}, subscription ${sanitizeConsoleText(result.subscriptionId)}${statusSuffix}${errorSuffix}`;
+      })
+    );
+  }
+
+  const nextSteps = [
+    `Run \`linkedin activity status --profile ${sanitizeConsoleText(report.profile_name)}\` to inspect daemon health and queue counts.`,
+    `Run \`linkedin activity deliveries --profile ${sanitizeConsoleText(report.profile_name)}\` to inspect recent webhook outcomes.`,
+    "Use `--json` if you need the structured activity payload for automation."
+  ];
+
+  if (
+    report.failedWatches > 0 ||
+    report.failedDeliveries > 0 ||
+    report.deadLetterDeliveries > 0
+  ) {
+    nextSteps.unshift(
+      "Review the failed watch or delivery entries above before relying on this polling configuration in production."
+    );
+  } else if (report.claimedWatches === 0 && report.claimedDeliveries === 0) {
+    nextSteps.unshift(
+      "No due activity work was found. Review watch schedules if you expected work to be processed now."
+    );
+  }
+
+  appendSection(lines, "Next Steps", nextSteps.map((step) => `- ${sanitizeConsoleText(step)}`));
+  return lines.join("\n");
+}

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -142,6 +142,41 @@ import {
   type SchedulerStopReport
 } from "../schedulerOutput.js";
 import {
+  formatActivityDeliveryListReport,
+  formatActivityError,
+  formatActivityEventListReport,
+  formatActivityRunOnceReport,
+  formatActivityStartReport,
+  formatActivityStatusReport,
+  formatActivityStopReport,
+  formatActivityWatchAddReport,
+  formatActivityWatchListReport,
+  formatActivityWatchMutationReport,
+  formatActivityWatchRemovalReport,
+  formatActivityWebhookAddReport,
+  formatActivityWebhookListReport,
+  formatActivityWebhookMutationReport,
+  formatActivityWebhookRemovalReport,
+  resolveActivityOutputMode,
+  type ActivityDaemonState,
+  type ActivityDaemonStateSummary,
+  type ActivityDeliveryListReport,
+  type ActivityEventListReport,
+  type ActivityOutputMode,
+  type ActivityRunOnceReport,
+  type ActivityStartReport,
+  type ActivityStatusReport,
+  type ActivityStopReport,
+  type ActivityWatchAddReport,
+  type ActivityWatchListReport,
+  type ActivityWatchMutationReport,
+  type ActivityWatchRemovalReport,
+  type ActivityWebhookAddReport,
+  type ActivityWebhookListReport,
+  type ActivityWebhookMutationReport,
+  type ActivityWebhookRemovalReport
+} from "../activityOutput.js";
+import {
   formatKeepAliveError,
   formatKeepAliveStartReport,
   formatKeepAliveStatusReport,
@@ -2090,7 +2125,7 @@ function writeKeepAliveProgressNotice(
 }
 
 function warnAboutExternalCdpDaemonSession(): void {
-  writeCliWarning("--cdp-url attaches keepalive to an existing browser session.");
+  writeCliWarning("--cdp-url attaches this daemon to an existing browser session.");
   writeCliNotice("The daemon will share cookies and session state with that browser until you stop it.");
   writeCliNotice("For an isolated tool-owned profile, omit --cdp-url.");
 }
@@ -3328,40 +3363,6 @@ async function runSchedulerDaemon(
   }
 }
 
-type ActivityDaemonStateSummary = Pick<
-  ActivityPollTickResult,
-  | "claimedWatches"
-  | "polledWatches"
-  | "failedWatches"
-  | "emittedEvents"
-  | "enqueuedDeliveries"
-  | "claimedDeliveries"
-  | "deliveredAttempts"
-  | "retriedDeliveries"
-  | "failedDeliveries"
-  | "deadLetterDeliveries"
-  | "disabledSubscriptions"
->;
-
-interface ActivityDaemonState {
-  pid: number;
-  profileName: string;
-  startedAt: string;
-  updatedAt: string;
-  status: "starting" | "running" | "idle" | "degraded" | "stopped";
-  daemonPollIntervalMs: number;
-  maxWatchesPerTick: number;
-  maxDeliveriesPerTick: number;
-  consecutiveFailures: number;
-  maxConsecutiveFailures: number;
-  lastTickAt?: string;
-  lastSuccessfulTickAt?: string;
-  lastSummary?: ActivityDaemonStateSummary;
-  lastError?: string;
-  cdpUrl?: string;
-  stoppedAt?: string;
-}
-
 interface ActivityFiles {
   dir: string;
   pidPath: string;
@@ -3370,6 +3371,82 @@ interface ActivityFiles {
 }
 
 const ACTIVITY_DAEMON_MAX_CONSECUTIVE_FAILURES = 5;
+const DIAGNOSTIC_URL_PATTERN = /\b(?:https?|wss?):\/\/[^\s"'<>]+/giu;
+
+function normalizeDiagnosticKey(key: string | undefined): string {
+  return (key ?? "")
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/-/g, "_")
+    .toLowerCase();
+}
+
+function sanitizeDiagnosticUrl(value: string): string {
+  try {
+    const parsed = new URL(value);
+    parsed.username = "";
+    parsed.password = "";
+    parsed.search = "";
+    parsed.hash = "";
+    return parsed.toString();
+  } catch {
+    return value;
+  }
+}
+
+function sanitizeDiagnosticText(value: string): string {
+  return value.replace(DIAGNOSTIC_URL_PATTERN, (candidate) => {
+    const trimmed = candidate.replace(/[),.;]+$/u, "");
+    const trailing = candidate.slice(trimmed.length);
+    return `${sanitizeDiagnosticUrl(trimmed)}${trailing}`;
+  });
+}
+
+function sanitizeActivityPersistenceValue(
+  value: unknown,
+  key?: string
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeActivityPersistenceValue(entry));
+  }
+
+  if (typeof value === "object" && value !== null) {
+    const output: Record<string, unknown> = {};
+    for (const [entryKey, entryValue] of Object.entries(value)) {
+      output[entryKey] = sanitizeActivityPersistenceValue(entryValue, entryKey);
+    }
+    return output;
+  }
+
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  const normalizedKey = normalizeDiagnosticKey(key);
+  const sanitizedText = sanitizeDiagnosticText(value);
+
+  if (
+    normalizedKey === "cdp_url" ||
+    normalizedKey === "cdpurl" ||
+    normalizedKey === "error" ||
+    normalizedKey === "last_error" ||
+    normalizedKey.endsWith("_message")
+  ) {
+    return sanitizedText;
+  }
+
+  return sanitizedText;
+}
+
+function sanitizeActivityPersistenceRecord<T extends object>(
+  value: T,
+  surface: "log" | "storage"
+): T {
+  return redactStructuredValue(
+    sanitizeActivityPersistenceValue(value) as T,
+    cliPrivacyConfig,
+    surface
+  );
+}
 
 function asCliObject(value: unknown): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
@@ -3537,7 +3614,10 @@ async function writeActivityState(
 ): Promise<void> {
   const files = getActivityFiles(profileName);
   await ensureActivityDir(files);
-  await writeJsonFile(files.statePath, state);
+  await writeJsonFile(
+    files.statePath,
+    sanitizeActivityPersistenceRecord(state, "storage")
+  );
 }
 
 async function appendActivityEvent(
@@ -3546,7 +3626,11 @@ async function appendActivityEvent(
 ): Promise<void> {
   const files = getActivityFiles(profileName);
   await ensureActivityDir(files);
-  await appendFile(files.logPath, `${JSON.stringify(event)}\n`, "utf8");
+  await appendFile(
+    files.logPath,
+    `${JSON.stringify(sanitizeActivityPersistenceRecord(event, "log"))}\n`,
+    "utf8"
+  );
 }
 
 function summarizeActivityTick(
@@ -3567,8 +3651,9 @@ function summarizeActivityTick(
   };
 }
 
-function resolveActivityStatusConfig(): Partial<
-  Record<"activity_config" | "activity_config_error", unknown>
+function resolveActivityStatusConfig(): Pick<
+  ActivityStatusReport,
+  "activity_config" | "activity_config_error"
 > {
   try {
     return {
@@ -3581,19 +3666,58 @@ function resolveActivityStatusConfig(): Partial<
   }
 }
 
+function emitActivityReport<Report extends object>(
+  report: Report,
+  outputMode: ActivityOutputMode,
+  formatter: (report: Report) => string
+): void {
+  if (outputMode === "json") {
+    printJson(report);
+    return;
+  }
+
+  console.log(
+    formatter(redactStructuredValue(report, cliPrivacyConfig, "cli") as Report)
+  );
+}
+
+async function runActivityCliAction(
+  input: { json?: boolean },
+  action: (outputMode: ActivityOutputMode) => Promise<void>
+): Promise<void> {
+  const outputMode = resolveActivityOutputMode(input, Boolean(stdout.isTTY));
+
+  try {
+    await action(outputMode);
+  } catch (error) {
+    if (outputMode === "json") {
+      throw error;
+    }
+
+    process.stderr.write(
+      `${formatActivityError(
+        toLinkedInAssistantErrorPayload(error, cliPrivacyConfig)
+      )}\n`
+    );
+    process.exitCode = 1;
+  }
+}
+
 async function runActivityWatchAdd(input: {
   profileName: string;
   kind: ActivityWatchKind;
   target?: Record<string, unknown>;
   intervalSeconds?: number;
   cron?: string;
-}, cdpUrl?: string): Promise<void> {
+}, outputMode: ActivityOutputMode, cdpUrl?: string): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.activity.watch.add.start", {
-      profileName: input.profileName,
-      kind: input.kind
+      kind: input.kind,
+      output_mode: outputMode,
+      profile_name: input.profileName,
+      schedule_kind: input.cron ? "cron" : "interval"
     });
 
     const watch = runtime.activityWatches.createWatch({
@@ -3607,16 +3731,17 @@ async function runActivityWatchAdd(input: {
     });
 
     runtime.logger.log("info", "cli.activity.watch.add.done", {
-      profileName: input.profileName,
-      watchId: watch.id,
-      kind: watch.kind
+      kind: watch.kind,
+      profile_name: input.profileName,
+      watch_id: watch.id
     });
 
-    printJson({
+    const report: ActivityWatchAddReport = {
       run_id: runtime.runId,
       profile_name: input.profileName,
       watch
-    });
+    };
+    emitActivityReport(report, outputMode, formatActivityWatchAddReport);
   } finally {
     runtime.close();
   }
@@ -3625,64 +3750,125 @@ async function runActivityWatchAdd(input: {
 async function runActivityWatchList(input: {
   profileName: string;
   status?: ActivityWatchStatus;
-}, cdpUrl?: string): Promise<void> {
+}, outputMode: ActivityOutputMode, cdpUrl?: string): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
+    runtime.logger.log("info", "cli.activity.watch.list.start", {
+      profile_name: input.profileName,
+      ...(input.status ? { status: input.status } : {})
+    });
+
     const watches = runtime.activityWatches.listWatches({
       profileName: input.profileName,
       ...(input.status ? { status: input.status } : {})
     });
 
-    printJson({
+    runtime.logger.log("info", "cli.activity.watch.list.done", {
+      count: watches.length,
+      profile_name: input.profileName,
+      ...(input.status ? { status: input.status } : {})
+    });
+
+    const report: ActivityWatchListReport = {
       run_id: runtime.runId,
       profile_name: input.profileName,
       count: watches.length,
       watches
-    });
+    };
+    emitActivityReport(report, outputMode, formatActivityWatchListReport);
   } finally {
     runtime.close();
   }
 }
 
-async function runActivityWatchPause(id: string, cdpUrl?: string): Promise<void> {
+async function runActivityWatchPause(
+  id: string,
+  outputMode: ActivityOutputMode,
+  cdpUrl?: string
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
+    runtime.logger.log("info", "cli.activity.watch.pause.start", {
+      watch_id: id
+    });
+
     const watch = runtime.activityWatches.pauseWatch(id);
-    printJson({
+
+    runtime.logger.log("info", "cli.activity.watch.pause.done", {
+      profile_name: watch.profileName,
+      watch_id: watch.id
+    });
+
+    const report: ActivityWatchMutationReport = {
       run_id: runtime.runId,
       watch
-    });
+    };
+    emitActivityReport(report, outputMode, (value) =>
+      formatActivityWatchMutationReport(value, "paused")
+    );
   } finally {
     runtime.close();
   }
 }
 
-async function runActivityWatchResume(id: string, cdpUrl?: string): Promise<void> {
+async function runActivityWatchResume(
+  id: string,
+  outputMode: ActivityOutputMode,
+  cdpUrl?: string
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
+    runtime.logger.log("info", "cli.activity.watch.resume.start", {
+      watch_id: id
+    });
+
     const watch = runtime.activityWatches.resumeWatch(id);
-    printJson({
+
+    runtime.logger.log("info", "cli.activity.watch.resume.done", {
+      profile_name: watch.profileName,
+      watch_id: watch.id
+    });
+
+    const report: ActivityWatchMutationReport = {
       run_id: runtime.runId,
       watch
-    });
+    };
+    emitActivityReport(report, outputMode, (value) =>
+      formatActivityWatchMutationReport(value, "resumed")
+    );
   } finally {
     runtime.close();
   }
 }
 
-async function runActivityWatchRemove(id: string, cdpUrl?: string): Promise<void> {
+async function runActivityWatchRemove(
+  id: string,
+  outputMode: ActivityOutputMode,
+  cdpUrl?: string
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
+    runtime.logger.log("info", "cli.activity.watch.remove.start", {
+      watch_id: id
+    });
+
     const removed = runtime.activityWatches.removeWatch(id);
-    printJson({
+
+    runtime.logger.log("info", "cli.activity.watch.remove.done", {
+      removed,
+      watch_id: id
+    });
+
+    const report: ActivityWatchRemovalReport = {
       run_id: runtime.runId,
       watch_id: id,
       removed
-    });
+    };
+    emitActivityReport(report, outputMode, formatActivityWatchRemovalReport);
   } finally {
     runtime.close();
   }
@@ -3694,10 +3880,16 @@ async function runActivityWebhookAdd(input: {
   eventTypes?: ActivityEventType[];
   signingSecret?: string;
   maxAttempts?: number;
-}, cdpUrl?: string): Promise<void> {
+}, outputMode: ActivityOutputMode, cdpUrl?: string): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
+    runtime.logger.log("info", "cli.activity.webhook.add.start", {
+      delivery_url: input.deliveryUrl,
+      output_mode: outputMode,
+      watch_id: input.watchId
+    });
+
     const subscription = runtime.activityWatches.createWebhookSubscription({
       watchId: input.watchId,
       deliveryUrl: input.deliveryUrl,
@@ -3708,10 +3900,16 @@ async function runActivityWebhookAdd(input: {
         : {})
     });
 
-    printJson({
+    runtime.logger.log("info", "cli.activity.webhook.add.done", {
+      webhook_subscription_id: subscription.id,
+      watch_id: subscription.watchId
+    });
+
+    const report: ActivityWebhookAddReport = {
       run_id: runtime.runId,
       subscription
-    });
+    };
+    emitActivityReport(report, outputMode, formatActivityWebhookAddReport);
   } finally {
     runtime.close();
   }
@@ -3721,22 +3919,36 @@ async function runActivityWebhookList(input: {
   profileName: string;
   watchId?: string;
   status?: WebhookSubscriptionStatus;
-}, cdpUrl?: string): Promise<void> {
+}, outputMode: ActivityOutputMode, cdpUrl?: string): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
+    runtime.logger.log("info", "cli.activity.webhook.list.start", {
+      profile_name: input.profileName,
+      ...(input.status ? { status: input.status } : {}),
+      ...(input.watchId ? { watch_id: input.watchId } : {})
+    });
+
     const subscriptions = runtime.activityWatches.listWebhookSubscriptions({
       profileName: input.profileName,
       ...(input.watchId ? { watchId: input.watchId } : {}),
       ...(input.status ? { status: input.status } : {})
     });
 
-    printJson({
+    runtime.logger.log("info", "cli.activity.webhook.list.done", {
+      count: subscriptions.length,
+      profile_name: input.profileName,
+      ...(input.status ? { status: input.status } : {}),
+      ...(input.watchId ? { watch_id: input.watchId } : {})
+    });
+
+    const report: ActivityWebhookListReport = {
       run_id: runtime.runId,
       profile_name: input.profileName,
       count: subscriptions.length,
       subscriptions
-    });
+    };
+    emitActivityReport(report, outputMode, formatActivityWebhookListReport);
   } finally {
     runtime.close();
   }
@@ -3744,16 +3956,30 @@ async function runActivityWebhookList(input: {
 
 async function runActivityWebhookPause(
   id: string,
+  outputMode: ActivityOutputMode,
   cdpUrl?: string
 ): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
+    runtime.logger.log("info", "cli.activity.webhook.pause.start", {
+      webhook_subscription_id: id
+    });
+
     const subscription = runtime.activityWatches.pauseWebhookSubscription(id);
-    printJson({
+
+    runtime.logger.log("info", "cli.activity.webhook.pause.done", {
+      webhook_subscription_id: subscription.id,
+      watch_id: subscription.watchId
+    });
+
+    const report: ActivityWebhookMutationReport = {
       run_id: runtime.runId,
       subscription
-    });
+    };
+    emitActivityReport(report, outputMode, (value) =>
+      formatActivityWebhookMutationReport(value, "paused")
+    );
   } finally {
     runtime.close();
   }
@@ -3761,16 +3987,30 @@ async function runActivityWebhookPause(
 
 async function runActivityWebhookResume(
   id: string,
+  outputMode: ActivityOutputMode,
   cdpUrl?: string
 ): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
+    runtime.logger.log("info", "cli.activity.webhook.resume.start", {
+      webhook_subscription_id: id
+    });
+
     const subscription = runtime.activityWatches.resumeWebhookSubscription(id);
-    printJson({
+
+    runtime.logger.log("info", "cli.activity.webhook.resume.done", {
+      webhook_subscription_id: subscription.id,
+      watch_id: subscription.watchId
+    });
+
+    const report: ActivityWebhookMutationReport = {
       run_id: runtime.runId,
       subscription
-    });
+    };
+    emitActivityReport(report, outputMode, (value) =>
+      formatActivityWebhookMutationReport(value, "resumed")
+    );
   } finally {
     runtime.close();
   }
@@ -3778,17 +4018,29 @@ async function runActivityWebhookResume(
 
 async function runActivityWebhookRemove(
   id: string,
+  outputMode: ActivityOutputMode,
   cdpUrl?: string
 ): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
+    runtime.logger.log("info", "cli.activity.webhook.remove.start", {
+      webhook_subscription_id: id
+    });
+
     const removed = runtime.activityWatches.removeWebhookSubscription(id);
-    printJson({
+
+    runtime.logger.log("info", "cli.activity.webhook.remove.done", {
+      removed,
+      webhook_subscription_id: id
+    });
+
+    const report: ActivityWebhookRemovalReport = {
       run_id: runtime.runId,
       subscription_id: id,
       removed
-    });
+    };
+    emitActivityReport(report, outputMode, formatActivityWebhookRemovalReport);
   } finally {
     runtime.close();
   }
@@ -3798,22 +4050,35 @@ async function runActivityEventsList(input: {
   profileName: string;
   watchId?: string;
   limit: number;
-}, cdpUrl?: string): Promise<void> {
+}, outputMode: ActivityOutputMode, cdpUrl?: string): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
+    runtime.logger.log("info", "cli.activity.events.list.start", {
+      limit: input.limit,
+      profile_name: input.profileName,
+      ...(input.watchId ? { watch_id: input.watchId } : {})
+    });
+
     const events = runtime.activityWatches.listEvents({
       profileName: input.profileName,
       ...(input.watchId ? { watchId: input.watchId } : {}),
       limit: input.limit
     });
 
-    printJson({
+    runtime.logger.log("info", "cli.activity.events.list.done", {
+      count: events.length,
+      profile_name: input.profileName,
+      ...(input.watchId ? { watch_id: input.watchId } : {})
+    });
+
+    const report: ActivityEventListReport = {
       run_id: runtime.runId,
       profile_name: input.profileName,
       count: events.length,
       events
-    });
+    };
+    emitActivityReport(report, outputMode, formatActivityEventListReport);
   } finally {
     runtime.close();
   }
@@ -3825,10 +4090,18 @@ async function runActivityDeliveriesList(input: {
   subscriptionId?: string;
   status?: WebhookDeliveryAttemptStatus;
   limit: number;
-}, cdpUrl?: string): Promise<void> {
+}, outputMode: ActivityOutputMode, cdpUrl?: string): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
+    runtime.logger.log("info", "cli.activity.deliveries.list.start", {
+      limit: input.limit,
+      profile_name: input.profileName,
+      ...(input.status ? { status: input.status } : {}),
+      ...(input.subscriptionId ? { subscription_id: input.subscriptionId } : {}),
+      ...(input.watchId ? { watch_id: input.watchId } : {})
+    });
+
     const deliveries = runtime.activityWatches.listDeliveries({
       profileName: input.profileName,
       ...(input.watchId ? { watchId: input.watchId } : {}),
@@ -3837,12 +4110,21 @@ async function runActivityDeliveriesList(input: {
       limit: input.limit
     });
 
-    printJson({
+    runtime.logger.log("info", "cli.activity.deliveries.list.done", {
+      count: deliveries.length,
+      profile_name: input.profileName,
+      ...(input.status ? { status: input.status } : {}),
+      ...(input.subscriptionId ? { subscription_id: input.subscriptionId } : {}),
+      ...(input.watchId ? { watch_id: input.watchId } : {})
+    });
+
+    const report: ActivityDeliveryListReport = {
       run_id: runtime.runId,
       profile_name: input.profileName,
       count: deliveries.length,
       deliveries
-    });
+    };
+    emitActivityReport(report, outputMode, formatActivityDeliveryListReport);
   } finally {
     runtime.close();
   }
@@ -3850,6 +4132,7 @@ async function runActivityDeliveriesList(input: {
 
 async function runActivityRunOnce(
   profileName: string,
+  outputMode: ActivityOutputMode,
   cdpUrl?: string
 ): Promise<void> {
   const normalizedProfileName = coerceProfileName(profileName);
@@ -3857,6 +4140,17 @@ async function runActivityRunOnce(
   const activityConfig = resolveActivityWebhookConfig();
 
   try {
+    runtime.logger.log("info", "cli.activity.run_once.start", {
+      profile_name: normalizedProfileName,
+      worker_id: `cli:${runtime.runId}`
+    });
+
+    if (outputMode === "human") {
+      writeCliNotice(
+        `Running one activity polling tick for profile "${normalizedProfileName}".`
+      );
+    }
+
     const result = await runtime.activityPoller.runTick({
       profileName: normalizedProfileName,
       workerId: `cli:${runtime.runId}`
@@ -3870,12 +4164,21 @@ async function runActivityRunOnce(
       process.exitCode = 1;
     }
 
-    printJson({
+    runtime.logger.log("info", "cli.activity.run_once.done", {
+      dead_letter_deliveries: result.deadLetterDeliveries,
+      failed_deliveries: result.failedDeliveries,
+      failed_watches: result.failedWatches,
+      profile_name: normalizedProfileName,
+      worker_id: result.workerId
+    });
+
+    const report: ActivityRunOnceReport = {
       run_id: runtime.runId,
       profile_name: normalizedProfileName,
       activity_config: activityConfig,
       ...result
-    });
+    };
+    emitActivityReport(report, outputMode, formatActivityRunOnceReport);
   } finally {
     runtime.close();
   }
@@ -3883,13 +4186,14 @@ async function runActivityRunOnce(
 
 async function runActivityStart(
   profileName: string,
+  outputMode: ActivityOutputMode,
   cdpUrl?: string
 ): Promise<void> {
   const normalizedProfileName = coerceProfileName(profileName);
   const files = getActivityFiles(normalizedProfileName);
   const existingPid = await readActivityPid(normalizedProfileName);
   if (existingPid && isProcessRunning(existingPid)) {
-    printJson({
+    const report: ActivityStartReport = {
       started: false,
       reason: "Activity daemon is already running for this profile.",
       profile_name: normalizedProfileName,
@@ -3898,7 +4202,8 @@ async function runActivityStart(
       state_path: files.statePath,
       log_path: files.logPath,
       ...resolveActivityStatusConfig()
-    });
+    };
+    emitActivityReport(report, outputMode, formatActivityStartReport);
     return;
   }
 
@@ -3906,7 +4211,16 @@ async function runActivityStart(
     await removeActivityPid(normalizedProfileName);
   }
 
+  if (cdpUrl) {
+    warnAboutExternalCdpDaemonSession();
+  }
   maybeWarnAboutSelectorLocaleConfig(cliSelectorLocale);
+
+  if (outputMode === "human") {
+    writeCliNotice(
+      `Starting the activity daemon for profile "${normalizedProfileName}".`
+    );
+  }
 
   const activityConfig = resolveActivityWebhookConfig();
   const cliEntrypoint = resolveKeepAliveCliEntrypoint();
@@ -3958,17 +4272,21 @@ async function runActivityStart(
   await writeActivityPid(normalizedProfileName, daemon.pid);
   await writeActivityState(normalizedProfileName, initialState);
 
-  printJson({
+  const report: ActivityStartReport = {
     started: true,
     profile_name: normalizedProfileName,
     pid: daemon.pid,
     state_path: files.statePath,
     log_path: files.logPath,
     activity_config: activityConfig
-  });
+  };
+  emitActivityReport(report, outputMode, formatActivityStartReport);
 }
 
-async function runActivityStatus(profileName: string): Promise<void> {
+async function runActivityStatus(
+  profileName: string,
+  outputMode: ActivityOutputMode
+): Promise<void> {
   const normalizedProfileName = coerceProfileName(profileName);
   const pid = await readActivityPid(normalizedProfileName);
   const state = await readActivityState(normalizedProfileName);
@@ -3992,7 +4310,7 @@ async function runActivityStatus(profileName: string): Promise<void> {
       limit: 5
     });
 
-    printJson({
+    const report: ActivityStatusReport = {
       profile_name: normalizedProfileName,
       running,
       pid: typeof pid === "number" ? pid : null,
@@ -4009,26 +4327,36 @@ async function runActivityStatus(profileName: string): Promise<void> {
       recent_event_count: recentEvents.length,
       recent_delivery_count: recentDeliveries.length,
       ...resolveActivityStatusConfig()
-    });
+    };
+
+    if (report.activity_config_error) {
+      process.exitCode = 1;
+    }
+
+    emitActivityReport(report, outputMode, formatActivityStatusReport);
   } finally {
     db.close();
   }
 }
 
-async function runActivityStop(profileName: string): Promise<void> {
+async function runActivityStop(
+  profileName: string,
+  outputMode: ActivityOutputMode
+): Promise<void> {
   const normalizedProfileName = coerceProfileName(profileName);
   const files = getActivityFiles(normalizedProfileName);
   const pid = await readActivityPid(normalizedProfileName);
   const previousState = await readActivityState(normalizedProfileName);
 
   if (!pid) {
-    printJson({
+    const report: ActivityStopReport = {
       stopped: false,
       profile_name: normalizedProfileName,
       reason: "No activity daemon is currently running for this profile.",
       state_path: files.statePath,
       log_path: files.logPath
-    });
+    };
+    emitActivityReport(report, outputMode, formatActivityStopReport);
     return;
   }
 
@@ -4044,15 +4372,22 @@ async function runActivityStop(profileName: string): Promise<void> {
         lastError: "Recovered from stale pid file."
       });
     }
-    printJson({
+    const report: ActivityStopReport = {
       stopped: true,
       profile_name: normalizedProfileName,
       pid,
       reason: "Removed a stale activity PID file for this profile.",
       state_path: files.statePath,
       log_path: files.logPath
-    });
+    };
+    emitActivityReport(report, outputMode, formatActivityStopReport);
     return;
+  }
+
+  if (outputMode === "human") {
+    writeCliNotice(
+      `Stopping the activity daemon for profile "${normalizedProfileName}".`
+    );
   }
 
   try {
@@ -4095,7 +4430,7 @@ async function runActivityStop(profileName: string): Promise<void> {
     });
   }
 
-  printJson({
+  const report: ActivityStopReport = {
     stopped: true,
     profile_name: normalizedProfileName,
     pid,
@@ -4105,7 +4440,8 @@ async function runActivityStop(profileName: string): Promise<void> {
       : "Activity daemon exited cleanly.",
     state_path: files.statePath,
     log_path: files.logPath
-  });
+  };
+  emitActivityReport(report, outputMode, formatActivityStopReport);
 }
 
 async function runActivityDaemon(
@@ -6125,16 +6461,20 @@ export function createCliProgram(): Command {
   const activityCommand = program
     .command("activity")
     .description(
-      "Manage poll-based LinkedIn activity watches, webhook subscriptions, and the local activity daemon"
+      "Use human-readable activity summaries by default in interactive terminals. Manage poll-based LinkedIn activity watches, webhook subscriptions, and the local activity daemon."
     )
     .addHelpText(
-      "afterAll",
+      "after",
       [
+        "",
+        "Interactive terminals default to human-readable activity summaries.",
+        "Use --json for automation, piping, or to inspect the full structured activity payload.",
+        "Use `linkedin activity run-once` when you want an immediate poll without keeping the daemon running.",
         "",
         "Examples:",
         "  linkedin activity watch add --profile default --kind notifications --interval-seconds 600",
         "  linkedin activity webhook add --watch <watch-id> --url https://example.com/hooks/linkedin",
-        "  linkedin activity run-once --profile default",
+        "  linkedin activity run-once --profile default --json",
         "  linkedin activity start --profile default",
         "  linkedin activity status --profile default",
         "  linkedin activity stop --profile default"
@@ -6154,33 +6494,38 @@ export function createCliProgram(): Command {
     .option("--cron <expression>", "Cron schedule expression")
     .option("--target <json>", "Watch target as JSON object text")
     .option("--target-file <path>", "Read watch target from a JSON file")
+    .option("--json", "Print the structured activity payload", false)
     .action(
       async (options: {
         kind: string;
+        json: boolean;
         profile: string;
         intervalSeconds?: string;
         cron?: string;
         target?: string;
         targetFile?: string;
       }) => {
-        const target = await readActivityTargetInput(options);
-        await runActivityWatchAdd(
-          {
-            profileName: options.profile,
-            kind: coerceActivityWatchKind(options.kind),
-            ...(typeof options.intervalSeconds === "string"
-              ? {
-                  intervalSeconds: coercePositiveInt(
-                    options.intervalSeconds,
-                    "interval-seconds"
-                  )
-                }
-              : {}),
-            ...(options.cron ? { cron: options.cron } : {}),
-            ...(target ? { target } : {})
-          },
-          readCdpUrl()
-        );
+        await runActivityCliAction(options, async (outputMode) => {
+          const target = await readActivityTargetInput(options);
+          await runActivityWatchAdd(
+            {
+              profileName: options.profile,
+              kind: coerceActivityWatchKind(options.kind),
+              ...(typeof options.intervalSeconds === "string"
+                ? {
+                    intervalSeconds: coercePositiveInt(
+                      options.intervalSeconds,
+                      "interval-seconds"
+                    )
+                  }
+                : {}),
+              ...(options.cron ? { cron: options.cron } : {}),
+              ...(target ? { target } : {})
+            },
+            outputMode,
+            readCdpUrl()
+          );
+        });
       }
     );
 
@@ -6192,40 +6537,53 @@ export function createCliProgram(): Command {
       "--status <status>",
       `Filter by status: ${ACTIVITY_WATCH_STATUSES.join(", ")}`
     )
-    .action(async (options: { profile: string; status?: string }) => {
-      await runActivityWatchList(
-        {
-          profileName: options.profile,
-          ...(options.status
-            ? { status: coerceActivityWatchStatusValue(options.status) }
-            : {})
-        },
-        readCdpUrl()
-      );
+    .option("--json", "Print the structured activity payload", false)
+    .action(async (options: { profile: string; status?: string; json: boolean }) => {
+      await runActivityCliAction(options, async (outputMode) => {
+        await runActivityWatchList(
+          {
+            profileName: options.profile,
+            ...(options.status
+              ? { status: coerceActivityWatchStatusValue(options.status) }
+              : {})
+          },
+          outputMode,
+          readCdpUrl()
+        );
+      });
     });
 
   activityWatchCommand
     .command("pause")
     .description("Pause an activity watch")
     .argument("<watchId>", "Activity watch id")
-    .action(async (watchId: string) => {
-      await runActivityWatchPause(watchId, readCdpUrl());
+    .option("--json", "Print the structured activity payload", false)
+    .action(async (watchId: string, options: { json: boolean }) => {
+      await runActivityCliAction(options, async (outputMode) => {
+        await runActivityWatchPause(watchId, outputMode, readCdpUrl());
+      });
     });
 
   activityWatchCommand
     .command("resume")
     .description("Resume an activity watch and make it due immediately")
     .argument("<watchId>", "Activity watch id")
-    .action(async (watchId: string) => {
-      await runActivityWatchResume(watchId, readCdpUrl());
+    .option("--json", "Print the structured activity payload", false)
+    .action(async (watchId: string, options: { json: boolean }) => {
+      await runActivityCliAction(options, async (outputMode) => {
+        await runActivityWatchResume(watchId, outputMode, readCdpUrl());
+      });
     });
 
   activityWatchCommand
     .command("remove")
     .description("Remove an activity watch")
     .argument("<watchId>", "Activity watch id")
-    .action(async (watchId: string) => {
-      await runActivityWatchRemove(watchId, readCdpUrl());
+    .option("--json", "Print the structured activity payload", false)
+    .action(async (watchId: string, options: { json: boolean }) => {
+      await runActivityCliAction(options, async (outputMode) => {
+        await runActivityWatchRemove(watchId, outputMode, readCdpUrl());
+      });
     });
 
   const activityWebhookCommand = activityCommand
@@ -6240,28 +6598,38 @@ export function createCliProgram(): Command {
     .option("-e, --event <eventType...>", `Event filters: ${ACTIVITY_EVENT_TYPES.join(", ")}`)
     .option("--secret <secret>", "Webhook signing secret")
     .option("--max-attempts <count>", "Maximum delivery attempts")
+    .option("--json", "Print the structured activity payload", false)
     .action(
       async (options: {
         watch: string;
         url: string;
         event?: string[];
+        json: boolean;
         secret?: string;
         maxAttempts?: string;
       }) => {
-        await runActivityWebhookAdd(
-          {
-            watchId: options.watch,
-            deliveryUrl: options.url,
-            ...(options.event
-              ? { eventTypes: coerceActivityEventTypes(options.event) }
-              : {}),
-            ...(options.secret ? { signingSecret: options.secret } : {}),
-            ...(typeof options.maxAttempts === "string"
-              ? { maxAttempts: coercePositiveInt(options.maxAttempts, "max-attempts") }
-              : {})
-          },
-          readCdpUrl()
-        );
+        await runActivityCliAction(options, async (outputMode) => {
+          await runActivityWebhookAdd(
+            {
+              watchId: options.watch,
+              deliveryUrl: options.url,
+              ...(options.event
+                ? { eventTypes: coerceActivityEventTypes(options.event) }
+                : {}),
+              ...(options.secret ? { signingSecret: options.secret } : {}),
+              ...(typeof options.maxAttempts === "string"
+                ? {
+                    maxAttempts: coercePositiveInt(
+                      options.maxAttempts,
+                      "max-attempts"
+                    )
+                  }
+                : {})
+            },
+            outputMode,
+            readCdpUrl()
+          );
+        });
       }
     );
 
@@ -6274,18 +6642,22 @@ export function createCliProgram(): Command {
       "--status <status>",
       `Filter by status: ${WEBHOOK_SUBSCRIPTION_STATUSES.join(", ")}`
     )
+    .option("--json", "Print the structured activity payload", false)
     .action(
-      async (options: { profile: string; watch?: string; status?: string }) => {
-        await runActivityWebhookList(
-          {
-            profileName: options.profile,
-            ...(options.watch ? { watchId: options.watch } : {}),
-            ...(options.status
-              ? { status: coerceWebhookSubscriptionStatusValue(options.status) }
-              : {})
-          },
-          readCdpUrl()
-        );
+      async (options: { profile: string; watch?: string; status?: string; json: boolean }) => {
+        await runActivityCliAction(options, async (outputMode) => {
+          await runActivityWebhookList(
+            {
+              profileName: options.profile,
+              ...(options.watch ? { watchId: options.watch } : {}),
+              ...(options.status
+                ? { status: coerceWebhookSubscriptionStatusValue(options.status) }
+                : {})
+            },
+            outputMode,
+            readCdpUrl()
+          );
+        });
       }
     );
 
@@ -6293,24 +6665,33 @@ export function createCliProgram(): Command {
     .command("pause")
     .description("Pause a webhook subscription")
     .argument("<subscriptionId>", "Webhook subscription id")
-    .action(async (subscriptionId: string) => {
-      await runActivityWebhookPause(subscriptionId, readCdpUrl());
+    .option("--json", "Print the structured activity payload", false)
+    .action(async (subscriptionId: string, options: { json: boolean }) => {
+      await runActivityCliAction(options, async (outputMode) => {
+        await runActivityWebhookPause(subscriptionId, outputMode, readCdpUrl());
+      });
     });
 
   activityWebhookCommand
     .command("resume")
     .description("Resume a webhook subscription")
     .argument("<subscriptionId>", "Webhook subscription id")
-    .action(async (subscriptionId: string) => {
-      await runActivityWebhookResume(subscriptionId, readCdpUrl());
+    .option("--json", "Print the structured activity payload", false)
+    .action(async (subscriptionId: string, options: { json: boolean }) => {
+      await runActivityCliAction(options, async (outputMode) => {
+        await runActivityWebhookResume(subscriptionId, outputMode, readCdpUrl());
+      });
     });
 
   activityWebhookCommand
     .command("remove")
     .description("Remove a webhook subscription")
     .argument("<subscriptionId>", "Webhook subscription id")
-    .action(async (subscriptionId: string) => {
-      await runActivityWebhookRemove(subscriptionId, readCdpUrl());
+    .option("--json", "Print the structured activity payload", false)
+    .action(async (subscriptionId: string, options: { json: boolean }) => {
+      await runActivityCliAction(options, async (outputMode) => {
+        await runActivityWebhookRemove(subscriptionId, outputMode, readCdpUrl());
+      });
     });
 
   activityCommand
@@ -6319,15 +6700,19 @@ export function createCliProgram(): Command {
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("--watch <watchId>", "Filter by watch id")
     .option("-l, --limit <limit>", "Maximum events to return", "20")
-    .action(async (options: { profile: string; watch?: string; limit: string }) => {
-      await runActivityEventsList(
-        {
-          profileName: options.profile,
-          ...(options.watch ? { watchId: options.watch } : {}),
-          limit: coercePositiveInt(options.limit, "limit")
-        },
-        readCdpUrl()
-      );
+    .option("--json", "Print the structured activity payload", false)
+    .action(async (options: { profile: string; watch?: string; limit: string; json: boolean }) => {
+      await runActivityCliAction(options, async (outputMode) => {
+        await runActivityEventsList(
+          {
+            profileName: options.profile,
+            ...(options.watch ? { watchId: options.watch } : {}),
+            limit: coercePositiveInt(options.limit, "limit")
+          },
+          outputMode,
+          readCdpUrl()
+        );
+      });
     });
 
   activityCommand
@@ -6341,6 +6726,7 @@ export function createCliProgram(): Command {
       `Filter by status: ${WEBHOOK_DELIVERY_ATTEMPT_STATUSES.join(", ")}`
     )
     .option("-l, --limit <limit>", "Maximum deliveries to return", "20")
+    .option("--json", "Print the structured activity payload", false)
     .action(
       async (options: {
         profile: string;
@@ -6348,19 +6734,23 @@ export function createCliProgram(): Command {
         subscription?: string;
         status?: string;
         limit: string;
+        json: boolean;
       }) => {
-        await runActivityDeliveriesList(
-          {
-            profileName: options.profile,
-            ...(options.watch ? { watchId: options.watch } : {}),
-            ...(options.subscription ? { subscriptionId: options.subscription } : {}),
-            ...(options.status
-              ? { status: coerceWebhookDeliveryStatusValue(options.status) }
-              : {}),
-            limit: coercePositiveInt(options.limit, "limit")
-          },
-          readCdpUrl()
-        );
+        await runActivityCliAction(options, async (outputMode) => {
+          await runActivityDeliveriesList(
+            {
+              profileName: options.profile,
+              ...(options.watch ? { watchId: options.watch } : {}),
+              ...(options.subscription ? { subscriptionId: options.subscription } : {}),
+              ...(options.status
+                ? { status: coerceWebhookDeliveryStatusValue(options.status) }
+                : {}),
+              limit: coercePositiveInt(options.limit, "limit")
+            },
+            outputMode,
+            readCdpUrl()
+          );
+        });
       }
     );
 
@@ -6368,24 +6758,33 @@ export function createCliProgram(): Command {
     .command("start")
     .description("Start the local activity polling daemon for a profile")
     .option("-p, --profile <profile>", "Profile name", "default")
-    .action(async (options: { profile: string }) => {
-      await runActivityStart(options.profile, readCdpUrl());
+    .option("--json", "Print the structured activity payload", false)
+    .action(async (options: { profile: string; json: boolean }) => {
+      await runActivityCliAction(options, async (outputMode) => {
+        await runActivityStart(options.profile, outputMode, readCdpUrl());
+      });
     });
 
   activityCommand
     .command("status")
     .description("Show local activity daemon state and persistent queue counts")
     .option("-p, --profile <profile>", "Profile name", "default")
-    .action(async (options: { profile: string }) => {
-      await runActivityStatus(options.profile);
+    .option("--json", "Print the structured activity payload", false)
+    .action(async (options: { profile: string; json: boolean }) => {
+      await runActivityCliAction(options, async (outputMode) => {
+        await runActivityStatus(options.profile, outputMode);
+      });
     });
 
   activityCommand
     .command("stop")
     .description("Stop the local activity polling daemon")
     .option("-p, --profile <profile>", "Profile name", "default")
-    .action(async (options: { profile: string }) => {
-      await runActivityStop(options.profile);
+    .option("--json", "Print the structured activity payload", false)
+    .action(async (options: { profile: string; json: boolean }) => {
+      await runActivityCliAction(options, async (outputMode) => {
+        await runActivityStop(options.profile, outputMode);
+      });
     });
 
   activityCommand
@@ -6393,8 +6792,11 @@ export function createCliProgram(): Command {
     .alias("tick")
     .description("Run one activity polling tick immediately")
     .option("-p, --profile <profile>", "Profile name", "default")
-    .action(async (options: { profile: string }) => {
-      await runActivityRunOnce(options.profile, readCdpUrl());
+    .option("--json", "Print the structured activity payload", false)
+    .action(async (options: { profile: string; json: boolean }) => {
+      await runActivityCliAction(options, async (outputMode) => {
+        await runActivityRunOnce(options.profile, outputMode, readCdpUrl());
+      });
     });
 
   activityCommand

--- a/packages/cli/test/activityCli.test.ts
+++ b/packages/cli/test/activityCli.test.ts
@@ -1,0 +1,361 @@
+import { readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { stdin, stdout } from "node:process";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const activityCliMocks = vi.hoisted(() => ({
+  activityPollerRunTick: vi.fn(),
+  activityWatchesCreateWatch: vi.fn(),
+  activityWatchesCreateWebhookSubscription: vi.fn(),
+  close: vi.fn(),
+  createCoreRuntime: vi.fn(),
+  loggerLog: vi.fn()
+}));
+
+vi.mock("@linkedin-assistant/core", async () => {
+  const actual = await import("../../core/src/index.js");
+
+  return {
+    ...actual,
+    createCoreRuntime: activityCliMocks.createCoreRuntime
+  };
+});
+
+import {
+  LinkedInAssistantError,
+  resolveConfigPaths
+} from "@linkedin-assistant/core";
+import { createCliProgram, runCli } from "../src/bin/linkedin.js";
+
+function setInteractiveMode(inputIsTty: boolean, outputIsTty: boolean): void {
+  Object.defineProperty(stdin, "isTTY", {
+    configurable: true,
+    value: inputIsTty
+  });
+  Object.defineProperty(stdout, "isTTY", {
+    configurable: true,
+    value: outputIsTty
+  });
+  Object.defineProperty(process.stderr, "isTTY", {
+    configurable: true,
+    value: outputIsTty
+  });
+}
+
+function createWatch(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "watch_cli_123",
+    profileName: "default",
+    kind: "notifications",
+    target: {
+      limit: 20
+    },
+    scheduleKind: "interval",
+    pollIntervalMs: 900_000,
+    cronExpression: null,
+    status: "active",
+    nextPollAtMs: Date.parse("2026-03-09T09:00:00.000Z"),
+    lastPolledAtMs: null,
+    lastSuccessAtMs: null,
+    consecutiveFailures: 0,
+    lastErrorCode: null,
+    lastErrorMessage: null,
+    createdAtMs: Date.parse("2026-03-09T08:00:00.000Z"),
+    updatedAtMs: Date.parse("2026-03-09T08:00:00.000Z"),
+    ...overrides
+  };
+}
+
+function createTickResult(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    profileName: "default",
+    workerId: "cli:run-activity-cli",
+    claimedWatches: 1,
+    polledWatches: 1,
+    failedWatches: 0,
+    emittedEvents: 2,
+    enqueuedDeliveries: 2,
+    claimedDeliveries: 1,
+    deliveredAttempts: 1,
+    retriedDeliveries: 0,
+    failedDeliveries: 0,
+    deadLetterDeliveries: 0,
+    disabledSubscriptions: 0,
+    watchResults: [
+      {
+        watchId: "watch_cli_123",
+        kind: "notifications",
+        emittedEvents: 2,
+        enqueuedDeliveries: 2
+      }
+    ],
+    deliveryResults: [
+      {
+        deliveryId: "delivery_cli_123",
+        subscriptionId: "whsub_cli_123",
+        outcome: "delivered",
+        responseStatus: 204
+      }
+    ],
+    ...overrides
+  };
+}
+
+describe("linkedin activity CLI UX", () => {
+  let previousActivityEnabled: string | undefined;
+  let previousHome: string | undefined;
+  let stderrChunks: string[] = [];
+  let stdoutChunks: string[] = [];
+  let stderrWriteSpy: ReturnType<typeof vi.spyOn>;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let tempDir = "";
+
+  beforeEach(async () => {
+    tempDir = await import("node:fs/promises").then(({ mkdtemp }) =>
+      mkdtemp(path.join(os.tmpdir(), "linkedin-cli-activity-"))
+    );
+    previousActivityEnabled = process.env.LINKEDIN_ASSISTANT_ACTIVITY_ENABLED;
+    previousHome = process.env.LINKEDIN_ASSISTANT_HOME;
+    process.env.LINKEDIN_ASSISTANT_HOME = path.join(tempDir, "assistant-home");
+    delete process.env.LINKEDIN_ASSISTANT_ACTIVITY_ENABLED;
+
+    process.exitCode = undefined;
+    stderrChunks = [];
+    stdoutChunks = [];
+    setInteractiveMode(true, true);
+
+    vi.clearAllMocks();
+
+    activityCliMocks.activityPollerRunTick.mockResolvedValue(createTickResult());
+    activityCliMocks.activityWatchesCreateWatch.mockReturnValue(createWatch());
+    activityCliMocks.activityWatchesCreateWebhookSubscription.mockReturnValue({
+      id: "whsub_cli_123",
+      watchId: "watch_cli_123",
+      status: "active",
+      eventTypes: ["linkedin.notifications.item.created"],
+      deliveryUrl: "https://example.com/hooks/linkedin",
+      maxAttempts: 6,
+      signingSecret: "whsec_cli_123",
+      lastDeliveredAtMs: null,
+      lastErrorCode: null,
+      lastErrorMessage: null,
+      createdAtMs: Date.parse("2026-03-09T08:00:00.000Z"),
+      updatedAtMs: Date.parse("2026-03-09T08:00:00.000Z")
+    });
+
+    activityCliMocks.createCoreRuntime.mockImplementation(() => ({
+      runId: "run-activity-cli",
+      logger: {
+        log: activityCliMocks.loggerLog
+      },
+      activityPoller: {
+        runTick: activityCliMocks.activityPollerRunTick
+      },
+      activityWatches: {
+        createWatch: activityCliMocks.activityWatchesCreateWatch,
+        createWebhookSubscription:
+          activityCliMocks.activityWatchesCreateWebhookSubscription,
+        listDeliveries: vi.fn().mockReturnValue([]),
+        listEvents: vi.fn().mockReturnValue([]),
+        listWatches: vi.fn().mockReturnValue([]),
+        listWebhookSubscriptions: vi.fn().mockReturnValue([]),
+        pauseWatch: vi.fn().mockReturnValue(createWatch({ status: "paused" })),
+        pauseWebhookSubscription: vi.fn(),
+        removeWatch: vi.fn().mockReturnValue(true),
+        removeWebhookSubscription: vi.fn().mockReturnValue(true),
+        resumeWatch: vi.fn().mockReturnValue(createWatch()),
+        resumeWebhookSubscription: vi.fn()
+      },
+      close: activityCliMocks.close
+    }));
+
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
+      stdoutChunks.push(args.map((value) => String(value)).join(" "));
+    });
+    stderrWriteSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((...args: Parameters<typeof process.stderr.write>) => {
+        stderrChunks.push(String(args[0]));
+        return true;
+      });
+  });
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore();
+    stderrWriteSpy.mockRestore();
+    process.exitCode = undefined;
+
+    if (previousActivityEnabled === undefined) {
+      delete process.env.LINKEDIN_ASSISTANT_ACTIVITY_ENABLED;
+    } else {
+      process.env.LINKEDIN_ASSISTANT_ACTIVITY_ENABLED = previousActivityEnabled;
+    }
+
+    if (previousHome === undefined) {
+      delete process.env.LINKEDIN_ASSISTANT_HOME;
+    } else {
+      process.env.LINKEDIN_ASSISTANT_HOME = previousHome;
+    }
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("documents human-readable activity output and json mode in help", () => {
+    const program = createCliProgram();
+    const activityCommand = program.commands.find((command) => command.name() === "activity");
+    const activityWatchCommand = activityCommand?.commands.find(
+      (command) => command.name() === "watch"
+    );
+    const watchAddCommand = activityWatchCommand?.commands.find(
+      (command) => command.name() === "add"
+    );
+    const runOnceCommand = activityCommand?.commands.find(
+      (command) => command.name() === "run-once"
+    );
+
+    expect(activityCommand?.helpInformation() ?? "").toContain(
+      "human-readable activity summaries"
+    );
+    expect(watchAddCommand?.helpInformation() ?? "").toContain("--json");
+    expect(runOnceCommand?.helpInformation() ?? "").toContain("--json");
+  });
+
+  it("prints a human-readable watch creation summary", async () => {
+    await runCli([
+      "node",
+      "linkedin",
+      "activity",
+      "watch",
+      "add",
+      "--kind",
+      "notifications",
+      "--interval-seconds",
+      "900"
+    ]);
+
+    const output = stdoutChunks.join("\n");
+
+    expect(output).toContain("Created activity watch for profile default");
+    expect(output).toContain("Watch id: watch_cli_123");
+    expect(output).toContain("Next Steps");
+    expect(activityCliMocks.loggerLog).toHaveBeenCalledWith(
+      "info",
+      "cli.activity.watch.add.start",
+      expect.objectContaining({
+        profile_name: "default"
+      })
+    );
+  });
+
+  it("formats thrown activity command errors for humans", async () => {
+    activityCliMocks.activityWatchesCreateWebhookSubscription.mockImplementation(() => {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        "deliveryUrl must be a valid URL.",
+        {
+          example: "https://example.com/hooks/linkedin",
+          field: "deliveryUrl",
+          suggestion: "Use an absolute http(s) webhook endpoint.",
+          value: "not-a-url"
+        }
+      );
+    });
+
+    await runCli([
+      "node",
+      "linkedin",
+      "activity",
+      "webhook",
+      "add",
+      "--watch",
+      "watch_cli_123",
+      "--url",
+      "not-a-url"
+    ]);
+
+    const stderrOutput = stderrChunks.join("");
+
+    expect(stderrOutput).toContain("Activity command failed [ACTION_PRECONDITION_FAILED]");
+    expect(stderrOutput).toContain("Field: deliveryUrl");
+    expect(stderrOutput).toContain("Suggested fix: Use an absolute http(s) webhook endpoint.");
+    expect(stderrOutput).toContain("Rerun with --json if you need the structured error payload.");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("prints progress notices and a clear human-readable run-once summary", async () => {
+    activityCliMocks.activityPollerRunTick.mockResolvedValue(
+      createTickResult({
+        failedWatches: 1,
+        watchResults: [
+          {
+            watchId: "watch_cli_123",
+            kind: "notifications",
+            emittedEvents: 0,
+            enqueuedDeliveries: 0,
+            errorCode: "NETWORK_ERROR",
+            errorMessage: "Temporary timeout while polling notifications."
+          }
+        ]
+      })
+    );
+
+    await runCli(["node", "linkedin", "activity", "run-once", "--profile", "default"]);
+
+    expect(stderrChunks.join("")).toContain(
+      'Running one activity polling tick for profile "default".'
+    );
+    const output = stdoutChunks.join("\n");
+    expect(output).toContain("Activity poll tick completed for profile default");
+    expect(output).toContain("Watch Results");
+    expect(output).toContain("NETWORK_ERROR");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("shows actionable config guidance in human-readable status output", async () => {
+    process.env.LINKEDIN_ASSISTANT_ACTIVITY_ENABLED = "sometimes";
+
+    await runCli(["node", "linkedin", "activity", "status", "--profile", "default"]);
+
+    const output = stdoutChunks.join("\n");
+
+    expect(output).toContain("Activity daemon status for profile default");
+    expect(output).toContain("Config Issue");
+    expect(output).toContain("Setting: LINKEDIN_ASSISTANT_ACTIVITY_ENABLED");
+    expect(output).toContain("Example: LINKEDIN_ASSISTANT_ACTIVITY_ENABLED=false");
+    expect(output).toContain("Suggested fix:");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("redacts secret-bearing CDP URLs from persisted daemon diagnostics", async () => {
+    const secretBearingUrl =
+      "ws://user:pass@127.0.0.1:9222/devtools/browser/abc?token=secret#frag";
+    activityCliMocks.activityPollerRunTick.mockImplementation(async () => {
+      process.emit("SIGTERM");
+      throw new Error(`Failed to connect to ${secretBearingUrl}`);
+    });
+
+    await runCli([
+      "node",
+      "linkedin",
+      "--cdp-url",
+      secretBearingUrl,
+      "activity",
+      "__run",
+      "--profile",
+      "default"
+    ]);
+
+    const activityDir = path.join(resolveConfigPaths().baseDir, "activity");
+    const eventLog = await readFile(path.join(activityDir, "default.events.jsonl"), "utf8");
+    const stateFile = await readFile(path.join(activityDir, "default.state.json"), "utf8");
+
+    expect(eventLog).not.toContain("user:pass@");
+    expect(eventLog).not.toContain("token=secret");
+    expect(eventLog).not.toContain("#frag");
+    expect(stateFile).not.toContain("user:pass@");
+    expect(stateFile).not.toContain("token=secret");
+    expect(stateFile).not.toContain("#frag");
+    expect(eventLog).toContain("ws://127.0.0.1:9222/devtools/browser/abc");
+  });
+});

--- a/packages/core/src/__tests__/activityWatches.test.ts
+++ b/packages/core/src/__tests__/activityWatches.test.ts
@@ -474,6 +474,11 @@ describe("ActivityWatchesService", () => {
     expect(service.getWebhookSubscriptionById("whsub_invalid_json").eventTypes).toEqual(
       []
     );
+    expect(
+      service.listWebhookSubscriptions({
+        profileName: "default"
+      })
+    ).toHaveLength(3);
 
     runtime.db.insertActivityEvent({
       id: "evt_old",

--- a/packages/core/src/__tests__/config.test.ts
+++ b/packages/core/src/__tests__/config.test.ts
@@ -4,6 +4,8 @@ import { LinkedInAssistantError } from "../errors.js";
 
 const ACTIVITY_ENV_KEYS = [
   "LINKEDIN_ASSISTANT_ACTIVITY_ENABLED",
+  "LINKEDIN_ASSISTANT_ACTIVITY_INITIAL_BACKOFF_SECONDS",
+  "LINKEDIN_ASSISTANT_ACTIVITY_MAX_BACKOFF_SECONDS",
   "LINKEDIN_ASSISTANT_ACTIVITY_MAX_CONCURRENT_WATCHES",
   "LINKEDIN_ASSISTANT_ACTIVITY_MIN_POLL_INTERVAL_SECONDS",
   "LINKEDIN_ASSISTANT_ACTIVITY_MAX_EVENT_QUEUE_DEPTH",
@@ -66,6 +68,12 @@ describe("resolveActivityWebhookConfig", () => {
     expect(error.message).toBe(
       "LINKEDIN_ASSISTANT_ACTIVITY_ENABLED must use a boolean value: 1, 0, true, false, yes, no, on, or off. Unset it to use the default value."
     );
+    expect(error.details).toMatchObject({
+      default_value: "true",
+      env: "LINKEDIN_ASSISTANT_ACTIVITY_ENABLED",
+      example: "LINKEDIN_ASSISTANT_ACTIVITY_ENABLED=false"
+    });
+    expect(String(error.details.suggestion)).toContain("true or false");
   });
 
   it("rejects delivery lease settings that do not cover timeout plus clock skew", () => {
@@ -78,6 +86,11 @@ describe("resolveActivityWebhookConfig", () => {
     expect(error.message).toBe(
       "LINKEDIN_ASSISTANT_ACTIVITY_DELIVERY_LEASE_SECONDS must be greater than or equal to LINKEDIN_ASSISTANT_ACTIVITY_DELIVERY_TIMEOUT_SECONDS plus LINKEDIN_ASSISTANT_ACTIVITY_CLOCK_SKEW_SECONDS."
     );
+    expect(error.details).toMatchObject({
+      env: "LINKEDIN_ASSISTANT_ACTIVITY_DELIVERY_LEASE_SECONDS",
+      example: "LINKEDIN_ASSISTANT_ACTIVITY_DELIVERY_LEASE_SECONDS=20"
+    });
+    expect(String(error.details.suggestion)).toContain("at least 20");
   });
 
   it("rejects watch lease settings that do not exceed clock skew", () => {
@@ -89,5 +102,42 @@ describe("resolveActivityWebhookConfig", () => {
     expect(error.message).toBe(
       "LINKEDIN_ASSISTANT_ACTIVITY_WATCH_LEASE_SECONDS must be greater than LINKEDIN_ASSISTANT_ACTIVITY_CLOCK_SKEW_SECONDS."
     );
+    expect(error.details).toMatchObject({
+      env: "LINKEDIN_ASSISTANT_ACTIVITY_WATCH_LEASE_SECONDS",
+      example: "LINKEDIN_ASSISTANT_ACTIVITY_WATCH_LEASE_SECONDS=6"
+    });
+    expect(String(error.details.suggestion)).toContain("more than 5");
+  });
+
+  it("rejects malformed queue-depth values with a concrete example", () => {
+    process.env.LINKEDIN_ASSISTANT_ACTIVITY_MAX_EVENT_QUEUE_DEPTH = "many";
+
+    const error = captureLinkedInError(() => resolveActivityWebhookConfig());
+
+    expect(error.message).toBe(
+      "LINKEDIN_ASSISTANT_ACTIVITY_MAX_EVENT_QUEUE_DEPTH must be a whole number greater than 0. Unset it to use the default value."
+    );
+    expect(error.details).toMatchObject({
+      default_value: "250",
+      env: "LINKEDIN_ASSISTANT_ACTIVITY_MAX_EVENT_QUEUE_DEPTH",
+      example: "LINKEDIN_ASSISTANT_ACTIVITY_MAX_EVENT_QUEUE_DEPTH=500",
+      value: "many"
+    });
+  });
+
+  it("rejects max backoff settings that are below the initial backoff", () => {
+    process.env.LINKEDIN_ASSISTANT_ACTIVITY_INITIAL_BACKOFF_SECONDS = "90";
+    process.env.LINKEDIN_ASSISTANT_ACTIVITY_MAX_BACKOFF_SECONDS = "60";
+
+    const error = captureLinkedInError(() => resolveActivityWebhookConfig());
+
+    expect(error.message).toBe(
+      "LINKEDIN_ASSISTANT_ACTIVITY_MAX_BACKOFF_SECONDS must be greater than or equal to LINKEDIN_ASSISTANT_ACTIVITY_INITIAL_BACKOFF_SECONDS."
+    );
+    expect(error.details).toMatchObject({
+      env: "LINKEDIN_ASSISTANT_ACTIVITY_MAX_BACKOFF_SECONDS",
+      example: "LINKEDIN_ASSISTANT_ACTIVITY_MAX_BACKOFF_SECONDS=90"
+    });
+    expect(String(error.details.suggestion)).toContain("at least 90");
   });
 });

--- a/packages/core/src/activityPoller.ts
+++ b/packages/core/src/activityPoller.ts
@@ -47,6 +47,7 @@ import {
 
 const ACTIVITY_EVENT_VERSION = "2026-03-activity-v1";
 
+/** Service dependencies required to poll watches and deliver webhook events. */
 export interface ActivityPollerRuntime {
   activityConfig?: ActivityWebhookConfig;
   activityWatches: ActivityWatchesService;
@@ -60,6 +61,7 @@ export interface ActivityPollerRuntime {
   profile: LinkedInProfileService;
 }
 
+/** Per-watch outcome recorded during one polling tick. */
 export interface ActivityWatchTickResult {
   watchId: string;
   kind: ActivityWatchKind;
@@ -69,6 +71,7 @@ export interface ActivityWatchTickResult {
   errorMessage?: string;
 }
 
+/** Per-delivery outcome recorded during one polling tick. */
 export interface ActivityDeliveryTickResult {
   deliveryId: string;
   subscriptionId: string;
@@ -78,6 +81,7 @@ export interface ActivityDeliveryTickResult {
   errorMessage?: string;
 }
 
+/** Aggregate activity polling and delivery outcome for one profile tick. */
 export interface ActivityPollTickResult {
   profileName: string;
   workerId: string;
@@ -456,13 +460,16 @@ function hasFeedEngagementChanged(
   );
 }
 
+/** Polls due activity watches, emits events, and processes webhook deliveries. */
 export class ActivityPollerService {
   private readonly config: ActivityWebhookConfig;
 
+  /** Creates a new activity poller bound to the provided runtime graph. */
   constructor(private readonly runtime: ActivityPollerRuntime) {
     this.config = runtime.activityConfig ?? resolveActivityWebhookConfig();
   }
 
+  /** Runs one polling tick for the selected profile and returns a structured summary. */
   async runTick(input: {
     profileName?: string;
     workerId?: string;
@@ -472,6 +479,11 @@ export class ActivityPollerService {
     const emptyResult = this.buildEmptyTickResult(profileName, workerId);
 
     if (!this.config.enabled) {
+      this.runtime.logger.log("info", "activity.tick.skipped", {
+        profile_name: profileName,
+        reason: "disabled",
+        worker_id: workerId
+      });
       return emptyResult;
     }
 
@@ -643,7 +655,7 @@ export class ActivityPollerService {
         }
       }
 
-      return {
+      const result = {
         profileName,
         workerId,
         claimedWatches: claimedWatches.length,
@@ -660,6 +672,22 @@ export class ActivityPollerService {
         watchResults,
         deliveryResults
       };
+
+      this.runtime.logger.log("info", "activity.tick.completed", {
+        claimed_deliveries: result.claimedDeliveries,
+        claimed_watches: result.claimedWatches,
+        dead_letter_deliveries: result.deadLetterDeliveries,
+        delivered_attempts: result.deliveredAttempts,
+        disabled_subscriptions: result.disabledSubscriptions,
+        emitted_events: result.emittedEvents,
+        failed_deliveries: result.failedDeliveries,
+        failed_watches: result.failedWatches,
+        profile_name: profileName,
+        retried_deliveries: result.retriedDeliveries,
+        worker_id: workerId
+      });
+
+      return result;
     } finally {
       ACTIVE_ACTIVITY_TICKS.delete(tickKey);
     }

--- a/packages/core/src/activityWatches.ts
+++ b/packages/core/src/activityWatches.ts
@@ -31,6 +31,7 @@ import {
 
 const MAX_ACTIVITY_LIMIT = 50;
 
+/** Stored activity watch metadata and recent poll state for one target. */
 export interface ActivityWatch {
   id: string;
   profileName: string;
@@ -50,6 +51,7 @@ export interface ActivityWatch {
   updatedAtMs: number;
 }
 
+/** Persisted webhook subscription metadata attached to one activity watch. */
 export interface WebhookSubscription {
   id: string;
   watchId: string;
@@ -64,10 +66,12 @@ export interface WebhookSubscription {
   updatedAtMs: number;
 }
 
+/** Webhook subscription details returned immediately after creation. */
 export interface CreatedWebhookSubscription extends WebhookSubscription {
   signingSecret: string;
 }
 
+/** Stored activity event payload produced by a successful watch poll. */
 export interface ActivityEventRecord {
   id: string;
   watchId: string;
@@ -80,6 +84,7 @@ export interface ActivityEventRecord {
   createdAtMs: number;
 }
 
+/** Persisted webhook delivery attempt and retry metadata. */
 export interface WebhookDeliveryAttemptRecord {
   id: string;
   watchId: string;
@@ -101,6 +106,7 @@ export interface WebhookDeliveryAttemptRecord {
   updatedAtMs: number;
 }
 
+/** Input accepted when creating a durable activity watch. */
 export interface CreateActivityWatchInput {
   profileName?: string;
   kind: ActivityWatchKind;
@@ -109,6 +115,7 @@ export interface CreateActivityWatchInput {
   cron?: string;
 }
 
+/** Input accepted when attaching a webhook subscription to a watch. */
 export interface CreateWebhookSubscriptionInput {
   watchId: string;
   deliveryUrl: string;
@@ -117,6 +124,7 @@ export interface CreateWebhookSubscriptionInput {
   maxAttempts?: number;
 }
 
+/** Runtime dependencies required by the activity watch service. */
 export interface ActivityWatchesRuntime {
   db: AssistantDatabase;
   logger: JsonEventLogger;
@@ -157,7 +165,10 @@ function readText(value: unknown, label: string, required = false): string {
 
   throw new LinkedInAssistantError(
     "ACTION_PRECONDITION_FAILED",
-    `${label} is required.`
+    `${label} is required.`,
+    {
+      field: label
+    }
   );
 }
 
@@ -174,7 +185,13 @@ function readPositiveInteger(
   if (typeof value !== "number" || !Number.isFinite(value)) {
     throw new LinkedInAssistantError(
       "ACTION_PRECONDITION_FAILED",
-      `${label} must be a positive integer.`
+      `${label} must be a positive integer.`,
+      {
+        field: label,
+        maximum: max,
+        minimum: 1,
+        value
+      }
     );
   }
 
@@ -182,7 +199,13 @@ function readPositiveInteger(
   if (normalized <= 0 || normalized > max) {
     throw new LinkedInAssistantError(
       "ACTION_PRECONDITION_FAILED",
-      `${label} must be between 1 and ${max}.`
+      `${label} must be between 1 and ${max}.`,
+      {
+        field: label,
+        maximum: max,
+        minimum: 1,
+        value: normalized
+      }
     );
   }
 
@@ -198,14 +221,25 @@ function readHttpUrl(value: string, label: string): string {
     throw new LinkedInAssistantError(
       "ACTION_PRECONDITION_FAILED",
       `${label} must be a valid URL.`,
-      { cause_name: error instanceof Error ? error.name : undefined }
+      {
+        cause_name: error instanceof Error ? error.name : undefined,
+        example: "https://example.com/hooks/linkedin",
+        field: label,
+        value
+      }
     );
   }
 
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     throw new LinkedInAssistantError(
       "ACTION_PRECONDITION_FAILED",
-      `${label} must use http or https.`
+      `${label} must use http or https.`,
+      {
+        example: "https://example.com/hooks/linkedin",
+        field: label,
+        supported_protocols: ["http", "https"],
+        value
+      }
     );
   }
 
@@ -351,6 +385,7 @@ function parseCronField(
   return values;
 }
 
+/** Parses a 5-field cron expression into normalized matching sets. */
 export function parseCronExpression(expression: string): ParsedCronExpression {
   const parts = expression
     .trim()
@@ -387,6 +422,7 @@ function matchesCron(date: Date, parsed: ParsedCronExpression): boolean {
   );
 }
 
+/** Finds the next time a parsed cron expression would become due. */
 export function getNextCronOccurrenceMs(
   expression: string,
   afterMs: number
@@ -564,7 +600,10 @@ function ensureWatchExists(
 
   throw new LinkedInAssistantError(
     "TARGET_NOT_FOUND",
-    `Activity watch ${watchId} was not found.`
+    `Activity watch ${watchId} was not found.`,
+    {
+      watch_id: watchId
+    }
   );
 }
 
@@ -579,7 +618,10 @@ function ensureWebhookSubscriptionExists(
 
   throw new LinkedInAssistantError(
     "TARGET_NOT_FOUND",
-    `Webhook subscription ${subscriptionId} was not found.`
+    `Webhook subscription ${subscriptionId} was not found.`,
+    {
+      subscription_id: subscriptionId
+    }
   );
 }
 
@@ -618,18 +660,26 @@ function resolveEffectiveMinPollIntervalMs(
   );
 }
 
+/** Manages durable activity watches, webhook subscriptions, and history views. */
 export class ActivityWatchesService {
   private readonly config: ActivityWebhookConfig;
 
+  /** Creates a new activity watch service with resolved activity config. */
   constructor(private readonly runtime: ActivityWatchesRuntime) {
     this.config = runtime.activityConfig ?? resolveActivityWebhookConfig();
   }
 
+  /** Creates and stores a new activity watch. */
   createWatch(input: CreateActivityWatchInput): ActivityWatch {
     if (!ACTIVITY_WATCH_KINDS.includes(input.kind)) {
       throw new LinkedInAssistantError(
         "ACTION_PRECONDITION_FAILED",
-        `kind must be one of: ${ACTIVITY_WATCH_KINDS.join(", ")}.`
+        `kind must be one of: ${ACTIVITY_WATCH_KINDS.join(", ")}.`,
+        {
+          field: "kind",
+          provided_kind: input.kind,
+          supported_kinds: ACTIVITY_WATCH_KINDS
+        }
       );
     }
 
@@ -661,7 +711,12 @@ export class ActivityWatchesService {
     ) {
       throw new LinkedInAssistantError(
         "ACTION_PRECONDITION_FAILED",
-        `intervalSeconds must be at least ${Math.ceil(effectiveMinPollIntervalMs / 1_000)} for ${input.kind}.`
+        `intervalSeconds must be at least ${Math.ceil(effectiveMinPollIntervalMs / 1_000)} for ${input.kind}.`,
+        {
+          field: "intervalSeconds",
+          kind: input.kind,
+          minimum_seconds: Math.ceil(effectiveMinPollIntervalMs / 1_000)
+        }
       );
     }
 
@@ -689,6 +744,7 @@ export class ActivityWatchesService {
     return toActivityWatch(ensureWatchExists(this.runtime.db, id));
   }
 
+  /** Lists watches filtered by profile and status. */
   listWatches(input: {
     profileName?: string;
     status?: ActivityWatchStatus;
@@ -696,23 +752,38 @@ export class ActivityWatchesService {
     return this.runtime.db.listActivityWatches(input).map(toActivityWatch);
   }
 
+  /** Loads one activity watch by id or throws when it does not exist. */
   getWatchById(id: string): ActivityWatch {
     return toActivityWatch(ensureWatchExists(this.runtime.db, id));
   }
 
+  /** Pauses an existing activity watch. */
   pauseWatch(id: string): ActivityWatch {
     return this.setWatchStatus(id, "paused");
   }
 
+  /** Resumes an existing activity watch and makes it due immediately. */
   resumeWatch(id: string): ActivityWatch {
     return this.setWatchStatus(id, "active", Date.now());
   }
 
+  /** Deletes an activity watch and any related webhook subscriptions. */
   removeWatch(id: string): boolean {
-    ensureWatchExists(this.runtime.db, id);
-    return this.runtime.db.deleteActivityWatch(id);
+    const watch = ensureWatchExists(this.runtime.db, id);
+    const removed = this.runtime.db.deleteActivityWatch(id);
+
+    if (removed) {
+      this.runtime.logger.log("info", "activity.watch.removed", {
+        kind: watch.kind,
+        profile_name: watch.profile_name,
+        watch_id: watch.id
+      });
+    }
+
+    return removed;
   }
 
+  /** Creates a webhook subscription for an existing activity watch. */
   createWebhookSubscription(
     input: CreateWebhookSubscriptionInput
   ): CreatedWebhookSubscription {
@@ -757,6 +828,7 @@ export class ActivityWatchesService {
     };
   }
 
+  /** Lists webhook subscriptions filtered by watch, profile, and status. */
   listWebhookSubscriptions(input: {
     watchId?: string;
     profileName?: string;
@@ -767,25 +839,39 @@ export class ActivityWatchesService {
       .map(toWebhookSubscription);
   }
 
+  /** Loads one webhook subscription by id or throws when it does not exist. */
   getWebhookSubscriptionById(id: string): WebhookSubscription {
     return toWebhookSubscription(
       ensureWebhookSubscriptionExists(this.runtime.db, id)
     );
   }
 
+  /** Pauses a webhook subscription without deleting delivery history. */
   pauseWebhookSubscription(id: string): WebhookSubscription {
     return this.setWebhookSubscriptionStatus(id, "paused");
   }
 
+  /** Resumes a paused webhook subscription. */
   resumeWebhookSubscription(id: string): WebhookSubscription {
     return this.setWebhookSubscriptionStatus(id, "active");
   }
 
+  /** Deletes a webhook subscription while preserving historical deliveries. */
   removeWebhookSubscription(id: string): boolean {
-    ensureWebhookSubscriptionExists(this.runtime.db, id);
-    return this.runtime.db.deleteWebhookSubscription(id);
+    const subscription = ensureWebhookSubscriptionExists(this.runtime.db, id);
+    const removed = this.runtime.db.deleteWebhookSubscription(id);
+
+    if (removed) {
+      this.runtime.logger.log("info", "activity.webhook.removed", {
+        watch_id: subscription.watch_id,
+        webhook_subscription_id: subscription.id
+      });
+    }
+
+    return removed;
   }
 
+  /** Lists stored activity events for one profile or watch. */
   listEvents(input: {
     profileName?: string;
     watchId?: string;
@@ -794,6 +880,7 @@ export class ActivityWatchesService {
     return this.runtime.db.listActivityEvents(input).map(toActivityEventRecord);
   }
 
+  /** Lists stored webhook delivery attempts and retry state. */
   listDeliveries(input: {
     profileName?: string;
     watchId?: string;
@@ -821,6 +908,18 @@ export class ActivityWatchesService {
       ...(nextPollAtMs !== undefined ? { nextPollAtMs } : {}),
       updatedAtMs: Date.now()
     });
+
+    this.runtime.logger.log("info", "activity.watch.status.updated", {
+      from_status: existingWatch.status,
+      kind: existingWatch.kind,
+      profile_name: existingWatch.profile_name,
+      to_status: status,
+      watch_id: existingWatch.id,
+      ...(nextPollAtMs !== undefined
+        ? { next_poll_at: new Date(nextPollAtMs).toISOString() }
+        : {})
+    });
+
     return this.getWatchById(id);
   }
 
@@ -828,12 +927,20 @@ export class ActivityWatchesService {
     id: string,
     status: WebhookSubscriptionStatus
   ): WebhookSubscription {
-    ensureWebhookSubscriptionExists(this.runtime.db, id);
+    const existingSubscription = ensureWebhookSubscriptionExists(this.runtime.db, id);
     this.runtime.db.updateWebhookSubscriptionStatus({
       id,
       status,
       updatedAtMs: Date.now()
     });
+
+    this.runtime.logger.log("info", "activity.webhook.status.updated", {
+      from_status: existingSubscription.status,
+      to_status: status,
+      watch_id: existingSubscription.watch_id,
+      webhook_subscription_id: existingSubscription.id
+    });
+
     return this.getWebhookSubscriptionById(id);
   }
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -284,12 +284,157 @@ function invalidActivityWebhookConfig(
   message: string,
   details: Record<string, unknown>
 ): LinkedInAssistantError {
+  const env = typeof details.env === "string" ? details.env : undefined;
+  const guidance = env ? ACTIVITY_WEBHOOK_ENV_GUIDANCE[env] : undefined;
+  let suggestion = guidance?.suggestion;
+  let example = guidance ? `${env}=${guidance.exampleValue}` : undefined;
+
+  if (
+    env === "LINKEDIN_ASSISTANT_ACTIVITY_MAX_BACKOFF_SECONDS" &&
+    typeof details.initial_backoff_ms === "number"
+  ) {
+    const minimumSeconds = Math.ceil(details.initial_backoff_ms / 1_000);
+    suggestion =
+      `Increase ${env} to at least ${minimumSeconds}, or lower LINKEDIN_ASSISTANT_ACTIVITY_INITIAL_BACKOFF_SECONDS.`;
+    example = `${env}=${minimumSeconds}`;
+  }
+
+  if (
+    env === "LINKEDIN_ASSISTANT_ACTIVITY_DELIVERY_LEASE_SECONDS" &&
+    typeof details.delivery_timeout_ms === "number" &&
+    typeof details.clock_skew_allowance_ms === "number"
+  ) {
+    const minimumSeconds = Math.ceil(
+      (details.delivery_timeout_ms + details.clock_skew_allowance_ms) / 1_000
+    );
+    suggestion =
+      `Increase ${env} to at least ${minimumSeconds}, or lower the delivery timeout or clock skew allowance.`;
+    example = `${env}=${minimumSeconds}`;
+  } else if (
+    env === "LINKEDIN_ASSISTANT_ACTIVITY_DELIVERY_LEASE_SECONDS" &&
+    typeof details.clock_skew_allowance_ms === "number"
+  ) {
+    const minimumSeconds = Math.floor(details.clock_skew_allowance_ms / 1_000) + 1;
+    suggestion =
+      `Increase ${env} to more than ${Math.floor(details.clock_skew_allowance_ms / 1_000)}, or lower LINKEDIN_ASSISTANT_ACTIVITY_CLOCK_SKEW_SECONDS.`;
+    example = `${env}=${minimumSeconds}`;
+  }
+
+  if (
+    env === "LINKEDIN_ASSISTANT_ACTIVITY_WATCH_LEASE_SECONDS" &&
+    typeof details.clock_skew_allowance_ms === "number"
+  ) {
+    const minimumSeconds = Math.floor(details.clock_skew_allowance_ms / 1_000) + 1;
+    suggestion =
+      `Increase ${env} to more than ${Math.floor(details.clock_skew_allowance_ms / 1_000)}, or lower LINKEDIN_ASSISTANT_ACTIVITY_CLOCK_SKEW_SECONDS.`;
+    example = `${env}=${minimumSeconds}`;
+  }
+
   return new LinkedInAssistantError(
     "ACTION_PRECONDITION_FAILED",
     message,
-    details
+    {
+      ...details,
+      ...(guidance ? { default_value: guidance.defaultValue } : {}),
+      ...(example ? { example } : {}),
+      ...(suggestion ? { suggestion } : {})
+    }
   );
 }
+
+const ACTIVITY_WEBHOOK_ENV_GUIDANCE: Record<
+  string,
+  {
+    defaultValue: string;
+    exampleValue: string;
+    suggestion: string;
+  }
+> = {
+  LINKEDIN_ASSISTANT_ACTIVITY_ENABLED: {
+    defaultValue: "true",
+    exampleValue: "false",
+    suggestion:
+      "Use true or false to enable or disable activity polling, or unset the variable to restore the default."
+  },
+  LINKEDIN_ASSISTANT_ACTIVITY_DAEMON_POLL_INTERVAL_SECONDS: {
+    defaultValue: String(DEFAULT_ACTIVITY_DAEMON_POLL_INTERVAL_MS / 1_000),
+    exampleValue: "120",
+    suggestion:
+      "Use a whole-number daemon interval in seconds, such as 120, or unset the variable to restore the default cadence."
+  },
+  LINKEDIN_ASSISTANT_ACTIVITY_MAX_WATCHES_PER_TICK: {
+    defaultValue: String(DEFAULT_ACTIVITY_MAX_WATCHES_PER_TICK),
+    exampleValue: "8",
+    suggestion:
+      "Use a whole-number watch batch size, or unset the variable to restore the default per-tick watch budget."
+  },
+  LINKEDIN_ASSISTANT_ACTIVITY_MAX_CONCURRENT_WATCHES: {
+    defaultValue: String(DEFAULT_ACTIVITY_MAX_CONCURRENT_WATCHES),
+    exampleValue: "50",
+    suggestion:
+      "Use a whole-number per-profile watch limit, or pause existing watches before raising the limit."
+  },
+  LINKEDIN_ASSISTANT_ACTIVITY_WATCH_LEASE_SECONDS: {
+    defaultValue: String(DEFAULT_ACTIVITY_WATCH_LEASE_TTL_MS / 1_000),
+    exampleValue: "180",
+    suggestion:
+      "Use a whole-number lease duration in seconds that comfortably exceeds clock skew and expected poll time."
+  },
+  LINKEDIN_ASSISTANT_ACTIVITY_MIN_POLL_INTERVAL_SECONDS: {
+    defaultValue: String(DEFAULT_ACTIVITY_MIN_POLL_INTERVAL_MS / 1_000),
+    exampleValue: "300",
+    suggestion:
+      "Use a whole-number minimum poll interval in seconds, or unset the variable to restore the default lower bound."
+  },
+  LINKEDIN_ASSISTANT_ACTIVITY_MAX_DELIVERIES_PER_TICK: {
+    defaultValue: String(DEFAULT_ACTIVITY_MAX_DELIVERIES_PER_TICK),
+    exampleValue: "20",
+    suggestion:
+      "Use a whole-number delivery batch size, or unset the variable to restore the default per-tick delivery budget."
+  },
+  LINKEDIN_ASSISTANT_ACTIVITY_MAX_EVENT_QUEUE_DEPTH: {
+    defaultValue: String(DEFAULT_ACTIVITY_MAX_EVENT_QUEUE_DEPTH),
+    exampleValue: "500",
+    suggestion:
+      "Use a whole-number queue depth large enough for bursts, or unset the variable to restore the default queue cap."
+  },
+  LINKEDIN_ASSISTANT_ACTIVITY_DELIVERY_LEASE_SECONDS: {
+    defaultValue: String(DEFAULT_ACTIVITY_DELIVERY_LEASE_TTL_MS / 1_000),
+    exampleValue: "90",
+    suggestion:
+      "Use a whole-number delivery lease in seconds that exceeds the HTTP timeout and clock skew allowance."
+  },
+  LINKEDIN_ASSISTANT_ACTIVITY_DELIVERY_TIMEOUT_SECONDS: {
+    defaultValue: String(DEFAULT_ACTIVITY_DELIVERY_TIMEOUT_MS / 1_000),
+    exampleValue: "20",
+    suggestion:
+      "Use a whole-number webhook timeout in seconds that is lower than the delivery lease duration."
+  },
+  LINKEDIN_ASSISTANT_ACTIVITY_CLOCK_SKEW_SECONDS: {
+    defaultValue: String(DEFAULT_ACTIVITY_CLOCK_SKEW_ALLOWANCE_MS / 1_000),
+    exampleValue: "10",
+    suggestion:
+      "Use a whole-number clock-skew allowance in seconds, or unset the variable to restore the default tolerance."
+  },
+  LINKEDIN_ASSISTANT_ACTIVITY_MAX_DELIVERY_ATTEMPTS: {
+    defaultValue: String(DEFAULT_ACTIVITY_MAX_DELIVERY_ATTEMPTS),
+    exampleValue: "8",
+    suggestion:
+      "Use a whole-number retry-attempt budget, or unset the variable to restore the default delivery retry count."
+  },
+  LINKEDIN_ASSISTANT_ACTIVITY_INITIAL_BACKOFF_SECONDS: {
+    defaultValue: String(DEFAULT_ACTIVITY_INITIAL_BACKOFF_MS / 1_000),
+    exampleValue: "120",
+    suggestion:
+      "Use a whole-number retry backoff in seconds, or unset the variable to restore the default initial backoff."
+  },
+  LINKEDIN_ASSISTANT_ACTIVITY_MAX_BACKOFF_SECONDS: {
+    defaultValue: String(DEFAULT_ACTIVITY_MAX_BACKOFF_MS / 1_000),
+    exampleValue: "3600",
+    suggestion:
+      "Use a whole-number maximum backoff in seconds that is greater than or equal to the initial backoff."
+  }
+};
 
 function parseStrictBoolean(
   value: string | undefined,

--- a/packages/core/src/db/database.ts
+++ b/packages/core/src/db/database.ts
@@ -666,18 +666,18 @@ const ACTIVITY_EVENT_SELECT_COLUMNS = `
 `;
 
 const WEBHOOK_SUBSCRIPTION_SELECT_COLUMNS = `
-  id,
-  watch_id,
-  status,
-  event_types_json,
-  delivery_url,
-  signing_secret,
-  max_attempts,
-  last_delivered_at,
-  last_error_code,
-  last_error_message,
-  created_at,
-  updated_at
+  webhook_subscription.id AS id,
+  webhook_subscription.watch_id AS watch_id,
+  webhook_subscription.status AS status,
+  webhook_subscription.event_types_json AS event_types_json,
+  webhook_subscription.delivery_url AS delivery_url,
+  webhook_subscription.signing_secret AS signing_secret,
+  webhook_subscription.max_attempts AS max_attempts,
+  webhook_subscription.last_delivered_at AS last_delivered_at,
+  webhook_subscription.last_error_code AS last_error_code,
+  webhook_subscription.last_error_message AS last_error_message,
+  webhook_subscription.created_at AS created_at,
+  webhook_subscription.updated_at AS updated_at
 `;
 
 const WEBHOOK_DELIVERY_ATTEMPT_SELECT_COLUMNS = `


### PR DESCRIPTION
## Summary
- add human-readable activity command output with consistent `--json` overrides and clearer progress/error formatting
- enrich activity config validation, logging, and JSDoc coverage for the polling pipeline
- redact persisted daemon diagnostics and fix the profile-filtered webhook subscription query used by `linkedin activity status`

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

Closes #200