### PR TITLE
test: expand evasion module coverage

### DIFF
--- a/packages/core/src/__tests__/evasion.browser.test.ts
+++ b/packages/core/src/__tests__/evasion.browser.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  applyFingerprintHardening,
+  scrollPageBy,
+  simulateIdleDrift,
+  simulateMomentumScroll,
+  simulateTabBlur,
+  simulateViewportJitter
+} from "../evasion/browser.js";
+import {
+  MAX_DRIFT_COUNT,
+  MAX_DRIFT_RADIUS_PX,
+  MIN_BLUR_DURATION_MS,
+  MIN_DRIFT_COUNT,
+  MIN_SCROLL_STEPS
+} from "../evasion/shared.js";
+import { createPageMock } from "./evasionTestUtils.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("browser evasion helpers", () => {
+  it("overrides navigator.webdriver when fingerprint hardening is enabled", async () => {
+    const { page } = createPageMock();
+    const navigatorStub: Record<string, unknown> = {};
+    vi.stubGlobal("navigator", navigatorStub);
+
+    await applyFingerprintHardening(page, "moderate");
+
+    const descriptor = Object.getOwnPropertyDescriptor(navigatorStub, "webdriver");
+    expect(descriptor?.configurable).toBe(true);
+    expect(descriptor?.get?.()).toBeUndefined();
+  });
+
+  it("adds deterministic canvas pixel noise in paranoid mode when canvas APIs exist", async () => {
+    const { page } = createPageMock();
+
+    class CanvasContext2DMock {
+      getImageData(): { data: number[] } {
+        return { data: [10, 20, 30, 40] };
+      }
+    }
+
+    vi.stubGlobal("CanvasRenderingContext2D", CanvasContext2DMock);
+    vi.spyOn(Math, "random").mockReturnValue(0.004);
+
+    await applyFingerprintHardening(page, "paranoid");
+
+    const context = new CanvasContext2DMock();
+    const imageData = context.getImageData();
+    expect(imageData.data[0]).toBe(11);
+  });
+
+  it("passes smooth scrolling options through the browser context", async () => {
+    const { page } = createPageMock();
+    const scrollBy = vi.fn(
+      (options: { top: number; behavior: "auto" | "smooth" }) => {
+        void options;
+        return undefined;
+      }
+    );
+    vi.stubGlobal("scrollBy", scrollBy);
+
+    await scrollPageBy(page, 75, "smooth");
+
+    expect(scrollBy).toHaveBeenCalledWith({ top: 75, behavior: "smooth" });
+  });
+
+  it("defaults to automatic scrolling when no behavior is provided", async () => {
+    const { page } = createPageMock();
+    const scrollBy = vi.fn(
+      (options: { top: number; behavior: "auto" | "smooth" }) => {
+        void options;
+        return undefined;
+      }
+    );
+    vi.stubGlobal("scrollBy", scrollBy);
+
+    await scrollPageBy(page, -30);
+
+    expect(scrollBy).toHaveBeenCalledWith({ top: -30, behavior: "auto" });
+  });
+
+  it("clamps momentum scroll to the minimum number of steps", async () => {
+    const { evaluate, page, waitForTimeout } = createPageMock();
+
+    await simulateMomentumScroll(page, 120, 1);
+
+    expect(evaluate).toHaveBeenCalledTimes(MIN_SCROLL_STEPS);
+    expect(waitForTimeout).toHaveBeenCalledTimes(MIN_SCROLL_STEPS);
+  });
+
+  it("clamps idle drift count and radius into the supported range", async () => {
+    const { mouseMove, page } = createPageMock();
+    vi.spyOn(Math, "random").mockReturnValue(1);
+
+    await simulateIdleDrift(page, 10, 20, 0, MAX_DRIFT_RADIUS_PX + 50);
+
+    expect(mouseMove).toHaveBeenCalledTimes(MIN_DRIFT_COUNT);
+    const [x, y] = mouseMove.mock.calls[0] as [number, number];
+    expect(Math.hypot(x - 10, y - 20)).toBeLessThanOrEqual(MAX_DRIFT_RADIUS_PX + 0.001);
+  });
+
+  it("uses the maximum drift count and clamps negative radius to zero", async () => {
+    const { mouseMove, page } = createPageMock();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+    await simulateIdleDrift(page, 10, 20, MAX_DRIFT_COUNT + 5, -10);
+
+    expect(mouseMove).toHaveBeenCalledTimes(MAX_DRIFT_COUNT);
+    for (const [x, y] of mouseMove.mock.calls as [number, number][]) {
+      expect(x).toBeCloseTo(10, 5);
+      expect(y).toBeCloseTo(20, 5);
+    }
+  });
+
+  it("dispatches blur and focus lifecycle events in order", async () => {
+    const { page, waitForTimeout } = createPageMock();
+    const dispatchedEvents: string[] = [];
+    vi.stubGlobal(
+      "dispatchEvent",
+      vi.fn((event: { type: string }) => {
+        dispatchedEvents.push(event.type);
+        return true;
+      })
+    );
+    vi.stubGlobal(
+      "Event",
+      class {
+        readonly type: string;
+
+        constructor(type: string) {
+          this.type = type;
+        }
+      }
+    );
+
+    await simulateTabBlur(page, 0);
+
+    expect(waitForTimeout).toHaveBeenCalledWith(MIN_BLUR_DURATION_MS);
+    expect(dispatchedEvents).toEqual(["blur", "visibilitychange", "focus", "visibilitychange"]);
+  });
+
+  it("dispatches a resize event for viewport jitter", async () => {
+    const { page } = createPageMock();
+    const dispatchedEvents: string[] = [];
+    vi.stubGlobal(
+      "dispatchEvent",
+      vi.fn((event: { type: string }) => {
+        dispatchedEvents.push(event.type);
+        return true;
+      })
+    );
+    vi.stubGlobal(
+      "Event",
+      class {
+        readonly type: string;
+
+        constructor(type: string) {
+          this.type = type;
+        }
+      }
+    );
+
+    await simulateViewportJitter(page);
+
+    expect(dispatchedEvents).toEqual(["resize"]);
+  });
+});

--- a/packages/core/src/__tests__/evasion.math.test.ts
+++ b/packages/core/src/__tests__/evasion.math.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  computeBezierPath,
+  computeMomentumSteps,
+  computeReadingPauseMs,
+  samplePoissonInterval
+} from "../evasion/math.js";
+import { MAX_BEZIER_STEPS, MAX_READING_WPM, MIN_BEZIER_STEPS } from "../evasion/shared.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("math evasion helpers", () => {
+  describe("computeBezierPath", () => {
+    it("clamps the number of generated steps to the supported bounds", () => {
+      const from = { x: 0, y: 0 };
+      const to = { x: 100, y: 50 };
+
+      expect(computeBezierPath(from, to, { steps: 1, seed: 1 })).toHaveLength(MIN_BEZIER_STEPS + 1);
+      expect(computeBezierPath(from, to, { steps: MAX_BEZIER_STEPS + 1, seed: 1 })).toHaveLength(
+        MAX_BEZIER_STEPS + 1
+      );
+    });
+
+    it("clamps overshoot factors into the supported range", () => {
+      const from = { x: 0, y: 0 };
+      const to = { x: 100, y: 0 };
+
+      expect(computeBezierPath(from, to, { overshootFactor: -5, seed: 3 })).toEqual(
+        computeBezierPath(from, to, { overshootFactor: 0, seed: 3 })
+      );
+      expect(computeBezierPath(from, to, { overshootFactor: 99, seed: 3 })).toEqual(
+        computeBezierPath(from, to, { overshootFactor: 1, seed: 3 })
+      );
+    });
+
+    it("keeps zero-distance overshoot paths stationary", () => {
+      const point = { x: 42, y: 99 };
+      const path = computeBezierPath(point, point, { overshootFactor: 1, steps: 20, seed: 7 });
+
+      expect(path).toHaveLength(21);
+      for (const currentPoint of path) {
+        expect(currentPoint).toEqual(point);
+      }
+    });
+  });
+
+  describe("computeMomentumSteps", () => {
+    it("returns a single step when asked for one", () => {
+      expect(computeMomentumSteps(120, 1)).toEqual([120]);
+    });
+
+    it("preserves the total distance across positive and negative motion", () => {
+      const downward = computeMomentumSteps(300, 4);
+      const upward = computeMomentumSteps(-300, 4);
+
+      expect(downward).toHaveLength(4);
+      expect(upward).toHaveLength(4);
+      expect(downward.reduce((sum, amount) => sum + amount, 0)).toBeCloseTo(300, 10);
+      expect(upward.reduce((sum, amount) => sum + amount, 0)).toBeCloseTo(-300, 10);
+      expect(downward.map((amount) => Math.abs(amount))).toEqual(
+        [...downward].map((amount) => Math.abs(amount)).sort((left, right) => right - left)
+      );
+    });
+  });
+
+  describe("samplePoissonInterval", () => {
+    it("remains finite when Math.random reaches zero", () => {
+      vi.spyOn(Math, "random").mockReturnValue(0);
+
+      const interval = samplePoissonInterval(250);
+
+      expect(interval).toBeGreaterThan(0);
+      expect(Number.isFinite(interval)).toBe(true);
+    });
+  });
+
+  describe("computeReadingPauseMs", () => {
+    it("clamps reading speed to the configured maximum", () => {
+      expect(computeReadingPauseMs(500, MAX_READING_WPM + 10_000)).toBe(
+        computeReadingPauseMs(500, MAX_READING_WPM)
+      );
+    });
+  });
+});

--- a/packages/core/src/__tests__/evasion.shared.test.ts
+++ b/packages/core/src/__tests__/evasion.shared.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  CAPTCHA_SELECTORS,
+  CHARS_PER_WORD,
+  HONEYPOT_SELECTORS,
+  MAX_BEZIER_STEPS,
+  MAX_BLUR_DURATION_MS,
+  MAX_DRIFT_COUNT,
+  MAX_DRIFT_RADIUS_PX,
+  MAX_READING_WPM,
+  MAX_SCROLL_DISTANCE_PX,
+  MAX_SCROLL_STEPS,
+  MIN_BEZIER_STEPS,
+  MIN_BLUR_DURATION_MS,
+  MIN_DRIFT_COUNT,
+  MIN_SCROLL_STEPS,
+  clamp
+} from "../evasion/shared.js";
+
+describe("shared evasion constants", () => {
+  it("clamps values into inclusive bounds", () => {
+    expect(clamp(-5, 0, 10)).toBe(0);
+    expect(clamp(5, 0, 10)).toBe(5);
+    expect(clamp(15, 0, 10)).toBe(10);
+  });
+
+  it("defines sane numeric guardrails", () => {
+    expect(MIN_BEZIER_STEPS).toBeLessThan(MAX_BEZIER_STEPS);
+    expect(MIN_SCROLL_STEPS).toBeLessThan(MAX_SCROLL_STEPS);
+    expect(MIN_DRIFT_COUNT).toBeLessThan(MAX_DRIFT_COUNT);
+    expect(MIN_BLUR_DURATION_MS).toBeLessThan(MAX_BLUR_DURATION_MS);
+    expect(MAX_DRIFT_RADIUS_PX).toBeGreaterThan(0);
+    expect(MAX_SCROLL_DISTANCE_PX).toBeGreaterThan(0);
+    expect(MAX_READING_WPM).toBeGreaterThan(0);
+    expect(CHARS_PER_WORD).toBeGreaterThan(0);
+  });
+
+  it("keeps captcha and honeypot selectors unique and populated", () => {
+    expect(CAPTCHA_SELECTORS.length).toBeGreaterThan(0);
+    expect(HONEYPOT_SELECTORS.length).toBeGreaterThan(0);
+    expect(new Set(CAPTCHA_SELECTORS).size).toBe(CAPTCHA_SELECTORS.length);
+    expect(new Set(HONEYPOT_SELECTORS).size).toBe(HONEYPOT_SELECTORS.length);
+    expect(CAPTCHA_SELECTORS).toContain("[data-sitekey]");
+    expect(HONEYPOT_SELECTORS).toContain("input[tabindex='-1']");
+  });
+});

--- a/packages/core/src/__tests__/evasion.test.ts
+++ b/packages/core/src/__tests__/evasion.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { Page } from "playwright-core";
 import {
   applyFingerprintHardening,
   computeBezierPath,
@@ -14,47 +13,8 @@ import {
   simulateTabBlur,
   simulateViewportJitter
 } from "../evasion.js";
-
-// --- Mock factory ---
-
-function createPageMock() {
-  const waitForTimeout = vi.fn(async () => {});
-  const mouseMove = vi.fn(async () => {});
-  const evaluateCalls: unknown[] = [];
-  const locatorCounts: Map<string, number> = new Map();
-
-  const evaluate = vi.fn(async (callback: unknown, arg?: unknown) => {
-    evaluateCalls.push({ callback, arg });
-    if (typeof callback === "function") {
-      try {
-        callback(arg);
-      } catch {
-        // Ignore errors from browser-context code run in Node
-      }
-    }
-  });
-
-  const locator = vi.fn((selector: string) => ({
-    count: vi.fn(async () => locatorCounts.get(selector) ?? 0)
-  }));
-
-  const page = {
-    evaluate,
-    locator,
-    mouse: { move: mouseMove },
-    waitForTimeout
-  } as unknown as Page;
-
-  return {
-    evaluate,
-    evaluateCalls,
-    locator,
-    locatorCounts,
-    mouseMove,
-    page,
-    waitForTimeout
-  };
-}
+import { MAX_SCROLL_DISTANCE_PX } from "../evasion/shared.js";
+import { createPageMock } from "./evasionTestUtils.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -512,14 +472,19 @@ describe("EvasionSession", () => {
     });
 
     it("tracks mouse position after moving", async () => {
-      const { page } = createPageMock();
-      const session = new EvasionSession(page, "minimal");
+      const { mouseMove, page } = createPageMock();
+      const session = new EvasionSession(page, "moderate");
+
+      vi.spyOn(Math, "random").mockReturnValue(0);
 
       await session.moveMouse({ x: 0, y: 0 }, { x: 250, y: 375 });
+      mouseMove.mockClear();
+      await session.idle(300);
 
-      // Internal state is reflected in subsequent idle drift.
-      // (We verify indirectly: calling idle with drift enabled should use the updated coords)
-      expect(session.activeLevel).toBe("minimal"); // sanity check
+      expect(mouseMove).toHaveBeenCalledTimes(1);
+      const [x, y] = mouseMove.mock.calls[0] as [number, number];
+      expect(x).toBeCloseTo(250, 5);
+      expect(y).toBeCloseTo(375, 5);
     });
   });
 
@@ -568,6 +533,15 @@ describe("EvasionSession", () => {
       const session = new EvasionSession(page, "moderate");
 
       await expect(session.scroll(999_999)).rejects.toThrow(/20000/);
+    });
+
+    it("accepts the documented maximum scroll distance", async () => {
+      const { evaluate, page } = createPageMock();
+      const session = new EvasionSession(page, "minimal");
+
+      await session.scroll(MAX_SCROLL_DISTANCE_PX);
+
+      expect(evaluate).toHaveBeenCalledOnce();
     });
   });
 
@@ -703,6 +677,57 @@ describe("EvasionSession", () => {
 
       const fields = await session.findHoneypotFields();
       expect(fields).toContain("input[tabindex='-1']");
+    });
+  });
+
+  describe("integration", () => {
+    it("keeps minimal sessions on the least evasive path end to end", async () => {
+      const { evaluate, locatorCounts, mouseMove, page, waitForTimeout } = createPageMock();
+      locatorCounts.set("input[tabindex='-1']", 1);
+      const session = new EvasionSession(page, "minimal");
+
+      await session.hardenFingerprint();
+      await session.moveMouse({ x: 0, y: 0 }, { x: 50, y: 75 });
+      await session.scroll(120);
+      await session.idle(300);
+      await session.simulateTabSwitch(250);
+      await session.simulateViewportJitter();
+      await session.readingPause(500);
+
+      expect(session.sampleInterval(250)).toBe(250);
+      expect(await session.detectCaptcha()).toBe(false);
+      expect(await session.findHoneypotFields()).toEqual(["input[tabindex='-1']"]);
+      expect(evaluate).toHaveBeenCalledTimes(1);
+      expect(mouseMove).toHaveBeenCalledTimes(1);
+      expect(waitForTimeout).toHaveBeenCalledWith(300);
+    });
+
+    it("layers paranoid strategies without breaking detection helpers", async () => {
+      const { evaluate, locatorCounts, mouseMove, page, waitForTimeout } = createPageMock();
+      locatorCounts.set("[data-sitekey]", 1);
+      locatorCounts.set("input[tabindex='-1']", 1);
+      const session = new EvasionSession(page, "paranoid");
+
+      vi.spyOn(Math, "random").mockReturnValue(0.25);
+
+      await session.hardenFingerprint();
+      await session.moveMouse({ x: 10, y: 20 }, { x: 110, y: 120 });
+      await session.scroll(240);
+      await session.idle(900);
+      await session.simulateTabSwitch(250);
+      await session.simulateViewportJitter();
+      await session.readingPause(500);
+
+      expect(session.sampleInterval(250)).not.toBe(250);
+      expect(await session.detectCaptcha()).toBe(true);
+      expect(await session.findHoneypotFields()).toContain("input[tabindex='-1']");
+      expect(evaluate.mock.calls.length).toBeGreaterThan(10);
+      expect(waitForTimeout.mock.calls.length).toBeGreaterThan(8);
+      expect(mouseMove.mock.calls.length).toBeGreaterThan(5);
+      const lastMove = mouseMove.mock.calls.at(-1) as [number, number] | undefined;
+      expect(lastMove).toBeDefined();
+      const driftDistance = Math.hypot((lastMove?.[0] ?? 0) - 110, (lastMove?.[1] ?? 0) - 120);
+      expect(driftDistance).toBeLessThanOrEqual(EVASION_PROFILES.paranoid.mouseJitterRadius + 0.001);
     });
   });
 });

--- a/packages/core/src/__tests__/evasion.types.test.ts
+++ b/packages/core/src/__tests__/evasion.types.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { EVASION_PROFILES } from "../evasion/profiles.js";
+
+const EVASION_LEVELS = ["minimal", "moderate", "paranoid"] as const;
+const EVASION_PROFILE_KEYS = [
+  "bezierMouseMovement",
+  "mouseOvershootFactor",
+  "mouseJitterRadius",
+  "momentumScroll",
+  "simulateTabBlur",
+  "simulateViewportResize",
+  "idleDriftEnabled",
+  "readingPauseWpm",
+  "poissonIntervals",
+  "fingerprintHardening"
+] as const;
+
+describe("evasion runtime contracts", () => {
+  it("keeps the runtime profile map aligned with the supported levels", () => {
+    expect(Object.keys(EVASION_PROFILES)).toEqual([...EVASION_LEVELS]);
+  });
+
+  it("gives every profile the full public contract surface", () => {
+    const expectedKeys = [...EVASION_PROFILE_KEYS].sort();
+
+    for (const profile of Object.values(EVASION_PROFILES)) {
+      expect(Object.keys(profile).sort()).toEqual(expectedKeys);
+    }
+  });
+});

--- a/packages/core/src/__tests__/evasionTestUtils.ts
+++ b/packages/core/src/__tests__/evasionTestUtils.ts
@@ -1,0 +1,56 @@
+import type { Page } from "playwright-core";
+import { vi } from "vitest";
+
+export interface EvaluateCall {
+  callback: unknown;
+  arg: unknown;
+}
+
+export function createPageMock() {
+  const waitForTimeout = vi.fn(async (delayMs: number) => {
+    void delayMs;
+  });
+  const mouseMove = vi.fn(
+    async (x: number, y: number, options?: { steps?: number }) => {
+      void x;
+      void y;
+      void options;
+    }
+  );
+  const evaluateCalls: EvaluateCall[] = [];
+  const locatorCounts = new Map<string, number>();
+
+  const evaluate = vi.fn(async (callback: unknown, arg?: unknown) => {
+    evaluateCalls.push({ callback, arg });
+    if (typeof callback === "function") {
+      try {
+        (callback as (value?: unknown) => unknown)(arg);
+      } catch {
+        return undefined;
+      }
+    }
+
+    return undefined;
+  });
+
+  const locator = vi.fn((selector: string) => ({
+    count: vi.fn(async () => locatorCounts.get(selector) ?? 0)
+  }));
+
+  const page = {
+    evaluate,
+    locator,
+    mouse: { move: mouseMove },
+    waitForTimeout
+  } as unknown as Page;
+
+  return {
+    evaluate,
+    evaluateCalls,
+    locator,
+    locatorCounts,
+    mouseMove,
+    page,
+    waitForTimeout
+  };
+}


### PR DESCRIPTION
## Summary
- add focused unit coverage for the refactored evasion browser, math, shared, and runtime contract helpers
- extract a reusable page mock and strengthen the existing evasion session tests with boundary and state assertions
- add end-to-end integration checks for minimal and paranoid evasion flows after the phase 3 split

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #217