### PR TITLE
fix: harden anti-bot evasion edge cases and pacing

### DIFF
--- a/packages/core/src/__tests__/evasion.hardening.test.ts
+++ b/packages/core/src/__tests__/evasion.hardening.test.ts
@@ -1,0 +1,181 @@
+import type { Page } from "playwright-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  applyFingerprintHardening,
+  computeBezierPath,
+  detectCaptcha,
+  EVASION_PROFILES,
+  EvasionSession,
+  findHoneypotFields,
+  samplePoissonInterval,
+  simulateIdleDrift
+} from "../evasion.js";
+import { MAX_SCROLL_DISTANCE_PX } from "../evasion/shared.js";
+import { createPageMock } from "./evasionTestUtils.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("evasion hardening", () => {
+  it("keeps Bezier paths finite for invalid coordinates and options", () => {
+    const path = computeBezierPath(
+      { x: Number.NaN, y: 10 },
+      { x: 25, y: Number.POSITIVE_INFINITY },
+      { steps: Number.NaN, overshootFactor: Number.NaN, seed: 7 }
+    );
+
+    expect(path.length).toBeGreaterThan(0);
+    for (const point of path) {
+      expect(Number.isFinite(point.x)).toBe(true);
+      expect(Number.isFinite(point.y)).toBe(true);
+    }
+    expect(path[0]).toEqual({ x: 0, y: 10 });
+    expect(path.at(-1)).toEqual({ x: 25, y: 10 });
+  });
+
+  it("backs off sampled intervals when rate limited and a keep-alive cadence exists", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.999_999);
+
+    const interval = samplePoissonInterval(250, {
+      responseStatus: 429,
+      keepAliveIntervalMs: 1_000,
+      retryAfterMs: 800
+    });
+
+    expect(interval).toBeGreaterThanOrEqual(1_000);
+  });
+
+  it("registers init scripts when evaluate fails under restrictive environments", async () => {
+    const { addInitScript, page } = createPageMock({
+      includeAddInitScript: true,
+      evaluateError: new Error("CSP blocked")
+    });
+    const navigatorStub: Record<string, unknown> = {};
+    vi.stubGlobal("navigator", navigatorStub);
+
+    await expect(applyFingerprintHardening(page, "moderate")).resolves.toBeUndefined();
+
+    expect(addInitScript).toHaveBeenCalledOnce();
+    const descriptor = Object.getOwnPropertyDescriptor(navigatorStub, "webdriver");
+    expect(descriptor?.get?.()).toBeUndefined();
+  });
+
+  it("keeps paranoid canvas hardening idempotent across repeated calls", async () => {
+    const { page } = createPageMock();
+
+    class CanvasContext2DMock {
+      getImageData(): { data: number[] } {
+        return { data: [10, 20, 30, 40] };
+      }
+    }
+
+    vi.stubGlobal("CanvasRenderingContext2D", CanvasContext2DMock);
+    vi.spyOn(Math, "random").mockReturnValue(0.004);
+
+    await applyFingerprintHardening(page, "paranoid");
+    await applyFingerprintHardening(page, "paranoid");
+
+    const context = new CanvasContext2DMock();
+    expect(context.getImageData().data[0]).toBe(11);
+  });
+
+  it("clamps idle drift into tiny viewport bounds", async () => {
+    const { mouseMove, page } = createPageMock({ viewportSize: { width: 1, height: 1 } });
+    vi.spyOn(Math, "random").mockReturnValue(1);
+
+    await simulateIdleDrift(page, 50, 50, 2, 100);
+
+    for (const [x, y] of mouseMove.mock.calls as [number, number][]) {
+      expect(x).toBeGreaterThanOrEqual(0);
+      expect(x).toBeLessThanOrEqual(1);
+      expect(y).toBeGreaterThanOrEqual(0);
+      expect(y).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("continues selector checks after partial-load errors", async () => {
+    const { locatorCounts, page } = createPageMock({
+      locatorErrorSelectors: new Set(["[class*='captcha' i]", "input[style*='display:none']"])
+    });
+    locatorCounts.set("[data-sitekey]", 1);
+    locatorCounts.set("input[tabindex='-1']", 1);
+
+    await expect(detectCaptcha(page)).resolves.toBe(true);
+    await expect(findHoneypotFields(page)).resolves.toEqual(["input[tabindex='-1']"]);
+  });
+
+  it("freezes the public evasion profiles", () => {
+    expect(Object.isFrozen(EVASION_PROFILES)).toBe(true);
+    for (const profile of Object.values(EVASION_PROFILES)) {
+      expect(Object.isFrozen(profile)).toBe(true);
+    }
+  });
+
+  it("serializes concurrent session operations", async () => {
+    let releaseMove: (() => void) | undefined;
+    const blockedMove = new Promise<void>((resolve) => {
+      releaseMove = resolve;
+    });
+    const order: string[] = [];
+    const page = {
+      evaluate: vi.fn(async () => undefined),
+      locator: vi.fn(() => ({ count: vi.fn(async () => 0) })),
+      mouse: {
+        move: vi.fn(async () => {
+          order.push("move");
+          await blockedMove;
+        })
+      },
+      waitForTimeout: vi.fn(async () => {
+        order.push("wait");
+      })
+    } as unknown as Page;
+    const session = new EvasionSession(page, "minimal");
+
+    const movePromise = session.moveMouse({ x: 0, y: 0 }, { x: 10, y: 20 });
+    const idlePromise = session.idle(100);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(order).toEqual(["move"]);
+
+    releaseMove?.();
+    await Promise.all([movePromise, idlePromise]);
+
+    expect(order).toEqual(["move", "wait"]);
+  });
+
+  it("deduplicates concurrent fingerprint hardening for a single session", async () => {
+    const { evaluate, page } = createPageMock();
+    const session = new EvasionSession(page, "paranoid");
+
+    await Promise.all([session.hardenFingerprint(), session.hardenFingerprint()]);
+
+    expect(evaluate).toHaveBeenCalledTimes(2);
+  });
+
+  it("clamps excessive session scroll distances instead of throwing", async () => {
+    const { evaluateCalls, page } = createPageMock();
+    const session = new EvasionSession(page, "minimal");
+
+    await expect(session.scroll(999_999)).resolves.toBeUndefined();
+
+    const instruction = evaluateCalls[0]?.arg as { top: number; behavior: string } | undefined;
+    expect(instruction?.top).toBe(MAX_SCROLL_DISTANCE_PX);
+    expect(instruction?.behavior).toBe("smooth");
+  });
+
+  it("applies rate-limit backoff even when poisson timing is disabled", () => {
+    const { page } = createPageMock();
+    const session = new EvasionSession(page, "minimal");
+
+    const interval = session.sampleInterval(500, {
+      responseStatus: 429,
+      keepAliveIntervalMs: 2_000
+    });
+
+    expect(interval).toBe(2_000);
+  });
+});

--- a/packages/core/src/__tests__/evasion.test.ts
+++ b/packages/core/src/__tests__/evasion.test.ts
@@ -265,7 +265,10 @@ describe("simulateMomentumScroll", () => {
 
     await simulateMomentumScroll(page, 500, 5);
 
-    const amounts = evaluateCalls.map((c) => (c as { arg: number }).arg);
+    const amounts = evaluateCalls.map((c) => {
+      const instruction = c.arg as { top?: number } | undefined;
+      return instruction?.top ?? 0;
+    });
     const total = amounts.reduce((sum, v) => sum + v, 0);
     expect(total).toBeCloseTo(500, 5);
   });
@@ -276,7 +279,10 @@ describe("simulateMomentumScroll", () => {
     await simulateMomentumScroll(page, -200, 3);
 
     expect(evaluate.mock.calls.length).toBe(3);
-    const amounts = evaluateCalls.map((c) => (c as { arg: number }).arg);
+    const amounts = evaluateCalls.map((c) => {
+      const instruction = c.arg as { top?: number } | undefined;
+      return instruction?.top ?? 0;
+    });
     expect(amounts.every((a) => a < 0)).toBe(true);
   });
 
@@ -528,11 +534,18 @@ describe("EvasionSession", () => {
       expect(evaluate.mock.calls.length).toBe(1);
     });
 
-    it("throws for excessive scroll distances", async () => {
-      const { page } = createPageMock();
+    it("clamps excessive scroll distances", async () => {
+      const { evaluateCalls, page } = createPageMock();
       const session = new EvasionSession(page, "moderate");
 
-      await expect(session.scroll(999_999)).rejects.toThrow(/20000/);
+      await expect(session.scroll(999_999)).resolves.toBeUndefined();
+
+      const amounts = evaluateCalls.map((call) => {
+        const instruction = call.arg as { top?: number } | undefined;
+        return instruction?.top ?? 0;
+      });
+      const total = amounts.reduce((sum, amount) => sum + amount, 0);
+      expect(total).toBeCloseTo(MAX_SCROLL_DISTANCE_PX, 5);
     });
 
     it("accepts the documented maximum scroll distance", async () => {

--- a/packages/core/src/__tests__/evasionTestUtils.ts
+++ b/packages/core/src/__tests__/evasionTestUtils.ts
@@ -6,21 +6,44 @@ export interface EvaluateCall {
   arg: unknown;
 }
 
-export function createPageMock() {
+export interface PageMockOptions {
+  includeAddInitScript?: boolean;
+  viewportSize?: { width: number; height: number } | null;
+  evaluateError?: Error;
+  addInitScriptError?: Error;
+  waitForTimeoutError?: Error;
+  mouseMoveError?: Error;
+  locatorErrorSelectors?: ReadonlySet<string>;
+}
+
+export function createPageMock(options?: PageMockOptions) {
   const waitForTimeout = vi.fn(async (delayMs: number) => {
+    if (options?.waitForTimeoutError !== undefined) {
+      throw options.waitForTimeoutError;
+    }
+
     void delayMs;
   });
   const mouseMove = vi.fn(
-    async (x: number, y: number, options?: { steps?: number }) => {
+    async (x: number, y: number, moveOptions?: { steps?: number }) => {
+      if (options?.mouseMoveError !== undefined) {
+        throw options.mouseMoveError;
+      }
+
       void x;
       void y;
-      void options;
+      void moveOptions;
     }
   );
   const evaluateCalls: EvaluateCall[] = [];
+  const addInitScriptCalls: EvaluateCall[] = [];
   const locatorCounts = new Map<string, number>();
 
   const evaluate = vi.fn(async (callback: unknown, arg?: unknown) => {
+    if (options?.evaluateError !== undefined) {
+      throw options.evaluateError;
+    }
+
     evaluateCalls.push({ callback, arg });
     if (typeof callback === "function") {
       try {
@@ -33,24 +56,61 @@ export function createPageMock() {
     return undefined;
   });
 
+  const addInitScript = vi.fn(async (callback: unknown, arg?: unknown) => {
+    if (options?.addInitScriptError !== undefined) {
+      throw options.addInitScriptError;
+    }
+
+    addInitScriptCalls.push({ callback, arg });
+    if (typeof callback === "function") {
+      try {
+        (callback as (value?: unknown) => unknown)(arg);
+      } catch {
+        return undefined;
+      }
+    }
+
+    return undefined;
+  });
+
   const locator = vi.fn((selector: string) => ({
-    count: vi.fn(async () => locatorCounts.get(selector) ?? 0)
+    count: vi.fn(async () => {
+      if (options?.locatorErrorSelectors?.has(selector)) {
+        throw new Error(`Unable to count selector: ${selector}`);
+      }
+
+      return locatorCounts.get(selector) ?? 0;
+    })
   }));
 
-  const page = {
+  const viewportSize = vi.fn(() => options?.viewportSize ?? null);
+  const pageRecord: Record<string, unknown> = {
     evaluate,
     locator,
     mouse: { move: mouseMove },
     waitForTimeout
-  } as unknown as Page;
+  };
+
+  if (options?.includeAddInitScript === true || options?.addInitScriptError !== undefined) {
+    pageRecord["addInitScript"] = addInitScript;
+  }
+
+  if (options?.viewportSize !== undefined) {
+    pageRecord["viewportSize"] = viewportSize;
+  }
+
+  const page = pageRecord as unknown as Page;
 
   return {
+    addInitScript,
+    addInitScriptCalls,
     evaluate,
     evaluateCalls,
     locator,
     locatorCounts,
     mouseMove,
     page,
+    viewportSize,
     waitForTimeout
   };
 }

--- a/packages/core/src/evasion.ts
+++ b/packages/core/src/evasion.ts
@@ -2,4 +2,10 @@ export { applyFingerprintHardening, detectCaptcha, findHoneypotFields, simulateI
 export { computeBezierPath, computeReadingPauseMs, samplePoissonInterval } from "./evasion/math.js";
 export { EVASION_PROFILES } from "./evasion/profiles.js";
 export { EvasionSession } from "./evasion/session.js";
-export type { BezierPathOptions, EvasionLevel, EvasionProfile, Point2D } from "./evasion/types.js";
+export type {
+  BezierPathOptions,
+  EvasionLevel,
+  EvasionProfile,
+  IntervalSampleOptions,
+  Point2D
+} from "./evasion/types.js";

--- a/packages/core/src/evasion/browser.ts
+++ b/packages/core/src/evasion/browser.ts
@@ -10,11 +10,32 @@ import {
   MIN_BLUR_DURATION_MS,
   MIN_DRIFT_COUNT,
   MIN_SCROLL_STEPS,
-  clamp
+  clamp,
+  isFiniteNumber,
+  normalizeFiniteNumber
 } from "./shared.js";
 import type { EvasionLevel } from "./types.js";
 
 type ScrollBehavior = "auto" | "smooth";
+
+interface MousePoint {
+  x: number;
+  y: number;
+}
+
+interface ViewportBounds {
+  width: number;
+  height: number;
+}
+
+type PageWithInitScript = Page & Partial<Pick<Page, "addInitScript">>;
+type PageWithViewportSize = Page & Partial<Pick<Page, "viewportSize">>;
+type PageScriptInvoker = (script: unknown, arg?: unknown) => Promise<unknown>;
+
+type ScrollInstruction = {
+  top: number;
+  behavior: ScrollBehavior;
+};
 
 /**
  * Apply navigator and canvas fingerprint hardening to `page` by injecting
@@ -25,6 +46,9 @@ type ScrollBehavior = "auto" | "smooth";
  * - `moderate`: Removes the `navigator.webdriver` flag.
  * - `paranoid`: All `moderate` hardening plus per-session canvas pixel noise
  *   to reduce canvas fingerprint stability across sessions.
+ *
+ * The hardening is intentionally fail-open: if a browser blocks one technique,
+ * the helper silently falls back to any remaining techniques or a no-op.
  *
  * @param page - Playwright Page to harden.
  * @param level - Desired evasion level (defaults to `"moderate"`).
@@ -40,7 +64,7 @@ export async function applyFingerprintHardening(
   await applyWebdriverHardening(page);
 
   if (level === "paranoid") {
-    await applyCanvasNoise(page, (Math.random() * 256) | 0);
+    await applyCanvasNoise(page, Math.floor(Math.random() * 256));
   }
 }
 
@@ -58,12 +82,17 @@ export async function simulateMomentumScroll(
   pixels: number,
   steps = 6
 ): Promise<void> {
-  if (pixels === 0) {
+  const safePixels = normalizeFiniteNumber(pixels, 0);
+  if (safePixels === 0) {
     return;
   }
 
-  const totalSteps = clamp(steps, MIN_SCROLL_STEPS, MAX_SCROLL_STEPS);
-  for (const amount of computeMomentumSteps(pixels, totalSteps)) {
+  const totalSteps = Math.round(clamp(steps, MIN_SCROLL_STEPS, MAX_SCROLL_STEPS));
+  for (const amount of computeMomentumSteps(safePixels, totalSteps)) {
+    if (amount === 0) {
+      continue;
+    }
+
     await scrollPageBy(page, amount);
     await waitWithRandomJitter(page, 20, 30);
   }
@@ -86,15 +115,30 @@ export async function simulateIdleDrift(
   driftCount = 3,
   radius = 5
 ): Promise<void> {
-  const clampedCount = clamp(driftCount, MIN_DRIFT_COUNT, MAX_DRIFT_COUNT);
+  const basePoint: MousePoint = {
+    x: normalizeFiniteNumber(currentX, 0),
+    y: normalizeFiniteNumber(currentY, 0)
+  };
+  const clampedCount = Math.round(clamp(driftCount, MIN_DRIFT_COUNT, MAX_DRIFT_COUNT));
   const clampedRadius = clamp(radius, 0, MAX_DRIFT_RADIUS_PX);
+  const viewportBounds = resolveViewportBounds(page);
 
-  for (let i = 0; i < clampedCount; i++) {
+  for (let index = 0; index < clampedCount; index++) {
     const angle = Math.random() * Math.PI * 2;
     const distance = Math.random() * clampedRadius;
-    await page.mouse.move(currentX + Math.cos(angle) * distance, currentY + Math.sin(angle) * distance, {
-      steps: 1
-    });
+    const targetPoint = clampPointToViewport(
+      {
+        x: basePoint.x + Math.cos(angle) * distance,
+        y: basePoint.y + Math.sin(angle) * distance
+      },
+      viewportBounds
+    );
+
+    const moved = await safeMouseMove(page, targetPoint, 1);
+    if (!moved) {
+      return;
+    }
+
     await waitWithRandomJitter(page, 80, 120);
   }
 }
@@ -111,10 +155,10 @@ export async function simulateIdleDrift(
  *   (100–30 000, default 2 000).
  */
 export async function simulateTabBlur(page: Page, blurDurationMs = 2_000): Promise<void> {
-  const duration = clamp(blurDurationMs, MIN_BLUR_DURATION_MS, MAX_BLUR_DURATION_MS);
+  const duration = Math.round(clamp(blurDurationMs, MIN_BLUR_DURATION_MS, MAX_BLUR_DURATION_MS));
 
   await dispatchWindowEvents(page, ["blur", "visibilitychange"]);
-  await page.waitForTimeout(duration);
+  await safeWaitForTimeout(page, duration);
   await dispatchWindowEvents(page, ["focus", "visibilitychange"]);
 }
 
@@ -160,82 +204,35 @@ export async function scrollPageBy(
   pixels: number,
   behavior: ScrollBehavior = "auto"
 ): Promise<void> {
-  if (behavior === "smooth") {
-    await page.evaluate((scrollAmount: number) => {
-      globalThis.scrollBy({ top: scrollAmount, behavior: "smooth" });
-    }, pixels);
+  const safePixels = normalizeFiniteNumber(pixels, 0);
+  if (safePixels === 0) {
     return;
   }
 
-  await page.evaluate((scrollAmount: number) => {
-    globalThis.scrollBy({ top: scrollAmount, behavior: "auto" });
-  }, pixels);
+  const scrollInstruction: ScrollInstruction = {
+    top: safePixels,
+    behavior: behavior === "smooth" ? "smooth" : "auto"
+  };
+  await safeEvaluate(page, executeScrollBy, scrollInstruction);
 }
 
 async function applyWebdriverHardening(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    try {
-      const navigatorObject = (globalThis as Record<string, unknown>)["navigator"];
-      if (navigatorObject && typeof navigatorObject === "object") {
-        Object.defineProperty(navigatorObject, "webdriver", {
-          get: () => undefined,
-          configurable: true
-        });
-      }
-    } catch {
-      // Already defined non-configurably; skip.
-    }
-  });
+  await safeAddInitScript(page, installWebdriverHardening);
+  await safeEvaluate(page, installWebdriverHardening);
 }
 
 async function applyCanvasNoise(page: Page, salt: number): Promise<void> {
-  await page.evaluate((noiseSalt: number) => {
-    try {
-      const globalRecord = globalThis as Record<string, unknown>;
-      const contextConstructor = globalRecord["CanvasRenderingContext2D"];
-      if (typeof contextConstructor !== "function") {
-        return;
-      }
-
-      const prototype = (contextConstructor as { prototype: Record<string, unknown> }).prototype;
-      const originalGetImageData = prototype["getImageData"];
-      if (typeof originalGetImageData !== "function") {
-        return;
-      }
-
-      const typedGetImageData = originalGetImageData as (
-        this: unknown,
-        sx: number,
-        sy: number,
-        sw: number,
-        sh: number
-      ) => { data: { length: number; [index: number]: number } };
-
-      prototype["getImageData"] = function (
-        this: unknown,
-        sx: number,
-        sy: number,
-        sw: number,
-        sh: number
-      ): unknown {
-        const imageData = typedGetImageData.call(this, sx, sy, sw, sh);
-        if (imageData.data.length > 0) {
-          imageData.data[0] = ((imageData.data[0] ?? 0) + (noiseSalt & 1)) & 255;
-        }
-        return imageData;
-      };
-    } catch {
-      // Canvas API unavailable; skip.
-    }
-  }, salt);
+  const safeSalt = Math.round(clamp(salt, 0, 255));
+  await safeAddInitScript(page, installCanvasNoise, safeSalt);
+  await safeEvaluate(page, installCanvasNoise, safeSalt);
 }
 
 async function dispatchWindowEvents(page: Page, eventNames: readonly string[]): Promise<void> {
-  await page.evaluate((names: readonly string[]) => {
-    for (const name of names) {
-      globalThis.dispatchEvent(new Event(name));
-    }
-  }, [...eventNames]);
+  if (eventNames.length === 0) {
+    return;
+  }
+
+  await safeEvaluate(page, emitWindowEvents, [...eventNames]);
 }
 
 async function findMatchingSelectors(
@@ -258,9 +255,235 @@ async function findMatchingSelectors(
 }
 
 async function selectorMatches(page: Page, selector: string): Promise<boolean> {
-  return (await page.locator(selector).count()) > 0;
+  try {
+    return (await page.locator(selector).count()) > 0;
+  } catch {
+    return false;
+  }
 }
 
 async function waitWithRandomJitter(page: Page, baseMs: number, jitterMs: number): Promise<void> {
-  await page.waitForTimeout(baseMs + Math.floor(Math.random() * jitterMs));
+  const safeBaseMs = Math.max(0, Math.round(normalizeFiniteNumber(baseMs, 0)));
+  const safeJitterMs = Math.max(0, Math.round(normalizeFiniteNumber(jitterMs, 0)));
+  const delayMs = safeBaseMs + Math.floor(Math.random() * (safeJitterMs + 1));
+
+  await safeWaitForTimeout(page, delayMs);
+}
+
+async function safeWaitForTimeout(page: Page, delayMs: number): Promise<boolean> {
+  const safeDelayMs = Math.max(0, Math.round(normalizeFiniteNumber(delayMs, 0)));
+
+  try {
+    await page.waitForTimeout(safeDelayMs);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function safeMouseMove(page: Page, point: Readonly<MousePoint>, steps: number): Promise<boolean> {
+  try {
+    await page.mouse.move(point.x, point.y, { steps });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function safeAddInitScript(page: Page, callback: unknown, arg?: unknown): Promise<boolean> {
+  const pageWithInitScript = page as PageWithInitScript;
+  const addInitScript = pageWithInitScript.addInitScript as PageScriptInvoker | undefined;
+  if (typeof addInitScript !== "function") {
+    return false;
+  }
+
+  try {
+    await addInitScript(callback, arg);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function safeEvaluate(page: Page, callback: unknown, arg?: unknown): Promise<boolean> {
+  const evaluate = page.evaluate as unknown as PageScriptInvoker;
+
+  try {
+    await evaluate.call(page, callback, arg);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveViewportBounds(page: Page): ViewportBounds | null {
+  const pageWithViewportSize = page as PageWithViewportSize;
+  if (typeof pageWithViewportSize.viewportSize !== "function") {
+    return null;
+  }
+
+  try {
+    const viewportSize = pageWithViewportSize.viewportSize();
+    if (!isViewportSize(viewportSize)) {
+      return null;
+    }
+
+    return {
+      width: Math.max(0, viewportSize.width),
+      height: Math.max(0, viewportSize.height)
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isViewportSize(value: unknown): value is ViewportBounds {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return isFiniteNumber(record["width"]) && isFiniteNumber(record["height"]);
+}
+
+function clampPointToViewport(
+  point: Readonly<MousePoint>,
+  viewportBounds: ViewportBounds | null
+): MousePoint {
+  if (viewportBounds === null) {
+    return {
+      x: normalizeFiniteNumber(point.x, 0),
+      y: normalizeFiniteNumber(point.y, 0)
+    };
+  }
+
+  return {
+    x: clamp(point.x, 0, viewportBounds.width),
+    y: clamp(point.y, 0, viewportBounds.height)
+  };
+}
+
+function installWebdriverHardening(): void {
+  try {
+    const globalRecord = globalThis as Record<string, unknown>;
+    const stateKey = "__linkedinAssistantEvasionState__";
+    const existingState = globalRecord[stateKey];
+    const state =
+      typeof existingState === "object" && existingState !== null
+        ? (existingState as Record<string, unknown>)
+        : {};
+
+    if (globalRecord[stateKey] !== state) {
+      globalRecord[stateKey] = state;
+    }
+
+    const navigatorObject = globalRecord["navigator"];
+    if (!navigatorObject || typeof navigatorObject !== "object") {
+      return;
+    }
+
+    Object.defineProperty(navigatorObject, "webdriver", {
+      get: () => undefined,
+      configurable: true
+    });
+    state["webdriverApplied"] = true;
+  } catch {
+    // Already defined non-configurably or unavailable; skip.
+  }
+}
+
+function installCanvasNoise(noiseSalt: number): void {
+  try {
+    const globalRecord = globalThis as Record<string, unknown>;
+    const stateKey = "__linkedinAssistantEvasionState__";
+    const existingState = globalRecord[stateKey];
+    const state =
+      typeof existingState === "object" && existingState !== null
+        ? (existingState as Record<string, unknown>)
+        : {};
+
+    if (globalRecord[stateKey] !== state) {
+      globalRecord[stateKey] = state;
+    }
+
+    const existingCanvasState = state["canvas"];
+    const canvasState =
+      typeof existingCanvasState === "object" && existingCanvasState !== null
+        ? (existingCanvasState as Record<string, unknown>)
+        : {};
+
+    if (state["canvas"] !== canvasState) {
+      state["canvas"] = canvasState;
+    }
+
+    const safeNoiseSalt =
+      typeof noiseSalt === "number" && Number.isFinite(noiseSalt) ? noiseSalt : 0;
+    canvasState["salt"] = Math.round(safeNoiseSalt) & 255;
+
+    const contextConstructor = globalRecord["CanvasRenderingContext2D"];
+    if (typeof contextConstructor !== "function") {
+      return;
+    }
+
+    const prototype = (contextConstructor as { prototype: Record<string, unknown> }).prototype;
+    const originalGetImageData = prototype["getImageData"];
+    if (typeof originalGetImageData !== "function") {
+      return;
+    }
+
+    if (canvasState["patched"] === true) {
+      return;
+    }
+
+    const typedGetImageData = originalGetImageData as (
+      this: unknown,
+      sx: number,
+      sy: number,
+      sw: number,
+      sh: number
+    ) => { data?: { length?: number; [index: number]: number | undefined } };
+
+    prototype["getImageData"] = function (
+      this: unknown,
+      sx: number,
+      sy: number,
+      sw: number,
+      sh: number
+    ): unknown {
+      const imageData = typedGetImageData.call(this, sx, sy, sw, sh);
+      const imageDataRecord = imageData as { data?: { length?: number; [index: number]: number | undefined } };
+      const data = imageDataRecord.data;
+      if (data && typeof data.length === "number" && data.length > 0) {
+        const rawActiveSalt = canvasState["salt"];
+        const activeSalt =
+          typeof rawActiveSalt === "number" && Number.isFinite(rawActiveSalt)
+            ? Math.round(rawActiveSalt) & 255
+            : 0;
+        data[0] = ((data[0] ?? 0) + (activeSalt & 1)) & 255;
+      }
+      return imageData;
+    };
+
+    canvasState["patched"] = true;
+  } catch {
+    // Canvas API unavailable or blocked; skip.
+  }
+}
+
+function executeScrollBy(instruction: ScrollInstruction): void {
+  try {
+    globalThis.scrollBy({ top: instruction.top, behavior: instruction.behavior });
+  } catch {
+    // Browser scrolling unavailable; skip.
+  }
+}
+
+function emitWindowEvents(eventNames: readonly string[]): void {
+  try {
+    for (const name of eventNames) {
+      globalThis.dispatchEvent(new Event(name));
+    }
+  } catch {
+    // Event constructors or dispatch may be unavailable during partial loads.
+  }
 }

--- a/packages/core/src/evasion/math.ts
+++ b/packages/core/src/evasion/math.ts
@@ -3,9 +3,13 @@ import {
   MAX_BEZIER_STEPS,
   MAX_READING_WPM,
   MIN_BEZIER_STEPS,
-  clamp
+  clamp,
+  normalizeFiniteNumber
 } from "./shared.js";
-import type { BezierPathOptions, Point2D } from "./types.js";
+import type { BezierPathOptions, IntervalSampleOptions, Point2D } from "./types.js";
+
+const ORIGIN_POINT: Readonly<Point2D> = Object.freeze({ x: 0, y: 0 });
+const RATE_LIMIT_STATUS_CODES = new Set([429, 999]);
 
 /**
  * Compute a cubic Bezier mouse path from `from` to `to`.
@@ -27,12 +31,14 @@ export function computeBezierPath(
   to: Readonly<Point2D>,
   options?: BezierPathOptions
 ): readonly Point2D[] {
-  const steps = clamp(options?.steps ?? 20, MIN_BEZIER_STEPS, MAX_BEZIER_STEPS);
+  const safeFrom = normalizePoint(from);
+  const safeTo = normalizePoint(to, safeFrom);
+  const steps = Math.round(clamp(options?.steps ?? 20, MIN_BEZIER_STEPS, MAX_BEZIER_STEPS));
   const overshootFactor = clamp(options?.overshootFactor ?? 0, 0, 1);
   const rand = options?.seed !== undefined ? makeSeededRandom(options.seed) : Math.random;
 
-  const dx = to.x - from.x;
-  const dy = to.y - from.y;
+  const dx = safeTo.x - safeFrom.x;
+  const dy = safeTo.y - safeFrom.y;
   const dist = Math.hypot(dx, dy);
 
   const perpX = dist > 0 ? -dy / dist : 0;
@@ -40,31 +46,31 @@ export function computeBezierPath(
   const deviation1 = dist * 0.3 * (rand() - 0.5);
   const deviation2 = dist * 0.2 * (rand() - 0.5);
   const cp1: Point2D = {
-    x: lerp(from.x, to.x, 0.25) + perpX * deviation1,
-    y: lerp(from.y, to.y, 0.25) + perpY * deviation1
+    x: lerp(safeFrom.x, safeTo.x, 0.25) + perpX * deviation1,
+    y: lerp(safeFrom.y, safeTo.y, 0.25) + perpY * deviation1
   };
   const cp2: Point2D = {
-    x: lerp(from.x, to.x, 0.75) + perpX * deviation2,
-    y: lerp(from.y, to.y, 0.75) + perpY * deviation2
+    x: lerp(safeFrom.x, safeTo.x, 0.75) + perpX * deviation2,
+    y: lerp(safeFrom.y, safeTo.y, 0.75) + perpY * deviation2
   };
 
   const overshootEnabled = overshootFactor > 0;
   const overshootTarget: Point2D = overshootEnabled
     ? {
-        x: to.x + dx * overshootFactor * 0.2 * rand(),
-        y: to.y + dy * overshootFactor * 0.2 * rand()
+        x: safeTo.x + dx * overshootFactor * 0.2 * rand(),
+        y: safeTo.y + dy * overshootFactor * 0.2 * rand()
       }
-    : to;
-  const mainSteps = overshootEnabled ? Math.ceil(steps * 0.8) : steps;
+    : safeTo;
+  const mainSteps = Math.max(1, overshootEnabled ? Math.ceil(steps * 0.8) : steps);
   const points: Point2D[] = [];
 
   for (let i = 0; i <= mainSteps; i++) {
     const t = i / mainSteps;
-    points.push(evaluateCubicBezier(from, cp1, cp2, overshootTarget, t));
+    points.push(evaluateCubicBezier(safeFrom, cp1, cp2, overshootTarget, t));
   }
 
   if (overshootEnabled) {
-    appendCorrectionPoints(points, overshootTarget, to, steps - mainSteps);
+    appendCorrectionPoints(points, overshootTarget, safeTo, steps - mainSteps);
   }
 
   return points;
@@ -77,16 +83,22 @@ export function computeBezierPath(
  * distributions that better resemble human action timing than uniform random
  * or constant delays.
  *
+ * Optional constraints can clamp the sample, respect existing keep-alive
+ * cadences, and apply rate-limit backoff for `429` / `999` style responses.
+ *
  * @param meanMs - Expected average interval in milliseconds.
+ * @param options - Optional bounds and rate-limit hints.
  * @returns Sampled interval in milliseconds (≥ 0).
  */
-export function samplePoissonInterval(meanMs: number): number {
-  if (meanMs <= 0) {
+export function samplePoissonInterval(meanMs: number, options?: IntervalSampleOptions): number {
+  const safeMeanMs = Math.max(0, normalizeFiniteNumber(meanMs, 0));
+  if (safeMeanMs <= 0) {
     return 0;
   }
 
   const u = Math.max(Number.EPSILON, Math.random());
-  return -Math.log(u) * meanMs;
+  const sampledMs = -Math.log(u) * safeMeanMs;
+  return applyIntervalConstraints(sampledMs, safeMeanMs, options);
 }
 
 /**
@@ -101,22 +113,33 @@ export function samplePoissonInterval(meanMs: number): number {
  * @returns Estimated reading time in milliseconds (≥ 0).
  */
 export function computeReadingPauseMs(charCount: number, wpm: number): number {
-  if (charCount <= 0 || wpm <= 0) {
+  const safeCharCount = Math.max(0, normalizeFiniteNumber(charCount, 0));
+  const clampedWpm = clamp(wpm, 0, MAX_READING_WPM);
+  if (safeCharCount <= 0 || clampedWpm <= 0) {
     return 0;
   }
 
-  const clampedWpm = clamp(wpm, 0, MAX_READING_WPM);
-  const words = charCount / CHARS_PER_WORD;
+  const words = safeCharCount / CHARS_PER_WORD;
   const minutes = words / clampedWpm;
   return Math.round(minutes * 60_000);
 }
 
 export function computeMomentumSteps(totalPixels: number, steps: number): number[] {
+  const safeTotalPixels = normalizeFiniteNumber(totalPixels, 0);
+  if (safeTotalPixels === 0) {
+    return [];
+  }
+
+  const safeSteps = Math.max(1, Math.floor(normalizeFiniteNumber(steps, 1)));
+  if (safeSteps === 1) {
+    return [safeTotalPixels];
+  }
+
   const amounts: number[] = [];
-  let remaining = totalPixels;
+  let remaining = safeTotalPixels;
   const decayFactor = 0.55;
 
-  for (let i = 0; i < steps - 1; i++) {
+  for (let index = 0; index < safeSteps - 1; index++) {
     const amount = remaining * decayFactor;
     amounts.push(amount);
     remaining -= amount;
@@ -126,14 +149,19 @@ export function computeMomentumSteps(totalPixels: number, steps: number): number
   return amounts;
 }
 
+export function resolveIntervalMs(baseMs: number, options?: IntervalSampleOptions): number {
+  const safeBaseMs = Math.max(0, normalizeFiniteNumber(baseMs, 0));
+  return applyIntervalConstraints(safeBaseMs, safeBaseMs, options);
+}
+
 function appendCorrectionPoints(
   points: Point2D[],
   overshootTarget: Readonly<Point2D>,
   to: Readonly<Point2D>,
   correctionSteps: number
 ): void {
-  for (let i = 1; i <= correctionSteps; i++) {
-    const t = i / Math.max(1, correctionSteps);
+  for (let index = 1; index <= correctionSteps; index++) {
+    const t = index / Math.max(1, correctionSteps);
     points.push({
       x: lerp(overshootTarget.x, to.x, t),
       y: lerp(overshootTarget.y, to.y, t)
@@ -175,4 +203,59 @@ function makeSeededRandom(seed: number): () => number {
     state ^= state << 5;
     return (state >>> 0) / 0x100000000;
   };
+}
+
+function normalizePoint(
+  point: Readonly<Point2D>,
+  fallback: Readonly<Point2D> = ORIGIN_POINT
+): Point2D {
+  return {
+    x: normalizeFiniteNumber(point.x, fallback.x),
+    y: normalizeFiniteNumber(point.y, fallback.y)
+  };
+}
+
+function applyIntervalConstraints(
+  intervalMs: number,
+  baseMs: number,
+  options?: IntervalSampleOptions
+): number {
+  const safeBaseMs = Math.max(0, normalizeFiniteNumber(baseMs, 0));
+  const safeIntervalMs = Math.max(0, normalizeFiniteNumber(intervalMs, safeBaseMs));
+  const minIntervalMs = Math.max(0, normalizeFiniteNumber(options?.minIntervalMs ?? 0, 0));
+  const maxIntervalMs = resolveMaxIntervalMs(options?.maxIntervalMs);
+  const keepAliveIntervalMs = Math.max(
+    0,
+    normalizeFiniteNumber(options?.keepAliveIntervalMs ?? 0, 0)
+  );
+  const retryAfterMs = Math.max(0, normalizeFiniteNumber(options?.retryAfterMs ?? 0, 0));
+  const backoffMultiplier = clamp(options?.rateLimitBackoffMultiplier ?? 2, 1, 10);
+  const rateLimitFloor = isRateLimited(options)
+    ? Math.max(retryAfterMs, keepAliveIntervalMs, safeBaseMs * backoffMultiplier)
+    : 0;
+  const effectiveMinIntervalMs = Math.max(minIntervalMs, rateLimitFloor);
+  const effectiveMaxIntervalMs = Math.max(effectiveMinIntervalMs, maxIntervalMs);
+
+  return clamp(safeIntervalMs, effectiveMinIntervalMs, effectiveMaxIntervalMs);
+}
+
+function isRateLimited(options?: IntervalSampleOptions): boolean {
+  if (!options) {
+    return false;
+  }
+
+  return (
+    options.rateLimited === true ||
+    RATE_LIMIT_STATUS_CODES.has(Math.trunc(normalizeFiniteNumber(options.responseStatus ?? 0, 0))) ||
+    (options.retryAfterMs ?? 0) > 0
+  );
+}
+
+function resolveMaxIntervalMs(maxIntervalMs: number | undefined): number {
+  if (maxIntervalMs === undefined) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  const safeMaxIntervalMs = normalizeFiniteNumber(maxIntervalMs, Number.POSITIVE_INFINITY);
+  return safeMaxIntervalMs >= 0 ? safeMaxIntervalMs : Number.POSITIVE_INFINITY;
 }

--- a/packages/core/src/evasion/profiles.ts
+++ b/packages/core/src/evasion/profiles.ts
@@ -1,46 +1,53 @@
 import type { EvasionLevel, EvasionProfile } from "./types.js";
 
+const MINIMAL_PROFILE: Readonly<EvasionProfile> = Object.freeze({
+  bezierMouseMovement: false,
+  mouseOvershootFactor: 0,
+  mouseJitterRadius: 0,
+  momentumScroll: false,
+  simulateTabBlur: false,
+  simulateViewportResize: false,
+  idleDriftEnabled: false,
+  readingPauseWpm: 0,
+  poissonIntervals: false,
+  fingerprintHardening: false
+});
+
+const MODERATE_PROFILE: Readonly<EvasionProfile> = Object.freeze({
+  bezierMouseMovement: true,
+  mouseOvershootFactor: 0.15,
+  mouseJitterRadius: 3,
+  momentumScroll: true,
+  simulateTabBlur: false,
+  simulateViewportResize: false,
+  idleDriftEnabled: true,
+  readingPauseWpm: 230,
+  poissonIntervals: true,
+  fingerprintHardening: true
+});
+
+const PARANOID_PROFILE: Readonly<EvasionProfile> = Object.freeze({
+  bezierMouseMovement: true,
+  mouseOvershootFactor: 0.25,
+  mouseJitterRadius: 6,
+  momentumScroll: true,
+  simulateTabBlur: true,
+  simulateViewportResize: true,
+  idleDriftEnabled: true,
+  readingPauseWpm: 200,
+  poissonIntervals: true,
+  fingerprintHardening: true
+});
+
 /**
  * Predefined detection-evasion profiles ordered by intensity.
  *
  * Most production workflows should use `"moderate"`. Reserve `"paranoid"` for
  * environments with aggressive bot detection.
  */
-export const EVASION_PROFILES: Readonly<Record<EvasionLevel, EvasionProfile>> = {
-  minimal: {
-    bezierMouseMovement: false,
-    mouseOvershootFactor: 0,
-    mouseJitterRadius: 0,
-    momentumScroll: false,
-    simulateTabBlur: false,
-    simulateViewportResize: false,
-    idleDriftEnabled: false,
-    readingPauseWpm: 0,
-    poissonIntervals: false,
-    fingerprintHardening: false
-  },
-  moderate: {
-    bezierMouseMovement: true,
-    mouseOvershootFactor: 0.15,
-    mouseJitterRadius: 3,
-    momentumScroll: true,
-    simulateTabBlur: false,
-    simulateViewportResize: false,
-    idleDriftEnabled: true,
-    readingPauseWpm: 230,
-    poissonIntervals: true,
-    fingerprintHardening: true
-  },
-  paranoid: {
-    bezierMouseMovement: true,
-    mouseOvershootFactor: 0.25,
-    mouseJitterRadius: 6,
-    momentumScroll: true,
-    simulateTabBlur: true,
-    simulateViewportResize: true,
-    idleDriftEnabled: true,
-    readingPauseWpm: 200,
-    poissonIntervals: true,
-    fingerprintHardening: true
-  }
-};
+export const EVASION_PROFILES: Readonly<Record<EvasionLevel, Readonly<EvasionProfile>>> =
+  Object.freeze({
+    minimal: MINIMAL_PROFILE,
+    moderate: MODERATE_PROFILE,
+    paranoid: PARANOID_PROFILE
+  });

--- a/packages/core/src/evasion/session.ts
+++ b/packages/core/src/evasion/session.ts
@@ -9,10 +9,25 @@ import {
   simulateTabBlur as simulateTabBlurOnPage,
   simulateViewportJitter as simulateViewportJitterOnPage
 } from "./browser.js";
-import { computeBezierPath, computeReadingPauseMs, samplePoissonInterval } from "./math.js";
+import {
+  computeBezierPath,
+  computeReadingPauseMs,
+  resolveIntervalMs,
+  samplePoissonInterval
+} from "./math.js";
 import { EVASION_PROFILES } from "./profiles.js";
-import { MAX_SCROLL_DISTANCE_PX } from "./shared.js";
-import type { EvasionLevel, EvasionProfile, Point2D } from "./types.js";
+import { MAX_SCROLL_DISTANCE_PX, clamp, isFiniteNumber, normalizeFiniteNumber } from "./shared.js";
+import type { EvasionLevel, EvasionProfile, IntervalSampleOptions, Point2D } from "./types.js";
+
+const MIN_IDLE_DRIFT_DELAY_MS = 80;
+const ORIGIN_POINT: Readonly<Point2D> = Object.freeze({ x: 0, y: 0 });
+
+type PageWithViewportSize = Page & Partial<Pick<Page, "viewportSize">>;
+
+interface ViewportBounds {
+  width: number;
+  height: number;
+}
 
 /**
  * High-level detection-evasion session that combines a Playwright Page with
@@ -38,6 +53,8 @@ export class EvasionSession {
   private readonly level: EvasionLevel;
   private mouseX = 0;
   private mouseY = 0;
+  private operationQueue: Promise<void> = Promise.resolve();
+  private fingerprintHardeningPromise: Promise<void> | undefined;
 
   constructor(page: Page, level: EvasionLevel = "moderate") {
     this.page = page;
@@ -64,7 +81,13 @@ export class EvasionSession {
       return;
     }
 
-    await applyFingerprintHardening(this.page, this.level);
+    if (this.fingerprintHardeningPromise === undefined) {
+      this.fingerprintHardeningPromise = this.enqueue(async () => {
+        await applyFingerprintHardening(this.page, this.level);
+      }, undefined);
+    }
+
+    await this.fingerprintHardeningPromise;
   }
 
   /**
@@ -77,35 +100,57 @@ export class EvasionSession {
    * @param to - Destination coordinate.
    */
   async moveMouse(from: Readonly<Point2D>, to: Readonly<Point2D>): Promise<void> {
-    const path = this.profile.bezierMouseMovement
-      ? computeBezierPath(from, to, { overshootFactor: this.profile.mouseOvershootFactor })
-      : [to];
-    const steps = this.profile.bezierMouseMovement ? 1 : 5;
+    await this.enqueue(async () => {
+      const safeFrom = this.normalizePoint(from);
+      const safeTo = this.normalizePoint(to, safeFrom);
+      const path = this.profile.bezierMouseMovement
+        ? computeBezierPath(safeFrom, safeTo, { overshootFactor: this.profile.mouseOvershootFactor })
+        : [safeTo];
+      const steps = this.profile.bezierMouseMovement ? 1 : 5;
+      let lastPoint = safeFrom;
 
-    for (const point of path) {
-      await this.page.mouse.move(point.x, point.y, { steps });
-    }
+      for (const pointOnPath of path) {
+        const point = this.normalizePoint(pointOnPath, lastPoint);
+        const moved = await this.tryMoveMouse(point, steps);
+        if (!moved) {
+          await this.tryMoveMouse(safeTo, 5);
+          this.setMousePosition(safeTo);
+          return;
+        }
 
-    this.mouseX = to.x;
-    this.mouseY = to.y;
+        lastPoint = point;
+      }
+
+      this.setMousePosition(safeTo);
+    }, undefined);
   }
 
   /**
    * Scroll by `pixels` using momentum simulation when the profile enables it.
    *
+   * Distances are clamped into the supported range to avoid unrealistic jumps
+   * or throwing during recovery paths.
+   *
    * @param pixels - Distance in pixels (positive = down, negative = up).
    */
   async scroll(pixels: number): Promise<void> {
-    if (Math.abs(pixels) > MAX_SCROLL_DISTANCE_PX) {
-      throw new RangeError(`Scroll distance must not exceed ${MAX_SCROLL_DISTANCE_PX}px.`);
-    }
+    await this.enqueue(async () => {
+      const clampedPixels = clamp(
+        normalizeFiniteNumber(pixels, 0),
+        -MAX_SCROLL_DISTANCE_PX,
+        MAX_SCROLL_DISTANCE_PX
+      );
+      if (clampedPixels === 0) {
+        return;
+      }
 
-    if (this.profile.momentumScroll) {
-      await simulateMomentumScroll(this.page, pixels);
-      return;
-    }
+      if (this.profile.momentumScroll) {
+        await simulateMomentumScroll(this.page, clampedPixels);
+        return;
+      }
 
-    await scrollPageBy(this.page, pixels, "smooth");
+      await scrollPageBy(this.page, clampedPixels, "smooth");
+    }, undefined);
   }
 
   /**
@@ -117,24 +162,29 @@ export class EvasionSession {
    * @param durationMs - Idle duration in milliseconds.
    */
   async idle(durationMs: number): Promise<void> {
-    if (durationMs <= 0) {
+    const safeDurationMs = Math.max(0, Math.round(normalizeFiniteNumber(durationMs, 0)));
+    if (safeDurationMs <= 0) {
       return;
     }
 
-    const shouldDrift = this.profile.idleDriftEnabled && this.profile.mouseJitterRadius > 0;
-    if (shouldDrift) {
-      const driftSteps = Math.max(1, Math.floor(durationMs / 300));
-      await simulateIdleDrift(
-        this.page,
-        this.mouseX,
-        this.mouseY,
-        driftSteps,
-        this.profile.mouseJitterRadius
-      );
-      return;
-    }
+    await this.enqueue(async () => {
+      const shouldDrift = this.profile.idleDriftEnabled && this.profile.mouseJitterRadius > 0;
+      if (shouldDrift) {
+        const driftSteps = Math.max(1, Math.floor(safeDurationMs / 300));
+        await simulateIdleDrift(
+          this.page,
+          this.mouseX,
+          this.mouseY,
+          driftSteps,
+          this.profile.mouseJitterRadius
+        );
+        const remainingMs = Math.max(0, safeDurationMs - driftSteps * MIN_IDLE_DRIFT_DELAY_MS);
+        await this.waitForTimeoutSafely(remainingMs);
+        return;
+      }
 
-    await this.page.waitForTimeout(durationMs);
+      await this.waitForTimeoutSafely(safeDurationMs);
+    }, undefined);
   }
 
   /**
@@ -149,7 +199,9 @@ export class EvasionSession {
       return;
     }
 
-    await simulateTabBlurOnPage(this.page, blurDurationMs);
+    await this.enqueue(async () => {
+      await simulateTabBlurOnPage(this.page, blurDurationMs);
+    }, undefined);
   }
 
   /**
@@ -162,7 +214,9 @@ export class EvasionSession {
       return;
     }
 
-    await simulateViewportJitterOnPage(this.page);
+    await this.enqueue(async () => {
+      await simulateViewportJitterOnPage(this.page);
+    }, undefined);
   }
 
   /**
@@ -179,24 +233,30 @@ export class EvasionSession {
       return;
     }
 
-    const pauseMs = computeReadingPauseMs(charCount, this.profile.readingPauseWpm);
-    if (pauseMs > 0) {
-      await this.page.waitForTimeout(pauseMs);
-    }
+    await this.enqueue(async () => {
+      const pauseMs = computeReadingPauseMs(charCount, this.profile.readingPauseWpm);
+      if (pauseMs > 0) {
+        await this.waitForTimeoutSafely(pauseMs);
+      }
+    }, undefined);
   }
 
   /**
    * Sample an interval using the profile's timing strategy.
    *
    * Returns a Poisson-distributed value when `poissonIntervals` is enabled,
-   * otherwise returns `baseMs` unchanged. Use this between any two sequential
-   * actions to add realistic timing variation.
+   * otherwise returns `baseMs` unchanged apart from optional clamping and
+   * rate-limit backoff. Use this between any two sequential actions to add
+   * realistic timing variation.
    *
    * @param baseMs - Base interval in milliseconds.
+   * @param options - Optional bounds and rate-limit hints.
    * @returns Sampled interval in milliseconds.
    */
-  sampleInterval(baseMs: number): number {
-    return this.profile.poissonIntervals ? samplePoissonInterval(baseMs) : baseMs;
+  sampleInterval(baseMs: number, options?: IntervalSampleOptions): number {
+    return this.profile.poissonIntervals
+      ? samplePoissonInterval(baseMs, options)
+      : resolveIntervalMs(baseMs, options);
   }
 
   /**
@@ -206,7 +266,7 @@ export class EvasionSession {
    * CAPTCHAs; callers should pause and alert an operator.
    */
   async detectCaptcha(): Promise<boolean> {
-    return detectCaptchaOnPage(this.page);
+    return this.enqueue(async () => detectCaptchaOnPage(this.page), false);
   }
 
   /**
@@ -215,6 +275,109 @@ export class EvasionSession {
    * Returns CSS selectors of hidden inputs that should NOT be filled.
    */
   async findHoneypotFields(): Promise<readonly string[]> {
-    return findHoneypotFieldsOnPage(this.page);
+    return this.enqueue(async () => findHoneypotFieldsOnPage(this.page), []);
   }
+
+  private enqueue<T>(operation: () => Promise<T>, fallback: T): Promise<T> {
+    const task = this.operationQueue.catch(() => undefined).then(async () => {
+      try {
+        return await operation();
+      } catch {
+        return fallback;
+      }
+    });
+
+    this.operationQueue = task.then(
+      () => undefined,
+      () => undefined
+    );
+
+    return task;
+  }
+
+  private normalizePoint(
+    point: Readonly<Point2D>,
+    fallback: Readonly<Point2D> = ORIGIN_POINT
+  ): Point2D {
+    const normalizedPoint = {
+      x: normalizeFiniteNumber(point.x, fallback.x),
+      y: normalizeFiniteNumber(point.y, fallback.y)
+    };
+
+    return this.clampPointToViewport(normalizedPoint, this.resolveViewportBounds());
+  }
+
+  private resolveViewportBounds(): ViewportBounds | null {
+    const pageWithViewportSize = this.page as PageWithViewportSize;
+    if (typeof pageWithViewportSize.viewportSize !== "function") {
+      return null;
+    }
+
+    try {
+      const viewportSize = pageWithViewportSize.viewportSize();
+      if (!isViewportSize(viewportSize)) {
+        return null;
+      }
+
+      return {
+        width: Math.max(0, viewportSize.width),
+        height: Math.max(0, viewportSize.height)
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private clampPointToViewport(
+    point: Readonly<Point2D>,
+    viewportBounds: ViewportBounds | null
+  ): Point2D {
+    if (viewportBounds === null) {
+      return {
+        x: normalizeFiniteNumber(point.x, 0),
+        y: normalizeFiniteNumber(point.y, 0)
+      };
+    }
+
+    return {
+      x: clamp(point.x, 0, viewportBounds.width),
+      y: clamp(point.y, 0, viewportBounds.height)
+    };
+  }
+
+  private setMousePosition(point: Readonly<Point2D>): void {
+    this.mouseX = point.x;
+    this.mouseY = point.y;
+  }
+
+  private async tryMoveMouse(point: Readonly<Point2D>, steps: number): Promise<boolean> {
+    try {
+      await this.page.mouse.move(point.x, point.y, { steps });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async waitForTimeoutSafely(delayMs: number): Promise<void> {
+    const safeDelayMs = Math.max(0, Math.round(normalizeFiniteNumber(delayMs, 0)));
+    if (safeDelayMs <= 0) {
+      return;
+    }
+
+    try {
+      await this.page.waitForTimeout(safeDelayMs);
+    } catch {
+      // Ignore transient page timing failures.
+    }
+  }
+}
+
+function isViewportSize(value: unknown): value is ViewportBounds {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return isFiniteNumber(record["width"]) && isFiniteNumber(record["height"]);
 }

--- a/packages/core/src/evasion/shared.ts
+++ b/packages/core/src/evasion/shared.ts
@@ -29,6 +29,26 @@ export const HONEYPOT_SELECTORS = [
   "input[aria-hidden='true']"
 ] as const;
 
+export function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+export function normalizeFiniteNumber(value: number, fallback = 0): number {
+  return isFiniteNumber(value) ? value : fallback;
+}
+
 export function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
+  const safeMin = Number.isFinite(min) ? min : Number.NEGATIVE_INFINITY;
+  const safeMax = Number.isFinite(max) ? max : Number.POSITIVE_INFINITY;
+  const lower = Math.min(safeMin, safeMax);
+  const upper = Math.max(safeMin, safeMax);
+  const safeValue = Number.isFinite(value)
+    ? value
+    : value === Number.POSITIVE_INFINITY
+      ? upper
+      : value === Number.NEGATIVE_INFINITY
+        ? lower
+        : lower;
+
+  return Math.min(upper, Math.max(lower, safeValue));
 }

--- a/packages/core/src/evasion/types.ts
+++ b/packages/core/src/evasion/types.ts
@@ -36,6 +36,24 @@ export interface BezierPathOptions {
   seed?: number;
 }
 
+/** Optional guards and backoff hints for sampled action intervals. */
+export interface IntervalSampleOptions {
+  /** Lower bound for the returned interval in milliseconds. */
+  minIntervalMs?: number;
+  /** Upper bound for the returned interval in milliseconds. */
+  maxIntervalMs?: number;
+  /** Existing keep-alive cadence to respect when backing off. */
+  keepAliveIntervalMs?: number;
+  /** Server-provided retry hint in milliseconds, when available. */
+  retryAfterMs?: number;
+  /** Response status associated with the interval, such as `429` or `999`. */
+  responseStatus?: number;
+  /** Explicit rate-limit signal when a response status is unavailable. */
+  rateLimited?: boolean;
+  /** Multiplier applied to the base interval when rate limited. Defaults to `2`. */
+  rateLimitBackoffMultiplier?: number;
+}
+
 /** Configurable detection-evasion parameters. */
 export interface EvasionProfile {
   /** Whether to use cubic Bezier curves instead of straight-line mouse moves. */


### PR DESCRIPTION
## Summary
- harden the evasion helpers to fail open on restricted browser environments, invalid inputs, and partial page states
- serialize session operations, clamp viewport and scroll edge cases, and add rate-limit-aware interval backoff
- freeze evasion profiles and add focused hardening regressions for concurrency, CSP/init-script fallback, selector failures, and keep-alive pacing

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #219