### PR TITLE
feat: add paced LinkedIn profile seeding workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,18 @@ npm exec -w @linkedin-assistant/cli -- linkedin scheduler run-once --profile def
 - `scheduler run-once` and `scheduler start` reuse the same prepare-only safety model, but queue work near its due time instead of preparing everything immediately.
 - Successful scheduler ticks still leave follow-up work in the prepared state; nothing is sent automatically.
 
+Profile seeding commands:
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin profile editable --profile default
+npm exec -w @linkedin-assistant/cli -- linkedin profile apply-spec --profile default --spec docs/profile-seeds/issue-210-signikant-test-profile.json --allow-partial --yes --delay-ms 4000
+```
+
+- `profile editable` mirrors the MCP editable-profile surface in the CLI.
+- `profile apply-spec` reads a JSON profile spec, prepares the necessary profile edits, confirms them one by one, and inserts paced delays between actions.
+- The bundled issue-210 example spec currently needs `--allow-partial` because skills (`#228`) plus industry/custom public URL (`#252`) are still tracked as follow-up gaps.
+- See `docs/profile-seeding.md` for the full workflow, bundled spec, and current blockers.
+
 Confirm prepared actions by token:
 
 ```bash

--- a/docs/profile-seeding.md
+++ b/docs/profile-seeding.md
@@ -1,0 +1,50 @@
+# Profile seeding workflow
+
+This repo now includes CLI support for inspecting the editable LinkedIn profile
+surface and applying a paced JSON profile spec through the existing two-phase
+profile edit actions.
+
+## Commands
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin profile editable --profile <profile>
+npm exec -w @linkedin-assistant/cli -- linkedin profile apply-spec --profile <profile> --spec docs/profile-seeds/issue-210-signikant-test-profile.json --allow-partial --yes --delay-ms 4000 --output reports/profile-seed.json
+```
+
+## Intended issue-210 flow
+
+1. Authenticate a dedicated browser profile for the test account.
+2. Inspect the current editable profile surface:
+   ```bash
+   npm exec -w @linkedin-assistant/cli -- linkedin profile editable --profile <profile>
+   ```
+3. Apply the seeded profile spec:
+   ```bash
+   npm exec -w @linkedin-assistant/cli -- linkedin profile apply-spec --profile <profile> --spec docs/profile-seeds/issue-210-signikant-test-profile.json --allow-partial --yes --delay-ms 4000
+   ```
+4. Verify the rendered profile:
+   ```bash
+   npm exec -w @linkedin-assistant/cli -- linkedin profile view me --profile <profile>
+   ```
+
+## Current blockers
+
+- Skills are still unsupported by the MCP/CLI profile editing surface: #228.
+- Industry and custom public profile URL are now tracked separately: #252.
+- The current AO workspace does not yet have a provisioned authenticated session
+  for the dedicated `linkedin-mcp@signikant.com` test account: #253.
+
+Because of those gaps, the example issue-210 spec includes the full desired
+state, but `linkedin profile apply-spec` currently requires `--allow-partial`
+to ignore unsupported fields while still applying the supported intro/about/
+experience/education/certifications/languages/projects/volunteer sections.
+
+## Notes
+
+- `apply-spec` uses the existing profile prepare/confirm flow internally and
+  confirms one change at a time.
+- The command inserts a randomized delay around the configured `--delay-ms`
+  value between confirmed actions so large profile edits do not fire in a single
+  burst.
+- `--replace` removes unmatched items for sections included in the spec. This is
+  best suited for a fresh or intentionally reset test profile.

--- a/docs/profile-seeds/issue-210-signikant-test-profile.json
+++ b/docs/profile-seeds/issue-210-signikant-test-profile.json
@@ -1,0 +1,137 @@
+{
+  "intro": {
+    "firstName": "Emil",
+    "lastName": "Sorensen",
+    "headline": "AI/ML Engineer at Signikant | TypeScript, Python, LLM Systems, MLOps",
+    "location": "Copenhagen, Capital Region of Denmark, Denmark",
+    "industry": "Software Development",
+    "customProfileUrl": "emil-sorensen-signikant"
+  },
+  "about": "I build AI products that have to work outside the demo. Over the last several years I have worked across backend engineering, applied machine learning, and developer experience, shipping production systems in TypeScript and Python with a focus on quality, observability, and pragmatic product delivery.\n\nMy strongest work sits at the boundary between product and platform: retrieval and evaluation pipelines, internal AI tooling, model-backed user journeys, and the developer workflows required to make those systems trustworthy. I enjoy turning ambiguous ideas into reliable, well-instrumented services that teams can iterate on with confidence.\n\nAt Signikant I focus on LLM-powered automation, evaluation loops, and the platform pieces that help small teams ship faster without losing engineering discipline. I care a lot about clear communication, thoughtful DX, and keeping the human in the loop where it matters.",
+  "experience": [
+    {
+      "title": "AI/ML Engineer",
+      "company": "Signikant",
+      "employmentType": "Full-time",
+      "location": "Copenhagen, Denmark",
+      "currentlyWorkingHere": true,
+      "startMonth": "March",
+      "startYear": "2023",
+      "description": "Lead implementation of LLM-backed internal tools and customer-facing product experiments. Built evaluation loops, prompt/version management workflows, and observability patterns for model-assisted features. Partner closely with product and design to move from prototype to production with clear guardrails and measurable outcomes."
+    },
+    {
+      "title": "Senior Software Engineer, Applied AI",
+      "company": "Corti",
+      "employmentType": "Full-time",
+      "location": "Copenhagen, Denmark",
+      "startMonth": "January",
+      "startYear": "2021",
+      "endMonth": "February",
+      "endYear": "2023",
+      "description": "Worked on speech and NLP-adjacent product surfaces for healthcare workflows. Built backend services and developer tooling for model integration, annotation feedback loops, and production debugging. Helped improve deployment confidence through stronger test coverage, release automation, and runtime telemetry."
+    },
+    {
+      "title": "Software Engineer",
+      "company": "Pleo",
+      "employmentType": "Full-time",
+      "location": "Copenhagen, Denmark",
+      "startMonth": "August",
+      "startYear": "2018",
+      "endMonth": "December",
+      "endYear": "2020",
+      "description": "Built product and platform features across Node.js services and frontend applications. Contributed to internal tooling, API integrations, and CI improvements that reduced manual operations and improved delivery speed. Developed a strong foundation in product engineering, cross-functional collaboration, and operational quality."
+    }
+  ],
+  "education": [
+    {
+      "school": "University of Copenhagen",
+      "degree": "MSc",
+      "fieldOfStudy": "Computer Science",
+      "startMonth": "September",
+      "startYear": "2016",
+      "endMonth": "June",
+      "endYear": "2018",
+      "description": "Focused on machine learning, distributed systems, and data-intensive application design."
+    },
+    {
+      "school": "IT University of Copenhagen",
+      "degree": "BSc",
+      "fieldOfStudy": "Software Development",
+      "startMonth": "September",
+      "startYear": "2013",
+      "endMonth": "June",
+      "endYear": "2016",
+      "description": "Coursework included algorithms, databases, human-computer interaction, and web engineering."
+    }
+  ],
+  "certifications": [
+    {
+      "name": "Google Cloud Professional Machine Learning Engineer",
+      "issuingOrganization": "Google Cloud",
+      "issueMonth": "May",
+      "issueYear": "2024",
+      "credentialId": "GCP-PMLE-2024-1187"
+    },
+    {
+      "name": "AWS Certified Developer - Associate",
+      "issuingOrganization": "Amazon Web Services",
+      "issueMonth": "October",
+      "issueYear": "2022",
+      "credentialId": "AWS-CDA-2022-4471"
+    }
+  ],
+  "languages": [
+    {
+      "name": "English",
+      "proficiency": "Full professional proficiency"
+    },
+    {
+      "name": "Danish",
+      "proficiency": "Native or bilingual proficiency"
+    }
+  ],
+  "projects": [
+    {
+      "title": "LLM Evaluation Toolkit",
+      "description": "Designed a lightweight evaluation harness for prompt, retrieval, and regression testing across model-assisted workflows.",
+      "startMonth": "June",
+      "startYear": "2023"
+    },
+    {
+      "title": "Production RAG Platform",
+      "description": "Built reusable ingestion, retrieval, and citation services for internal AI workflows with traceability and observability baked in.",
+      "startMonth": "November",
+      "startYear": "2023"
+    }
+  ],
+  "volunteerExperience": [
+    {
+      "role": "Technical Mentor",
+      "organization": "Coding Pirates",
+      "cause": "Education",
+      "startMonth": "September",
+      "startYear": "2022",
+      "description": "Mentor students on programming fundamentals, simple hardware projects, and creative problem-solving with code."
+    }
+  ],
+  "skills": [
+    "TypeScript",
+    "JavaScript",
+    "Node.js",
+    "Python",
+    "Machine Learning",
+    "Applied AI",
+    "LLMs",
+    "Prompt Engineering",
+    "MLOps",
+    "Retrieval-Augmented Generation (RAG)",
+    "OpenAI API",
+    "FastAPI",
+    "PostgreSQL",
+    "Docker",
+    "Kubernetes",
+    "CI/CD",
+    "Observability",
+    "Playwright"
+  ]
+}

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -190,6 +190,12 @@ import {
   type KeepAliveStatusReport,
   type KeepAliveStopReport
 } from "../keepAliveOutput.js";
+import {
+  createProfileSeedPlan,
+  parseProfileSeedSpec,
+  type ProfileSeedPlanAction,
+  type ProfileSeedUnsupportedField
+} from "../profileSeed.js";
 
 const cliPrivacyConfig = resolvePrivacyConfig();
 const SELECTOR_AUDIT_DOC_PATH = "docs/selector-audit.md";
@@ -5373,6 +5379,213 @@ async function runProfileView(input: {
   }
 }
 
+async function runProfileViewEditable(input: {
+  profileName: string;
+}, cdpUrl?: string): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.profile.view_editable.start", {
+      profileName: input.profileName
+    });
+
+    const profile = await runtime.profile.viewEditableProfile({
+      profileName: input.profileName
+    });
+
+    runtime.logger.log("info", "cli.profile.view_editable.done", {
+      profileName: input.profileName,
+      sectionCount: profile.sections.length
+    });
+
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      profile
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+function summarizeProfileSeedUnsupportedFields(
+  unsupportedFields: readonly ProfileSeedUnsupportedField[]
+): string {
+  return unsupportedFields
+    .map((field) => `${field.path} (#${field.issueNumber})`)
+    .join(", ");
+}
+
+function createProfileSeedUnsupportedFieldsError(
+  unsupportedFields: readonly ProfileSeedUnsupportedField[]
+): LinkedInAssistantError {
+  return new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    `Profile seed spec includes unsupported fields: ${summarizeProfileSeedUnsupportedFields(unsupportedFields)}. Remove them or rerun with --allow-partial.`,
+    {
+      unsupported_fields: unsupportedFields.map((field) => ({
+        path: field.path,
+        issue_number: field.issueNumber,
+        reason: field.reason
+      }))
+    }
+  );
+}
+
+function sampleProfileSeedDelay(baseDelayMs: number): number {
+  if (baseDelayMs <= 0) {
+    return 0;
+  }
+
+  const jitter = Math.max(250, Math.round(baseDelayMs * 0.35));
+  const minimum = Math.max(0, baseDelayMs - jitter);
+  const maximum = baseDelayMs + jitter;
+  return minimum + Math.floor(Math.random() * (maximum - minimum + 1));
+}
+
+function prepareProfileSeedAction(
+  runtime: ReturnType<typeof createRuntime>,
+  action: ProfileSeedPlanAction
+) {
+  switch (action.kind) {
+    case "update_intro":
+      return runtime.profile.prepareUpdateIntro(action.input);
+    case "upsert_section_item":
+      return runtime.profile.prepareUpsertSectionItem(action.input);
+    case "remove_section_item":
+      return runtime.profile.prepareRemoveSectionItem(action.input);
+  }
+}
+
+async function runProfileApplySpec(input: {
+  profileName: string;
+  specPath: string;
+  replace: boolean;
+  allowPartial: boolean;
+  delayMs: number;
+  yes: boolean;
+  outputPath?: string;
+}, cdpUrl?: string): Promise<void> {
+  const resolvedSpecPath = path.resolve(input.specPath);
+  const rawSpec = await readJsonInputFile(resolvedSpecPath, "profile seed spec");
+  const spec = parseProfileSeedSpec(rawSpec);
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.profile.apply_spec.start", {
+      profileName: input.profileName,
+      specPath: resolvedSpecPath,
+      replace: input.replace,
+      allowPartial: input.allowPartial,
+      delayMs: input.delayMs
+    });
+
+    const editableProfile = await runtime.profile.viewEditableProfile({
+      profileName: input.profileName
+    });
+    const plan = createProfileSeedPlan(editableProfile, spec, {
+      profileName: input.profileName,
+      operatorNote: `profile seed: ${path.basename(resolvedSpecPath)}`,
+      replace: input.replace
+    });
+
+    if (plan.unsupportedFields.length > 0 && !input.allowPartial) {
+      throw createProfileSeedUnsupportedFieldsError(plan.unsupportedFields);
+    }
+
+    if (plan.unsupportedFields.length > 0) {
+      writeCliWarning(
+        `Ignoring unsupported profile fields for this run: ${summarizeProfileSeedUnsupportedFields(plan.unsupportedFields)}.`
+      );
+    }
+
+    if (plan.actions.length > 0) {
+      writeCliNotice(
+        `Loaded ${resolvedSpecPath} with ${plan.actions.length} supported profile ${plan.actions.length === 1 ? "edit" : "edits"}.`
+      );
+    } else {
+      writeCliNotice(`Loaded ${resolvedSpecPath}; no supported profile edits are required.`);
+    }
+
+    if (!input.yes && plan.actions.length > 0) {
+      if (!stdin.isTTY || !stdout.isTTY) {
+        throw new LinkedInAssistantError(
+          "ACTION_PRECONDITION_FAILED",
+          "Refusing to apply a profile seed spec without --yes in non-interactive mode."
+        );
+      }
+
+      const confirmed = await promptYesNo(
+        `Apply ${plan.actions.length} LinkedIn profile ${plan.actions.length === 1 ? "edit" : "edits"}?`,
+        process.stderr
+      );
+      if (!confirmed) {
+        throw new LinkedInAssistantError(
+          "ACTION_PRECONDITION_FAILED",
+          "Operator declined profile seed execution."
+        );
+      }
+    }
+
+    const actionResults: Array<Record<string, unknown>> = [];
+    for (let index = 0; index < plan.actions.length; index += 1) {
+      const action = plan.actions[index]!;
+      const prepared = prepareProfileSeedAction(runtime, action);
+      const confirmed = await runtime.twoPhaseCommit.confirmByToken({
+        confirmToken: prepared.confirmToken
+      });
+
+      actionResults.push({
+        summary: action.summary,
+        action_type: confirmed.actionType,
+        prepared_action_id: confirmed.preparedActionId,
+        status: confirmed.status,
+        result: confirmed.result,
+        artifacts: confirmed.artifacts
+      });
+
+      if (index < plan.actions.length - 1 && input.delayMs > 0) {
+        await sleep(sampleProfileSeedDelay(input.delayMs));
+      }
+    }
+
+    const finalProfile = await runtime.profile.viewProfile({
+      profileName: input.profileName,
+      target: "me"
+    });
+
+    const report: Record<string, unknown> = {
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      spec_path: resolvedSpecPath,
+      replace: input.replace,
+      allow_partial: input.allowPartial,
+      delay_ms: input.delayMs,
+      planned_action_count: plan.actions.length,
+      executed_action_count: actionResults.length,
+      unsupported_fields: plan.unsupportedFields,
+      actions: actionResults,
+      profile: finalProfile
+    };
+
+    if (input.outputPath) {
+      report.output_path = await writeOutputJsonFile(input.outputPath, report);
+    }
+
+    runtime.logger.log("info", "cli.profile.apply_spec.done", {
+      profileName: input.profileName,
+      specPath: resolvedSpecPath,
+      plannedActionCount: plan.actions.length,
+      executedActionCount: actionResults.length,
+      unsupportedFieldCount: plan.unsupportedFields.length
+    });
+
+    printJson(report);
+  } finally {
+    runtime.close();
+  }
+}
+
 async function runSearch(input: {
   profileName: string;
   query: string;
@@ -7616,6 +7829,71 @@ export function createCliProgram(): Command {
         target
       }, readCdpUrl());
     });
+
+  profileCommand
+    .command("editable")
+    .description("Inspect the logged-in member's editable LinkedIn profile surface")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .action(async (options: { profile: string }) => {
+      await runProfileViewEditable({
+        profileName: options.profile
+      }, readCdpUrl());
+    });
+
+  profileCommand
+    .command("apply-spec")
+    .description("Apply a JSON profile seed spec with paced LinkedIn profile edits")
+    .requiredOption("--spec <path>", "Path to a JSON profile seed spec")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .option(
+      "--replace",
+      "Remove unmatched supported section items for sections included in the spec",
+      false
+    )
+    .option(
+      "--allow-partial",
+      "Continue when the spec includes unsupported fields such as skills or custom public URL",
+      false
+    )
+    .option(
+      "--delay-ms <ms>",
+      "Base delay between confirmed profile edits",
+      "3500"
+    )
+    .option("-y, --yes", "Skip the interactive confirmation prompt", false)
+    .option("--output <path>", "Write the final JSON report to a file")
+    .addHelpText(
+      "after",
+      [
+        "",
+        "Notes:",
+        "  - uses the existing two-phase profile edit actions under the hood and confirms them one by one",
+        "  - paces edits with a randomized delay so large profile updates do not fire back-to-back",
+        "  - unsupported fields currently include skills (#228) plus industry/custom public URL (#252)",
+        "  - run \"linkedin profile editable\" first if you want to inspect the current section structure"
+      ].join("\n")
+    )
+    .action(
+      async (options: {
+        profile: string;
+        spec: string;
+        replace: boolean;
+        allowPartial: boolean;
+        delayMs: string;
+        yes: boolean;
+        output?: string;
+      }) => {
+        await runProfileApplySpec({
+          profileName: options.profile,
+          specPath: options.spec,
+          replace: options.replace,
+          allowPartial: options.allowPartial,
+          delayMs: coerceNonNegativeInt(options.delayMs, "delay-ms"),
+          yes: options.yes,
+          ...(options.output ? { outputPath: options.output } : {})
+        }, readCdpUrl());
+      }
+    );
 
   const auditCommand = program
     .command("audit")

--- a/packages/cli/src/profileSeed.ts
+++ b/packages/cli/src/profileSeed.ts
@@ -1,0 +1,639 @@
+import {
+  LINKEDIN_PROFILE_SECTION_TYPES,
+  LinkedInAssistantError,
+  type LinkedInEditableProfile,
+  type LinkedInProfileEditableSection,
+  type LinkedInProfileEditableSectionItem,
+  type LinkedInProfileSectionItemMatch,
+  type LinkedInProfileSectionType,
+  type PrepareRemoveSectionItemInput,
+  type PrepareUpdateIntroInput,
+  type PrepareUpsertSectionItemInput
+} from "@linkedin-assistant/core";
+
+const SUPPORTED_SECTION_TYPES = LINKEDIN_PROFILE_SECTION_TYPES.filter(
+  (section) => section !== "about"
+);
+
+const SECTION_KEY_ALIASES = new Map<string, LinkedInProfileSectionType>([
+  ["experience", "experience"],
+  ["education", "education"],
+  ["certifications", "certifications"],
+  ["licensescertifications", "certifications"],
+  ["languages", "languages"],
+  ["projects", "projects"],
+  ["volunteerexperience", "volunteer_experience"],
+  ["volunteer_experience", "volunteer_experience"],
+  ["honorsawards", "honors_awards"],
+  ["honors_awards", "honors_awards"]
+]);
+
+const INTRO_FIELD_KEYS = new Set(["firstName", "lastName", "headline", "location"]);
+const INTRO_UNSUPPORTED_FIELD_KEYS = new Map<string, { reason: string; issueNumber: number }>([
+  [
+    "industry",
+    {
+      reason: "Industry is not exposed by the current LinkedIn profile edit automation.",
+      issueNumber: 252
+    }
+  ],
+  [
+    "customProfileUrl",
+    {
+      reason:
+        "Custom public profile URL is not exposed by the current LinkedIn profile edit automation.",
+      issueNumber: 252
+    }
+  ],
+  [
+    "publicProfileUrl",
+    {
+      reason:
+        "Custom public profile URL is not exposed by the current LinkedIn profile edit automation.",
+      issueNumber: 252
+    }
+  ],
+  [
+    "vanityUrl",
+    {
+      reason:
+        "Custom public profile URL is not exposed by the current LinkedIn profile edit automation.",
+      issueNumber: 252
+    }
+  ]
+]);
+
+const SECTION_IDENTITY_FIELDS: Record<Exclude<LinkedInProfileSectionType, "about">, string[]> = {
+  experience: ["title", "company"],
+  education: ["school", "degree"],
+  certifications: ["name", "issuingOrganization"],
+  languages: ["name"],
+  projects: ["title"],
+  volunteer_experience: ["role", "organization"],
+  honors_awards: ["title", "issuer"]
+};
+
+type SeedSectionType = Exclude<LinkedInProfileSectionType, "about">;
+
+export interface ProfileSeedUnsupportedField {
+  path: string;
+  reason: string;
+  issueNumber: number;
+}
+
+export interface ProfileSeedSectionInput {
+  itemId?: string;
+  match?: LinkedInProfileSectionItemMatch;
+  values: Record<string, unknown>;
+}
+
+export interface ProfileSeedSpec {
+  intro?: Record<string, unknown>;
+  about?: string | null;
+  sections: Partial<Record<SeedSectionType, ProfileSeedSectionInput[]>>;
+  unsupportedFields: ProfileSeedUnsupportedField[];
+}
+
+export interface ProfileSeedPlan {
+  actions: ProfileSeedPlanAction[];
+  unsupportedFields: ProfileSeedUnsupportedField[];
+}
+
+export type ProfileSeedPlanAction =
+  | {
+      kind: "update_intro";
+      summary: string;
+      input: PrepareUpdateIntroInput;
+    }
+  | {
+      kind: "upsert_section_item";
+      summary: string;
+      input: PrepareUpsertSectionItemInput;
+    }
+  | {
+      kind: "remove_section_item";
+      summary: string;
+      input: PrepareRemoveSectionItemInput;
+    };
+
+export function parseProfileSeedSpec(input: unknown): ProfileSeedSpec {
+  if (!isRecord(input)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "Profile seed spec must be a JSON object."
+    );
+  }
+
+  const unsupportedFields: ProfileSeedUnsupportedField[] = [];
+  const intro = normalizeIntroSpec(input.intro, unsupportedFields);
+  const about = normalizeAboutSpec(input.about);
+  const sections: Partial<Record<SeedSectionType, ProfileSeedSectionInput[]>> = {};
+
+  for (const [rawKey, rawValue] of Object.entries(input)) {
+    if (rawKey === "intro" || rawKey === "about" || rawKey === "metadata" || rawKey === "notes") {
+      continue;
+    }
+
+    if (rawKey === "skills") {
+      if (Array.isArray(rawValue) && rawValue.length > 0) {
+        unsupportedFields.push({
+          path: "skills",
+          reason: "Skills are not exposed by the current LinkedIn profile edit automation.",
+          issueNumber: 228
+        });
+      }
+      continue;
+    }
+
+    if (rawKey === "industry" || rawKey === "customProfileUrl" || rawKey === "publicProfileUrl") {
+      unsupportedFields.push({
+        path: rawKey,
+        reason:
+          rawKey === "industry"
+            ? "Industry is not exposed by the current LinkedIn profile edit automation."
+            : "Custom public profile URL is not exposed by the current LinkedIn profile edit automation.",
+        issueNumber: 252
+      });
+      continue;
+    }
+
+    const section = SECTION_KEY_ALIASES.get(normalizeKey(rawKey));
+    if (!section || section === "about") {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `Unsupported profile seed spec key "".`
+      );
+    }
+
+    sections[section] = normalizeSectionInputs(rawValue, rawKey);
+  }
+
+  return {
+    ...(intro ? { intro } : {}),
+    ...(about !== undefined ? { about } : {}),
+    sections,
+    unsupportedFields
+  };
+}
+
+export function createProfileSeedPlan(
+  current: LinkedInEditableProfile,
+  spec: ProfileSeedSpec,
+  options: {
+    profileName: string;
+    operatorNote?: string;
+    replace: boolean;
+  }
+): ProfileSeedPlan {
+  const actions: ProfileSeedPlanAction[] = [];
+  const currentSections = new Map<LinkedInProfileSectionType, LinkedInProfileEditableSection>(
+    current.sections.map((section) => [section.section, section])
+  );
+
+  if (spec.intro) {
+    const introUpdates = createIntroUpdates(current, spec.intro);
+    if (Object.keys(introUpdates).length > 0) {
+      actions.push({
+        kind: "update_intro",
+        summary: `Update intro (${Object.keys(introUpdates).join(", ")})`,
+        input: {
+          profileName: options.profileName,
+          ...introUpdates,
+          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
+        }
+      });
+    }
+  }
+
+  if (spec.about !== undefined) {
+    const aboutSection = currentSections.get("about");
+    const currentAboutItem = aboutSection?.items[0];
+    const desiredAbout = typeof spec.about === "string" ? spec.about.trim() : "";
+    const currentAbout = readCurrentAboutText(currentAboutItem);
+
+    if (desiredAbout !== currentAbout) {
+      if (desiredAbout.length === 0) {
+        actions.push({
+          kind: "remove_section_item",
+          summary: currentAboutItem ? "Clear about summary" : "No-op clear about summary",
+          input: {
+            profileName: options.profileName,
+            section: "about",
+            ...(currentAboutItem ? { itemId: currentAboutItem.item_id } : {}),
+            ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
+          }
+        });
+      } else {
+        actions.push({
+          kind: "upsert_section_item",
+          summary: currentAboutItem ? "Update about summary" : "Create about summary",
+          input: {
+            profileName: options.profileName,
+            section: "about",
+            ...(currentAboutItem ? { itemId: currentAboutItem.item_id } : {}),
+            values: { text: desiredAbout },
+            ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
+          }
+        });
+      }
+    }
+  }
+
+  for (const section of SUPPORTED_SECTION_TYPES) {
+    const desiredItems = spec.sections[section];
+    if (!desiredItems) {
+      continue;
+    }
+
+    const currentItems = currentSections.get(section)?.items ?? [];
+    const matchedCurrentItemIds = new Set<string>();
+
+    for (const desiredItem of desiredItems) {
+      const matchedItem = findCurrentSectionItem(currentItems, section, desiredItem);
+      const resolvedItemId = matchedItem?.item_id ?? desiredItem.itemId;
+      if (matchedItem) {
+        matchedCurrentItemIds.add(matchedItem.item_id);
+      }
+
+      actions.push({
+        kind: "upsert_section_item",
+        summary: buildUpsertSummary(section, desiredItem.values, Boolean(resolvedItemId)),
+        input: {
+          profileName: options.profileName,
+          section,
+          ...(resolvedItemId ? { itemId: resolvedItemId } : {}),
+          ...(!resolvedItemId && desiredItem.match ? { match: desiredItem.match } : {}),
+          values: desiredItem.values,
+          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
+        }
+      });
+    }
+
+    if (options.replace) {
+      for (const currentItem of currentItems) {
+        if (matchedCurrentItemIds.has(currentItem.item_id)) {
+          continue;
+        }
+
+        actions.push({
+          kind: "remove_section_item",
+          summary: buildRemoveSummary(section, currentItem),
+          input: {
+            profileName: options.profileName,
+            section,
+            itemId: currentItem.item_id,
+            ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
+          }
+        });
+      }
+    }
+  }
+
+  return {
+    actions,
+    unsupportedFields: [...spec.unsupportedFields]
+  };
+}
+
+function normalizeIntroSpec(
+  value: unknown,
+  unsupportedFields: ProfileSeedUnsupportedField[]
+): Record<string, unknown> | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!isRecord(value)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "profile seed intro must be a JSON object."
+    );
+  }
+
+  const intro: Record<string, unknown> = {};
+
+  for (const [key, rawValue] of Object.entries(value)) {
+    if (INTRO_FIELD_KEYS.has(key)) {
+      intro[key] = rawValue;
+      continue;
+    }
+
+    const unsupported = INTRO_UNSUPPORTED_FIELD_KEYS.get(key);
+    if (unsupported) {
+      if (rawValue !== undefined && rawValue !== null && rawValue !== "") {
+        unsupportedFields.push({
+          path: `intro.${key}`,
+          reason: unsupported.reason,
+          issueNumber: unsupported.issueNumber
+        });
+      }
+      continue;
+    }
+
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `Unsupported intro field "" in profile seed spec.`
+    );
+  }
+
+  return Object.keys(intro).length > 0 ? intro : undefined;
+}
+
+function normalizeAboutSpec(value: unknown): string | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (isRecord(value) && typeof value.text === "string") {
+    return value.text;
+  }
+
+  throw new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    'profile seed "about" must be a string, null, or an object with a string "text" field.'
+  );
+}
+
+function normalizeSectionInputs(
+  value: unknown,
+  label: string
+): ProfileSeedSectionInput[] {
+  if (!Array.isArray(value)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must be a JSON array.`
+    );
+  }
+
+  return value.map((entry, index) => normalizeSectionInput(entry, `${label}[${index}]`));
+}
+
+function normalizeSectionInput(
+  value: unknown,
+  label: string
+): ProfileSeedSectionInput {
+  if (!isRecord(value)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must be a JSON object.`
+    );
+  }
+
+  const itemId = typeof value.itemId === "string" ? value.itemId.trim() : undefined;
+  const rawMatch =
+    isRecord(value.match) || isRecord(value._match)
+      ? (isRecord(value.match) ? value.match : value._match)
+      : undefined;
+  const match = rawMatch ? normalizeMatch(rawMatch as Record<string, unknown>, `.match`) : undefined;
+  const values: Record<string, unknown> = {};
+
+  for (const [key, entryValue] of Object.entries(value)) {
+    if (key === "itemId" || key === "match" || key === "_match" || key === "_itemId") {
+      continue;
+    }
+    values[key] = entryValue;
+  }
+
+  if (Object.keys(values).length === 0) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must include at least one section value.`
+    );
+  }
+
+  return {
+    ...(itemId ? { itemId } : {}),
+    ...(match ? { match } : {}),
+    values
+  };
+}
+
+function normalizeMatch(
+  value: Record<string, unknown>,
+  label: string
+): LinkedInProfileSectionItemMatch {
+  const match: LinkedInProfileSectionItemMatch = {};
+
+  for (const [key, rawValue] of Object.entries(value)) {
+    if (typeof rawValue !== "string") {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `${label}.${key} must be a string.`
+      );
+    }
+
+    if (
+      key !== "sourceId" &&
+      key !== "primaryText" &&
+      key !== "secondaryText" &&
+      key !== "tertiaryText" &&
+      key !== "rawText"
+    ) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `${label}.${key} is not a supported match field.`
+      );
+    }
+
+    match[key] = rawValue;
+  }
+
+  return match;
+}
+
+function createIntroUpdates(
+  current: LinkedInEditableProfile,
+  desiredIntro: Record<string, unknown>
+): Record<string, string> {
+  const updates: Record<string, string> = {};
+
+  for (const [key, rawValue] of Object.entries(desiredIntro)) {
+    const desiredValue = readString(rawValue);
+    if (!desiredValue) {
+      continue;
+    }
+
+    const currentValue =
+      key === "firstName"
+        ? normalizeForCompare(readFirstName(current.intro.full_name))
+        : key === "lastName"
+          ? normalizeForCompare(readLastName(current.intro.full_name))
+          : key === "headline"
+            ? normalizeForCompare(current.intro.headline)
+            : normalizeForCompare(current.intro.location);
+
+    if (normalizeForCompare(desiredValue) !== currentValue) {
+      updates[key] = desiredValue;
+    }
+  }
+
+  return updates;
+}
+
+function readFirstName(fullName: string): string {
+  return fullName.trim().split(/\s+/)[0] ?? "";
+}
+
+function readLastName(fullName: string): string {
+  const parts = fullName.trim().split(/\s+/);
+  return parts.length > 1 ? parts.slice(1).join(" ") : "";
+}
+
+function readCurrentAboutText(item: LinkedInProfileEditableSectionItem | undefined): string {
+  if (!item) {
+    return "";
+  }
+
+  return readString(item.description || item.raw_text || item.primary_text);
+}
+
+function findCurrentSectionItem(
+  currentItems: readonly LinkedInProfileEditableSectionItem[],
+  section: SeedSectionType,
+  desiredItem: ProfileSeedSectionInput
+): LinkedInProfileEditableSectionItem | undefined {
+  if (desiredItem.itemId) {
+    return currentItems.find((item) => item.item_id === desiredItem.itemId);
+  }
+
+  const explicitMatch = desiredItem.match;
+  if (explicitMatch) {
+    return currentItems.find((item) => doesItemMatch(item, explicitMatch));
+  }
+
+  const identityStrings = SECTION_IDENTITY_FIELDS[section]
+    .map((field) => normalizeForCompare(desiredItem.values[field]))
+    .filter(Boolean);
+
+  if (identityStrings.length === 0) {
+    return undefined;
+  }
+
+  return currentItems.find((item) => {
+    const haystack = normalizeForCompare(
+      [item.primary_text, item.secondary_text, item.tertiary_text, item.description, item.raw_text]
+        .filter(Boolean)
+        .join(" ")
+    );
+    return identityStrings.every((needle) => haystack.includes(needle));
+  });
+}
+
+function doesItemMatch(
+  item: LinkedInProfileEditableSectionItem,
+  match: LinkedInProfileSectionItemMatch
+): boolean {
+  const comparisons: Array<[string | undefined, string]> = [
+    [match.sourceId, normalizeForCompare(item.source_id)],
+    [match.primaryText, normalizeForCompare(item.primary_text)],
+    [match.secondaryText, normalizeForCompare(item.secondary_text)],
+    [match.tertiaryText, normalizeForCompare(item.tertiary_text)],
+    [match.rawText, normalizeForCompare(item.raw_text)]
+  ];
+  let matched = 0;
+
+  for (const [expected, actual] of comparisons) {
+    if (!expected) {
+      continue;
+    }
+
+    const normalizedExpected = normalizeForCompare(expected);
+    if (!normalizedExpected) {
+      continue;
+    }
+
+    if (actual === normalizedExpected || actual.includes(normalizedExpected)) {
+      matched += 1;
+      continue;
+    }
+
+    return false;
+  }
+
+  return matched > 0;
+}
+
+function buildUpsertSummary(
+  section: SeedSectionType,
+  values: Record<string, unknown>,
+  updating: boolean
+): string {
+  const subject = describeSectionValues(section, values);
+  return `${updating ? "Update" : "Create"} ${section.replaceAll("_", " ")} item${subject ? `: ${subject}` : ""}`;
+}
+
+function buildRemoveSummary(
+  section: SeedSectionType,
+  item: LinkedInProfileEditableSectionItem
+): string {
+  const subject = describeSectionItem(section, item);
+  return `Remove ${section.replaceAll("_", " ")} item${subject ? `: ${subject}` : ""}`;
+}
+
+function describeSectionValues(
+  section: SeedSectionType,
+  values: Record<string, unknown>
+): string {
+  switch (section) {
+    case "experience":
+      return joinSummaryParts(values.title, values.company);
+    case "education":
+      return joinSummaryParts(values.school, values.degree);
+    case "certifications":
+      return joinSummaryParts(values.name, values.issuingOrganization);
+    case "languages":
+      return joinSummaryParts(values.name, values.proficiency);
+    case "projects":
+      return readString(values.title);
+    case "volunteer_experience":
+      return joinSummaryParts(values.role, values.organization);
+    case "honors_awards":
+      return joinSummaryParts(values.title, values.issuer);
+  }
+}
+
+function describeSectionItem(
+  section: SeedSectionType,
+  item: LinkedInProfileEditableSectionItem
+): string {
+  switch (section) {
+    case "experience":
+    case "education":
+    case "certifications":
+    case "volunteer_experience":
+    case "honors_awards":
+      return joinSummaryParts(item.primary_text, item.secondary_text);
+    case "languages":
+      return joinSummaryParts(item.primary_text, item.secondary_text);
+    case "projects":
+      return readString(item.primary_text);
+  }
+}
+
+function joinSummaryParts(...parts: unknown[]): string {
+  return parts.map((part) => readString(part)).filter(Boolean).join(" — ");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeKey(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeForCompare(value: unknown): string {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}

--- a/packages/cli/test/profileCli.test.ts
+++ b/packages/cli/test/profileCli.test.ts
@@ -1,0 +1,258 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const profileCliMocks = vi.hoisted(() => ({
+  close: vi.fn(),
+  confirmByToken: vi.fn(),
+  createCoreRuntime: vi.fn(),
+  loggerLog: vi.fn(),
+  prepareRemoveSectionItem: vi.fn(),
+  prepareUpdateIntro: vi.fn(),
+  prepareUpsertSectionItem: vi.fn(),
+  viewEditableProfile: vi.fn(),
+  viewProfile: vi.fn()
+}));
+
+vi.mock("@linkedin-assistant/core", async () => {
+  const actual = await import("../../core/src/index.js");
+  return {
+    ...actual,
+    createCoreRuntime: profileCliMocks.createCoreRuntime
+  };
+});
+
+import { runCli } from "../src/bin/linkedin.js";
+
+describe("CLI profile commands", () => {
+  let tempDir = "";
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutChunks: string[] = [];
+  let stderrChunks: string[] = [];
+  let stderrWriteSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-cli-profile-"));
+    process.env.LINKEDIN_ASSISTANT_HOME = path.join(tempDir, "assistant-home");
+    process.exitCode = undefined;
+    stdoutChunks = [];
+    stderrChunks = [];
+    vi.clearAllMocks();
+
+    profileCliMocks.createCoreRuntime.mockImplementation(() => ({
+      close: profileCliMocks.close,
+      logger: { log: profileCliMocks.loggerLog },
+      profile: {
+        viewEditableProfile: profileCliMocks.viewEditableProfile,
+        viewProfile: profileCliMocks.viewProfile,
+        prepareUpdateIntro: profileCliMocks.prepareUpdateIntro,
+        prepareUpsertSectionItem: profileCliMocks.prepareUpsertSectionItem,
+        prepareRemoveSectionItem: profileCliMocks.prepareRemoveSectionItem
+      },
+      runId: "run-profile-cli",
+      twoPhaseCommit: {
+        confirmByToken: profileCliMocks.confirmByToken
+      }
+    }));
+
+    profileCliMocks.viewEditableProfile.mockResolvedValue({
+      profile_url: "https://www.linkedin.com/in/me/",
+      intro: {
+        full_name: "Emil Sorensen",
+        headline: "Software Engineer",
+        location: "Copenhagen, Denmark",
+        supported_fields: ["firstName", "lastName", "headline", "location"]
+      },
+      sections: []
+    });
+    profileCliMocks.viewProfile.mockResolvedValue({
+      profile_url: "https://www.linkedin.com/in/emil-sorensen-signikant/",
+      vanity_name: "emil-sorensen-signikant",
+      full_name: "Emil Sorensen",
+      headline: "AI/ML Engineer at Signikant",
+      location: "Copenhagen, Capital Region of Denmark, Denmark",
+      about: "Building production LLM systems.",
+      connection_degree: "",
+      experience: [],
+      education: []
+    });
+    profileCliMocks.prepareUpdateIntro.mockReturnValue({
+      preparedActionId: "pa_intro",
+      confirmToken: "ct_intro",
+      expiresAtMs: 1,
+      preview: { summary: "Update intro" }
+    });
+    profileCliMocks.prepareUpsertSectionItem.mockReturnValue({
+      preparedActionId: "pa_about",
+      confirmToken: "ct_about",
+      expiresAtMs: 1,
+      preview: { summary: "Update about" }
+    });
+    profileCliMocks.prepareRemoveSectionItem.mockReturnValue({
+      preparedActionId: "pa_remove",
+      confirmToken: "ct_remove",
+      expiresAtMs: 1,
+      preview: { summary: "Remove item" }
+    });
+    profileCliMocks.confirmByToken
+      .mockResolvedValueOnce({
+        preparedActionId: "pa_intro",
+        status: "executed",
+        actionType: "profile.update_intro",
+        result: { status: "profile_intro_updated" },
+        artifacts: []
+      })
+      .mockResolvedValueOnce({
+        preparedActionId: "pa_about",
+        status: "executed",
+        actionType: "profile.upsert_section_item",
+        result: { status: "profile_section_item_upserted" },
+        artifacts: []
+      });
+
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation((value?: unknown) => {
+      stdoutChunks.push(String(value ?? ""));
+    });
+    stderrWriteSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((...args: Parameters<typeof process.stderr.write>) => {
+        const [chunk] = args;
+        stderrChunks.push(String(chunk));
+        return true;
+      });
+  });
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore();
+    stderrWriteSpy.mockRestore();
+    process.exitCode = undefined;
+    delete process.env.LINKEDIN_ASSISTANT_HOME;
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("prints the editable profile surface", async () => {
+    await runCli(["node", "linkedin", "profile", "editable", "--profile", "smoke"]);
+
+    const output = JSON.parse(stdoutChunks.join("\n")) as {
+      profile: {
+        intro: {
+          full_name: string;
+        };
+      };
+      profile_name: string;
+      run_id: string;
+    };
+
+    expect(output.profile_name).toBe("smoke");
+    expect(output.run_id).toBe("run-profile-cli");
+    expect(output.profile.intro.full_name).toBe("Emil Sorensen");
+    expect(profileCliMocks.viewEditableProfile).toHaveBeenCalledWith({
+      profileName: "smoke"
+    });
+  });
+
+  it("applies a profile seed spec and reports unsupported fields when partial mode is enabled", async () => {
+    const specPath = path.join(tempDir, "profile-spec.json");
+    await writeFile(
+      specPath,
+      JSON.stringify(
+        {
+          intro: {
+            headline: "AI/ML Engineer at Signikant",
+            location: "Copenhagen, Capital Region of Denmark, Denmark"
+          },
+          about: "Building production LLM systems.",
+          skills: ["TypeScript", "Python"]
+        },
+        null,
+        2
+      )
+    );
+
+    await runCli([
+      "node",
+      "linkedin",
+      "profile",
+      "apply-spec",
+      "--profile",
+      "smoke",
+      "--spec",
+      specPath,
+      "--allow-partial",
+      "--yes",
+      "--delay-ms",
+      "0"
+    ]);
+
+    const output = JSON.parse(stdoutChunks.join("\n")) as {
+      actions: Array<{ action_type: string }>;
+      executed_action_count: number;
+      profile_name: string;
+      unsupported_fields: Array<{ issueNumber: number; path: string }>;
+    };
+
+    expect(output.profile_name).toBe("smoke");
+    expect(output.executed_action_count).toBe(2);
+    expect(output.actions.map((action) => action.action_type)).toEqual([
+      "profile.update_intro",
+      "profile.upsert_section_item"
+    ]);
+    expect(output.unsupported_fields).toEqual([
+      {
+        path: "skills",
+        reason: "Skills are not exposed by the current LinkedIn profile edit automation.",
+        issueNumber: 228
+      }
+    ]);
+    expect(profileCliMocks.prepareUpdateIntro).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profileName: "smoke",
+        headline: "AI/ML Engineer at Signikant",
+        location: "Copenhagen, Capital Region of Denmark, Denmark"
+      })
+    );
+    expect(profileCliMocks.prepareUpsertSectionItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profileName: "smoke",
+        section: "about",
+        values: { text: "Building production LLM systems." }
+      })
+    );
+    expect(stderrChunks.join("")).toContain("Ignoring unsupported profile fields");
+  });
+
+  it("rejects unsupported fields when partial mode is disabled", async () => {
+    const specPath = path.join(tempDir, "profile-spec-strict.json");
+    await writeFile(
+      specPath,
+      JSON.stringify(
+        {
+          intro: {
+            headline: "AI/ML Engineer at Signikant"
+          },
+          skills: ["TypeScript"]
+        },
+        null,
+        2
+      )
+    );
+
+    await expect(
+      runCli([
+        "node",
+        "linkedin",
+        "profile",
+        "apply-spec",
+        "--profile",
+        "smoke",
+        "--spec",
+        specPath,
+        "--yes"
+      ])
+    ).rejects.toThrow("Profile seed spec includes unsupported fields: skills (#228)");
+
+    expect(profileCliMocks.prepareUpdateIntro).not.toHaveBeenCalled();
+    expect(profileCliMocks.confirmByToken).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/test/profileSeed.test.ts
+++ b/packages/cli/test/profileSeed.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import {
+  createProfileSeedPlan,
+  parseProfileSeedSpec,
+  type ProfileSeedSpec
+} from "../src/profileSeed.js";
+
+const baseEditableProfile = {
+  profile_url: "https://www.linkedin.com/in/me/",
+  intro: {
+    full_name: "Emil Sorensen",
+    headline: "Software Engineer",
+    location: "Copenhagen, Denmark",
+    supported_fields: ["firstName", "lastName", "headline", "location"]
+  },
+  sections: [
+    {
+      section: "about",
+      label: "About",
+      supported_fields: ["text"],
+      can_add: true,
+      items: []
+    },
+    {
+      section: "certifications",
+      label: "Licenses & certifications",
+      supported_fields: [
+        "name",
+        "issuingOrganization",
+        "issueMonth",
+        "issueYear",
+        "credentialId",
+        "credentialUrl"
+      ],
+      can_add: true,
+      items: [
+        {
+          item_id: "cert-1",
+          section: "certifications",
+          primary_text: "Old Cert",
+          secondary_text: "Old Org",
+          tertiary_text: "Issued 2020",
+          description: "",
+          raw_text: "Old Cert Old Org Issued 2020",
+          source_id: null
+        }
+      ]
+    }
+  ]
+} as const;
+
+describe("profile seed planner", () => {
+  it("parses supported sections and records unsupported fields", () => {
+    const spec = parseProfileSeedSpec({
+      intro: {
+        firstName: "Emil",
+        headline: "AI/ML Engineer at Signikant",
+        industry: "Software Development"
+      },
+      about: "Building production LLM systems.",
+      certifications: [
+        {
+          name: "Google Cloud Professional Machine Learning Engineer",
+          issuingOrganization: "Google Cloud",
+          issueMonth: "May",
+          issueYear: "2024"
+        }
+      ],
+      skills: ["TypeScript", "Python"]
+    });
+
+    expect(spec.intro).toMatchObject({
+      firstName: "Emil",
+      headline: "AI/ML Engineer at Signikant"
+    });
+    expect(spec.about).toBe("Building production LLM systems.");
+    expect(spec.sections.certifications).toHaveLength(1);
+    expect(spec.unsupportedFields).toEqual([
+      {
+        path: "intro.industry",
+        reason: "Industry is not exposed by the current LinkedIn profile edit automation.",
+        issueNumber: 252
+      },
+      {
+        path: "skills",
+        reason: "Skills are not exposed by the current LinkedIn profile edit automation.",
+        issueNumber: 228
+      }
+    ]);
+  });
+
+  it("builds intro, about, upsert, and replace actions", () => {
+    const spec = parseProfileSeedSpec({
+      intro: {
+        headline: "AI/ML Engineer at Signikant",
+        location: "Copenhagen, Capital Region of Denmark, Denmark"
+      },
+      about: "Building production LLM systems.",
+      certifications: [],
+      languages: [
+        {
+          name: "English",
+          proficiency: "Full professional proficiency"
+        }
+      ]
+    }) as ProfileSeedSpec;
+
+    const plan = createProfileSeedPlan(baseEditableProfile, spec, {
+      profileName: "smoke",
+      operatorNote: "issue-210 test",
+      replace: true
+    });
+
+    expect(plan.actions.map((action) => action.kind)).toEqual([
+      "update_intro",
+      "upsert_section_item",
+      "remove_section_item",
+      "upsert_section_item"
+    ]);
+    expect(plan.actions[0]).toMatchObject({
+      kind: "update_intro",
+      input: {
+        profileName: "smoke",
+        headline: "AI/ML Engineer at Signikant",
+        location: "Copenhagen, Capital Region of Denmark, Denmark"
+      }
+    });
+    expect(plan.actions[1]).toMatchObject({
+      kind: "upsert_section_item",
+      input: {
+        profileName: "smoke",
+        section: "about",
+        values: {
+          text: "Building production LLM systems."
+        }
+      }
+    });
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({
+        kind: "remove_section_item",
+        input: expect.objectContaining({
+          profileName: "smoke",
+          section: "certifications",
+          itemId: "cert-1"
+        })
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `linkedin profile editable` and `linkedin profile apply-spec` to expose the editable profile surface and a paced JSON profile-seeding workflow in the CLI
- add a reusable profile seed planner plus targeted CLI/planner tests
- bundle the issue-210 Signikant test-profile spec and a short runbook for operators

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

## Notes
- live execution against the dedicated test account is still blocked in this workspace because the AO environment does not have a provisioned authenticated session for `linkedin-mcp@signikant.com` yet (#253)
- the bundled issue-210 spec includes the full desired profile, but `skills` remains tracked in #228 and `industry` / custom public profile URL remain tracked in #252, so the current command needs `--allow-partial` for those fields

Closes #210
