### PR TITLE
feat: add AI profile image generation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,6 +610,17 @@ npm exec -w @linkedin-assistant/cli -- linkedin profile apply-spec --profile def
 - The bundled issue-210 example spec currently needs `--allow-partial` because skills (`#228`) plus industry/custom public URL (`#252`) are still tracked as follow-up gaps.
 - See `docs/profile-seeding.md` for the full workflow, bundled spec, and current blockers.
 
+Profile image generation commands:
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin assets generate-profile-images --profile default --spec docs/profile-seeds/issue-210-signikant-test-profile.json --post-count 6 --upload-profile-media --upload-delay-ms 4500 --output reports/profile-images.json
+```
+
+- `assets generate-profile-images` uses OpenAI image generation to create a cohesive profile photo, banner, and reusable post-image bundle from the seeded persona.
+- Generated files and the manifest are written under `artifacts/<run-id>/linkedin-ai-assets/<persona-slug>/<timestamp>/`.
+- `--upload-profile-media` reuses the existing profile photo/banner upload flow and paces the two uploads to avoid back-to-back updates.
+- See `docs/profile-image-generation.md` for the end-to-end workflow and the matching MCP tool.
+
 Confirm prepared actions by token:
 
 ```bash
@@ -646,6 +657,7 @@ Exposed tools:
 - `linkedin.profile.prepare_featured_add`
 - `linkedin.profile.prepare_featured_remove`
 - `linkedin.profile.prepare_featured_reorder`
+- `linkedin.assets.generate_profile_images`
 - `linkedin.search`
 - `linkedin.inbox.list_threads`
 - `linkedin.inbox.get_thread`

--- a/docs/profile-image-generation.md
+++ b/docs/profile-image-generation.md
@@ -1,0 +1,78 @@
+# Profile image generation workflow
+
+Issue #211 adds a reusable OpenAI-backed workflow for generating a cohesive
+LinkedIn profile photo, banner, and reusable post images for the seeded test
+persona.
+
+## Requirements
+
+- `OPENAI_API_KEY` must be set in the environment.
+- For `--upload-profile-media`, the target LinkedIn profile must already be
+  authenticated in the chosen browser profile.
+
+## CLI command
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin assets generate-profile-images \
+  --profile <profile> \
+  --spec docs/profile-seeds/issue-210-signikant-test-profile.json \
+  --post-count 6 \
+  --upload-profile-media \
+  --upload-delay-ms 4500 \
+  --output reports/profile-images.json
+```
+
+What the command does:
+
+1. Reads the persona from the JSON spec.
+2. Generates:
+   - one square profile photo (`800x800`)
+   - one LinkedIn banner (`1584x396`)
+   - a set of post images in mixed LinkedIn-friendly aspect ratios
+3. Stores the generated files plus `manifest.json` under:
+   `artifacts/<run-id>/linkedin-ai-assets/<persona-slug>/<timestamp>/`
+4. Optionally uploads the profile photo and banner through the existing
+   LinkedIn profile upload actions with a paced delay between the two uploads.
+
+## Output bundle
+
+The generated manifest includes:
+
+- persona metadata derived from the seed spec
+- the selected OpenAI model
+- the bundle directory and manifest path
+- prompt metadata and hashes for every generated image
+- optional upload results for the profile photo and banner
+
+Generated file names are intentionally realistic, for example:
+
+- `emil-sorensen-profile-photo.png`
+- `emil-sorensen-banner-ai-systems.png`
+- `emil-sorensen-post-01-copenhagen-workspace.png`
+
+## MCP tool
+
+The same workflow is available through:
+
+- `linkedin.assets.generate_profile_images`
+
+Example MCP args:
+
+```json
+{
+  "profileName": "default",
+  "specPath": "docs/profile-seeds/issue-210-signikant-test-profile.json",
+  "postImageCount": 6,
+  "uploadProfileMedia": true,
+  "uploadDelayMs": 4500
+}
+```
+
+## Notes
+
+- The runtime defaults to `gpt-image-1.5`, but both CLI and MCP allow an
+  explicit model override.
+- Banner generation keeps the left side visually calmer so the LinkedIn avatar
+  overlay does not obscure the composition.
+- Diagram-style post images avoid dense generated text to reduce obvious
+  AI-image artifacts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1375,6 +1375,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pngjs": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.5.tgz",
+      "integrity": "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/proper-lockfile": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz",
@@ -3995,6 +4005,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -5296,10 +5315,12 @@
         "better-sqlite3": "^11.9.0",
         "fflate": "^0.8.2",
         "playwright-core": "^1.50.1",
+        "pngjs": "^7.0.0",
         "proper-lockfile": "^4.1.2"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.12",
+        "@types/pngjs": "^6.0.5",
         "@types/proper-lockfile": "^4.1.4"
       }
     },

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -32,6 +32,7 @@ import {
   createLocalDataDeletionPlan,
   createEmptyFixtureManifest,
   buildFixtureRouteKey,
+  buildLinkedInImagePersonaFromProfileSeed,
   evaluateDraftQuality,
   getLinkedInSelectorLocaleConfigWarning,
   isInRateLimitCooldown,
@@ -5758,6 +5759,61 @@ async function runProfileApplySpec(input: {
   }
 }
 
+async function runAssetsGenerateProfileImages(input: {
+  profileName: string;
+  specPath: string;
+  postImageCount: number;
+  uploadProfileMedia: boolean;
+  uploadDelayMs: number;
+  model?: string;
+  outputPath?: string;
+}, cdpUrl?: string): Promise<void> {
+  const resolvedSpecPath = path.resolve(input.specPath);
+  const rawSpec = await readJsonInputFile(resolvedSpecPath, "image persona spec");
+  const persona = buildLinkedInImagePersonaFromProfileSeed(rawSpec);
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.assets.generate_profile_images.start", {
+      profileName: input.profileName,
+      specPath: resolvedSpecPath,
+      postImageCount: input.postImageCount,
+      uploadProfileMedia: input.uploadProfileMedia,
+      model: input.model ?? null
+    });
+
+    const report: Record<string, unknown> = {
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      spec_path: resolvedSpecPath,
+      ...await runtime.imageAssets.generatePersonaImageSet({
+        persona,
+        postImageCount: input.postImageCount,
+        uploadProfileMedia: input.uploadProfileMedia,
+        profileName: input.profileName,
+        uploadDelayMs: input.uploadDelayMs,
+        operatorNote: `issue-211 persona images: ${path.basename(resolvedSpecPath)}`,
+        ...(input.model ? { model: input.model } : {})
+      })
+    };
+
+    if (input.outputPath) {
+      report.output_path = await writeOutputJsonFile(input.outputPath, report);
+    }
+
+    runtime.logger.log("info", "cli.assets.generate_profile_images.done", {
+      profileName: input.profileName,
+      specPath: resolvedSpecPath,
+      postImageCount: input.postImageCount,
+      uploadProfileMedia: input.uploadProfileMedia
+    });
+
+    printJson(report);
+  } finally {
+    runtime.close();
+  }
+}
+
 async function runSearch(input: {
   profileName: string;
   query: string;
@@ -8159,6 +8215,61 @@ export function createCliProgram(): Command {
           allowPartial: options.allowPartial,
           delayMs: coerceNonNegativeInt(options.delayMs, "delay-ms"),
           yes: options.yes,
+          ...(options.output ? { outputPath: options.output } : {})
+        }, readCdpUrl());
+      }
+    );
+
+  const assetsCommand = program
+    .command("assets")
+    .description("Generate LinkedIn-ready AI image assets");
+
+  assetsCommand
+    .command("generate-profile-images")
+    .description("Generate a profile photo, banner, and post images from a persona spec")
+    .requiredOption("--spec <path>", "Path to a JSON persona/profile seed spec")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .option("--post-count <count>", "Number of post images to generate", "6")
+    .option("--model <model>", "OpenAI image model override")
+    .option(
+      "--upload-profile-media",
+      "Upload the generated photo and banner through the existing LinkedIn profile flow",
+      false
+    )
+    .option(
+      "--upload-delay-ms <ms>",
+      "Base delay between the photo and banner upload when --upload-profile-media is enabled",
+      "4500"
+    )
+    .option("--output <path>", "Write the final JSON report to a file")
+    .addHelpText(
+      "after",
+      [
+        "",
+        "Notes:",
+        "  - requires OPENAI_API_KEY in the environment",
+        "  - generated assets are stored in the run artifacts directory under linkedin-ai-assets/",
+        "  - --upload-profile-media reuses the existing profile photo/banner upload actions and paces the two uploads",
+        "  - the issue-210 persona spec is a good default source for the test account"
+      ].join("\n")
+    )
+    .action(
+      async (options: {
+        profile: string;
+        spec: string;
+        postCount: string;
+        model?: string;
+        uploadProfileMedia: boolean;
+        uploadDelayMs: string;
+        output?: string;
+      }) => {
+        await runAssetsGenerateProfileImages({
+          profileName: options.profile,
+          specPath: options.spec,
+          postImageCount: coercePositiveInt(options.postCount, "post-count"),
+          uploadProfileMedia: options.uploadProfileMedia,
+          uploadDelayMs: coerceNonNegativeInt(options.uploadDelayMs, "upload-delay-ms"),
+          ...(options.model ? { model: options.model } : {}),
           ...(options.output ? { outputPath: options.output } : {})
         }, readCdpUrl());
       }

--- a/packages/cli/test/assetsCli.test.ts
+++ b/packages/cli/test/assetsCli.test.ts
@@ -1,0 +1,204 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const assetsCliMocks = vi.hoisted(() => ({
+  close: vi.fn(),
+  createCoreRuntime: vi.fn(),
+  generatePersonaImageSet: vi.fn(),
+  loggerLog: vi.fn()
+}));
+
+vi.mock("@linkedin-assistant/core", async () => {
+  const actual = await import("../../core/src/index.js");
+  return {
+    ...actual,
+    createCoreRuntime: assetsCliMocks.createCoreRuntime
+  };
+});
+
+import { runCli } from "../src/bin/linkedin.js";
+
+describe("CLI assets commands", () => {
+  let tempDir = "";
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutChunks: string[] = [];
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-cli-assets-"));
+    process.env.LINKEDIN_ASSISTANT_HOME = path.join(tempDir, "assistant-home");
+    stdoutChunks = [];
+    vi.clearAllMocks();
+
+    assetsCliMocks.createCoreRuntime.mockImplementation(() => ({
+      close: assetsCliMocks.close,
+      logger: {
+        log: assetsCliMocks.loggerLog
+      },
+      imageAssets: {
+        generatePersonaImageSet: assetsCliMocks.generatePersonaImageSet
+      },
+      runId: "run-assets-cli"
+    }));
+
+    assetsCliMocks.generatePersonaImageSet.mockResolvedValue({
+      generated_at: "2026-03-10T10:00:00.000Z",
+      model: "gpt-image-1.5",
+      bundle_relative_dir: "linkedin-ai-assets/emil-sorensen/2026-03-10T10-00-00-000Z",
+      bundle_absolute_dir: path.join(tempDir, "artifacts", "bundle"),
+      manifest_path: path.join(tempDir, "artifacts", "bundle", "manifest.json"),
+      persona: {
+        slug: "emil-sorensen",
+        full_name: "Emil Sorensen",
+        headline: "AI/ML Engineer at Signikant",
+        location: "Copenhagen, Denmark",
+        summary: "I build AI products that have to work outside the demo.",
+        current_role: "AI/ML Engineer",
+        current_company: "Signikant",
+        focus_areas: ["TypeScript", "Python", "LLMs"],
+        project_titles: ["LLM Evaluation Toolkit"]
+      },
+      profile_photo: {
+        kind: "profile_photo",
+        title: "Profile Photo",
+        concept_key: "profile-photo",
+        file_name: "emil-sorensen-profile-photo.png",
+        relative_path: "linkedin-ai-assets/emil-sorensen/profile-photo.png",
+        absolute_path: path.join(tempDir, "artifacts", "profile-photo.png"),
+        mime_type: "image/png",
+        width: 800,
+        height: 800,
+        size_bytes: 1200,
+        sha256: "abc123",
+        prompt: "Create a headshot.",
+        revised_prompt: "Create a refined headshot."
+      },
+      banner: {
+        kind: "banner",
+        title: "Profile Banner",
+        concept_key: "profile-banner",
+        file_name: "emil-sorensen-banner-ai-systems.png",
+        relative_path: "linkedin-ai-assets/emil-sorensen/banner.png",
+        absolute_path: path.join(tempDir, "artifacts", "banner.png"),
+        mime_type: "image/png",
+        width: 1584,
+        height: 396,
+        size_bytes: 2200,
+        sha256: "def456",
+        prompt: "Create a banner.",
+        revised_prompt: null
+      },
+      post_images: [
+        {
+          kind: "post_image",
+          title: "Workspace",
+          concept_key: "copenhagen-workspace",
+          file_name: "emil-sorensen-post-01-copenhagen-workspace.png",
+          relative_path: "linkedin-ai-assets/emil-sorensen/post-01.png",
+          absolute_path: path.join(tempDir, "artifacts", "post-01.png"),
+          mime_type: "image/png",
+          width: 1536,
+          height: 1024,
+          size_bytes: 1400,
+          sha256: "ghi789",
+          prompt: "Create a workspace scene.",
+          revised_prompt: null
+        }
+      ]
+    });
+
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation((value?: unknown) => {
+      stdoutChunks.push(String(value ?? ""));
+    });
+  });
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore();
+    delete process.env.LINKEDIN_ASSISTANT_HOME;
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("generates profile image assets from a persona spec and writes the report", async () => {
+    const specPath = path.join(tempDir, "persona-spec.json");
+    const outputPath = path.join(tempDir, "report.json");
+    await writeFile(
+      specPath,
+      JSON.stringify(
+        {
+          intro: {
+            firstName: "Emil",
+            lastName: "Sorensen",
+            headline:
+              "AI/ML Engineer at Signikant | TypeScript, Python, LLM Systems, MLOps",
+            location: "Copenhagen, Capital Region of Denmark, Denmark"
+          },
+          about: "I build AI products that have to work outside the demo.",
+          experience: [
+            {
+              title: "AI/ML Engineer",
+              company: "Signikant"
+            }
+          ],
+          skills: ["TypeScript", "Python", "LLMs"]
+        },
+        null,
+        2
+      )
+    );
+
+    await runCli([
+      "node",
+      "linkedin",
+      "assets",
+      "generate-profile-images",
+      "--profile",
+      "smoke",
+      "--spec",
+      specPath,
+      "--post-count",
+      "6",
+      "--model",
+      "gpt-image-1.5",
+      "--upload-profile-media",
+      "--upload-delay-ms",
+      "0",
+      "--output",
+      outputPath
+    ]);
+
+    const output = JSON.parse(stdoutChunks.join("\n")) as {
+      output_path: string;
+      profile_name: string;
+      run_id: string;
+      spec_path: string;
+    };
+    const writtenReport = JSON.parse(await readFile(outputPath, "utf8")) as {
+      profile_name: string;
+      profile_photo: { file_name: string };
+    };
+
+    expect(output.run_id).toBe("run-assets-cli");
+    expect(output.profile_name).toBe("smoke");
+    expect(output.spec_path).toBe(path.resolve(specPath));
+    expect(output.output_path).toBe(path.resolve(outputPath));
+    expect(writtenReport.profile_name).toBe("smoke");
+    expect(writtenReport.profile_photo.file_name).toBe(
+      "emil-sorensen-profile-photo.png"
+    );
+    expect(assetsCliMocks.generatePersonaImageSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profileName: "smoke",
+        postImageCount: 6,
+        uploadProfileMedia: true,
+        uploadDelayMs: 0,
+        model: "gpt-image-1.5",
+        operatorNote: "issue-211 persona images: persona-spec.json",
+        persona: expect.objectContaining({
+          full_name: "Emil Sorensen",
+          current_company: "Signikant"
+        })
+      })
+    );
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,10 +19,12 @@
     "better-sqlite3": "^11.9.0",
     "fflate": "^0.8.2",
     "playwright-core": "^1.50.1",
+    "pngjs": "^7.0.0",
     "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.12",
+    "@types/pngjs": "^6.0.5",
     "@types/proper-lockfile": "^4.1.4"
   }
 }

--- a/packages/core/src/__tests__/linkedinImageAssets.test.ts
+++ b/packages/core/src/__tests__/linkedinImageAssets.test.ts
@@ -1,0 +1,307 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PNG } from "pngjs";
+import { ArtifactHelpers } from "../artifacts.js";
+import {
+  buildLinkedInImagePersonaFromProfileSeed,
+  LinkedInImageAssetsService
+} from "../linkedinImageAssets.js";
+
+const tempDirs: string[] = [];
+
+function createTempArtifactsRoot(): string {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "linkedin-image-assets-"));
+  tempDirs.push(tempDir);
+  return tempDir;
+}
+
+function createSolidPng(
+  width: number,
+  height: number,
+  color: { red: number; green: number; blue: number }
+): Buffer {
+  const png = new PNG({ width, height });
+  for (let index = 0; index < png.data.length; index += 4) {
+    png.data[index] = color.red;
+    png.data[index + 1] = color.green;
+    png.data[index + 2] = color.blue;
+    png.data[index + 3] = 255;
+  }
+  return PNG.sync.write(png);
+}
+
+function createFetchMock() {
+  return vi.fn(async (_input: string | URL | Request, init?: { body?: unknown }) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { size?: string };
+    const size = body.size;
+    const dimensions =
+      size === "1024x1536"
+        ? { width: 1024, height: 1536, color: { red: 50, green: 90, blue: 140 } }
+        : size === "1536x1024"
+          ? { width: 1536, height: 1024, color: { red: 80, green: 130, blue: 180 } }
+          : { width: 1024, height: 1024, color: { red: 120, green: 80, blue: 160 } };
+
+    return new Response(
+      JSON.stringify({
+        data: [
+          {
+            b64_json: createSolidPng(
+              dimensions.width,
+              dimensions.height,
+              dimensions.color
+            ).toString("base64"),
+            revised_prompt: "refined prompt"
+          }
+        ],
+        usage: {
+          size
+        }
+      }),
+      {
+        status: 200,
+        headers: {
+          "content-type": "application/json"
+        }
+      }
+    );
+  });
+}
+
+function createService() {
+  const artifactsRoot = createTempArtifactsRoot();
+  const artifacts = new ArtifactHelpers(
+    {
+      baseDir: artifactsRoot,
+      artifactsDir: artifactsRoot,
+      profilesDir: path.join(artifactsRoot, "profiles"),
+      dbPath: path.join(artifactsRoot, "state.sqlite")
+    },
+    "run-test"
+  );
+  const prepareUploadPhoto = vi.fn();
+  const prepareUploadBanner = vi.fn();
+  const confirmPreparedAction = vi.fn();
+
+  return {
+    artifacts,
+    prepareUploadPhoto,
+    prepareUploadBanner,
+    confirmPreparedAction,
+    service: new LinkedInImageAssetsService(
+      {
+        logger: {
+          log: vi.fn()
+        },
+        artifacts,
+        profile: {
+          prepareUploadPhoto,
+          prepareUploadBanner
+        },
+        confirmPreparedAction
+      },
+      {
+        apiKey: "test-key",
+        baseUrl: "https://api.openai.com/v1",
+        defaultModel: "gpt-image-1.5"
+      }
+    )
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+
+  while (tempDirs.length > 0) {
+    const tempDir = tempDirs.pop();
+    if (!tempDir) {
+      continue;
+    }
+
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe("buildLinkedInImagePersonaFromProfileSeed", () => {
+  it("extracts the issue-210 persona fields needed for image generation", () => {
+    const persona = buildLinkedInImagePersonaFromProfileSeed({
+      intro: {
+        firstName: "Emil",
+        lastName: "Sorensen",
+        headline: "AI/ML Engineer at Signikant | TypeScript, Python, LLM Systems, MLOps",
+        location: "Copenhagen, Capital Region of Denmark, Denmark"
+      },
+      about: "I build AI products that have to work outside the demo.",
+      experience: [
+        {
+          title: "AI/ML Engineer",
+          company: "Signikant"
+        }
+      ],
+      skills: ["TypeScript", "Python", "LLMs", "MLOps"],
+      projects: [{ title: "LLM Evaluation Toolkit" }]
+    });
+
+    expect(persona).toMatchObject({
+      slug: "emil-sorensen",
+      full_name: "Emil Sorensen",
+      current_role: "AI/ML Engineer",
+      current_company: "Signikant",
+      focus_areas: [
+        "TypeScript",
+        "Python",
+        "LLMs",
+        "MLOps",
+        "LLM Evaluation Toolkit"
+      ]
+    });
+  });
+});
+
+describe("LinkedInImageAssetsService", () => {
+  it("generates a cohesive image bundle with the required dimensions", async () => {
+    const { service } = createService();
+    vi.stubGlobal("fetch", createFetchMock());
+
+    const persona = buildLinkedInImagePersonaFromProfileSeed({
+      intro: {
+        firstName: "Emil",
+        lastName: "Sorensen",
+        headline: "AI/ML Engineer at Signikant | TypeScript, Python, LLM Systems, MLOps",
+        location: "Copenhagen, Capital Region of Denmark, Denmark"
+      },
+      about: "I build AI products that have to work outside the demo.",
+      experience: [
+        {
+          title: "AI/ML Engineer",
+          company: "Signikant"
+        }
+      ],
+      skills: ["TypeScript", "Python", "LLMs", "MLOps"],
+      projects: [{ title: "LLM Evaluation Toolkit" }]
+    });
+
+    const result = await service.generatePersonaImageSet({
+      persona,
+      postImageCount: 5
+    });
+
+    expect(result.model).toBe("gpt-image-1.5");
+    expect(result.post_images).toHaveLength(5);
+    expect(result.profile_photo.file_name).toBe("emil-sorensen-profile-photo.png");
+    expect(result.banner.file_name).toBe("emil-sorensen-banner-ai-systems.png");
+    expect(existsSync(result.manifest_path)).toBe(true);
+    expect(existsSync(result.profile_photo.absolute_path)).toBe(true);
+    expect(existsSync(result.banner.absolute_path)).toBe(true);
+
+    const profilePng = PNG.sync.read(readFileSync(result.profile_photo.absolute_path));
+    const bannerPng = PNG.sync.read(readFileSync(result.banner.absolute_path));
+
+    expect(profilePng.width).toBe(800);
+    expect(profilePng.height).toBe(800);
+    expect(bannerPng.width).toBe(1584);
+    expect(bannerPng.height).toBe(396);
+
+    const manifest = JSON.parse(readFileSync(result.manifest_path, "utf8")) as {
+      post_images: unknown[];
+      profile_photo: { file_name: string };
+    };
+    expect(manifest.profile_photo.file_name).toBe(
+      "emil-sorensen-profile-photo.png"
+    );
+    expect(manifest.post_images).toHaveLength(5);
+  });
+
+  it("optionally uploads the generated photo and banner through the existing profile flow", async () => {
+    const {
+      service,
+      prepareUploadPhoto,
+      prepareUploadBanner,
+      confirmPreparedAction
+    } = createService();
+    vi.stubGlobal("fetch", createFetchMock());
+
+    prepareUploadPhoto.mockResolvedValue({
+      confirmToken: "ct-photo"
+    });
+    prepareUploadBanner.mockResolvedValue({
+      confirmToken: "ct-banner"
+    });
+    confirmPreparedAction
+      .mockResolvedValueOnce({
+        preparedActionId: "pa-photo",
+        actionType: "profile.upload_photo",
+        status: "executed",
+        result: { status: "profile_photo_uploaded" },
+        artifacts: []
+      })
+      .mockResolvedValueOnce({
+        preparedActionId: "pa-banner",
+        actionType: "profile.upload_banner",
+        status: "executed",
+        result: { status: "profile_banner_uploaded" },
+        artifacts: []
+      });
+
+    const persona = buildLinkedInImagePersonaFromProfileSeed({
+      intro: {
+        firstName: "Emil",
+        lastName: "Sorensen",
+        headline: "AI/ML Engineer at Signikant | TypeScript, Python, LLM Systems, MLOps",
+        location: "Copenhagen, Capital Region of Denmark, Denmark"
+      },
+      about: "I build AI products that have to work outside the demo.",
+      experience: [
+        {
+          title: "AI/ML Engineer",
+          company: "Signikant"
+        }
+      ]
+    });
+
+    const result = await service.generatePersonaImageSet({
+      persona,
+      postImageCount: 2,
+      uploadProfileMedia: true,
+      profileName: "default",
+      uploadDelayMs: 0,
+      operatorNote: "Issue 211"
+    });
+
+    expect(prepareUploadPhoto).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profileName: "default",
+        filePath: result.profile_photo.absolute_path,
+        operatorNote: "Issue 211"
+      })
+    );
+    expect(prepareUploadBanner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profileName: "default",
+        filePath: result.banner.absolute_path,
+        operatorNote: "Issue 211"
+      })
+    );
+    expect(confirmPreparedAction).toHaveBeenCalledTimes(2);
+    expect(result.upload_results).toEqual({
+      profile_photo: {
+        prepared_action_id: "pa-photo",
+        action_type: "profile.upload_photo",
+        status: "executed",
+        file_name: "emil-sorensen-profile-photo.png",
+        result: { status: "profile_photo_uploaded" },
+        artifacts: []
+      },
+      banner: {
+        prepared_action_id: "pa-banner",
+        action_type: "profile.upload_banner",
+        status: "executed",
+        file_name: "emil-sorensen-banner-ai-systems.png",
+        result: { status: "profile_banner_uploaded" },
+        artifacts: []
+      }
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export * from "./liveValidation.js";
 export * from "./linkedinConnections.js";
 export * from "./linkedinFeed.js";
 export * from "./linkedinFollowups.js";
+export * from "./linkedinImageAssets.js";
 export * from "./linkedinInbox.js";
 export * from "./linkedinProfile.js";
 export * from "./linkedinJobs.js";

--- a/packages/core/src/linkedinImageAssets.ts
+++ b/packages/core/src/linkedinImageAssets.ts
@@ -1,0 +1,1064 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { PNG } from "pngjs";
+import type { ArtifactHelpers } from "./artifacts.js";
+import { LinkedInAssistantError } from "./errors.js";
+import type { JsonEventLogger } from "./logging.js";
+import type { LinkedInProfileService } from "./linkedinProfile.js";
+
+const DEFAULT_OPENAI_IMAGES_BASE_URL = "https://api.openai.com/v1";
+export const DEFAULT_OPENAI_IMAGE_MODEL = "gpt-image-1.5";
+export const DEFAULT_LINKEDIN_PERSONA_POST_IMAGE_COUNT = 6;
+export const MAX_LINKEDIN_PERSONA_POST_IMAGE_COUNT = 10;
+const DEFAULT_PROFILE_UPLOAD_DELAY_MS = 4_500;
+const PROFILE_PHOTO_OUTPUT_WIDTH = 800;
+const PROFILE_PHOTO_OUTPUT_HEIGHT = 800;
+const PROFILE_BANNER_OUTPUT_WIDTH = 1_584;
+const PROFILE_BANNER_OUTPUT_HEIGHT = 396;
+
+type LinkedInImageAssetKind = "profile_photo" | "banner" | "post_image";
+type OpenAiImageSize = "1024x1024" | "1536x1024" | "1024x1536";
+
+interface OpenAiImageGenerationResponse {
+  created?: number;
+  data?: Array<{
+    b64_json?: string;
+    revised_prompt?: string;
+    url?: string;
+  }>;
+  usage?: Record<string, unknown>;
+}
+
+interface PlannedLinkedInImageAsset {
+  kind: LinkedInImageAssetKind;
+  conceptKey: string;
+  title: string;
+  fileName: string;
+  prompt: string;
+  sourceSize: OpenAiImageSize;
+  outputWidth: number;
+  outputHeight: number;
+}
+
+interface OpenAiImageGenerationConfig {
+  apiKey?: string;
+  baseUrl?: string;
+  defaultModel?: string;
+}
+
+export interface LinkedInImagePersona {
+  slug: string;
+  full_name: string;
+  headline: string;
+  location: string;
+  summary: string;
+  current_role?: string;
+  current_company?: string;
+  focus_areas: string[];
+  project_titles: string[];
+}
+
+export interface GenerateLinkedInPersonaImageSetInput {
+  persona: LinkedInImagePersona;
+  postImageCount?: number;
+  model?: string;
+  uploadProfileMedia?: boolean;
+  profileName?: string;
+  operatorNote?: string;
+  uploadDelayMs?: number;
+}
+
+export interface GeneratedLinkedInImageAsset {
+  kind: LinkedInImageAssetKind;
+  title: string;
+  concept_key: string;
+  file_name: string;
+  relative_path: string;
+  absolute_path: string;
+  mime_type: "image/png";
+  width: number;
+  height: number;
+  size_bytes: number;
+  sha256: string;
+  prompt: string;
+  revised_prompt: string | null;
+}
+
+export interface LinkedInPersonaMediaUploadResult {
+  prepared_action_id: string;
+  action_type: string;
+  status: string;
+  file_name: string;
+  result: Record<string, unknown>;
+  artifacts: string[];
+}
+
+export interface GeneratedLinkedInPersonaImageSet {
+  generated_at: string;
+  model: string;
+  bundle_relative_dir: string;
+  bundle_absolute_dir: string;
+  manifest_path: string;
+  persona: LinkedInImagePersona;
+  profile_photo: GeneratedLinkedInImageAsset;
+  banner: GeneratedLinkedInImageAsset;
+  post_images: GeneratedLinkedInImageAsset[];
+  upload_results?: {
+    profile_photo: LinkedInPersonaMediaUploadResult;
+    banner: LinkedInPersonaMediaUploadResult;
+  };
+  openai_usage?: Record<string, unknown>;
+}
+
+interface ConfirmPreparedActionResult {
+  preparedActionId: string;
+  actionType: string;
+  status: string;
+  result: Record<string, unknown>;
+  artifacts: string[];
+}
+
+export interface LinkedInImageAssetsRuntime {
+  logger: Pick<JsonEventLogger, "log">;
+  artifacts: ArtifactHelpers;
+  profile: Pick<LinkedInProfileService, "prepareUploadPhoto" | "prepareUploadBanner">;
+  confirmPreparedAction: (
+    confirmToken: string
+  ) => Promise<ConfirmPreparedActionResult>;
+}
+
+const POST_IMAGE_BLUEPRINTS = [
+  {
+    key: "copenhagen-workspace",
+    title: "Copenhagen AI Workspace",
+    size: "1536x1024",
+    width: 1536,
+    height: 1024,
+    createPrompt: (persona: LinkedInImagePersona, personaDescriptor: string) =>
+      [
+        "Create a realistic LinkedIn post image of a polished Copenhagen tech workspace.",
+        `${personaDescriptor}.`,
+        "Scene: standing desk, laptop, secondary monitor with abstract code blocks and charts, notebook, coffee, clean Scandinavian office styling, soft daylight, muted slate and teal palette.",
+        "The image should feel like an authentic workplace photo for a post about AI product building and developer tools.",
+        "No logos, no watermarks, no unreadable interface text, no deformed hands, no duplicate objects."
+      ].join(" ")
+  },
+  {
+    key: "meetup-stage",
+    title: "AI Meetup Stage Portrait",
+    size: "1024x1536",
+    width: 1024,
+    height: 1536,
+    createPrompt: (persona: LinkedInImagePersona, personaDescriptor: string) =>
+      [
+        "Create a portrait-oriented LinkedIn post image from a small AI or developer-tools meetup in Copenhagen.",
+        `${personaDescriptor}.`,
+        "A confident speaker is on stage in business-casual clothing, warm event lighting, attentive audience silhouettes, modern Nordic venue, tasteful depth of field.",
+        "Keep it realistic and professional, like a candid event photo for engineering culture content.",
+        "No logos, no banner text, no distorted faces, no extra fingers, no watermarks."
+      ].join(" ")
+  },
+  {
+    key: "llm-evaluation-map",
+    title: "LLM Evaluation Diagram",
+    size: "1024x1024",
+    width: 1024,
+    height: 1024,
+    createPrompt: (persona: LinkedInImagePersona, personaDescriptor: string) =>
+      [
+        "Create a clean square diagram-style illustration for a LinkedIn post about evaluating LLM systems.",
+        `${personaDescriptor}.`,
+        "Show abstract blocks, retrieval paths, test cases, observability signals, and feedback loops in a modern vector-like style with teal, graphite, sand, and off-white colors.",
+        "Make it readable as a diagram without relying on body text or logos.",
+        "No fake UI chrome, no gibberish text, no watermarks."
+      ].join(" ")
+  },
+  {
+    key: "whiteboard-session",
+    title: "Developer Tools Whiteboard Session",
+    size: "1536x1024",
+    width: 1536,
+    height: 1024,
+    createPrompt: (persona: LinkedInImagePersona, personaDescriptor: string) =>
+      [
+        "Create a realistic LinkedIn post image of an engineering team whiteboard session.",
+        `${personaDescriptor}.`,
+        "Show two or three professionals in a bright Scandinavian meeting room with a whiteboard covered in simple architecture sketches, sticky notes, and arrows, plus laptops on the table.",
+        "Tone: thoughtful, collaborative, grounded, suitable for a post about developer experience and engineering culture.",
+        "No company logos, no readable brand names, no malformed hands or faces, no watermarks."
+      ].join(" ")
+  },
+  {
+    key: "observability-grid",
+    title: "AI Observability Grid",
+    size: "1024x1024",
+    width: 1024,
+    height: 1024,
+    createPrompt: (persona: LinkedInImagePersona, personaDescriptor: string) =>
+      [
+        "Create a square infographic-style illustration for a LinkedIn post about AI observability.",
+        `${personaDescriptor}.`,
+        "Use a refined Scandinavian tech aesthetic with modular panels, traces, alerts, token flows, evaluation snapshots, and calm negative space.",
+        "Keep it visual-first with iconography and shapes instead of paragraphs of text.",
+        "No gibberish labels, no logos, no watermarks."
+      ].join(" ")
+  },
+  {
+    key: "pair-programming",
+    title: "Pair Programming Session",
+    size: "1536x1024",
+    width: 1536,
+    height: 1024,
+    createPrompt: (persona: LinkedInImagePersona, personaDescriptor: string) =>
+      [
+        "Create a realistic LinkedIn post image of a calm pair-programming session in a Copenhagen office.",
+        `${personaDescriptor}.`,
+        "Two engineers collaborate at a desk with large monitors, soft daylight, subtle plants, notebooks, and a clean modern office environment.",
+        "The vibe should fit a post about engineering culture, code review, and thoughtful product development.",
+        "No visible brand logos, no uncanny hands, no unreadable text, no watermarks."
+      ].join(" ")
+  },
+  {
+    key: "conference-corridor",
+    title: "Conference Hallway Conversation",
+    size: "1024x1536",
+    width: 1024,
+    height: 1536,
+    createPrompt: (persona: LinkedInImagePersona, personaDescriptor: string) =>
+      [
+        "Create a portrait-oriented LinkedIn post image of an authentic conference hallway conversation for AI engineers.",
+        `${personaDescriptor}.`,
+        "Modern European venue, business-casual professionals, soft natural lighting, subtle badges without readable text, candid energy, premium editorial photography feel.",
+        "Suitable for a post about meetups, conferences, or lessons learned from the community.",
+        "No logos, no gibberish text, no distorted anatomy, no watermarks."
+      ].join(" ")
+  },
+  {
+    key: "platform-blueprint",
+    title: "Platform Architecture Blueprint",
+    size: "1024x1024",
+    width: 1024,
+    height: 1024,
+    createPrompt: (persona: LinkedInImagePersona, personaDescriptor: string) =>
+      [
+        "Create a square architectural blueprint illustration for a LinkedIn post about AI platform design.",
+        `${personaDescriptor}.`,
+        "Show modular services, data flows, guardrails, evaluation checkpoints, and deployment layers in a crisp diagram aesthetic with calm Nordic colors.",
+        "Use shapes and light annotations only if they remain simple and clean; avoid dense text.",
+        "No watermarks, no fake logos, no gibberish."
+      ].join(" ")
+  },
+  {
+    key: "coffee-chat",
+    title: "Engineering Coffee Chat",
+    size: "1536x1024",
+    width: 1536,
+    height: 1024,
+    createPrompt: (persona: LinkedInImagePersona, personaDescriptor: string) =>
+      [
+        "Create a realistic LinkedIn post image of two engineers having a thoughtful coffee chat in a bright Copenhagen office lounge.",
+        `${personaDescriptor}.`,
+        "Natural daylight, minimalist furniture, laptop on the side, notebooks, relaxed but professional body language, editorial business photography feel.",
+        "Suitable for a post about mentoring, team health, or engineering leadership.",
+        "No logos, no awkward anatomy, no watermarks."
+      ].join(" ")
+  },
+  {
+    key: "city-office",
+    title: "Copenhagen Office Window Scene",
+    size: "1536x1024",
+    width: 1536,
+    height: 1024,
+    createPrompt: (persona: LinkedInImagePersona, personaDescriptor: string) =>
+      [
+        "Create a realistic LinkedIn post image of a modern AI engineer office setup with large windows overlooking Copenhagen rooftops.",
+        `${personaDescriptor}.`,
+        "Standing desk, laptop, external monitor with abstract charts, notebook, soft morning light, polished Scandinavian design.",
+        "The image should feel practical and aspirational for a post about developer tools or focused engineering work.",
+        "No logos, no gibberish text, no watermarks."
+      ].join(" ")
+  }
+] as const satisfies ReadonlyArray<{
+  key: string;
+  title: string;
+  size: OpenAiImageSize;
+  width: number;
+  height: number;
+  createPrompt: (persona: LinkedInImagePersona, personaDescriptor: string) => string;
+}>;
+
+function normalizeRecord(
+  value: unknown,
+  message: string
+): Record<string, unknown> {
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+
+  throw new LinkedInAssistantError("ACTION_PRECONDITION_FAILED", message);
+}
+
+function readRequiredText(
+  record: Record<string, unknown>,
+  key: string,
+  message: string
+): string {
+  const value = record[key];
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  throw new LinkedInAssistantError("ACTION_PRECONDITION_FAILED", message, {
+    field: key
+  });
+}
+
+function readOptionalText(
+  record: Record<string, unknown>,
+  key: string
+): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function readOptionalTextArray(
+  record: Record<string, unknown>,
+  key: string
+): string[] {
+  const value = record[key];
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function slugifyPathComponent(value: string): string {
+  const normalized = value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return normalized.length > 0 ? normalized : "asset";
+}
+
+function buildPersonaDescriptor(persona: LinkedInImagePersona): string {
+  const descriptors = [
+    persona.headline,
+    persona.location,
+    ...persona.focus_areas.slice(0, 4)
+  ];
+
+  if (persona.current_role && persona.current_company) {
+    descriptors.unshift(
+      `${persona.current_role} at ${persona.current_company}`
+    );
+  } else if (persona.current_role) {
+    descriptors.unshift(persona.current_role);
+  }
+
+  return descriptors.join(", ");
+}
+
+function buildProfilePhotoPrompt(persona: LinkedInImagePersona): string {
+  const personaDescriptor = buildPersonaDescriptor(persona);
+  return [
+    "Create a highly realistic professional LinkedIn headshot.",
+    `${persona.full_name} is a Copenhagen-based tech professional: ${personaDescriptor}.`,
+    "Business casual or smart casual styling, approachable confidence, natural expression, shoulders-up framing, eye-level camera, soft daylight, subtle studio or modern office background, realistic skin texture, sharp focus on the face.",
+    "The result should feel authentic and trustworthy for a real AI/ML engineer profile photo on LinkedIn.",
+    "No extra people, no text, no logos, no watermarks, no glamour retouching, no distorted anatomy."
+  ].join(" ");
+}
+
+function buildBannerPrompt(persona: LinkedInImagePersona): string {
+  const personaDescriptor = buildPersonaDescriptor(persona);
+  return [
+    "Create a wide professional LinkedIn banner image for an AI and developer-tools professional.",
+    `${persona.full_name} is described as: ${personaDescriptor}.`,
+    "Use a refined Scandinavian visual language with clean geometry, subtle gradients, abstract system diagrams, observability motifs, code-inspired patterns, and calm slate, teal, and warm neutral colors.",
+    "Keep the left third visually quiet because the LinkedIn profile photo overlays there; concentrate detail in the center-right without becoming busy.",
+    "No text, no logos, no watermarks, no people, no clutter."
+  ].join(" ");
+}
+
+function parseOpenAiImageSize(size: OpenAiImageSize): {
+  width: number;
+  height: number;
+} {
+  switch (size) {
+    case "1024x1024":
+      return { width: 1024, height: 1024 };
+    case "1536x1024":
+      return { width: 1536, height: 1024 };
+    case "1024x1536":
+      return { width: 1024, height: 1536 };
+  }
+}
+
+function validatePostImageCount(value: number | undefined): number {
+  if (value === undefined) {
+    return DEFAULT_LINKEDIN_PERSONA_POST_IMAGE_COUNT;
+  }
+
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "postImageCount must be a whole number greater than 0."
+    );
+  }
+
+  if (value > MAX_LINKEDIN_PERSONA_POST_IMAGE_COUNT) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `postImageCount must be ${MAX_LINKEDIN_PERSONA_POST_IMAGE_COUNT} or fewer.`,
+      {
+        max_post_image_count: MAX_LINKEDIN_PERSONA_POST_IMAGE_COUNT
+      }
+    );
+  }
+
+  return value;
+}
+
+function buildImagePlan(
+  persona: LinkedInImagePersona,
+  postImageCount: number
+): PlannedLinkedInImageAsset[] {
+  const filePrefix = slugifyPathComponent(persona.slug || persona.full_name);
+  const personaDescriptor = buildPersonaDescriptor(persona);
+  const plan: PlannedLinkedInImageAsset[] = [
+    {
+      kind: "profile_photo",
+      conceptKey: "profile-photo",
+      title: "Profile Photo",
+      fileName: `${filePrefix}-profile-photo.png`,
+      prompt: buildProfilePhotoPrompt(persona),
+      sourceSize: "1024x1024",
+      outputWidth: PROFILE_PHOTO_OUTPUT_WIDTH,
+      outputHeight: PROFILE_PHOTO_OUTPUT_HEIGHT
+    },
+    {
+      kind: "banner",
+      conceptKey: "profile-banner",
+      title: "Profile Banner",
+      fileName: `${filePrefix}-banner-ai-systems.png`,
+      prompt: buildBannerPrompt(persona),
+      sourceSize: "1536x1024",
+      outputWidth: PROFILE_BANNER_OUTPUT_WIDTH,
+      outputHeight: PROFILE_BANNER_OUTPUT_HEIGHT
+    }
+  ];
+
+  for (let index = 0; index < postImageCount; index += 1) {
+    const blueprint = POST_IMAGE_BLUEPRINTS[index]!;
+    plan.push({
+      kind: "post_image",
+      conceptKey: blueprint.key,
+      title: blueprint.title,
+      fileName: `${filePrefix}-post-${String(index + 1).padStart(2, "0")}-${blueprint.key}.png`,
+      prompt: blueprint.createPrompt(persona, personaDescriptor),
+      sourceSize: blueprint.size,
+      outputWidth: blueprint.width,
+      outputHeight: blueprint.height
+    });
+  }
+
+  return plan;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function sampleDelay(baseDelayMs: number): number {
+  if (baseDelayMs <= 0) {
+    return 0;
+  }
+
+  const jitter = Math.max(250, Math.round(baseDelayMs * 0.25));
+  const minimum = Math.max(0, baseDelayMs - jitter);
+  const maximum = baseDelayMs + jitter;
+  return minimum + Math.floor(Math.random() * (maximum - minimum + 1));
+}
+
+function bilinearSample(
+  data: Uint8Array,
+  width: number,
+  height: number,
+  x: number,
+  y: number
+): [number, number, number, number] {
+  const clampedX = Math.min(Math.max(x, 0), width - 1);
+  const clampedY = Math.min(Math.max(y, 0), height - 1);
+  const x0 = Math.floor(clampedX);
+  const y0 = Math.floor(clampedY);
+  const x1 = Math.min(x0 + 1, width - 1);
+  const y1 = Math.min(y0 + 1, height - 1);
+  const xWeight = clampedX - x0;
+  const yWeight = clampedY - y0;
+
+  const topLeftIndex = (y0 * width + x0) * 4;
+  const topRightIndex = (y0 * width + x1) * 4;
+  const bottomLeftIndex = (y1 * width + x0) * 4;
+  const bottomRightIndex = (y1 * width + x1) * 4;
+
+  const sampleChannel = (offset: number): number => {
+    const top =
+      data[topLeftIndex + offset]! * (1 - xWeight) +
+      data[topRightIndex + offset]! * xWeight;
+    const bottom =
+      data[bottomLeftIndex + offset]! * (1 - xWeight) +
+      data[bottomRightIndex + offset]! * xWeight;
+    return Math.round(top * (1 - yWeight) + bottom * yWeight);
+  };
+
+  return [
+    sampleChannel(0),
+    sampleChannel(1),
+    sampleChannel(2),
+    sampleChannel(3)
+  ];
+}
+
+function resizePngCover(
+  sourcePng: PNG,
+  outputWidth: number,
+  outputHeight: number
+): PNG {
+  const destination = new PNG({
+    width: outputWidth,
+    height: outputHeight
+  });
+  const sourceAspect = sourcePng.width / sourcePng.height;
+  const outputAspect = outputWidth / outputHeight;
+
+  let cropWidth = sourcePng.width;
+  let cropHeight = sourcePng.height;
+  let offsetX = 0;
+  let offsetY = 0;
+
+  if (sourceAspect > outputAspect) {
+    cropWidth = sourcePng.height * outputAspect;
+    offsetX = (sourcePng.width - cropWidth) / 2;
+  } else if (sourceAspect < outputAspect) {
+    cropHeight = sourcePng.width / outputAspect;
+    offsetY = (sourcePng.height - cropHeight) / 2;
+  }
+
+  for (let y = 0; y < outputHeight; y += 1) {
+    for (let x = 0; x < outputWidth; x += 1) {
+      const sourceX = offsetX + ((x + 0.5) / outputWidth) * cropWidth - 0.5;
+      const sourceY = offsetY + ((y + 0.5) / outputHeight) * cropHeight - 0.5;
+      const [red, green, blue, alpha] = bilinearSample(
+        sourcePng.data,
+        sourcePng.width,
+        sourcePng.height,
+        sourceX,
+        sourceY
+      );
+      const destinationIndex = (y * outputWidth + x) * 4;
+      destination.data[destinationIndex] = red;
+      destination.data[destinationIndex + 1] = green;
+      destination.data[destinationIndex + 2] = blue;
+      destination.data[destinationIndex + 3] = alpha;
+    }
+  }
+
+  return destination;
+}
+
+function renderOutputPng(
+  inputBuffer: Buffer,
+  outputWidth: number,
+  outputHeight: number
+): Buffer {
+  const source = PNG.sync.read(inputBuffer);
+  const resized = resizePngCover(source, outputWidth, outputHeight);
+  return PNG.sync.write(resized);
+}
+
+function hashBuffer(value: Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function buildArtifactMetadata(
+  plannedAsset: PlannedLinkedInImageAsset,
+  revisedPrompt: string | null,
+  sha256: string,
+  sizeBytes: number
+): Record<string, unknown> {
+  return {
+    concept_key: plannedAsset.conceptKey,
+    kind: plannedAsset.kind,
+    prompt: plannedAsset.prompt,
+    revised_prompt: revisedPrompt,
+    sha256,
+    size_bytes: sizeBytes,
+    width: plannedAsset.outputWidth,
+    height: plannedAsset.outputHeight
+  };
+}
+
+function writeBinaryArtifact(
+  artifacts: ArtifactHelpers,
+  relativePath: string,
+  contents: Buffer,
+  metadata: Record<string, unknown>
+): string {
+  const absolutePath = artifacts.resolve(relativePath);
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, contents);
+  artifacts.registerArtifact(relativePath, "image/png", metadata);
+  return absolutePath;
+}
+
+function parseJsonResponseBody(
+  value: unknown
+): Record<string, unknown> | undefined {
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+
+  return undefined;
+}
+
+async function readOpenAiImageBuffer(
+  response: OpenAiImageGenerationResponse
+): Promise<{ buffer: Buffer; revisedPrompt: string | null }> {
+  const firstImage = response.data?.[0];
+  if (!firstImage) {
+    throw new LinkedInAssistantError(
+      "NETWORK_ERROR",
+      "OpenAI image generation returned no images."
+    );
+  }
+
+  if (typeof firstImage.b64_json === "string" && firstImage.b64_json.length > 0) {
+    return {
+      buffer: Buffer.from(firstImage.b64_json, "base64"),
+      revisedPrompt:
+        typeof firstImage.revised_prompt === "string"
+          ? firstImage.revised_prompt
+          : null
+    };
+  }
+
+  if (typeof firstImage.url === "string" && firstImage.url.length > 0) {
+    const downloadResponse = await fetch(firstImage.url, {
+      signal: AbortSignal.timeout(120_000)
+    });
+    if (!downloadResponse.ok) {
+      throw new LinkedInAssistantError(
+        "NETWORK_ERROR",
+        "OpenAI image download URL could not be fetched.",
+        {
+          status: downloadResponse.status
+        }
+      );
+    }
+
+    return {
+      buffer: Buffer.from(await downloadResponse.arrayBuffer()),
+      revisedPrompt:
+        typeof firstImage.revised_prompt === "string"
+          ? firstImage.revised_prompt
+          : null
+    };
+  }
+
+  throw new LinkedInAssistantError(
+    "NETWORK_ERROR",
+    "OpenAI image generation returned an unsupported payload."
+  );
+}
+
+export function buildLinkedInImagePersonaFromProfileSeed(
+  input: unknown
+): LinkedInImagePersona {
+  const root = normalizeRecord(
+    input,
+    "Image persona seed must be a JSON object."
+  );
+  const intro = normalizeRecord(
+    root.intro,
+    'Image persona seed must include an "intro" object.'
+  );
+  const firstName = readRequiredText(
+    intro,
+    "firstName",
+    'Image persona seed intro must include "firstName".'
+  );
+  const lastName = readRequiredText(
+    intro,
+    "lastName",
+    'Image persona seed intro must include "lastName".'
+  );
+  const headline = readRequiredText(
+    intro,
+    "headline",
+    'Image persona seed intro must include "headline".'
+  );
+  const location = readRequiredText(
+    intro,
+    "location",
+    'Image persona seed intro must include "location".'
+  );
+  const summary = readRequiredText(
+    root,
+    "about",
+    'Image persona seed must include an "about" summary.'
+  );
+  const experience = Array.isArray(root.experience) ? root.experience : [];
+  const firstExperience =
+    experience.length > 0
+      ? normalizeRecord(
+          experience[0],
+          "Image persona seed experience entries must be objects."
+        )
+      : undefined;
+  const skills = readOptionalTextArray(root, "skills");
+  const projects = Array.isArray(root.projects)
+    ? root.projects
+        .map((entry) =>
+          normalizeRecord(
+            entry,
+            "Image persona seed project entries must be objects."
+          )
+        )
+        .map((entry) => readOptionalText(entry, "title"))
+        .filter((value): value is string => typeof value === "string")
+    : [];
+  const focusAreas = [
+    ...skills.slice(0, 5),
+    ...projects.slice(0, 3)
+  ].filter((value, index, values) => values.indexOf(value) === index);
+  const currentRole = firstExperience
+    ? readOptionalText(firstExperience, "title")
+    : undefined;
+  const currentCompany = firstExperience
+    ? readOptionalText(firstExperience, "company")
+    : undefined;
+
+  return {
+    slug: slugifyPathComponent(`${firstName}-${lastName}`),
+    full_name: `${firstName} ${lastName}`.trim(),
+    headline,
+    location,
+    summary,
+    ...(currentRole ? { current_role: currentRole } : {}),
+    ...(currentCompany ? { current_company: currentCompany } : {}),
+    focus_areas: focusAreas,
+    project_titles: projects.slice(0, 5)
+  };
+}
+
+export class LinkedInImageAssetsService {
+  constructor(
+    private readonly runtime: LinkedInImageAssetsRuntime,
+    private readonly config: OpenAiImageGenerationConfig = {}
+  ) {}
+
+  async generatePersonaImageSet(
+    input: GenerateLinkedInPersonaImageSetInput
+  ): Promise<GeneratedLinkedInPersonaImageSet> {
+    const apiKey = this.config.apiKey?.trim();
+    if (!apiKey) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        "OpenAI image generation requires OPENAI_API_KEY to be configured."
+      );
+    }
+
+    const postImageCount = validatePostImageCount(input.postImageCount);
+    const model =
+      input.model?.trim() ||
+      this.config.defaultModel?.trim() ||
+      DEFAULT_OPENAI_IMAGE_MODEL;
+    const baseUrl =
+      this.config.baseUrl?.trim() || DEFAULT_OPENAI_IMAGES_BASE_URL;
+    const persona = input.persona;
+    const generatedAt = new Date().toISOString();
+    const timestampSlug = generatedAt.replace(/[:.]/g, "-");
+    const bundleRelativeDir = `linkedin-ai-assets/${persona.slug}/${timestampSlug}`;
+    const bundleAbsoluteDir = this.runtime.artifacts.resolve(bundleRelativeDir);
+    mkdirSync(bundleAbsoluteDir, { recursive: true });
+
+    this.runtime.logger.log("info", "image_assets.generate.start", {
+      persona_slug: persona.slug,
+      model,
+      post_image_count: postImageCount,
+      upload_profile_media: Boolean(input.uploadProfileMedia)
+    });
+
+    const plan = buildImagePlan(persona, postImageCount);
+    const renderedAssets: GeneratedLinkedInImageAsset[] = [];
+    let openAiUsage: Record<string, unknown> | undefined;
+
+    for (const plannedAsset of plan) {
+      this.runtime.logger.log("info", "image_assets.generate.asset.start", {
+        concept_key: plannedAsset.conceptKey,
+        kind: plannedAsset.kind,
+        size: plannedAsset.sourceSize
+      });
+
+      const response = await fetch(`${baseUrl.replace(/\/$/, "")}/images/generations`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          model,
+          prompt: plannedAsset.prompt,
+          size: plannedAsset.sourceSize,
+          quality: "high",
+          output_format: "png",
+          n: 1
+        }),
+        signal: AbortSignal.timeout(180_000)
+      }).catch((error: unknown) => {
+        throw new LinkedInAssistantError(
+          "NETWORK_ERROR",
+          "OpenAI image generation request failed.",
+          {
+            cause: error instanceof Error ? error.message : String(error),
+            concept_key: plannedAsset.conceptKey
+          }
+        );
+      });
+
+      if (!response.ok) {
+        const requestId = response.headers.get("x-request-id");
+        let responseBody: unknown;
+        try {
+          responseBody = await response.json();
+        } catch {
+          responseBody = await response.text();
+        }
+
+        const errorPayload = parseJsonResponseBody(responseBody);
+        if (response.status === 401) {
+          throw new LinkedInAssistantError(
+            "ACTION_PRECONDITION_FAILED",
+            "OpenAI image generation was rejected. Check OPENAI_API_KEY.",
+            {
+              status: response.status,
+              request_id: requestId,
+              response: errorPayload ?? String(responseBody)
+            }
+          );
+        }
+
+        if (response.status === 429) {
+          throw new LinkedInAssistantError(
+            "RATE_LIMITED",
+            "OpenAI image generation is rate limited right now.",
+            {
+              status: response.status,
+              request_id: requestId,
+              response: errorPayload ?? String(responseBody)
+            }
+          );
+        }
+
+        throw new LinkedInAssistantError(
+          "NETWORK_ERROR",
+          "OpenAI image generation failed.",
+          {
+            status: response.status,
+            request_id: requestId,
+            response: errorPayload ?? String(responseBody),
+            concept_key: plannedAsset.conceptKey
+          }
+        );
+      }
+
+      const responseJson = (await response.json()) as OpenAiImageGenerationResponse;
+      if (responseJson.usage && !openAiUsage) {
+        openAiUsage = responseJson.usage;
+      }
+
+      const { buffer: rawBuffer, revisedPrompt } = await readOpenAiImageBuffer(
+        responseJson
+      );
+      const { width: sourceWidth, height: sourceHeight } = parseOpenAiImageSize(
+        plannedAsset.sourceSize
+      );
+      const renderedBuffer =
+        sourceWidth === plannedAsset.outputWidth &&
+        sourceHeight === plannedAsset.outputHeight
+          ? rawBuffer
+          : renderOutputPng(
+              rawBuffer,
+              plannedAsset.outputWidth,
+              plannedAsset.outputHeight
+            );
+      const relativePath = `${bundleRelativeDir}/${plannedAsset.fileName}`;
+      const sha256 = hashBuffer(renderedBuffer);
+      const absolutePath = writeBinaryArtifact(
+        this.runtime.artifacts,
+        relativePath,
+        renderedBuffer,
+        buildArtifactMetadata(
+          plannedAsset,
+          revisedPrompt,
+          sha256,
+          renderedBuffer.byteLength
+        )
+      );
+
+      renderedAssets.push({
+        kind: plannedAsset.kind,
+        title: plannedAsset.title,
+        concept_key: plannedAsset.conceptKey,
+        file_name: plannedAsset.fileName,
+        relative_path: relativePath,
+        absolute_path: absolutePath,
+        mime_type: "image/png",
+        width: plannedAsset.outputWidth,
+        height: plannedAsset.outputHeight,
+        size_bytes: renderedBuffer.byteLength,
+        sha256,
+        prompt: plannedAsset.prompt,
+        revised_prompt: revisedPrompt
+      });
+
+      this.runtime.logger.log("info", "image_assets.generate.asset.done", {
+        concept_key: plannedAsset.conceptKey,
+        kind: plannedAsset.kind,
+        relative_path: relativePath
+      });
+    }
+
+    const profilePhoto = renderedAssets.find(
+      (asset) => asset.kind === "profile_photo"
+    );
+    const banner = renderedAssets.find((asset) => asset.kind === "banner");
+    const postImages = renderedAssets.filter(
+      (asset) => asset.kind === "post_image"
+    );
+
+    if (!profilePhoto || !banner) {
+      throw new LinkedInAssistantError(
+        "UNKNOWN",
+        "Image generation plan did not produce the required profile media."
+      );
+    }
+
+    let manifest: GeneratedLinkedInPersonaImageSet = {
+      generated_at: generatedAt,
+      model,
+      bundle_relative_dir: bundleRelativeDir,
+      bundle_absolute_dir: bundleAbsoluteDir,
+      manifest_path: this.runtime.artifacts.resolve(`${bundleRelativeDir}/manifest.json`),
+      persona,
+      profile_photo: profilePhoto,
+      banner,
+      post_images: postImages,
+      ...(openAiUsage ? { openai_usage: openAiUsage } : {})
+    };
+
+    this.runtime.artifacts.writeJson(`${bundleRelativeDir}/manifest.json`, manifest, {
+      kind: "linkedin_ai_image_manifest",
+      persona_slug: persona.slug,
+      model,
+      post_image_count: postImages.length
+    });
+
+    if (input.uploadProfileMedia) {
+      const profileName = input.profileName?.trim() || "default";
+      const uploadDelayMs =
+        typeof input.uploadDelayMs === "number"
+          ? Math.max(0, Math.round(input.uploadDelayMs))
+          : DEFAULT_PROFILE_UPLOAD_DELAY_MS;
+      const operatorNote =
+        input.operatorNote?.trim() || `issue-211 persona images for ${persona.full_name}`;
+
+      this.runtime.logger.log("info", "image_assets.upload_profile_media.start", {
+        persona_slug: persona.slug,
+        profile_name: profileName
+      });
+
+      const preparedPhoto = await this.runtime.profile.prepareUploadPhoto({
+        profileName,
+        filePath: profilePhoto.absolute_path,
+        operatorNote
+      });
+      const confirmedPhoto = await this.runtime.confirmPreparedAction(
+        preparedPhoto.confirmToken
+      );
+
+      const photoUploadResult: LinkedInPersonaMediaUploadResult = {
+        prepared_action_id: confirmedPhoto.preparedActionId,
+        action_type: confirmedPhoto.actionType,
+        status: confirmedPhoto.status,
+        file_name: profilePhoto.file_name,
+        result: confirmedPhoto.result,
+        artifacts: confirmedPhoto.artifacts
+      };
+
+      const actualDelayMs = sampleDelay(uploadDelayMs);
+      if (actualDelayMs > 0) {
+        await sleep(actualDelayMs);
+      }
+
+      const preparedBanner = await this.runtime.profile.prepareUploadBanner({
+        profileName,
+        filePath: banner.absolute_path,
+        operatorNote
+      });
+      const confirmedBanner = await this.runtime.confirmPreparedAction(
+        preparedBanner.confirmToken
+      );
+
+      const bannerUploadResult: LinkedInPersonaMediaUploadResult = {
+        prepared_action_id: confirmedBanner.preparedActionId,
+        action_type: confirmedBanner.actionType,
+        status: confirmedBanner.status,
+        file_name: banner.file_name,
+        result: confirmedBanner.result,
+        artifacts: confirmedBanner.artifacts
+      };
+
+      manifest = {
+        ...manifest,
+        upload_results: {
+          profile_photo: photoUploadResult,
+          banner: bannerUploadResult
+        }
+      };
+
+      this.runtime.artifacts.writeJson(`${bundleRelativeDir}/manifest.json`, manifest, {
+        kind: "linkedin_ai_image_manifest",
+        persona_slug: persona.slug,
+        model,
+        uploaded_profile_media: true,
+        post_image_count: postImages.length
+      });
+
+      this.runtime.logger.log("info", "image_assets.upload_profile_media.done", {
+        persona_slug: persona.slug,
+        profile_name: profileName
+      });
+    }
+
+    this.runtime.logger.log("info", "image_assets.generate.done", {
+      persona_slug: persona.slug,
+      bundle_relative_dir: bundleRelativeDir,
+      post_image_count: postImages.length
+    });
+
+    return manifest;
+  }
+}

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -41,6 +41,7 @@ import {
   LinkedInProfileService,
   type LinkedInProfileRuntime
 } from "./linkedinProfile.js";
+import { LinkedInImageAssetsService } from "./linkedinImageAssets.js";
 import {
   LinkedInJobsService,
   type LinkedInJobsRuntime
@@ -150,6 +151,7 @@ export interface CoreRuntime {
   profileManager: ProfileManager;
   auth: LinkedInAuthService;
   profile: LinkedInProfileService;
+  imageAssets: LinkedInImageAssetsService;
   search: LinkedInSearchService;
   jobs: LinkedInJobsService;
   notifications: LinkedInNotificationsService;
@@ -301,6 +303,7 @@ export function createCoreRuntime(
       evasion
     ),
     profile: undefined as unknown as LinkedInProfileService,
+    imageAssets: undefined as unknown as LinkedInImageAssetsService,
     search: undefined as unknown as LinkedInSearchService,
     jobs: undefined as unknown as LinkedInJobsService,
     notifications: undefined as unknown as LinkedInNotificationsService,
@@ -339,6 +342,26 @@ export function createCoreRuntime(
 
   const profileRuntime: LinkedInProfileRuntime = runtime;
   runtime.profile = new LinkedInProfileService(profileRuntime);
+  runtime.imageAssets = new LinkedInImageAssetsService(
+    {
+      logger,
+      artifacts,
+      profile: runtime.profile,
+      confirmPreparedAction: (confirmToken) =>
+        runtime.twoPhaseCommit.confirmByToken({ confirmToken })
+    },
+    {
+      ...(process.env.OPENAI_API_KEY
+        ? { apiKey: process.env.OPENAI_API_KEY }
+        : {}),
+      ...(process.env.OPENAI_BASE_URL
+        ? { baseUrl: process.env.OPENAI_BASE_URL }
+        : {}),
+      ...(process.env.LINKEDIN_ASSISTANT_OPENAI_IMAGE_MODEL
+        ? { defaultModel: process.env.LINKEDIN_ASSISTANT_OPENAI_IMAGE_MODEL }
+        : {})
+    }
+  );
   const searchRuntime: LinkedInSearchRuntime = runtime;
   runtime.search = new LinkedInSearchService(searchRuntime);
   const jobsRuntime: LinkedInJobsRuntime = runtime;

--- a/packages/mcp/src/bin/linkedin-mcp.ts
+++ b/packages/mcp/src/bin/linkedin-mcp.ts
@@ -1,14 +1,18 @@
 #!/usr/bin/env node
+import path from "node:path";
+import { readFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 import {
   ACTIVITY_EVENT_TYPES,
   ACTIVITY_WATCH_KINDS,
   ACTIVITY_WATCH_STATUSES,
+  DEFAULT_LINKEDIN_PERSONA_POST_IMAGE_COUNT,
   DEFAULT_FOLLOWUP_SINCE,
   LINKEDIN_FEED_REACTION_TYPES,
   LINKEDIN_POST_VISIBILITY_TYPES,
   LINKEDIN_SELECTOR_LOCALES,
   LinkedInAssistantError,
+  buildLinkedInImagePersonaFromProfileSeed,
   createCoreRuntime,
   normalizeLinkedInFeedReaction,
   normalizeLinkedInPostVisibility,
@@ -34,6 +38,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import {
   LINKEDIN_ACTIONS_CONFIRM_TOOL,
+  LINKEDIN_ASSETS_GENERATE_PROFILE_IMAGES_TOOL,
   LINKEDIN_ACTIVITY_DELIVERIES_LIST_TOOL,
   LINKEDIN_ACTIVITY_EVENTS_LIST_TOOL,
   LINKEDIN_ACTIVITY_POLLER_RUN_ONCE_TOOL,
@@ -151,6 +156,26 @@ function readPositiveNumber(
   return value;
 }
 
+function readNonNegativeNumber(
+  args: ToolArgs,
+  key: string,
+  fallback: number
+): number {
+  const value = args[key];
+  if (typeof value !== "number") {
+    return fallback;
+  }
+
+  if (!Number.isFinite(value) || value < 0) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${key} must be zero or a positive number.`
+    );
+  }
+
+  return value;
+}
+
 function readBoolean(args: ToolArgs, key: string, fallback: boolean): boolean {
   const value = args[key];
   return typeof value === "boolean" ? value : fallback;
@@ -220,6 +245,40 @@ function readObject(
     "ACTION_PRECONDITION_FAILED",
     `${key} must be an object.`
   );
+}
+
+async function readJsonInputFile(
+  filePath: string,
+  label: string
+): Promise<unknown> {
+  const resolvedPath = path.resolve(filePath);
+  let rawValue = "";
+
+  try {
+    rawValue = await readFile(resolvedPath, "utf8");
+  } catch (error) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `Could not read ${label}.`,
+      {
+        path: resolvedPath,
+        cause: error instanceof Error ? error.message : String(error)
+      }
+    );
+  }
+
+  try {
+    return JSON.parse(rawValue) as unknown;
+  } catch (error) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must contain valid JSON.`,
+      {
+        path: resolvedPath,
+        cause: error instanceof Error ? error.message : String(error)
+      }
+    );
+  }
 }
 
 function coerceEnumValue<T extends string>(
@@ -1125,6 +1184,65 @@ async function handleProfilePrepareFeaturedReorder(
       run_id: runtime.runId,
       profile_name: profileName,
       ...prepared
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function handleAssetsGenerateProfileImages(
+  args: ToolArgs
+): Promise<ToolResult> {
+  const runtime = createRuntime(args);
+
+  try {
+    const profileName = readString(args, "profileName", "default");
+    const specPath = readRequiredString(args, "specPath");
+    const postImageCount = readPositiveNumber(
+      args,
+      "postImageCount",
+      DEFAULT_LINKEDIN_PERSONA_POST_IMAGE_COUNT
+    );
+    const uploadProfileMedia = readBoolean(args, "uploadProfileMedia", false);
+    const uploadDelayMs = readNonNegativeNumber(args, "uploadDelayMs", 4_500);
+    const model = readString(args, "model", "");
+    const operatorNote = readString(args, "operatorNote", "");
+    const resolvedSpecPath = path.resolve(specPath);
+    const persona = buildLinkedInImagePersonaFromProfileSeed(
+      await readJsonInputFile(resolvedSpecPath, "image persona spec")
+    );
+
+    runtime.logger.log("info", "mcp.assets.generate_profile_images.start", {
+      profileName,
+      specPath: resolvedSpecPath,
+      postImageCount,
+      uploadProfileMedia,
+      model: model || null
+    });
+
+    const report = await runtime.imageAssets.generatePersonaImageSet({
+      persona,
+      postImageCount,
+      uploadProfileMedia,
+      profileName,
+      uploadDelayMs,
+      operatorNote:
+        operatorNote || `issue-211 persona images: ${path.basename(resolvedSpecPath)}`,
+      ...(model ? { model } : {})
+    });
+
+    runtime.logger.log("info", "mcp.assets.generate_profile_images.done", {
+      profileName,
+      specPath: resolvedSpecPath,
+      postImageCount,
+      uploadProfileMedia
+    });
+
+    return toToolResult({
+      run_id: runtime.runId,
+      profile_name: profileName,
+      spec_path: resolvedSpecPath,
+      ...report
     });
   } finally {
     runtime.close();
@@ -3081,6 +3199,49 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         }
       },
       {
+        name: LINKEDIN_ASSETS_GENERATE_PROFILE_IMAGES_TOOL,
+        description:
+          "Generate a LinkedIn-ready profile photo, banner, and reusable post images from a local persona JSON spec using OpenAI. Optionally uploads the photo and banner through the existing LinkedIn profile upload flow.",
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+          required: ["specPath"],
+          properties: withCdpSchemaProperties({
+            profileName: {
+              type: "string",
+              description: "Persistent Playwright profile name. Defaults to default."
+            },
+            specPath: {
+              type: "string",
+              description: "Local path to the JSON persona/profile seed spec."
+            },
+            postImageCount: {
+              type: "number",
+              description:
+                "Number of post images to generate. Defaults to 6 and must be 10 or fewer."
+            },
+            model: {
+              type: "string",
+              description: "Optional OpenAI image model override."
+            },
+            uploadProfileMedia: {
+              type: "boolean",
+              description:
+                "If true, upload the generated profile photo and banner after generation."
+            },
+            uploadDelayMs: {
+              type: "number",
+              description:
+                "Base delay between the photo and banner uploads when uploadProfileMedia is true. Defaults to 4500."
+            },
+            operatorNote: {
+              type: "string",
+              description: "Optional note attached to the upload actions."
+            }
+          })
+        }
+      },
+      {
         name: LINKEDIN_SEARCH_TOOL,
         description: withSelectorAuditHint(
           "Search LinkedIn for people, companies, or jobs."
@@ -4164,6 +4325,8 @@ const TOOL_HANDLERS: Record<string, ToolHandler> = {
     handleProfilePrepareFeaturedRemove,
   [LINKEDIN_PROFILE_PREPARE_FEATURED_REORDER_TOOL]:
     handleProfilePrepareFeaturedReorder,
+  [LINKEDIN_ASSETS_GENERATE_PROFILE_IMAGES_TOOL]:
+    handleAssetsGenerateProfileImages,
   [LINKEDIN_SEARCH_TOOL]: handleSearch,
   [LINKEDIN_CONNECTIONS_LIST_TOOL]: handleConnectionsList,
   [LINKEDIN_CONNECTIONS_PENDING_TOOL]: handleConnectionsPending,

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -29,6 +29,8 @@ export const LINKEDIN_PROFILE_PREPARE_FEATURED_REMOVE_TOOL =
   "linkedin.profile.prepare_featured_remove";
 export const LINKEDIN_PROFILE_PREPARE_FEATURED_REORDER_TOOL =
   "linkedin.profile.prepare_featured_reorder";
+export const LINKEDIN_ASSETS_GENERATE_PROFILE_IMAGES_TOOL =
+  "linkedin.assets.generate_profile_images";
 export const LINKEDIN_SEARCH_TOOL = "linkedin.search";
 export const LINKEDIN_CONNECTIONS_LIST_TOOL = "linkedin.connections.list";
 export const LINKEDIN_CONNECTIONS_PENDING_TOOL = "linkedin.connections.pending";


### PR DESCRIPTION
## Summary

- add a reusable core service that turns the issue-210 persona seed into a LinkedIn-ready image bundle via OpenAI
- expose the workflow through both CLI (`linkedin assets generate-profile-images`) and MCP (`linkedin.assets.generate_profile_images`)
- document the operator workflow and cover the new service/CLI plumbing with tests

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

## Live run notes

- Generated a real bundle locally with the new CLI at:
  `/Users/user/.linkedin-assistant/linkedin-owa-agentools/artifacts/run_20260310132228603_5bf28e8f83/linkedin-ai-assets/emil-sorensen/2026-03-10T13-22-28-609Z`
- Verified the generated profile photo, banner, and post images visually from that bundle.
- Did **not** complete a live profile upload because the authenticated `default` profile is a real account, not a safe dedicated test account, and the existing profile photo upload executor failed with selector drift.
- Filed the upload failure as bug #259.
- The dedicated test-account session gap remains tracked in #253.

Closes #211
