### PR TITLE
fix: polish evasion diagnostics and session reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Default tool-owned state home (profiles, DB, artifacts):
 - `~/.linkedin-assistant/linkedin-owa-agentools`
 - Override with `LINKEDIN_ASSISTANT_HOME=/custom/path`
 - Confirm-failure trace size cap: `LINKEDIN_ASSISTANT_CONFIRM_TRACE_MAX_BYTES` (defaults to `26214400`)
+- Anti-bot evasion profile: `LINKEDIN_ASSISTANT_EVASION_LEVEL` (defaults to `moderate`; supports `minimal`, `moderate`, `paranoid`)
+- Verbose evasion diagnostics: `LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS` (defaults to `false`; when `true`, debug evasion events are written to the run log)
+- See `docs/evasion.md` for the evasion profiles, status output, and diagnostics hooks
 - Selector locale for UI-text fallbacks: `LINKEDIN_ASSISTANT_SELECTOR_LOCALE` (defaults to `en`; supports `en`, `da`; region tags like `da-DK` normalize to `da`; unsupported values fall back to `en` with a warning; see `docs/selector-locale.md`)
 
 Scheduler / scheduled follow-up configuration:
@@ -173,6 +176,43 @@ await hp.type('[role="textbox"]', "Thanks for sharing this update.", {
 See `packages/core/README.md` for more profile examples and
 `docs/human-typing-architecture.md` for the underlying design.
 
+## Anti-bot evasion
+
+The core package ships an opt-in anti-bot evasion module for Playwright pages,
+along with runtime-level status snapshots and debug diagnostics.
+
+Configuration surface:
+
+- default level: `moderate`
+- `LINKEDIN_ASSISTANT_EVASION_LEVEL=minimal|moderate|paranoid`
+- `LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS=true|false`
+- `createCoreRuntime({ evasionLevel, evasionDiagnostics })` for direct Core callers
+
+Diagnostics surface:
+
+- `linkedin status` includes a top-level `evasion` block
+- `linkedin health` includes `session.evasion`
+- read-only status and health checks report the resolved config without injecting synthetic input
+- enabling diagnostics records `evasion.*` events in the run log for easier troubleshooting
+
+```ts
+import { EvasionSession, createCoreRuntime } from "@linkedin-assistant/core";
+
+const runtime = createCoreRuntime({
+  evasionLevel: "paranoid",
+  evasionDiagnostics: true
+});
+
+const session = new EvasionSession(page, runtime.evasion.level, {
+  diagnosticsEnabled: runtime.evasion.diagnosticsEnabled,
+  diagnosticsLabel: "feed",
+  logger: runtime.logger
+});
+```
+
+See `docs/evasion.md` for the profile matrix, CLI/MCP diagnostics notes, and
+API examples.
+
 ## Selector Locale Support
 
 Locale-aware selectors let the runtime prefer localized LinkedIn UI phrases
@@ -208,8 +248,11 @@ Run commands via workspace binaries:
 
 ```bash
 npm exec -w @linkedin-assistant/cli -- linkedin status --profile default
+npm exec -w @linkedin-assistant/cli -- linkedin health --profile default
 npm exec -w @linkedin-assistant/cli -- linkedin login --profile default --timeout-minutes 10
 ```
+
+- `linkedin status` and `linkedin health` now include the resolved anti-bot evasion snapshot in their JSON output so you can confirm the active level, enabled features, and diagnostics flag before reproducing session issues.
 
 Isolation note:
 

--- a/docs/evasion.md
+++ b/docs/evasion.md
@@ -1,0 +1,85 @@
+# Anti-bot evasion
+
+The anti-bot evasion module adds opt-in behavioral pacing, browser-signal hardening,
+and developer-facing diagnostics for Playwright-driven LinkedIn flows.
+
+## Defaults
+
+The default evasion level is `moderate`.
+
+Available profiles:
+
+- `minimal` keeps behavioral and fingerprint simulation disabled for deterministic
+  development and test flows.
+- `moderate` enables Bezier mouse movement, momentum scroll, idle drift,
+  reading pauses, Poisson timing, and fingerprint hardening.
+- `paranoid` enables the `moderate` profile plus synthetic tab blur and
+  viewport resize signals with stronger cursor jitter.
+
+## Configuration
+
+Runtime callers can override the defaults through `createCoreRuntime()`:
+
+```ts
+import { createCoreRuntime } from "@linkedin-assistant/core";
+
+const runtime = createCoreRuntime({
+  evasionLevel: "paranoid",
+  evasionDiagnostics: true
+});
+```
+
+Shell and CLI users can configure the same defaults with environment variables:
+
+- `LINKEDIN_ASSISTANT_EVASION_LEVEL=minimal|moderate|paranoid`
+- `LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS=true|false`
+
+`LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS` defaults to `false`, so debug evasion
+logs stay quiet unless you opt in.
+
+## Status and health output
+
+The resolved evasion configuration is surfaced in both CLI and MCP status flows:
+
+- `linkedin status` includes a top-level `evasion` block.
+- `linkedin health` includes `session.evasion`.
+- MCP `linkedin.session.status` includes `status.evasion`.
+- MCP `linkedin.session.health` includes `session.evasion`.
+
+These read-only status and health checks report the resolved configuration for
+diagnostics, but they do not inject synthetic input or fingerprint hardening into
+the inspected page.
+
+## Session diagnostics
+
+`EvasionSession` accepts optional diagnostics controls so callers can trace the
+important moments without adding noise by default:
+
+```ts
+import { EvasionSession, createCoreRuntime } from "@linkedin-assistant/core";
+
+const runtime = createCoreRuntime({
+  evasionLevel: "moderate",
+  evasionDiagnostics: true
+});
+
+const session = new EvasionSession(page, runtime.evasion.level, {
+  diagnosticsEnabled: runtime.evasion.diagnosticsEnabled,
+  diagnosticsLabel: "feed",
+  logger: runtime.logger
+});
+
+await session.hardenFingerprint();
+await session.moveMouse({ x: 0, y: 0 }, { x: 200, y: 120 });
+await session.scroll(300);
+```
+
+When diagnostics are enabled, the run log records high-signal events such as:
+
+- session creation and fingerprint hardening
+- clamped scroll distances and rate-limit-aware interval sampling
+- detected CAPTCHA or honeypot signals
+- fail-open recoveries like rejected mouse moves or timer calls
+
+That makes it easier to understand what the evasion layer attempted without
+forcing noisy output into normal CLI runs.

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -22,6 +22,8 @@ import {
   ACTIVITY_WATCH_KINDS,
   ACTIVITY_WATCH_STATUSES,
   DEFAULT_FOLLOWUP_SINCE,
+  LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS_ENV,
+  LINKEDIN_ASSISTANT_EVASION_LEVEL_ENV,
   LINKEDIN_ASSISTANT_SELECTOR_LOCALE_ENV,
   AssistantDatabase,
   alignToBusinessHours,
@@ -1763,9 +1765,11 @@ async function runStatus(profileName: string, cdpUrl?: string): Promise<void> {
     const status = await runtime.auth.status({ profileName });
     runtime.logger.log("info", "cli.status.done", {
       profileName,
-      authenticated: status.authenticated
+      authenticated: status.authenticated,
+      evasion_level: status.evasion?.level,
+      evasion_diagnostics_enabled: status.evasion?.diagnosticsEnabled ?? false
     });
-    printJson({ run_id: runtime.runId, ...status });
+    printJson({ run_id: runtime.runId, profile_name: profileName, ...status });
   } finally {
     runtime.close();
   }
@@ -5710,6 +5714,16 @@ export function createCliProgram(): Command {
     .command("status")
     .description("Check whether the persistent LinkedIn profile is authenticated")
     .option("-p, --profile <profile>", "Profile name", "default")
+    .addHelpText(
+      "after",
+      [
+        "",
+        "Diagnostics:",
+        "  - output includes an evasion block with the resolved level, enabled features, and diagnostics flag",
+        `  - ${LINKEDIN_ASSISTANT_EVASION_LEVEL_ENV}=minimal|moderate|paranoid sets the default anti-bot profile`,
+        `  - ${LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS_ENV}=true records debug evasion events in the run log`
+      ].join("\n")
+    )
     .action(async (options: { profile: string }) => {
       await runStatus(options.profile, readCdpUrl());
     });
@@ -7534,11 +7548,31 @@ export function createCliProgram(): Command {
     .command("health")
     .description("Check browser and LinkedIn session health")
     .option("-p, --profile <profile>", "Profile name", "default")
+    .addHelpText(
+      "after",
+      [
+        "",
+        "Diagnostics:",
+        "  - output includes session.evasion with the resolved anti-bot profile and diagnostics status",
+        `  - ${LINKEDIN_ASSISTANT_EVASION_LEVEL_ENV}=minimal|moderate|paranoid selects the default anti-bot profile`,
+        `  - ${LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS_ENV}=true records debug evasion events in the run log`
+      ].join("\n")
+    )
     .action(async (options: { profile: string }) => {
       const runtime = createRuntime(readCdpUrl());
       try {
+        runtime.logger.log("info", "cli.health.start", {
+          profileName: options.profile
+        });
         const health = await runtime.healthCheck({ profileName: options.profile });
-        printJson({ run_id: runtime.runId, ...health });
+        runtime.logger.log("info", "cli.health.done", {
+          profileName: options.profile,
+          browser_healthy: health.browser.healthy,
+          authenticated: health.session.authenticated,
+          evasion_level: health.session.evasion.level,
+          evasion_diagnostics_enabled: health.session.evasion.diagnosticsEnabled
+        });
+        printJson({ run_id: runtime.runId, profile_name: options.profile, ...health });
         if (!health.browser.healthy || !health.session.authenticated) {
           process.exitCode = 1;
         }

--- a/packages/cli/test/evasionCli.test.ts
+++ b/packages/cli/test/evasionCli.test.ts
@@ -1,0 +1,181 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const evasionCliMocks = vi.hoisted(() => ({
+  authStatus: vi.fn(async () => ({
+    authenticated: true,
+    checkedAt: "2026-03-10T09:00:00.000Z",
+    currentUrl: "https://www.linkedin.com/feed/",
+    evasion: {
+      diagnosticsEnabled: true,
+      disabledFeatures: ["tab_blur_simulation", "viewport_resize_simulation"],
+      enabledFeatures: [
+        "bezier_mouse_movement",
+        "momentum_scroll",
+        "idle_drift",
+        "reading_pauses",
+        "poisson_timing",
+        "fingerprint_hardening"
+      ],
+      level: "moderate",
+      profile: {
+        bezierMouseMovement: true,
+        fingerprintHardening: true,
+        idleDriftEnabled: true,
+        momentumScroll: true,
+        mouseJitterRadius: 3,
+        mouseOvershootFactor: 0.15,
+        poissonIntervals: true,
+        readingPauseWpm: 230,
+        simulateTabBlur: false,
+        simulateViewportResize: false
+      },
+      source: "env",
+      summary:
+        "Moderate evasion enables Bezier mouse movement, momentum scroll, idle drift, reading pauses, Poisson timing, and fingerprint hardening."
+    },
+    reason: "LinkedIn session appears authenticated.",
+    sessionCookiePresent: true
+  })),
+  close: vi.fn(),
+  createCoreRuntime: vi.fn(() => ({
+    auth: { status: evasionCliMocks.authStatus },
+    close: evasionCliMocks.close,
+    healthCheck: evasionCliMocks.healthCheck,
+    logger: { log: evasionCliMocks.loggerLog },
+    runId: "run-evasion-cli"
+  })),
+  healthCheck: vi.fn(async () => ({
+    browser: {
+      browserConnected: true,
+      checkedAt: "2026-03-10T09:00:00.000Z",
+      healthy: true,
+      pageResponsive: true
+    },
+    session: {
+      authenticated: true,
+      checkedAt: "2026-03-10T09:00:00.000Z",
+      checkpointDetected: false,
+      cookieExpiringSoon: false,
+      currentUrl: "https://www.linkedin.com/feed/",
+      evasion: {
+        diagnosticsEnabled: false,
+        disabledFeatures: ["tab_blur_simulation", "viewport_resize_simulation"],
+        enabledFeatures: [
+          "bezier_mouse_movement",
+          "momentum_scroll",
+          "idle_drift",
+          "reading_pauses",
+          "poisson_timing",
+          "fingerprint_hardening"
+        ],
+        level: "moderate",
+        profile: {
+          bezierMouseMovement: true,
+          fingerprintHardening: true,
+          idleDriftEnabled: true,
+          momentumScroll: true,
+          mouseJitterRadius: 3,
+          mouseOvershootFactor: 0.15,
+          poissonIntervals: true,
+          readingPauseWpm: 230,
+          simulateTabBlur: false,
+          simulateViewportResize: false
+        },
+        source: "default",
+        summary:
+          "Moderate evasion enables Bezier mouse movement, momentum scroll, idle drift, reading pauses, Poisson timing, and fingerprint hardening."
+      },
+      loginWallDetected: false,
+      nextCookieExpiryAt: null,
+      rateLimited: false,
+      reason: "LinkedIn session appears authenticated.",
+      sessionCookieFingerprint: "health-evasion-fingerprint",
+      sessionCookiePresent: true,
+      sessionCookies: []
+    }
+  })),
+  loggerLog: vi.fn()
+}));
+
+vi.mock("@linkedin-assistant/core", async () => {
+  const actual = await import("../../core/src/index.js");
+  return {
+    ...actual,
+    createCoreRuntime: evasionCliMocks.createCoreRuntime
+  };
+});
+
+import { runCli } from "../src/bin/linkedin.js";
+
+describe("CLI evasion diagnostics output", () => {
+  let tempDir = "";
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutChunks: string[] = [];
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-cli-evasion-"));
+    process.env.LINKEDIN_ASSISTANT_HOME = path.join(tempDir, "assistant-home");
+    process.exitCode = undefined;
+    stdoutChunks = [];
+    vi.clearAllMocks();
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation((value?: unknown) => {
+      stdoutChunks.push(String(value ?? ""));
+    });
+  });
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore();
+    process.exitCode = undefined;
+    delete process.env.LINKEDIN_ASSISTANT_HOME;
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("includes evasion details in status output", async () => {
+    await runCli(["node", "linkedin", "status", "--profile", "smoke"]);
+
+    const output = JSON.parse(stdoutChunks.join("\n")) as {
+      evasion: {
+        diagnosticsEnabled: boolean;
+        level: string;
+        source: string;
+      };
+      profile_name: string;
+      run_id: string;
+    };
+
+    expect(output.profile_name).toBe("smoke");
+    expect(output.run_id).toBe("run-evasion-cli");
+    expect(output.evasion).toMatchObject({
+      diagnosticsEnabled: true,
+      level: "moderate",
+      source: "env"
+    });
+  });
+
+  it("includes session evasion details in health output", async () => {
+    await runCli(["node", "linkedin", "health", "--profile", "smoke"]);
+
+    const output = JSON.parse(stdoutChunks.join("\n")) as {
+      profile_name: string;
+      run_id: string;
+      session: {
+        evasion: {
+          diagnosticsEnabled: boolean;
+          level: string;
+          source: string;
+        };
+      };
+    };
+
+    expect(output.profile_name).toBe("smoke");
+    expect(output.run_id).toBe("run-evasion-cli");
+    expect(output.session.evasion).toMatchObject({
+      diagnosticsEnabled: false,
+      level: "moderate",
+      source: "default"
+    });
+  });
+});

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -132,6 +132,45 @@ await hp.type('input[name="password"]', password, {
 });
 ```
 
+## Anti-bot evasion
+
+`@linkedin-assistant/core` exports an anti-bot evasion module that can be used
+independently or alongside `createCoreRuntime()`.
+
+Key entry points:
+
+- `EvasionSession` for page-level behavioral helpers and optional diagnostics
+- `DEFAULT_EVASION_LEVEL`, `EVASION_LEVELS`, and `EVASION_PROFILES` for profile selection
+- `createEvasionStatus()` and `resolveEvasionConfig()` for resolved config snapshots
+
+Example:
+
+```ts
+import { EvasionSession, createCoreRuntime } from "@linkedin-assistant/core";
+
+const runtime = createCoreRuntime({
+  evasionLevel: "moderate",
+  evasionDiagnostics: true
+});
+
+const session = new EvasionSession(page, runtime.evasion.level, {
+  diagnosticsEnabled: runtime.evasion.diagnosticsEnabled,
+  diagnosticsLabel: "message-compose",
+  logger: runtime.logger
+});
+
+await session.hardenFingerprint();
+await session.moveMouse({ x: 0, y: 0 }, { x: 240, y: 140 });
+await session.scroll(320);
+```
+
+Use `runtime.evasion.summary` for a human-readable snapshot, and inspect
+`linkedin status`, `linkedin health`, `linkedin.session.status`, or
+`linkedin.session.health` when you want to confirm the resolved runtime config.
+
+See `../../docs/evasion.md` for the environment variables, profile behavior,
+and diagnostics guidance.
+
 ## Tier 3 write validation
 
 Tier 3 live write validation is exported from the core package through

--- a/packages/core/src/__tests__/config.test.ts
+++ b/packages/core/src/__tests__/config.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { resolveActivityWebhookConfig } from "../config.js";
+import {
+  LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS_ENV,
+  LINKEDIN_ASSISTANT_EVASION_LEVEL_ENV,
+  resolveActivityWebhookConfig,
+  resolveEvasionConfig
+} from "../config.js";
 import { LinkedInAssistantError } from "../errors.js";
 
 const ACTIVITY_ENV_KEYS = [
@@ -15,13 +20,32 @@ const ACTIVITY_ENV_KEYS = [
   "LINKEDIN_ASSISTANT_ACTIVITY_WATCH_LEASE_SECONDS"
 ] as const;
 
+const EVASION_ENV_KEYS = [
+  LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS_ENV,
+  LINKEDIN_ASSISTANT_EVASION_LEVEL_ENV
+] as const;
+
 const ORIGINAL_ACTIVITY_ENV = new Map(
   ACTIVITY_ENV_KEYS.map((key) => [key, process.env[key]] as const)
+);
+const ORIGINAL_EVASION_ENV = new Map(
+  EVASION_ENV_KEYS.map((key) => [key, process.env[key]] as const)
 );
 
 function restoreActivityEnv(): void {
   for (const key of ACTIVITY_ENV_KEYS) {
     const originalValue = ORIGINAL_ACTIVITY_ENV.get(key);
+    if (originalValue === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = originalValue;
+    }
+  }
+}
+
+function restoreEvasionEnv(): void {
+  for (const key of EVASION_ENV_KEYS) {
+    const originalValue = ORIGINAL_EVASION_ENV.get(key);
     if (originalValue === undefined) {
       delete process.env[key];
     } else {
@@ -43,6 +67,7 @@ function captureLinkedInError(action: () => unknown): LinkedInAssistantError {
 
 afterEach(() => {
   restoreActivityEnv();
+  restoreEvasionEnv();
 });
 
 describe("resolveActivityWebhookConfig", () => {
@@ -139,5 +164,70 @@ describe("resolveActivityWebhookConfig", () => {
       example: "LINKEDIN_ASSISTANT_ACTIVITY_MAX_BACKOFF_SECONDS=90"
     });
     expect(String(error.details.suggestion)).toContain("at least 90");
+  });
+});
+
+describe("resolveEvasionConfig", () => {
+  it("returns the documented defaults when no overrides are configured", () => {
+    expect(resolveEvasionConfig()).toMatchObject({
+      diagnosticsEnabled: false,
+      enabledFeatures: [
+        "bezier_mouse_movement",
+        "momentum_scroll",
+        "idle_drift",
+        "reading_pauses",
+        "poisson_timing",
+        "fingerprint_hardening"
+      ],
+      level: "moderate",
+      source: "default"
+    });
+  });
+
+  it("parses env overrides for the evasion level and diagnostics flag", () => {
+    process.env[LINKEDIN_ASSISTANT_EVASION_LEVEL_ENV] = "paranoid";
+    process.env[LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS_ENV] = "true";
+
+    expect(resolveEvasionConfig()).toMatchObject({
+      diagnosticsEnabled: true,
+      enabledFeatures: expect.arrayContaining([
+        "tab_blur_simulation",
+        "viewport_resize_simulation"
+      ]),
+      level: "paranoid",
+      source: "env"
+    });
+  });
+
+  it("rejects invalid env evasion levels with a concrete example", () => {
+    process.env[LINKEDIN_ASSISTANT_EVASION_LEVEL_ENV] = "aggressive";
+
+    const error = captureLinkedInError(() => resolveEvasionConfig());
+
+    expect(error.message).toBe(
+      "LINKEDIN_ASSISTANT_EVASION_LEVEL must be one of minimal, moderate, paranoid. Unset it to use the default value."
+    );
+    expect(error.details).toMatchObject({
+      default_value: "moderate",
+      env: LINKEDIN_ASSISTANT_EVASION_LEVEL_ENV,
+      example: `${LINKEDIN_ASSISTANT_EVASION_LEVEL_ENV}=paranoid`,
+      value: "aggressive"
+    });
+    expect(String(error.details.suggestion)).toContain("minimal");
+  });
+
+  it("rejects malformed diagnostics booleans with clear guidance", () => {
+    process.env[LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS_ENV] = "verbose";
+
+    const error = captureLinkedInError(() => resolveEvasionConfig());
+
+    expect(error.message).toBe(
+      "LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS must use a boolean value: 1, 0, true, false, yes, no, on, or off. Unset it to use the default value."
+    );
+    expect(error.details).toMatchObject({
+      default_value: "false",
+      env: LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS_ENV,
+      example: `${LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS_ENV}=true`
+    });
   });
 });

--- a/packages/core/src/__tests__/evasion.diagnostics.test.ts
+++ b/packages/core/src/__tests__/evasion.diagnostics.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import type { EvasionLevel } from "../evasion.js";
+import { EvasionSession } from "../evasion.js";
+import { createPageMock } from "./evasionTestUtils.js";
+
+describe("evasion diagnostics", () => {
+  it("throws a clear error when JS callers pass an unsupported evasion level", () => {
+    const { page } = createPageMock();
+
+    expect(
+      () =>
+        new EvasionSession(
+          page,
+          "aggressive" as unknown as EvasionLevel
+        )
+    ).toThrowError("EvasionSession level must be one of minimal, moderate, paranoid.");
+  });
+
+  it("logs fail-open recovery paths when diagnostics are enabled", async () => {
+    const { page } = createPageMock({
+      mouseMoveError: new Error("move blocked"),
+      waitForTimeoutError: new Error("timer blocked")
+    });
+    const logger = {
+      log: vi.fn()
+    };
+
+    const session = new EvasionSession(page, "minimal", {
+      diagnosticsEnabled: true,
+      diagnosticsLabel: "fallback",
+      logger
+    });
+
+    await session.moveMouse({ x: 0, y: 0 }, { x: 50, y: 20 });
+    await session.idle(120);
+
+    expect(logger.log).toHaveBeenCalledWith(
+      "debug",
+      "evasion.session.mouse_move.failed",
+      expect.objectContaining({
+        diagnostics_label: "fallback",
+        error_message: "move blocked",
+        evasion_level: "minimal"
+      })
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      "debug",
+      "evasion.session.wait_for_timeout.failed",
+      expect.objectContaining({
+        diagnostics_label: "fallback",
+        delay_ms: 120,
+        error_message: "timer blocked",
+        evasion_level: "minimal"
+      })
+    );
+  });
+
+  it("emits opt-in debug diagnostics for important session operations", async () => {
+    const { page, locatorCounts } = createPageMock({
+      includeAddInitScript: true,
+      viewportSize: { width: 1280, height: 720 }
+    });
+    const logger = {
+      log: vi.fn()
+    };
+
+    locatorCounts.set("[class*='captcha' i]", 1);
+    locatorCounts.set("input[tabindex='-1']", 1);
+
+    const session = new EvasionSession(page, "paranoid", {
+      diagnosticsEnabled: true,
+      diagnosticsLabel: "smoke",
+      logger
+    });
+
+    await session.hardenFingerprint();
+    await session.readingPause(400);
+    await session.simulateTabSwitch(200);
+    await session.simulateViewportJitter();
+    session.sampleInterval(500, { rateLimited: true, responseStatus: 429 });
+    expect(await session.detectCaptcha()).toBe(true);
+    expect(await session.findHoneypotFields()).toContain("input[tabindex='-1']");
+
+    const events = logger.log.mock.calls.map((call) => call[1]);
+
+    expect(events).toEqual(
+      expect.arrayContaining([
+        "evasion.session.created",
+        "evasion.session.fingerprint_hardening.applied",
+        "evasion.session.reading_pause.applied",
+        "evasion.session.tab_switch.simulated",
+        "evasion.session.viewport_jitter.simulated",
+        "evasion.session.interval.sampled",
+        "evasion.session.captcha.detected",
+        "evasion.session.honeypots.detected"
+      ])
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      "debug",
+      "evasion.session.captcha.detected",
+      expect.objectContaining({
+        diagnostics_label: "smoke",
+        evasion_level: "paranoid"
+      })
+    );
+  });
+});

--- a/packages/core/src/__tests__/evasion.types.test.ts
+++ b/packages/core/src/__tests__/evasion.types.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { EVASION_PROFILES } from "../evasion/profiles.js";
+import { EVASION_LEVELS, EVASION_PROFILES } from "../evasion.js";
 
-const EVASION_LEVELS = ["minimal", "moderate", "paranoid"] as const;
 const EVASION_PROFILE_KEYS = [
   "bezierMouseMovement",
   "mouseOvershootFactor",

--- a/packages/core/src/__tests__/healthCheck.test.ts
+++ b/packages/core/src/__tests__/healthCheck.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Browser, BrowserContext, Locator, Page } from "playwright-core";
+import { resolveEvasionConfig } from "../config.js";
 import { checkBrowserHealth, checkLinkedInSession } from "../healthCheck.js";
 
 function createMockPage(opts: {
@@ -138,6 +139,11 @@ describe("checkLinkedInSession", () => {
     expect(status.currentUrl).toContain("/feed");
     expect(status.loginWallDetected).toBe(false);
     expect(status.reason).toContain("authenticated");
+    expect(status.evasion).toMatchObject({
+      diagnosticsEnabled: false,
+      level: "moderate",
+      source: "default"
+    });
     expect(status.sessionCookiePresent).toBe(false);
   });
 
@@ -190,5 +196,24 @@ describe("checkLinkedInSession", () => {
     expect(status.sessionCookieFingerprint).toMatch(/^[a-f0-9]{64}$/u);
     expect(status.sessionCookiePresent).toBe(true);
     expect(status.sessionCookies).toHaveLength(1);
+  });
+
+  it("propagates the runtime evasion snapshot into health output", async () => {
+    const page = createMockPage({
+      url: "https://www.linkedin.com/feed/",
+      isVisible: (selector) => selector === "nav.global-nav"
+    });
+    const context = createMockContext({
+      connected: true,
+      pages: [page]
+    });
+    const evasion = resolveEvasionConfig({
+      diagnosticsEnabled: true,
+      level: "paranoid"
+    });
+
+    const status = await checkLinkedInSession(context, { evasion });
+
+    expect(status.evasion).toBe(evasion);
   });
 });

--- a/packages/core/src/__tests__/sessionAuth.test.ts
+++ b/packages/core/src/__tests__/sessionAuth.test.ts
@@ -144,6 +144,11 @@ describe("LinkedInAuthService auth flow", () => {
     const status = await auth.status({ profileName: "default" });
 
     expect(status.authenticated).toBe(true);
+    expect(status.evasion).toMatchObject({
+      diagnosticsEnabled: false,
+      level: "moderate",
+      source: "default"
+    });
     expect(status.rateLimitActive).toBeUndefined();
     expect(rateLimitStateMocks.clearRateLimitState).toHaveBeenCalledTimes(1);
   });

--- a/packages/core/src/auth/session.ts
+++ b/packages/core/src/auth/session.ts
@@ -1,4 +1,5 @@
 import type { BrowserContext, Page } from "playwright-core";
+import { resolveEvasionConfig, type EvasionConfig } from "../config.js";
 import { LinkedInAssistantError } from "../errors.js";
 import { attachHumanizeLogger, detachHumanizeLogger, humanize } from "../humanize.js";
 import type { JsonEventLogger } from "../logging.js";
@@ -18,11 +19,14 @@ import {
   type RateLimitState
 } from "./rateLimitState.js";
 
+/** Authentication snapshot for a LinkedIn browser profile. */
 export interface SessionStatus {
   authenticated: boolean;
   checkedAt: string;
   checkpointDetected?: boolean;
   currentUrl: string;
+  /** Resolved anti-bot evasion status when available. */
+  evasion?: EvasionConfig;
   loginWallDetected?: boolean;
   reason: string;
   rateLimitActive?: boolean;
@@ -31,20 +35,24 @@ export interface SessionStatus {
   sessionCookiePresent?: boolean;
 }
 
+/** Common profile/session options accepted by auth helpers. */
 export interface SessionOptions {
   profileName?: string;
   cdpUrl?: string | undefined;
 }
 
+/** Options for the interactive open-login poll loop. */
 export interface OpenLoginOptions extends SessionOptions {
   timeoutMs?: number;
   pollIntervalMs?: number;
 }
 
+/** Result returned by the interactive open-login flow. */
 export interface OpenLoginResult extends SessionStatus {
   timedOut: boolean;
 }
 
+/** Options for the headless credential-based login flow. */
 export interface HeadlessLoginOptions extends SessionOptions {
   email: string;
   password: string;
@@ -57,6 +65,7 @@ export interface HeadlessLoginOptions extends SessionOptions {
   retryBaseDelayMs?: number;
 }
 
+/** Result returned by the headless credential-based login flow. */
 export interface HeadlessLoginResult extends SessionStatus {
   timedOut: boolean;
   checkpoint: boolean;
@@ -98,9 +107,11 @@ export class LinkedInAuthService {
     private readonly cdpUrl?: string,
     private readonly selectorLocale: LinkedInSelectorLocale =
       DEFAULT_LINKEDIN_SELECTOR_LOCALE,
-    private readonly logger?: Pick<JsonEventLogger, "log">
+    private readonly logger?: Pick<JsonEventLogger, "log">,
+    private readonly evasion: EvasionConfig = resolveEvasionConfig()
   ) {}
 
+  /** Checks whether the profile currently looks authenticated to LinkedIn. */
   async status(options: SessionOptions = {}): Promise<SessionStatus> {
     const profileName = options.profileName ?? "default";
     const cdpUrl = options.cdpUrl ?? this.cdpUrl;
@@ -127,22 +138,62 @@ export class LinkedInAuthService {
     );
 
     if (status.authenticated) {
-      return status;
+      const resolvedStatus = {
+        ...status,
+        evasion: this.evasion
+      };
+      this.logger?.log("debug", "auth.session.status.checked", {
+        authenticated: true,
+        current_url: status.currentUrl,
+        evasion_level: this.evasion.level,
+        profileName,
+        reason: status.reason
+      });
+
+      return resolvedStatus;
     }
 
     const cooldown = await isInRateLimitCooldown();
     if (cooldown.active && cooldown.state) {
-      return {
+      const resolvedStatus = {
         ...status,
+        evasion: this.evasion,
         reason: `${status.reason} Rate-limit cooldown is active until ${cooldown.state.rateLimitedUntil}.`,
         rateLimitActive: true,
         rateLimitUntil: cooldown.state.rateLimitedUntil
       };
+
+      this.logger?.log("debug", "auth.session.status.checked", {
+        authenticated: false,
+        checkpoint_detected: status.checkpointDetected ?? false,
+        current_url: status.currentUrl,
+        evasion_level: this.evasion.level,
+        profileName,
+        rate_limit_active: true,
+        reason: resolvedStatus.reason
+      });
+
+      return resolvedStatus;
     }
 
-    return status;
+    const resolvedStatus = {
+      ...status,
+      evasion: this.evasion
+    };
+    this.logger?.log("debug", "auth.session.status.checked", {
+      authenticated: false,
+      checkpoint_detected: status.checkpointDetected ?? false,
+      current_url: status.currentUrl,
+      evasion_level: this.evasion.level,
+      profileName,
+      rate_limit_active: false,
+      reason: status.reason
+    });
+
+    return resolvedStatus;
   }
 
+  /** Throws a structured error when the session is not currently authenticated. */
   async ensureAuthenticated(options: SessionOptions = {}): Promise<SessionStatus> {
     const status = await this.status(options);
 
@@ -155,6 +206,14 @@ export class LinkedInAuthService {
       const guidance = status.rateLimitActive
         ? `Wait for cooldown expiry (${status.rateLimitUntil}) or clear it with "linkedin rate-limit --clear".`
         : `Run "linkedin login --profile ${options.profileName ?? "default"}" first.`;
+      this.logger?.log("warn", "auth.session.ensure_authenticated.failed", {
+        code,
+        current_url: status.currentUrl,
+        evasion_level: status.evasion?.level,
+        profileName: options.profileName ?? "default",
+        rate_limit_active: status.rateLimitActive ?? false,
+        reason: status.reason
+      });
       throw new LinkedInAssistantError(
         code,
         `${status.reason} ${guidance}`,
@@ -162,6 +221,7 @@ export class LinkedInAuthService {
           profile_name: options.profileName ?? "default",
           current_url: status.currentUrl,
           checked_at: status.checkedAt,
+          ...(status.evasion ? { evasion_level: status.evasion.level } : {}),
           rate_limit_active: status.rateLimitActive ?? false,
           ...(status.rateLimitUntil
             ? { rate_limit_until: status.rateLimitUntil }
@@ -173,6 +233,7 @@ export class LinkedInAuthService {
     return status;
   }
 
+  /** Runs the headless login flow and optionally retries rate-limit checkpoints. */
   async headlessLogin(options: HeadlessLoginOptions): Promise<HeadlessLoginResult> {
     const cooldown = await isInRateLimitCooldown();
     if (cooldown.active && cooldown.state) {
@@ -180,6 +241,7 @@ export class LinkedInAuthService {
         authenticated: false,
         checkedAt: new Date().toISOString(),
         currentUrl: "N/A (skipped — rate limit cooldown)",
+        evasion: this.evasion,
         reason: `Skipped — rate limit cooldown active until ${cooldown.state.rateLimitedUntil}`,
         timedOut: false,
         checkpoint: false,
@@ -192,7 +254,10 @@ export class LinkedInAuthService {
     const maxRetries = options.maxRetries ?? 3;
     const retryBaseDelayMs = options.retryBaseDelayMs ?? 30_000;
 
-    let result = await this.performHeadlessLogin(options);
+    let result = {
+      ...(await this.performHeadlessLogin(options)),
+      evasion: this.evasion
+    };
     if (!retryOnRateLimit || result.checkpointType !== "rate_limited") {
       return result;
     }
@@ -201,7 +266,10 @@ export class LinkedInAuthService {
       const backoffMs = retryBaseDelayMs * 2 ** (attempt - 1) + Math.random() * 5_000;
       await sleep(backoffMs);
 
-      result = await this.performHeadlessLogin(options);
+      result = {
+        ...(await this.performHeadlessLogin(options)),
+        evasion: this.evasion
+      };
       if (result.checkpointType !== "rate_limited") {
         return result;
       }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -9,6 +9,14 @@ import {
   type LinkedInSelectorLocaleResolution,
   type LinkedInSelectorLocale
 } from "./selectorLocale.js";
+import {
+  createEvasionStatus,
+  DEFAULT_EVASION_LEVEL,
+  EVASION_LEVELS,
+  resolveEvasionLevel,
+  type EvasionLevel,
+  type EvasionStatus
+} from "./evasion.js";
 import { LinkedInAssistantError } from "./errors.js";
 
 /**
@@ -41,6 +49,17 @@ export const DEFAULT_CONFIRM_TRACE_MAX_BYTES = 25 * 1024 * 1024;
 export interface ConfirmFailureArtifactConfig {
   traceMaxBytes: number;
 }
+
+/** Environment variable that configures the default anti-bot evasion level. */
+export const LINKEDIN_ASSISTANT_EVASION_LEVEL_ENV =
+  "LINKEDIN_ASSISTANT_EVASION_LEVEL";
+
+/** Environment variable that enables verbose evasion diagnostics in run logs. */
+export const LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS_ENV =
+  "LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS";
+
+/** Resolved evasion configuration shared across runtime/session diagnostics. */
+export type EvasionConfig = EvasionStatus;
 
 /**
  * Scheduler lane names accepted by config validation.
@@ -342,6 +361,25 @@ function invalidActivityWebhookConfig(
   );
 }
 
+function invalidEvasionConfig(
+  message: string,
+  details: Record<string, unknown>
+): LinkedInAssistantError {
+  const env = typeof details.env === "string" ? details.env : undefined;
+  const guidance = env ? EVASION_ENV_GUIDANCE[env] : undefined;
+
+  return new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    message,
+    {
+      ...details,
+      ...(guidance ? { default_value: guidance.defaultValue } : {}),
+      ...(guidance ? { example: `${env}=${guidance.exampleValue}` } : {}),
+      ...(guidance ? { suggestion: guidance.suggestion } : {})
+    }
+  );
+}
+
 const ACTIVITY_WEBHOOK_ENV_GUIDANCE: Record<
   string,
   {
@@ -433,6 +471,28 @@ const ACTIVITY_WEBHOOK_ENV_GUIDANCE: Record<
     exampleValue: "3600",
     suggestion:
       "Use a whole-number maximum backoff in seconds that is greater than or equal to the initial backoff."
+  }
+};
+
+const EVASION_ENV_GUIDANCE: Record<
+  string,
+  {
+    defaultValue: string;
+    exampleValue: string;
+    suggestion: string;
+  }
+> = {
+  [LINKEDIN_ASSISTANT_EVASION_LEVEL_ENV]: {
+    defaultValue: DEFAULT_EVASION_LEVEL,
+    exampleValue: "paranoid",
+    suggestion:
+      "Use minimal for deterministic development and tests, moderate for the default balance, or paranoid for the fullest anti-bot profile."
+  },
+  [LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS_ENV]: {
+    defaultValue: "false",
+    exampleValue: "true",
+    suggestion:
+      "Use true to record debug evasion diagnostics in the run log, or unset the variable to restore the default quiet mode."
   }
 };
 
@@ -711,6 +771,65 @@ export function resolveConfirmFailureArtifactConfig(): ConfirmFailureArtifactCon
       DEFAULT_CONFIRM_TRACE_MAX_BYTES
     )
   };
+}
+
+/**
+ * Resolves the effective anti-bot evasion configuration from runtime options
+ * and environment variables.
+ */
+export function resolveEvasionConfig(options: {
+  diagnosticsEnabled?: boolean;
+  level?: string | EvasionLevel;
+} = {}): EvasionConfig {
+  const rawLevel =
+    typeof options.level === "string"
+      ? options.level
+      : process.env[LINKEDIN_ASSISTANT_EVASION_LEVEL_ENV];
+  const source =
+    typeof options.level === "string"
+      ? "option"
+      : typeof process.env[LINKEDIN_ASSISTANT_EVASION_LEVEL_ENV] === "string"
+        ? "env"
+        : "default";
+  const diagnosticsEnabled =
+    typeof options.diagnosticsEnabled === "boolean"
+      ? options.diagnosticsEnabled
+      : parseStrictBoolean(
+          process.env[LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS_ENV],
+          false,
+          LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS_ENV,
+          invalidEvasionConfig
+        );
+
+  let level: EvasionLevel;
+  try {
+    level = resolveEvasionLevel(
+      rawLevel,
+      source === "option"
+        ? "evasionLevel"
+        : LINKEDIN_ASSISTANT_EVASION_LEVEL_ENV,
+      DEFAULT_EVASION_LEVEL
+    );
+  } catch (error) {
+    if (source === "env" && error instanceof LinkedInAssistantError) {
+      throw invalidEvasionConfig(
+        `${LINKEDIN_ASSISTANT_EVASION_LEVEL_ENV} must be one of ${EVASION_LEVELS.join(", ")}. Unset it to use the default value.`,
+        {
+          env: LINKEDIN_ASSISTANT_EVASION_LEVEL_ENV,
+          supported_values: [...EVASION_LEVELS],
+          value: rawLevel
+        }
+      );
+    }
+
+    throw error;
+  }
+
+  return createEvasionStatus({
+    diagnosticsEnabled,
+    level,
+    source
+  });
 }
 
 /**

--- a/packages/core/src/evasion.ts
+++ b/packages/core/src/evasion.ts
@@ -1,11 +1,33 @@
 export { applyFingerprintHardening, detectCaptcha, findHoneypotFields, simulateIdleDrift, simulateMomentumScroll, simulateTabBlur, simulateViewportJitter } from "./evasion/browser.js";
-export { computeBezierPath, computeReadingPauseMs, samplePoissonInterval } from "./evasion/math.js";
-export { EVASION_PROFILES } from "./evasion/profiles.js";
+export {
+  computeBezierPath,
+  computeMomentumSteps,
+  computeReadingPauseMs,
+  resolveIntervalMs,
+  samplePoissonInterval
+} from "./evasion/math.js";
+export {
+  createEvasionStatus,
+  DEFAULT_EVASION_LEVEL,
+  describeEvasionLevel,
+  EVASION_LEVELS,
+  EVASION_PROFILES,
+  getDisabledEvasionFeatures,
+  getEnabledEvasionFeatures,
+  isEvasionLevel,
+  resolveEvasionLevel,
+  resolveEvasionProfile
+} from "./evasion/profiles.js";
 export { EvasionSession } from "./evasion/session.js";
 export type {
   BezierPathOptions,
+  EvasionConfigSource,
+  EvasionDiagnosticsLogger,
+  EvasionFeatureName,
   EvasionLevel,
   EvasionProfile,
+  EvasionSessionOptions,
+  EvasionStatus,
   IntervalSampleOptions,
   Point2D
 } from "./evasion/types.js";

--- a/packages/core/src/evasion/browser.ts
+++ b/packages/core/src/evasion/browser.ts
@@ -199,6 +199,14 @@ export async function findHoneypotFields(page: Page): Promise<readonly string[]>
   return findMatchingSelectors(page, HONEYPOT_SELECTORS);
 }
 
+/**
+ * Scrolls the page by a fixed distance using the requested browser scroll
+ * behavior.
+ *
+ * @param page - Playwright Page to scroll.
+ * @param pixels - Distance in pixels (positive = down, negative = up).
+ * @param behavior - Native browser scroll behavior to request.
+ */
 export async function scrollPageBy(
   page: Page,
   pixels: number,

--- a/packages/core/src/evasion/math.ts
+++ b/packages/core/src/evasion/math.ts
@@ -124,6 +124,14 @@ export function computeReadingPauseMs(charCount: number, wpm: number): number {
   return Math.round(minutes * 60_000);
 }
 
+/**
+ * Breaks a total scroll distance into a decelerating sequence of momentum
+ * steps that sum back to the requested distance.
+ *
+ * @param totalPixels - Total distance to scroll.
+ * @param steps - Number of momentum steps to generate.
+ * @returns Array of per-step scroll deltas.
+ */
 export function computeMomentumSteps(totalPixels: number, steps: number): number[] {
   const safeTotalPixels = normalizeFiniteNumber(totalPixels, 0);
   if (safeTotalPixels === 0) {
@@ -149,6 +157,13 @@ export function computeMomentumSteps(totalPixels: number, steps: number): number
   return amounts;
 }
 
+/**
+ * Applies interval bounds and rate-limit backoff rules to a fixed base delay.
+ *
+ * @param baseMs - Base interval in milliseconds.
+ * @param options - Optional bounds and rate-limit hints.
+ * @returns Resolved interval in milliseconds.
+ */
 export function resolveIntervalMs(baseMs: number, options?: IntervalSampleOptions): number {
   const safeBaseMs = Math.max(0, normalizeFiniteNumber(baseMs, 0));
   return applyIntervalConstraints(safeBaseMs, safeBaseMs, options);

--- a/packages/core/src/evasion/profiles.ts
+++ b/packages/core/src/evasion/profiles.ts
@@ -1,4 +1,17 @@
-import type { EvasionLevel, EvasionProfile } from "./types.js";
+import { LinkedInAssistantError } from "../errors.js";
+import type {
+  EvasionConfigSource,
+  EvasionFeatureName,
+  EvasionLevel,
+  EvasionProfile,
+  EvasionStatus
+} from "./types.js";
+
+/** Default evasion level applied when no explicit override is configured. */
+export const DEFAULT_EVASION_LEVEL: EvasionLevel = "moderate";
+
+/** Supported evasion levels in ascending order of intensity. */
+export const EVASION_LEVELS = ["minimal", "moderate", "paranoid"] as const;
 
 const MINIMAL_PROFILE: Readonly<EvasionProfile> = Object.freeze({
   bezierMouseMovement: false,
@@ -51,3 +64,134 @@ export const EVASION_PROFILES: Readonly<Record<EvasionLevel, Readonly<EvasionPro
     moderate: MODERATE_PROFILE,
     paranoid: PARANOID_PROFILE
   });
+
+const EVASION_FEATURES = [
+  {
+    name: "bezier_mouse_movement",
+    enabled: (profile: Readonly<EvasionProfile>) => profile.bezierMouseMovement
+  },
+  {
+    name: "momentum_scroll",
+    enabled: (profile: Readonly<EvasionProfile>) => profile.momentumScroll
+  },
+  {
+    name: "tab_blur_simulation",
+    enabled: (profile: Readonly<EvasionProfile>) => profile.simulateTabBlur
+  },
+  {
+    name: "viewport_resize_simulation",
+    enabled: (profile: Readonly<EvasionProfile>) => profile.simulateViewportResize
+  },
+  {
+    name: "idle_drift",
+    enabled: (profile: Readonly<EvasionProfile>) => profile.idleDriftEnabled
+  },
+  {
+    name: "reading_pauses",
+    enabled: (profile: Readonly<EvasionProfile>) => profile.readingPauseWpm > 0
+  },
+  {
+    name: "poisson_timing",
+    enabled: (profile: Readonly<EvasionProfile>) => profile.poissonIntervals
+  },
+  {
+    name: "fingerprint_hardening",
+    enabled: (profile: Readonly<EvasionProfile>) => profile.fingerprintHardening
+  }
+] as const satisfies readonly {
+  name: EvasionFeatureName;
+  enabled: (profile: Readonly<EvasionProfile>) => boolean;
+}[];
+
+/** Returns whether `value` is one of the supported evasion levels. */
+export function isEvasionLevel(value: string): value is EvasionLevel {
+  return EVASION_LEVELS.includes(value as EvasionLevel);
+}
+
+/**
+ * Resolves a user-supplied evasion level and throws a clear error when the
+ * value is unsupported.
+ */
+export function resolveEvasionLevel(
+  value: string | EvasionLevel | undefined,
+  sourceLabel = "evasion level",
+  defaultLevel: EvasionLevel = DEFAULT_EVASION_LEVEL
+): EvasionLevel {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return defaultLevel;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (isEvasionLevel(normalized)) {
+    return normalized;
+  }
+
+  throw new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    `${sourceLabel} must be one of ${EVASION_LEVELS.join(", ")}.`,
+    {
+      source: sourceLabel,
+      value,
+      supported_values: [...EVASION_LEVELS],
+      default_value: defaultLevel,
+      suggestion:
+        "Use minimal for deterministic development and test flows, moderate for the default balance, or paranoid for the most aggressive evasion profile."
+    }
+  );
+}
+
+/** Returns the immutable evasion profile for `level`. */
+export function resolveEvasionProfile(level: EvasionLevel): Readonly<EvasionProfile> {
+  return EVASION_PROFILES[level];
+}
+
+/** Returns the stable feature names enabled by `profile`. */
+export function getEnabledEvasionFeatures(
+  profile: Readonly<EvasionProfile>
+): readonly EvasionFeatureName[] {
+  return EVASION_FEATURES.filter((feature) => feature.enabled(profile)).map(
+    (feature) => feature.name
+  );
+}
+
+/** Returns the stable feature names disabled by `profile`. */
+export function getDisabledEvasionFeatures(
+  profile: Readonly<EvasionProfile>
+): readonly EvasionFeatureName[] {
+  return EVASION_FEATURES.filter((feature) => !feature.enabled(profile)).map(
+    (feature) => feature.name
+  );
+}
+
+/** Returns a human-readable summary for the supplied evasion level. */
+export function describeEvasionLevel(level: EvasionLevel): string {
+  switch (level) {
+    case "minimal":
+      return "Minimal evasion keeps behavioral and fingerprint simulation disabled for deterministic development and test flows.";
+    case "moderate":
+      return "Moderate evasion enables Bezier mouse movement, momentum scroll, idle drift, reading pauses, Poisson timing, and fingerprint hardening.";
+    case "paranoid":
+      return "Paranoid evasion enables the moderate profile plus synthetic tab blur and viewport resize signals with stronger cursor jitter.";
+  }
+}
+
+/** Builds a structured evasion status snapshot for diagnostics and status output. */
+export function createEvasionStatus(input: {
+  diagnosticsEnabled?: boolean;
+  level?: string | EvasionLevel;
+  source?: EvasionConfigSource;
+} = {}): EvasionStatus {
+  const source = input.source ?? "default";
+  const level = resolveEvasionLevel(input.level, "evasion level");
+  const profile = resolveEvasionProfile(level);
+
+  return {
+    diagnosticsEnabled: input.diagnosticsEnabled ?? false,
+    disabledFeatures: getDisabledEvasionFeatures(profile),
+    enabledFeatures: getEnabledEvasionFeatures(profile),
+    level,
+    profile,
+    source,
+    summary: describeEvasionLevel(level)
+  };
+}

--- a/packages/core/src/evasion/session.ts
+++ b/packages/core/src/evasion/session.ts
@@ -15,9 +15,15 @@ import {
   resolveIntervalMs,
   samplePoissonInterval
 } from "./math.js";
-import { EVASION_PROFILES } from "./profiles.js";
+import { resolveEvasionLevel, resolveEvasionProfile } from "./profiles.js";
 import { MAX_SCROLL_DISTANCE_PX, clamp, isFiniteNumber, normalizeFiniteNumber } from "./shared.js";
-import type { EvasionLevel, EvasionProfile, IntervalSampleOptions, Point2D } from "./types.js";
+import type {
+  EvasionLevel,
+  EvasionProfile,
+  EvasionSessionOptions,
+  IntervalSampleOptions,
+  Point2D
+} from "./types.js";
 
 const MIN_IDLE_DRIFT_DELAY_MS = 80;
 const ORIGIN_POINT: Readonly<Point2D> = Object.freeze({ x: 0, y: 0 });
@@ -51,15 +57,36 @@ export class EvasionSession {
   private readonly page: Page;
   private readonly profile: Readonly<EvasionProfile>;
   private readonly level: EvasionLevel;
+  private readonly diagnosticsEnabled: boolean;
+  private readonly diagnosticsLabel: string;
+  private readonly logger: EvasionSessionOptions["logger"];
   private mouseX = 0;
   private mouseY = 0;
   private operationQueue: Promise<void> = Promise.resolve();
   private fingerprintHardeningPromise: Promise<void> | undefined;
 
-  constructor(page: Page, level: EvasionLevel = "moderate") {
+  /**
+   * @param page - Playwright page to wrap with evasion helpers.
+   * @param level - Desired evasion level. Defaults to `"moderate"`.
+   * @param options - Optional diagnostics controls for debug logging.
+   */
+  constructor(
+    page: Page,
+    level: EvasionLevel = "moderate",
+    options: EvasionSessionOptions = {}
+  ) {
     this.page = page;
-    this.level = level;
-    this.profile = EVASION_PROFILES[level];
+    this.level = resolveEvasionLevel(level, "EvasionSession level");
+    this.profile = resolveEvasionProfile(this.level);
+    this.logger = options.logger;
+    this.diagnosticsEnabled = options.diagnosticsEnabled ?? this.logger !== undefined;
+    this.diagnosticsLabel = options.diagnosticsLabel ?? "default";
+
+    this.logDebug("evasion.session.created", {
+      diagnostics_enabled: this.diagnosticsEnabled,
+      diagnostics_label: this.diagnosticsLabel,
+      profile: this.profile
+    });
   }
 
   /** The active evasion level. */
@@ -82,8 +109,11 @@ export class EvasionSession {
     }
 
     if (this.fingerprintHardeningPromise === undefined) {
-      this.fingerprintHardeningPromise = this.enqueue(async () => {
+      this.fingerprintHardeningPromise = this.enqueue("harden_fingerprint", async () => {
         await applyFingerprintHardening(this.page, this.level);
+        this.logDebug("evasion.session.fingerprint_hardening.applied", {
+          diagnostics_label: this.diagnosticsLabel
+        });
       }, undefined);
     }
 
@@ -100,7 +130,7 @@ export class EvasionSession {
    * @param to - Destination coordinate.
    */
   async moveMouse(from: Readonly<Point2D>, to: Readonly<Point2D>): Promise<void> {
-    await this.enqueue(async () => {
+    await this.enqueue("move_mouse", async () => {
       const safeFrom = this.normalizePoint(from);
       const safeTo = this.normalizePoint(to, safeFrom);
       const path = this.profile.bezierMouseMovement
@@ -113,6 +143,11 @@ export class EvasionSession {
         const point = this.normalizePoint(pointOnPath, lastPoint);
         const moved = await this.tryMoveMouse(point, steps);
         if (!moved) {
+          this.logDebug("evasion.session.mouse_move.fallback_to_direct", {
+            diagnostics_label: this.diagnosticsLabel,
+            destination: safeTo,
+            attempted_point: point
+          });
           await this.tryMoveMouse(safeTo, 5);
           this.setMousePosition(safeTo);
           return;
@@ -134,14 +169,24 @@ export class EvasionSession {
    * @param pixels - Distance in pixels (positive = down, negative = up).
    */
   async scroll(pixels: number): Promise<void> {
-    await this.enqueue(async () => {
+    await this.enqueue("scroll", async () => {
+      const requestedPixels = normalizeFiniteNumber(pixels, 0);
       const clampedPixels = clamp(
-        normalizeFiniteNumber(pixels, 0),
+        requestedPixels,
         -MAX_SCROLL_DISTANCE_PX,
         MAX_SCROLL_DISTANCE_PX
       );
       if (clampedPixels === 0) {
         return;
+      }
+
+      if (requestedPixels !== clampedPixels) {
+        this.logDebug("evasion.session.scroll.clamped", {
+          diagnostics_label: this.diagnosticsLabel,
+          requested_pixels: requestedPixels,
+          clamped_pixels: clampedPixels,
+          max_scroll_distance_px: MAX_SCROLL_DISTANCE_PX
+        });
       }
 
       if (this.profile.momentumScroll) {
@@ -167,10 +212,16 @@ export class EvasionSession {
       return;
     }
 
-    await this.enqueue(async () => {
+    await this.enqueue("idle", async () => {
       const shouldDrift = this.profile.idleDriftEnabled && this.profile.mouseJitterRadius > 0;
       if (shouldDrift) {
         const driftSteps = Math.max(1, Math.floor(safeDurationMs / 300));
+        this.logDebug("evasion.session.idle.drift", {
+          diagnostics_label: this.diagnosticsLabel,
+          drift_steps: driftSteps,
+          jitter_radius_px: this.profile.mouseJitterRadius,
+          requested_duration_ms: safeDurationMs
+        });
         await simulateIdleDrift(
           this.page,
           this.mouseX,
@@ -199,8 +250,12 @@ export class EvasionSession {
       return;
     }
 
-    await this.enqueue(async () => {
+    await this.enqueue("simulate_tab_switch", async () => {
       await simulateTabBlurOnPage(this.page, blurDurationMs);
+      this.logDebug("evasion.session.tab_switch.simulated", {
+        blur_duration_ms: blurDurationMs,
+        diagnostics_label: this.diagnosticsLabel
+      });
     }, undefined);
   }
 
@@ -214,8 +269,11 @@ export class EvasionSession {
       return;
     }
 
-    await this.enqueue(async () => {
+    await this.enqueue("simulate_viewport_jitter", async () => {
       await simulateViewportJitterOnPage(this.page);
+      this.logDebug("evasion.session.viewport_jitter.simulated", {
+        diagnostics_label: this.diagnosticsLabel
+      });
     }, undefined);
   }
 
@@ -233,9 +291,15 @@ export class EvasionSession {
       return;
     }
 
-    await this.enqueue(async () => {
+    await this.enqueue("reading_pause", async () => {
       const pauseMs = computeReadingPauseMs(charCount, this.profile.readingPauseWpm);
       if (pauseMs > 0) {
+        this.logDebug("evasion.session.reading_pause.applied", {
+          char_count: charCount,
+          diagnostics_label: this.diagnosticsLabel,
+          pause_ms: pauseMs,
+          reading_pause_wpm: this.profile.readingPauseWpm
+        });
         await this.waitForTimeoutSafely(pauseMs);
       }
     }, undefined);
@@ -254,9 +318,25 @@ export class EvasionSession {
    * @returns Sampled interval in milliseconds.
    */
   sampleInterval(baseMs: number, options?: IntervalSampleOptions): number {
-    return this.profile.poissonIntervals
+    const intervalMs = this.profile.poissonIntervals
       ? samplePoissonInterval(baseMs, options)
       : resolveIntervalMs(baseMs, options);
+
+    if (
+      this.profile.poissonIntervals &&
+      (options?.rateLimited === true ||
+        typeof options?.retryAfterMs === "number" ||
+        typeof options?.responseStatus === "number")
+    ) {
+      this.logDebug("evasion.session.interval.sampled", {
+        base_ms: baseMs,
+        diagnostics_label: this.diagnosticsLabel,
+        interval_ms: intervalMs,
+        options
+      });
+    }
+
+    return intervalMs;
   }
 
   /**
@@ -266,7 +346,16 @@ export class EvasionSession {
    * CAPTCHAs; callers should pause and alert an operator.
    */
   async detectCaptcha(): Promise<boolean> {
-    return this.enqueue(async () => detectCaptchaOnPage(this.page), false);
+    return this.enqueue("detect_captcha", async () => {
+      const detected = await detectCaptchaOnPage(this.page);
+      if (detected) {
+        this.logDebug("evasion.session.captcha.detected", {
+          diagnostics_label: this.diagnosticsLabel
+        });
+      }
+
+      return detected;
+    }, false);
   }
 
   /**
@@ -275,14 +364,44 @@ export class EvasionSession {
    * Returns CSS selectors of hidden inputs that should NOT be filled.
    */
   async findHoneypotFields(): Promise<readonly string[]> {
-    return this.enqueue(async () => findHoneypotFieldsOnPage(this.page), []);
+    return this.enqueue("find_honeypot_fields", async () => {
+      const fields = await findHoneypotFieldsOnPage(this.page);
+      if (fields.length > 0) {
+        this.logDebug("evasion.session.honeypots.detected", {
+          diagnostics_label: this.diagnosticsLabel,
+          selectors: fields
+        });
+      }
+
+      return fields;
+    }, []);
   }
 
-  private enqueue<T>(operation: () => Promise<T>, fallback: T): Promise<T> {
+  private logDebug(event: string, payload: Record<string, unknown>): void {
+    if (!this.diagnosticsEnabled || this.logger === undefined) {
+      return;
+    }
+
+    this.logger.log("debug", event, {
+      evasion_level: this.level,
+      ...payload
+    });
+  }
+
+  private enqueue<T>(
+    operationName: string,
+    operation: () => Promise<T>,
+    fallback: T
+  ): Promise<T> {
     const task = this.operationQueue.catch(() => undefined).then(async () => {
       try {
         return await operation();
-      } catch {
+      } catch (error) {
+        this.logDebug("evasion.session.operation.failed", {
+          diagnostics_label: this.diagnosticsLabel,
+          error_message: getErrorMessage(error),
+          operation_name: operationName
+        });
         return fallback;
       }
     });
@@ -354,7 +473,13 @@ export class EvasionSession {
     try {
       await this.page.mouse.move(point.x, point.y, { steps });
       return true;
-    } catch {
+    } catch (error) {
+      this.logDebug("evasion.session.mouse_move.failed", {
+        diagnostics_label: this.diagnosticsLabel,
+        error_message: getErrorMessage(error),
+        point,
+        steps
+      });
       return false;
     }
   }
@@ -367,10 +492,18 @@ export class EvasionSession {
 
     try {
       await this.page.waitForTimeout(safeDelayMs);
-    } catch {
-      // Ignore transient page timing failures.
+    } catch (error) {
+      this.logDebug("evasion.session.wait_for_timeout.failed", {
+        delay_ms: safeDelayMs,
+        diagnostics_label: this.diagnosticsLabel,
+        error_message: getErrorMessage(error)
+      });
     }
   }
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Unknown error";
 }
 
 function isViewportSize(value: unknown): value is ViewportBounds {

--- a/packages/core/src/evasion/types.ts
+++ b/packages/core/src/evasion/types.ts
@@ -86,3 +86,54 @@ export interface EvasionProfile {
    */
   fingerprintHardening: boolean;
 }
+
+/** Source used to resolve the effective evasion level. */
+export type EvasionConfigSource = "default" | "env" | "option";
+
+/** Stable feature names surfaced in status output and diagnostics. */
+export type EvasionFeatureName =
+  | "bezier_mouse_movement"
+  | "momentum_scroll"
+  | "tab_blur_simulation"
+  | "viewport_resize_simulation"
+  | "idle_drift"
+  | "reading_pauses"
+  | "poisson_timing"
+  | "fingerprint_hardening";
+
+/** Minimal logger surface used by optional evasion diagnostics. */
+export interface EvasionDiagnosticsLogger {
+  log(
+    level: "debug" | "info" | "warn" | "error",
+    event: string,
+    payload?: Record<string, unknown>
+  ): unknown;
+}
+
+/** Resolved evasion status exposed through runtime/session diagnostics. */
+export interface EvasionStatus {
+  /** Whether verbose evasion diagnostics are enabled for this run. */
+  diagnosticsEnabled: boolean;
+  /** Stable feature names disabled by the active profile. */
+  disabledFeatures: readonly EvasionFeatureName[];
+  /** Stable feature names enabled by the active profile. */
+  enabledFeatures: readonly EvasionFeatureName[];
+  /** Effective evasion level. */
+  level: EvasionLevel;
+  /** Concrete profile values used for this run. */
+  profile: Readonly<EvasionProfile>;
+  /** Whether the level came from the default, env, or runtime option. */
+  source: EvasionConfigSource;
+  /** Human-readable summary for CLI, MCP, and logs. */
+  summary: string;
+}
+
+/** Optional diagnostics controls for {@link EvasionSession}. */
+export interface EvasionSessionOptions {
+  /** Override whether debug diagnostics are emitted for this session. */
+  diagnosticsEnabled?: boolean;
+  /** Optional label added to emitted diagnostics for easier correlation. */
+  diagnosticsLabel?: string;
+  /** Structured logger that receives optional evasion diagnostics. */
+  logger?: EvasionDiagnosticsLogger;
+}

--- a/packages/core/src/healthCheck.ts
+++ b/packages/core/src/healthCheck.ts
@@ -1,5 +1,6 @@
 import type { BrowserContext, Page } from "playwright-core";
 import { inspectLinkedInSession } from "./auth/sessionInspection.js";
+import { resolveEvasionConfig, type EvasionConfig } from "./config.js";
 import {
   getLinkedInSessionFingerprint,
   summarizeLinkedInSessionCookies,
@@ -8,6 +9,7 @@ import {
 
 export const DEFAULT_SESSION_COOKIE_EXPIRY_WARNING_MS = 60 * 60_000;
 
+/** Browser reachability snapshot for one health-check run. */
 export interface BrowserHealthStatus {
   healthy: boolean;
   browserConnected: boolean;
@@ -15,6 +17,7 @@ export interface BrowserHealthStatus {
   checkedAt: string;
 }
 
+/** LinkedIn session health snapshot for one health-check run. */
 export interface SessionHealthStatus {
   authenticated: boolean;
   currentUrl: string;
@@ -22,6 +25,8 @@ export interface SessionHealthStatus {
   checkedAt: string;
   checkpointDetected: boolean;
   cookieExpiringSoon: boolean;
+  /** Resolved anti-bot evasion status for the current runtime. */
+  evasion: EvasionConfig;
   loginWallDetected: boolean;
   nextCookieExpiryAt: string | null;
   rateLimited: boolean;
@@ -30,9 +35,15 @@ export interface SessionHealthStatus {
   sessionCookies: LinkedInSessionCookieMetadata[];
 }
 
+/** Combined browser + LinkedIn session health report. */
 export interface FullHealthStatus {
   browser: BrowserHealthStatus;
   session: SessionHealthStatus;
+}
+
+/** Optional enrichments applied to session and full health checks. */
+export interface HealthCheckOptions {
+  evasion?: EvasionConfig;
 }
 
 async function getFirstPage(context: BrowserContext): Promise<Page> {
@@ -44,6 +55,7 @@ async function getFirstPage(context: BrowserContext): Promise<Page> {
   return context.newPage();
 }
 
+/** Checks whether the underlying browser context is connected and responsive. */
 export async function checkBrowserHealth(
   context: BrowserContext
 ): Promise<BrowserHealthStatus> {
@@ -69,9 +81,13 @@ export async function checkBrowserHealth(
   };
 }
 
+/** Checks the LinkedIn session state and enriches it with cookie + evasion diagnostics. */
 export async function checkLinkedInSession(
-  context: BrowserContext
+  context: BrowserContext,
+  options: HealthCheckOptions = {}
 ): Promise<SessionHealthStatus> {
+  const evasion = options.evasion ?? resolveEvasionConfig();
+
   try {
     const page = await getFirstPage(context);
     await page.goto("https://www.linkedin.com/feed/", {
@@ -94,6 +110,7 @@ export async function checkLinkedInSession(
     return {
       ...inspection,
       cookieExpiringSoon,
+      evasion,
       nextCookieExpiryAt,
       sessionCookieFingerprint:
         sessionCookies.length > 0
@@ -108,8 +125,8 @@ export async function checkLinkedInSession(
     const currentUrl = context.pages()[0]?.url() ?? "";
     const reason =
       error instanceof Error
-        ? `Session health check failed: ${error.message}`
-        : "Session health check failed.";
+        ? `Session health check failed before LinkedIn could be inspected: ${error.message}. Check browser connectivity and reload the profile before retrying.`
+        : "Session health check failed before LinkedIn could be inspected. Check browser connectivity and reload the profile before retrying.";
 
     return {
       authenticated: false,
@@ -118,6 +135,7 @@ export async function checkLinkedInSession(
       reason,
       checkpointDetected: false,
       cookieExpiringSoon: false,
+      evasion,
       loginWallDetected: false,
       nextCookieExpiryAt: null,
       rateLimited: false,
@@ -128,11 +146,13 @@ export async function checkLinkedInSession(
   }
 }
 
+/** Runs both browser and LinkedIn session checks and returns one combined report. */
 export async function checkFullHealth(
-  context: BrowserContext
+  context: BrowserContext,
+  options: HealthCheckOptions = {}
 ): Promise<FullHealthStatus> {
   const browser = await checkBrowserHealth(context);
-  const session = await checkLinkedInSession(context);
+  const session = await checkLinkedInSession(context, options);
 
   return {
     browser,

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -8,9 +8,11 @@ import {
   resolveConfirmFailureArtifactConfig,
   resolveLinkedInSelectorLocaleConfigResolution,
   resolveActivityWebhookConfig,
+  resolveEvasionConfig,
   type ActivityWebhookConfig,
   type ConfigPaths,
-  type ConfirmFailureArtifactConfig
+  type ConfirmFailureArtifactConfig,
+  type EvasionConfig
 } from "./config.js";
 import { AssistantDatabase } from "./db/database.js";
 import { LinkedInAuthService } from "./auth/session.js";
@@ -75,6 +77,7 @@ import {
   DEFAULT_LINKEDIN_SELECTOR_LOCALE,
   type LinkedInSelectorLocale
 } from "./selectorLocale.js";
+import type { EvasionLevel } from "./evasion.js";
 
 function summarizeSelectorLocaleInput(
   normalizedInput: string | undefined,
@@ -99,6 +102,10 @@ export interface CreateCoreRuntimeOptions {
   runId?: string;
   cdpUrl?: string | undefined;
   privacy?: Partial<PrivacyConfig>;
+  /** Enables verbose anti-bot evasion diagnostics in run logs. */
+  evasionDiagnostics?: boolean;
+  /** Overrides the default anti-bot evasion level for this runtime. */
+  evasionLevel?: string | EvasionLevel;
   selectorLocale?: string | LinkedInSelectorLocale;
 }
 
@@ -111,6 +118,8 @@ export interface CoreRuntime {
   runId: string;
   cdpUrl?: string | undefined;
   selectorLocale: LinkedInSelectorLocale;
+  /** Resolved anti-bot evasion snapshot shared across status and health checks. */
+  evasion: EvasionConfig;
   confirmFailureArtifacts: ConfirmFailureArtifactConfig;
   privacy: PrivacyConfig;
   postSafetyLint: LinkedInPostSafetyLintConfig;
@@ -151,6 +160,14 @@ export function createCoreRuntime(
   const privacy = resolvePrivacyConfig(options.privacy);
   const postSafetyLint = resolveLinkedInPostSafetyLintConfig(paths.baseDir);
   const activityConfig = resolveActivityWebhookConfig();
+  const evasion = resolveEvasionConfig({
+    ...(typeof options.evasionDiagnostics === "boolean"
+      ? { diagnosticsEnabled: options.evasionDiagnostics }
+      : {}),
+    ...(typeof options.evasionLevel === "string"
+      ? { level: options.evasionLevel }
+      : {})
+  });
   const selectorLocaleResolution = resolveLinkedInSelectorLocaleConfigResolution(
     options.selectorLocale
   );
@@ -231,6 +248,7 @@ export function createCoreRuntime(
     runId,
     cdpUrl: options.cdpUrl,
     selectorLocale,
+    evasion,
     confirmFailureArtifacts,
     privacy,
     postSafetyLint,
@@ -245,7 +263,8 @@ export function createCoreRuntime(
       profileManager,
       options.cdpUrl,
       selectorLocale,
-      logger
+      logger,
+      evasion
     ),
     profile: undefined as unknown as LinkedInProfileService,
     search: undefined as unknown as LinkedInSearchService,
@@ -270,7 +289,7 @@ export function createCoreRuntime(
           profileName,
           headless: true
         },
-        (context) => checkFullHealth(context)
+        (context) => checkFullHealth(context, { evasion })
       );
     },
     close: () => {
@@ -308,7 +327,20 @@ export function createCoreRuntime(
   logger.log("info", "runtime.started", {
     runId,
     baseDir: paths.baseDir,
+    evasion_diagnostics_enabled: evasion.diagnosticsEnabled,
+    evasion_level: evasion.level,
+    evasion_source: evasion.source,
     selector_locale: selectorLocale
+  });
+
+  logger.log("debug", "runtime.evasion.configured", {
+    diagnostics_enabled: evasion.diagnosticsEnabled,
+    disabled_features: evasion.disabledFeatures,
+    enabled_features: evasion.enabledFeatures,
+    evasion_level: evasion.level,
+    evasion_source: evasion.source,
+    profile: evasion.profile,
+    summary: evasion.summary
   });
 
   return runtime;

--- a/packages/core/test/runtimeEvasion.test.ts
+++ b/packages/core/test/runtimeEvasion.test.ts
@@ -1,0 +1,79 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createCoreRuntime, resolveConfigPaths } from "../src/index.js";
+
+interface LoggedEvent {
+  level: string;
+  event: string;
+  payload: Record<string, unknown>;
+}
+
+async function readRunEvents(baseDir: string, runId: string): Promise<LoggedEvent[]> {
+  const eventsPath = path.join(resolveConfigPaths(baseDir).artifactsDir, runId, "events.jsonl");
+  const contents = await readFile(eventsPath, "utf8");
+
+  return contents
+    .trim()
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as LoggedEvent);
+}
+
+describe("runtime evasion diagnostics", () => {
+  let baseDir = "";
+
+  beforeEach(async () => {
+    baseDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-runtime-evasion-"));
+  });
+
+  afterEach(async () => {
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  it("exposes resolved evasion config and records a debug diagnostics snapshot", async () => {
+    const runtime = createCoreRuntime({
+      baseDir,
+      dbPath: ":memory:",
+      evasionDiagnostics: true,
+      evasionLevel: "paranoid",
+      runId: "run-evasion-config"
+    });
+    let closed = false;
+
+    try {
+      expect(runtime.evasion).toMatchObject({
+        diagnosticsEnabled: true,
+        level: "paranoid",
+        source: "option"
+      });
+
+      runtime.close();
+      closed = true;
+
+      const events = await readRunEvents(baseDir, "run-evasion-config");
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            level: "debug",
+            event: "runtime.evasion.configured",
+            payload: expect.objectContaining({
+              diagnostics_enabled: true,
+              enabled_features: expect.arrayContaining([
+                "tab_blur_simulation",
+                "viewport_resize_simulation"
+              ]),
+              evasion_level: "paranoid",
+              evasion_source: "option"
+            })
+          })
+        ])
+      );
+    } finally {
+      if (!closed) {
+        runtime.close();
+      }
+    }
+  });
+});

--- a/packages/mcp/src/bin/linkedin-mcp.ts
+++ b/packages/mcp/src/bin/linkedin-mcp.ts
@@ -387,7 +387,9 @@ async function handleSessionStatus(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.session.status.done", {
       profileName,
-      authenticated: status.authenticated
+      authenticated: status.authenticated,
+      evasion_level: status.evasion?.level,
+      evasion_diagnostics_enabled: status.evasion?.diagnosticsEnabled ?? false
     });
 
     return toToolResult({
@@ -450,7 +452,9 @@ async function handleSessionHealth(args: ToolArgs): Promise<ToolResult> {
     runtime.logger.log("info", "mcp.session.health.done", {
       profileName,
       browserHealthy: health.browser.healthy,
-      authenticated: health.session.authenticated
+      authenticated: health.session.authenticated,
+      evasion_level: health.session.evasion.level,
+      evasion_diagnostics_enabled: health.session.evasion.diagnosticsEnabled
     });
 
     return toToolResult({
@@ -1524,7 +1528,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     tools: [
       {
         name: LINKEDIN_SESSION_STATUS_TOOL,
-        description: "Check LinkedIn session authentication status for a profile.",
+        description:
+          "Check LinkedIn session authentication status for a profile, including the resolved anti-bot evasion configuration.",
         inputSchema: {
           type: "object",
           additionalProperties: false,
@@ -1556,7 +1561,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: LINKEDIN_SESSION_HEALTH_TOOL,
-        description: "Check browser connectivity and LinkedIn session health for a profile.",
+        description:
+          "Check browser connectivity and LinkedIn session health for a profile, including the resolved anti-bot evasion configuration.",
         inputSchema: {
           type: "object",
           additionalProperties: false,


### PR DESCRIPTION
## Summary
- surface the resolved evasion profile in session status and health output across Core, CLI, and MCP
- add validated evasion config, opt-in debug diagnostics, and clearer developer-facing error messages
- document the evasion profiles and diagnostics hooks, and cover the new behavior with runtime, core, and CLI tests

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #221