### PR TITLE
docs: document anti-bot evasion integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
 - Human-like typing simulation documentation across the README surfaces,
   write-validation guide, public API JSDoc, and usage examples for speed,
   variance, and pause-pattern tuning.
+- Anti-bot evasion documentation covering architecture, configuration
+  precedence, CLI and MCP integration, troubleshooting guidance, and public API
+  examples.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -187,12 +187,17 @@ Configuration surface:
 - `LINKEDIN_ASSISTANT_EVASION_LEVEL=minimal|moderate|paranoid`
 - `LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS=true|false`
 - `createCoreRuntime({ evasionLevel, evasionDiagnostics })` for direct Core callers
+- precedence is runtime option → environment variable → built-in default
 
 Diagnostics surface:
 
+- there is no standalone `linkedin evasion` CLI group or `linkedin.evasion.*` MCP tool today
 - `linkedin status` includes a top-level `evasion` block
 - `linkedin health` includes `session.evasion`
+- `linkedin.session.status` includes `status.evasion`
+- `linkedin.session.health` includes `session.evasion`
 - read-only status and health checks report the resolved config without injecting synthetic input
+- CLI and MCP do not expose evasion-specific flags or tool args; use env vars or direct Core runtime options
 - enabling diagnostics records `evasion.*` events in the run log for easier troubleshooting
 
 ```ts
@@ -210,8 +215,8 @@ const session = new EvasionSession(page, runtime.evasion.level, {
 });
 ```
 
-See `docs/evasion.md` for the profile matrix, CLI/MCP diagnostics notes, and
-API examples.
+See `docs/evasion.md` for the profile matrix, configuration reference,
+CLI/MCP JSON paths, and troubleshooting guide.
 
 ## Selector Locale Support
 
@@ -253,6 +258,7 @@ npm exec -w @linkedin-assistant/cli -- linkedin login --profile default --timeou
 ```
 
 - `linkedin status` and `linkedin health` now include the resolved anti-bot evasion snapshot in their JSON output so you can confirm the active level, enabled features, and diagnostics flag before reproducing session issues.
+- There is no dedicated `linkedin evasion` command group yet; configure evasion through env vars and inspect it through `status` / `health`. See `docs/evasion.md` for the exact JSON paths and troubleshooting workflow.
 
 Isolation note:
 
@@ -652,6 +658,12 @@ Example tool arguments:
 
 See `docs/selector-locale.md` for the full locale configuration guide and
 `docs/selector-audit.md` for the CLI-only selector audit workflow.
+
+For anti-bot evasion, MCP surfaces the resolved snapshot through
+`linkedin.session.status` (`status.evasion`) and `linkedin.session.health`
+(`session.evasion`). There is no `linkedin.evasion.*` tool family yet, and the
+server reads evasion defaults from env vars at startup. See `docs/evasion.md`
+for the full integration and troubleshooting guide.
 
 - explicit `selectorLocale` wins over `LINKEDIN_ASSISTANT_SELECTOR_LOCALE`
 - supported values are `en`, `da`, and region tags like `da-DK`

--- a/docs/evasion.md
+++ b/docs/evasion.md
@@ -1,59 +1,87 @@
 # Anti-bot evasion
 
-The anti-bot evasion module adds opt-in behavioral pacing, browser-signal hardening,
-and developer-facing diagnostics for Playwright-driven LinkedIn flows.
+The anti-bot evasion module adds **opt-in behavioral pacing, browser-signal
+hardening, and session-aware diagnostics** for Playwright-driven LinkedIn
+flows.
 
-## Defaults
+The design is intentionally conservative:
 
-The default evasion level is `moderate`.
+- it adds human-like timing and input patterns where the runtime already owns
+  the page
+- it surfaces the resolved configuration in status and health checks for easy
+  inspection
+- it fails open when possible so diagnostics do not turn recoverable browser
+  glitches into broken operator workflows
+- it does **not** solve CAPTCHAs, rotate proxies, spoof network identity, or
+  bypass LinkedIn checkpoints by itself
 
-Available profiles:
+## What the module covers
 
-- `minimal` keeps behavioral and fingerprint simulation disabled for deterministic
-  development and test flows.
-- `moderate` enables Bezier mouse movement, momentum scroll, idle drift,
-  reading pauses, Poisson timing, and fingerprint hardening.
-- `paranoid` enables the `moderate` profile plus synthetic tab blur and
-  viewport resize signals with stronger cursor jitter.
+The evasion system has three layers:
 
-## Configuration
+1. **Browser fingerprint hardening**
+   - `moderate` removes the `navigator.webdriver` signal
+   - `paranoid` adds the `moderate` hardening plus per-session canvas noise
+2. **Behavioral timing and movement**
+   - Bezier mouse paths with overshoot
+   - momentum-style scroll steps
+   - idle cursor drift
+   - content-proportional reading pauses
+   - Poisson-distributed interval sampling with rate-limit-aware backoff
+3. **Session management and diagnostics**
+   - `createCoreRuntime()` resolves one evasion snapshot for the whole run
+   - `runtime.evasion` is injected into auth and health responses
+   - `EvasionSession` wraps a single Playwright page with page-level helpers
 
-Runtime callers can override the defaults through `createCoreRuntime()`:
+## Architecture overview
 
-```ts
-import { createCoreRuntime } from "@linkedin-assistant/core";
+The evasion flow is built around one resolved runtime snapshot and one optional
+page session wrapper.
 
-const runtime = createCoreRuntime({
-  evasionLevel: "paranoid",
-  evasionDiagnostics: true
-});
-```
+### 1. Configuration resolution
 
-Shell and CLI users can configure the same defaults with environment variables:
+`resolveEvasionConfig()` combines three inputs into one `EvasionStatus` object:
 
-- `LINKEDIN_ASSISTANT_EVASION_LEVEL=minimal|moderate|paranoid`
-- `LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS=true|false`
+- built-in defaults
+- environment variables
+- explicit runtime options
 
-`LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS` defaults to `false`, so debug evasion
-logs stay quiet unless you opt in.
+Precedence is:
 
-## Status and health output
+1. `createCoreRuntime({ evasionLevel, evasionDiagnostics })`
+2. `LINKEDIN_ASSISTANT_EVASION_LEVEL` and
+   `LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS`
+3. built-in defaults
 
-The resolved evasion configuration is surfaced in both CLI and MCP status flows:
+The resolved object includes:
 
-- `linkedin status` includes a top-level `evasion` block.
-- `linkedin health` includes `session.evasion`.
-- MCP `linkedin.session.status` includes `status.evasion`.
-- MCP `linkedin.session.health` includes `session.evasion`.
+- `level`
+- `source`
+- `diagnosticsEnabled`
+- `enabledFeatures`
+- `disabledFeatures`
+- `profile`
+- `summary`
 
-These read-only status and health checks report the resolved configuration for
-diagnostics, but they do not inject synthetic input or fingerprint hardening into
-the inspected page.
+### 2. Runtime wiring
 
-## Session diagnostics
+`createCoreRuntime()` stores the resolved snapshot on `runtime.evasion`. That
+same snapshot is then surfaced through:
 
-`EvasionSession` accepts optional diagnostics controls so callers can trace the
-important moments without adding noise by default:
+- `runtime.auth.status()` as top-level `evasion`
+- `runtime.healthCheck()` as `session.evasion`
+- CLI `linkedin status` and `linkedin health`
+- MCP `linkedin.session.status` and `linkedin.session.health`
+
+These read-only status and health flows **report the active evasion config but
+do not inject synthetic input or fingerprint changes into the inspected page**.
+
+### 3. Page-level execution
+
+`EvasionSession` is the page wrapper used by custom Playwright flows when you
+want the behavior layer itself.
+
+Typical sequence:
 
 ```ts
 import { EvasionSession, createCoreRuntime } from "@linkedin-assistant/core";
@@ -70,16 +98,253 @@ const session = new EvasionSession(page, runtime.evasion.level, {
 });
 
 await session.hardenFingerprint();
-await session.moveMouse({ x: 0, y: 0 }, { x: 200, y: 120 });
-await session.scroll(300);
+await session.moveMouse({ x: 0, y: 0 }, { x: 240, y: 160 });
+await session.scroll(320);
+await session.readingPause(500);
 ```
 
-When diagnostics are enabled, the run log records high-signal events such as:
+The public page helpers cover:
 
-- session creation and fingerprint hardening
-- clamped scroll distances and rate-limit-aware interval sampling
-- detected CAPTCHA or honeypot signals
-- fail-open recoveries like rejected mouse moves or timer calls
+- `hardenFingerprint()`
+- `moveMouse()`
+- `scroll()`
+- `idle()`
+- `simulateTabSwitch()`
+- `simulateViewportJitter()`
+- `readingPause()`
+- `sampleInterval()`
+- `detectCaptcha()`
+- `findHoneypotFields()`
 
-That makes it easier to understand what the evasion layer attempted without
-forcing noisy output into normal CLI runs.
+### 4. Fail-open behavior
+
+The session wrapper is intentionally defensive:
+
+- out-of-range scroll distances are clamped instead of throwing
+- mouse coordinates are normalized and viewport-clamped when possible
+- failed mouse moves and timer calls are logged when diagnostics are enabled
+- fingerprint hardening is deduplicated per session
+
+That keeps diagnostics actionable without making recoverable browser issues more
+disruptive than the underlying LinkedIn workflow.
+
+## Profile matrix
+
+The default evasion level is `moderate`.
+
+| Level | Intended use | Fingerprint hardening | Mouse/scroll behavior | Timing behavior | Extra signals |
+| --- | --- | --- | --- | --- | --- |
+| `minimal` | deterministic development and test flows | disabled | straight mouse moves, no momentum scroll, no idle drift | fixed intervals, no reading pauses | no tab blur, no viewport jitter |
+| `moderate` | default production balance | `navigator.webdriver` hardening | Bezier moves, `0.15` overshoot, `3px` jitter, momentum scroll, idle drift | Poisson timing, reading pauses at `230 WPM` | no synthetic tab blur, no viewport jitter |
+| `paranoid` | more aggressive environments | `moderate` hardening plus canvas noise | Bezier moves, `0.25` overshoot, `6px` jitter, momentum scroll, idle drift | Poisson timing, reading pauses at `200 WPM` | synthetic tab blur and viewport resize events |
+
+The stable feature names surfaced in status output are:
+
+- `bezier_mouse_movement`
+- `momentum_scroll`
+- `tab_blur_simulation`
+- `viewport_resize_simulation`
+- `idle_drift`
+- `reading_pauses`
+- `poisson_timing`
+- `fingerprint_hardening`
+
+## Configuration reference
+
+### Environment variables
+
+| Variable | Values | Default | Notes |
+| --- | --- | --- | --- |
+| `LINKEDIN_ASSISTANT_EVASION_LEVEL` | `minimal`, `moderate`, `paranoid` | `moderate` | Sets the default evasion profile for CLI, MCP, and any Core caller that does not override it |
+| `LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS` | strict boolean values such as `true`, `false`, `1`, `0`, `yes`, `no`, `on`, `off` | `false` | Enables `evasion.*` debug events in the run log |
+
+Example:
+
+```bash
+export LINKEDIN_ASSISTANT_EVASION_LEVEL=paranoid
+export LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS=true
+```
+
+### Core runtime options
+
+Direct Core callers can override env/default values per runtime:
+
+```ts
+import { createCoreRuntime } from "@linkedin-assistant/core";
+
+const runtime = createCoreRuntime({
+  evasionLevel: "minimal",
+  evasionDiagnostics: false
+});
+```
+
+### Resolved status fields
+
+Every surfaced evasion snapshot uses the same shape:
+
+| Field | Meaning |
+| --- | --- |
+| `level` | effective level after precedence is applied |
+| `source` | where the level came from: `default`, `env`, or `option` |
+| `diagnosticsEnabled` | whether verbose `evasion.*` events should be logged |
+| `enabledFeatures` / `disabledFeatures` | stable feature-name lists for UI and automation |
+| `profile` | concrete numeric and boolean values used by the active level |
+| `summary` | human-readable one-line description |
+
+## CLI integration
+
+There is **no standalone `linkedin evasion ...` command group** in the current
+CLI.
+
+Instead, the CLI exposes evasion through the session diagnostics commands:
+
+- `linkedin status --profile <name>` returns a top-level `evasion` block
+- `linkedin health --profile <name>` returns `session.evasion`
+
+Important CLI behavior:
+
+- there are **no** `--evasion-level` or `--evasion-diagnostics` flags today
+- the CLI inherits evasion defaults from environment variables or built-in
+  defaults
+- the command `--help` text for `status` and `health` points operators to the
+  evasion env vars
+- enabling diagnostics affects the run log, not the JSON schema
+
+Example:
+
+```bash
+LINKEDIN_ASSISTANT_EVASION_LEVEL=paranoid \
+LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS=true \
+npm exec -w @linkedin-assistant/cli -- linkedin status --profile default
+```
+
+Shape to inspect:
+
+```json
+{
+  "authenticated": true,
+  "evasion": {
+    "level": "paranoid",
+    "source": "env",
+    "diagnosticsEnabled": true,
+    "enabledFeatures": ["bezier_mouse_movement", "momentum_scroll"]
+  }
+}
+```
+
+## MCP integration
+
+There is **no dedicated `linkedin.evasion.*` MCP tool family** in the current
+server.
+
+The evasion snapshot is exposed through the existing session tools:
+
+- `linkedin.session.status` returns `status.evasion`
+- `linkedin.session.health` returns `session.evasion`
+
+Important MCP behavior:
+
+- there are **no** per-tool evasion args today
+- MCP callers cannot set evasion level or diagnostics in tool input
+- the server process inherits env/default-driven evasion settings when it
+  starts
+- if you need per-run overrides, start the server with env vars or use the Core
+  API directly
+
+Start the server with explicit evasion defaults:
+
+```bash
+LINKEDIN_ASSISTANT_EVASION_LEVEL=moderate \
+LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS=true \
+npm exec -w @linkedin-assistant/mcp -- linkedin-mcp
+```
+
+### JSON path reference
+
+| Surface | JSON path |
+| --- | --- |
+| CLI `linkedin status` | `evasion` |
+| CLI `linkedin health` | `session.evasion` |
+| MCP `linkedin.session.status` | `status.evasion` |
+| MCP `linkedin.session.health` | `session.evasion` |
+
+## Core API notes
+
+The `@linkedin-assistant/core` package exports the evasion building blocks in
+three groups:
+
+- **profiles and status** — `DEFAULT_EVASION_LEVEL`, `EVASION_LEVELS`,
+  `EVASION_PROFILES`, `createEvasionStatus()`, `resolveEvasionLevel()`,
+  `resolveEvasionProfile()`
+- **page behavior** — `EvasionSession`, `applyFingerprintHardening()`,
+  `simulateMomentumScroll()`, `simulateIdleDrift()`, `simulateTabBlur()`,
+  `simulateViewportJitter()`, `detectCaptcha()`, `findHoneypotFields()`
+- **timing helpers** — `computeBezierPath()`, `computeMomentumSteps()`,
+  `computeReadingPauseMs()`, `samplePoissonInterval()`, `resolveIntervalMs()`
+
+Example status-only usage without a full runtime:
+
+```ts
+import { createEvasionStatus, resolveEvasionProfile } from "@linkedin-assistant/core";
+
+const evasion = createEvasionStatus({
+  level: "moderate",
+  diagnosticsEnabled: true,
+  source: "option"
+});
+
+const profile = resolveEvasionProfile(evasion.level);
+console.log(evasion.summary, profile.mouseOvershootFactor);
+```
+
+## Troubleshooting
+
+### LinkedIn still shows a checkpoint, login wall, or CAPTCHA
+
+- use `linkedin status` or `linkedin health` first to inspect `currentUrl`,
+  `reason`, `checkpointDetected`, `loginWallDetected`, and `rateLimited`
+- remember that the evasion layer does **not** solve CAPTCHA challenges
+- in custom Playwright flows, call `detectCaptcha()` and
+  `findHoneypotFields()` to stop and alert an operator
+- move from `minimal` to `moderate`, then to `paranoid`; do not assume the most
+  aggressive profile is always the best fit
+
+### Output shows the wrong level or the wrong source
+
+- inspect `source` first: `default`, `env`, or `option`
+- CLI and MCP surfaces do not accept evasion-specific flags or tool args, so
+  unexpected values usually come from environment variables or direct Core
+  runtime options
+- if multiple shells or daemons are involved, confirm the env vars were present
+  in the process that created the runtime
+
+### Diagnostics are enabled, but no `evasion.*` events appear
+
+- `status` and `health` only surface the resolved snapshot; they do not trigger
+  mouse movement, scrolling, or fingerprint hardening
+- `evasion.*` log events appear when an `EvasionSession` is actively used
+- ensure diagnostics are enabled via `LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS`
+  or `createCoreRuntime({ evasionDiagnostics: true })`
+
+Typical events include:
+
+- `runtime.evasion.configured`
+- `evasion.session.created`
+- `evasion.session.fingerprint_hardening.applied`
+- `evasion.session.interval.sampled`
+- `evasion.session.captcha.detected`
+- `evasion.session.honeypots.detected`
+- `evasion.session.operation.failed`
+
+### Tests need deterministic timing
+
+- use `minimal` for repeatable local and CI-style flows
+- `minimal` disables behavioral and fingerprint simulation while keeping the
+  same status-reporting surface available for assertions
+
+### Scroll or mouse recovery seems unusual
+
+- large scroll requests are clamped by design to avoid unrealistic jumps
+- viewport bounds are used when available to keep pointer coordinates valid
+- when diagnostics are enabled, look for `.clamped`, `.failed`, and
+  `.fallback_to_direct` events in the run log

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -27,6 +27,30 @@ Useful reminders:
 See `../../docs/activity-webhooks.md` for the full operator guide and
 `../../docs/activity-webhooks-architecture.md` for the underlying design.
 
+## Anti-bot evasion diagnostics
+
+The CLI does not expose a dedicated `linkedin evasion ...` command group.
+
+Instead, evasion is configured globally and surfaced through the session
+diagnostics commands:
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin status --profile default
+npm exec -w @linkedin-assistant/cli -- linkedin health --profile default
+```
+
+Important details:
+
+- `linkedin status` returns a top-level `evasion` block
+- `linkedin health` returns `session.evasion`
+- there are no CLI flags for evasion level or evasion diagnostics today
+- use `LINKEDIN_ASSISTANT_EVASION_LEVEL` and
+  `LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS` to change the default behavior
+- enabling diagnostics writes `evasion.*` events to the run log
+
+See `../../docs/evasion.md` for the profile matrix, exact JSON paths, and the
+troubleshooting guide.
+
 ## Tier 3 write validation
 
 Use the CLI for the Tier 3 live write-validation harness:

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -142,6 +142,7 @@ Key entry points:
 - `EvasionSession` for page-level behavioral helpers and optional diagnostics
 - `DEFAULT_EVASION_LEVEL`, `EVASION_LEVELS`, and `EVASION_PROFILES` for profile selection
 - `createEvasionStatus()` and `resolveEvasionConfig()` for resolved config snapshots
+- `computeBezierPath()`, `samplePoissonInterval()`, and the other low-level helpers for custom automation flows
 
 Example:
 
@@ -168,8 +169,11 @@ Use `runtime.evasion.summary` for a human-readable snapshot, and inspect
 `linkedin status`, `linkedin health`, `linkedin.session.status`, or
 `linkedin.session.health` when you want to confirm the resolved runtime config.
 
-See `../../docs/evasion.md` for the environment variables, profile behavior,
-and diagnostics guidance.
+`runtime.evasion.source` shows whether the active level came from the built-in
+default, an environment variable, or an explicit runtime option.
+
+See `../../docs/evasion.md` for the profile matrix, configuration precedence,
+CLI/MCP integration details, and troubleshooting guidance.
 
 ## Tier 3 write validation
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -50,15 +50,36 @@ export interface ConfirmFailureArtifactConfig {
   traceMaxBytes: number;
 }
 
-/** Environment variable that configures the default anti-bot evasion level. */
+/**
+ * Environment variable that configures the default anti-bot evasion level.
+ *
+ * @example
+ * ```ts
+ * process.env[LINKEDIN_ASSISTANT_EVASION_LEVEL_ENV] = "paranoid";
+ * ```
+ */
 export const LINKEDIN_ASSISTANT_EVASION_LEVEL_ENV =
   "LINKEDIN_ASSISTANT_EVASION_LEVEL";
 
-/** Environment variable that enables verbose evasion diagnostics in run logs. */
+/**
+ * Environment variable that enables verbose evasion diagnostics in run logs.
+ *
+ * @example
+ * ```ts
+ * process.env[LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS_ENV] = "true";
+ * ```
+ */
 export const LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS_ENV =
   "LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS";
 
-/** Resolved evasion configuration shared across runtime/session diagnostics. */
+/**
+ * Resolved evasion configuration shared across runtime/session diagnostics.
+ *
+ * @example
+ * ```ts
+ * const config: EvasionConfig = resolveEvasionConfig({ level: "moderate" });
+ * ```
+ */
 export type EvasionConfig = EvasionStatus;
 
 /**
@@ -776,6 +797,14 @@ export function resolveConfirmFailureArtifactConfig(): ConfirmFailureArtifactCon
 /**
  * Resolves the effective anti-bot evasion configuration from runtime options
  * and environment variables.
+ *
+ * @example
+ * ```ts
+ * const evasion = resolveEvasionConfig({
+ *   level: "paranoid",
+ *   diagnosticsEnabled: true
+ * });
+ * ```
  */
 export function resolveEvasionConfig(options: {
   diagnosticsEnabled?: boolean;

--- a/packages/core/src/evasion/browser.ts
+++ b/packages/core/src/evasion/browser.ts
@@ -52,6 +52,11 @@ type ScrollInstruction = {
  *
  * @param page - Playwright Page to harden.
  * @param level - Desired evasion level (defaults to `"moderate"`).
+ *
+ * @example
+ * ```ts
+ * await applyFingerprintHardening(page, "paranoid");
+ * ```
  */
 export async function applyFingerprintHardening(
   page: Page,
@@ -76,6 +81,11 @@ export async function applyFingerprintHardening(
  * @param pixels - Total scroll distance in pixels (positive = down,
  *   negative = up).
  * @param steps - Number of deceleration steps (2–20, default 6).
+ *
+ * @example
+ * ```ts
+ * await simulateMomentumScroll(page, 320);
+ * ```
  */
 export async function simulateMomentumScroll(
   page: Page,
@@ -107,6 +117,11 @@ export async function simulateMomentumScroll(
  * @param currentY - Current mouse Y coordinate.
  * @param driftCount - Number of micro-moves to perform (1–20, default 3).
  * @param radius - Maximum drift radius in pixels (0–100, default 5).
+ *
+ * @example
+ * ```ts
+ * await simulateIdleDrift(page, 240, 160, 4, 6);
+ * ```
  */
 export async function simulateIdleDrift(
   page: Page,
@@ -153,6 +168,11 @@ export async function simulateIdleDrift(
  * @param page - Playwright Page.
  * @param blurDurationMs - Duration of the simulated blur in milliseconds
  *   (100–30 000, default 2 000).
+ *
+ * @example
+ * ```ts
+ * await simulateTabBlur(page, 1_500);
+ * ```
  */
 export async function simulateTabBlur(page: Page, blurDurationMs = 2_000): Promise<void> {
   const duration = Math.round(clamp(blurDurationMs, MIN_BLUR_DURATION_MS, MAX_BLUR_DURATION_MS));
@@ -168,6 +188,11 @@ export async function simulateTabBlur(page: Page, blurDurationMs = 2_000): Promi
  * resize event may flag the session.
  *
  * @param page - Playwright Page.
+ *
+ * @example
+ * ```ts
+ * await simulateViewportJitter(page);
+ * ```
  */
 export async function simulateViewportJitter(page: Page): Promise<void> {
   await dispatchWindowEvents(page, ["resize"]);
@@ -181,6 +206,13 @@ export async function simulateViewportJitter(page: Page): Promise<void> {
  * operator when this returns `true`.
  *
  * @param page - Playwright Page to inspect.
+ *
+ * @example
+ * ```ts
+ * if (await detectCaptcha(page)) {
+ *   throw new Error("Operator intervention required");
+ * }
+ * ```
  */
 export async function detectCaptcha(page: Page): Promise<boolean> {
   return (await findMatchingSelectors(page, CAPTCHA_SELECTORS, true)).length > 0;
@@ -194,6 +226,11 @@ export async function detectCaptcha(page: Page): Promise<boolean> {
  * an array of CSS selectors for any suspected honeypot fields found.
  *
  * @param page - Playwright Page to inspect.
+ *
+ * @example
+ * ```ts
+ * const selectors = await findHoneypotFields(page);
+ * ```
  */
 export async function findHoneypotFields(page: Page): Promise<readonly string[]> {
   return findMatchingSelectors(page, HONEYPOT_SELECTORS);

--- a/packages/core/src/evasion/math.ts
+++ b/packages/core/src/evasion/math.ts
@@ -25,6 +25,15 @@ const RATE_LIMIT_STATUS_CODES = new Set([429, 999]);
  * @param options - Optional tuning and seed.
  * @returns Read-only array of points along the curved path, including both
  *          endpoints.
+ *
+ * @example
+ * ```ts
+ * const path = computeBezierPath(
+ *   { x: 0, y: 0 },
+ *   { x: 200, y: 120 },
+ *   { steps: 16, overshootFactor: 0.15, seed: 7 }
+ * );
+ * ```
  */
 export function computeBezierPath(
   from: Readonly<Point2D>,
@@ -89,6 +98,15 @@ export function computeBezierPath(
  * @param meanMs - Expected average interval in milliseconds.
  * @param options - Optional bounds and rate-limit hints.
  * @returns Sampled interval in milliseconds (≥ 0).
+ *
+ * @example
+ * ```ts
+ * const waitMs = samplePoissonInterval(800, {
+ *   minIntervalMs: 300,
+ *   maxIntervalMs: 2_000,
+ *   responseStatus: 429
+ * });
+ * ```
  */
 export function samplePoissonInterval(meanMs: number, options?: IntervalSampleOptions): number {
   const safeMeanMs = Math.max(0, normalizeFiniteNumber(meanMs, 0));
@@ -111,6 +129,11 @@ export function samplePoissonInterval(meanMs: number, options?: IntervalSampleOp
  * @param charCount - Number of visible characters to "read".
  * @param wpm - Reading speed in words per minute (1–1000).
  * @returns Estimated reading time in milliseconds (≥ 0).
+ *
+ * @example
+ * ```ts
+ * const pauseMs = computeReadingPauseMs(450, 230);
+ * ```
  */
 export function computeReadingPauseMs(charCount: number, wpm: number): number {
   const safeCharCount = Math.max(0, normalizeFiniteNumber(charCount, 0));
@@ -131,6 +154,11 @@ export function computeReadingPauseMs(charCount: number, wpm: number): number {
  * @param totalPixels - Total distance to scroll.
  * @param steps - Number of momentum steps to generate.
  * @returns Array of per-step scroll deltas.
+ *
+ * @example
+ * ```ts
+ * const steps = computeMomentumSteps(320, 6);
+ * ```
  */
 export function computeMomentumSteps(totalPixels: number, steps: number): number[] {
   const safeTotalPixels = normalizeFiniteNumber(totalPixels, 0);
@@ -163,6 +191,14 @@ export function computeMomentumSteps(totalPixels: number, steps: number): number
  * @param baseMs - Base interval in milliseconds.
  * @param options - Optional bounds and rate-limit hints.
  * @returns Resolved interval in milliseconds.
+ *
+ * @example
+ * ```ts
+ * const nextDelayMs = resolveIntervalMs(1_000, {
+ *   keepAliveIntervalMs: 5_000,
+ *   retryAfterMs: 2_000
+ * });
+ * ```
  */
 export function resolveIntervalMs(baseMs: number, options?: IntervalSampleOptions): number {
   const safeBaseMs = Math.max(0, normalizeFiniteNumber(baseMs, 0));

--- a/packages/core/src/evasion/profiles.ts
+++ b/packages/core/src/evasion/profiles.ts
@@ -7,10 +7,27 @@ import type {
   EvasionStatus
 } from "./types.js";
 
-/** Default evasion level applied when no explicit override is configured. */
+/**
+ * Default evasion level applied when no explicit override is configured.
+ *
+ * @example
+ * ```ts
+ * console.log(DEFAULT_EVASION_LEVEL);
+ * // "moderate"
+ * ```
+ */
 export const DEFAULT_EVASION_LEVEL: EvasionLevel = "moderate";
 
-/** Supported evasion levels in ascending order of intensity. */
+/**
+ * Supported evasion levels in ascending order of intensity.
+ *
+ * @example
+ * ```ts
+ * if (EVASION_LEVELS.includes("paranoid")) {
+ *   console.log("supported");
+ * }
+ * ```
+ */
 export const EVASION_LEVELS = ["minimal", "moderate", "paranoid"] as const;
 
 const MINIMAL_PROFILE: Readonly<EvasionProfile> = Object.freeze({
@@ -57,6 +74,11 @@ const PARANOID_PROFILE: Readonly<EvasionProfile> = Object.freeze({
  *
  * Most production workflows should use `"moderate"`. Reserve `"paranoid"` for
  * environments with aggressive bot detection.
+ *
+ * @example
+ * ```ts
+ * const overshoot = EVASION_PROFILES.paranoid.mouseOvershootFactor;
+ * ```
  */
 export const EVASION_PROFILES: Readonly<Record<EvasionLevel, Readonly<EvasionProfile>>> =
   Object.freeze({
@@ -103,7 +125,16 @@ const EVASION_FEATURES = [
   enabled: (profile: Readonly<EvasionProfile>) => boolean;
 }[];
 
-/** Returns whether `value` is one of the supported evasion levels. */
+/**
+ * Returns whether `value` is one of the supported evasion levels.
+ *
+ * @example
+ * ```ts
+ * if (isEvasionLevel(input)) {
+ *   console.log(`Using ${input}`);
+ * }
+ * ```
+ */
 export function isEvasionLevel(value: string): value is EvasionLevel {
   return EVASION_LEVELS.includes(value as EvasionLevel);
 }
@@ -111,6 +142,11 @@ export function isEvasionLevel(value: string): value is EvasionLevel {
 /**
  * Resolves a user-supplied evasion level and throws a clear error when the
  * value is unsupported.
+ *
+ * @example
+ * ```ts
+ * const level = resolveEvasionLevel(process.env.LINKEDIN_ASSISTANT_EVASION_LEVEL);
+ * ```
  */
 export function resolveEvasionLevel(
   value: string | EvasionLevel | undefined,
@@ -140,12 +176,27 @@ export function resolveEvasionLevel(
   );
 }
 
-/** Returns the immutable evasion profile for `level`. */
+/**
+ * Returns the immutable evasion profile for `level`.
+ *
+ * @example
+ * ```ts
+ * const profile = resolveEvasionProfile("moderate");
+ * console.log(profile.fingerprintHardening);
+ * ```
+ */
 export function resolveEvasionProfile(level: EvasionLevel): Readonly<EvasionProfile> {
   return EVASION_PROFILES[level];
 }
 
-/** Returns the stable feature names enabled by `profile`. */
+/**
+ * Returns the stable feature names enabled by `profile`.
+ *
+ * @example
+ * ```ts
+ * const enabled = getEnabledEvasionFeatures(EVASION_PROFILES.moderate);
+ * ```
+ */
 export function getEnabledEvasionFeatures(
   profile: Readonly<EvasionProfile>
 ): readonly EvasionFeatureName[] {
@@ -154,7 +205,14 @@ export function getEnabledEvasionFeatures(
   );
 }
 
-/** Returns the stable feature names disabled by `profile`. */
+/**
+ * Returns the stable feature names disabled by `profile`.
+ *
+ * @example
+ * ```ts
+ * const disabled = getDisabledEvasionFeatures(EVASION_PROFILES.minimal);
+ * ```
+ */
 export function getDisabledEvasionFeatures(
   profile: Readonly<EvasionProfile>
 ): readonly EvasionFeatureName[] {
@@ -163,7 +221,14 @@ export function getDisabledEvasionFeatures(
   );
 }
 
-/** Returns a human-readable summary for the supplied evasion level. */
+/**
+ * Returns a human-readable summary for the supplied evasion level.
+ *
+ * @example
+ * ```ts
+ * console.log(describeEvasionLevel("paranoid"));
+ * ```
+ */
 export function describeEvasionLevel(level: EvasionLevel): string {
   switch (level) {
     case "minimal":
@@ -175,7 +240,18 @@ export function describeEvasionLevel(level: EvasionLevel): string {
   }
 }
 
-/** Builds a structured evasion status snapshot for diagnostics and status output. */
+/**
+ * Builds a structured evasion status snapshot for diagnostics and status output.
+ *
+ * @example
+ * ```ts
+ * const status = createEvasionStatus({
+ *   level: "moderate",
+ *   diagnosticsEnabled: true,
+ *   source: "option"
+ * });
+ * ```
+ */
 export function createEvasionStatus(input: {
   diagnosticsEnabled?: boolean;
   level?: string | EvasionLevel;

--- a/packages/core/src/evasion/types.ts
+++ b/packages/core/src/evasion/types.ts
@@ -5,10 +5,22 @@
  * - `moderate`: Bezier mouse paths, momentum scroll, and navigator fingerprint hardening.
  * - `paranoid`: All `moderate` techniques plus tab simulation, viewport jitter, and
  *   canvas noise hardening.
+ *
+ * @example
+ * ```ts
+ * const level: EvasionLevel = "moderate";
+ * ```
  */
 export type EvasionLevel = "minimal" | "moderate" | "paranoid";
 
-/** 2D coordinate used for Bezier path computation. */
+/**
+ * 2D coordinate used for Bezier path computation.
+ *
+ * @example
+ * ```ts
+ * const point: Point2D = { x: 120, y: 48 };
+ * ```
+ */
 export interface Point2D {
   /** Horizontal coordinate in pixels. */
   x: number;
@@ -16,7 +28,18 @@ export interface Point2D {
   y: number;
 }
 
-/** Options for {@link computeBezierPath}. */
+/**
+ * Options for {@link computeBezierPath}.
+ *
+ * @example
+ * ```ts
+ * const options: BezierPathOptions = {
+ *   steps: 24,
+ *   overshootFactor: 0.2,
+ *   seed: 7
+ * };
+ * ```
+ */
 export interface BezierPathOptions {
   /**
    * Number of intermediate coordinate points to generate (min 2, max 200).
@@ -36,7 +59,19 @@ export interface BezierPathOptions {
   seed?: number;
 }
 
-/** Optional guards and backoff hints for sampled action intervals. */
+/**
+ * Optional guards and backoff hints for sampled action intervals.
+ *
+ * @example
+ * ```ts
+ * const options: IntervalSampleOptions = {
+ *   minIntervalMs: 300,
+ *   maxIntervalMs: 1_500,
+ *   responseStatus: 429,
+ *   retryAfterMs: 2_000
+ * };
+ * ```
+ */
 export interface IntervalSampleOptions {
   /** Lower bound for the returned interval in milliseconds. */
   minIntervalMs?: number;
@@ -54,7 +89,16 @@ export interface IntervalSampleOptions {
   rateLimitBackoffMultiplier?: number;
 }
 
-/** Configurable detection-evasion parameters. */
+/**
+ * Configurable detection-evasion parameters.
+ *
+ * @example
+ * ```ts
+ * import { EVASION_PROFILES } from "@linkedin-assistant/core";
+ *
+ * const profile: EvasionProfile = EVASION_PROFILES.moderate;
+ * ```
+ */
 export interface EvasionProfile {
   /** Whether to use cubic Bezier curves instead of straight-line mouse moves. */
   bezierMouseMovement: boolean;
@@ -87,10 +131,24 @@ export interface EvasionProfile {
   fingerprintHardening: boolean;
 }
 
-/** Source used to resolve the effective evasion level. */
+/**
+ * Source used to resolve the effective evasion level.
+ *
+ * @example
+ * ```ts
+ * const source: EvasionConfigSource = "env";
+ * ```
+ */
 export type EvasionConfigSource = "default" | "env" | "option";
 
-/** Stable feature names surfaced in status output and diagnostics. */
+/**
+ * Stable feature names surfaced in status output and diagnostics.
+ *
+ * @example
+ * ```ts
+ * const feature: EvasionFeatureName = "fingerprint_hardening";
+ * ```
+ */
 export type EvasionFeatureName =
   | "bezier_mouse_movement"
   | "momentum_scroll"
@@ -101,7 +159,18 @@ export type EvasionFeatureName =
   | "poisson_timing"
   | "fingerprint_hardening";
 
-/** Minimal logger surface used by optional evasion diagnostics. */
+/**
+ * Minimal logger surface used by optional evasion diagnostics.
+ *
+ * @example
+ * ```ts
+ * const logger: EvasionDiagnosticsLogger = {
+ *   log(level, event, payload) {
+ *     console.log(level, event, payload);
+ *   }
+ * };
+ * ```
+ */
 export interface EvasionDiagnosticsLogger {
   log(
     level: "debug" | "info" | "warn" | "error",
@@ -110,7 +179,20 @@ export interface EvasionDiagnosticsLogger {
   ): unknown;
 }
 
-/** Resolved evasion status exposed through runtime/session diagnostics. */
+/**
+ * Resolved evasion status exposed through runtime/session diagnostics.
+ *
+ * @example
+ * ```ts
+ * import { createEvasionStatus } from "@linkedin-assistant/core";
+ *
+ * const status: EvasionStatus = createEvasionStatus({
+ *   level: "paranoid",
+ *   diagnosticsEnabled: true,
+ *   source: "option"
+ * });
+ * ```
+ */
 export interface EvasionStatus {
   /** Whether verbose evasion diagnostics are enabled for this run. */
   diagnosticsEnabled: boolean;
@@ -128,7 +210,22 @@ export interface EvasionStatus {
   summary: string;
 }
 
-/** Optional diagnostics controls for {@link EvasionSession}. */
+/**
+ * Optional diagnostics controls for {@link EvasionSession}.
+ *
+ * @example
+ * ```ts
+ * const options: EvasionSessionOptions = {
+ *   diagnosticsEnabled: true,
+ *   diagnosticsLabel: "feed",
+ *   logger: {
+ *     log(level, event) {
+ *       console.log(level, event);
+ *     }
+ *   }
+ * };
+ * ```
+ */
 export interface EvasionSessionOptions {
   /** Override whether debug diagnostics are emitted for this session. */
   diagnosticsEnabled?: boolean;

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -95,7 +95,17 @@ function summarizeSelectorLocaleInput(
   };
 }
 
-/** Options for constructing a fully wired LinkedIn Assistant runtime. */
+/**
+ * Options for constructing a fully wired LinkedIn Assistant runtime.
+ *
+ * @example
+ * ```ts
+ * const options: CreateCoreRuntimeOptions = {
+ *   evasionLevel: "moderate",
+ *   evasionDiagnostics: true
+ * };
+ * ```
+ */
 export interface CreateCoreRuntimeOptions {
   baseDir?: string;
   dbPath?: string;
@@ -112,6 +122,13 @@ export interface CreateCoreRuntimeOptions {
 /**
  * Fully wired service graph used by the CLI, MCP server, and real-session E2E
  * suites. `close()` is safe to call repeatedly.
+ *
+ * @example
+ * ```ts
+ * const runtime = createCoreRuntime();
+ * console.log(runtime.evasion.level);
+ * runtime.close();
+ * ```
  */
 export interface CoreRuntime {
   paths: ConfigPaths;
@@ -151,6 +168,17 @@ export interface CoreRuntime {
 /**
  * Creates the fully wired LinkedIn Assistant runtime and all supporting
  * services for one execution context.
+ *
+ * @example
+ * ```ts
+ * const runtime = createCoreRuntime({
+ *   evasionLevel: "paranoid",
+ *   evasionDiagnostics: true
+ * });
+ *
+ * console.log(runtime.evasion.summary);
+ * runtime.close();
+ * ```
  */
 export function createCoreRuntime(
   options: CreateCoreRuntimeOptions = {}

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -19,6 +19,27 @@ or stop the local background activity daemon.
 See `../../docs/activity-webhooks.md` for command workflows and
 `../../docs/activity-webhooks-architecture.md` for the implementation details.
 
+## Anti-bot evasion visibility
+
+The MCP server does not expose a dedicated `linkedin.evasion.*` tool family.
+
+Instead, MCP clients inspect the resolved evasion snapshot through the existing
+session tools:
+
+- `linkedin.session.status` returns `status.evasion`
+- `linkedin.session.health` returns `session.evasion`
+
+Important details:
+
+- tool inputs do not accept evasion-specific args today
+- the MCP process inherits evasion defaults from
+  `LINKEDIN_ASSISTANT_EVASION_LEVEL` and
+  `LINKEDIN_ASSISTANT_EVASION_DIAGNOSTICS` when the server starts
+- enabling diagnostics affects the run log, not the MCP tool schema
+
+See `../../docs/evasion.md` for the JSON path reference, configuration model,
+and troubleshooting guide.
+
 ## Tier 3 write validation boundary
 
 Tier 3 live write validation is intentionally not exposed as an MCP surface.


### PR DESCRIPTION
## Summary
- expand the anti-bot evasion guide with architecture, configuration precedence, CLI and MCP integration, and troubleshooting
- update README and package README surfaces so the documented CLI and MCP evasion paths match the current implementation
- add public API JSDoc examples for the evasion helpers, profiles, and config entry points

Closes #224