### PR TITLE
feat: automate daily CalVer releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,125 @@
+name: Release
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+      RELEASE_MODE: ${{ github.event_name == 'workflow_dispatch' && 'manual' || 'scheduled' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Fetch tags
+        run: git fetch --force --tags origin
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Decide release
+        id: release
+        run: >
+          node ./scripts/prepare-release.mjs
+          --mode "$RELEASE_MODE"
+          --check-only
+          --notes-file "${{ runner.temp }}/release-notes.md"
+
+      - name: Nothing to release
+        if: steps.release.outputs.skip == 'true'
+        run: echo "${{ steps.release.outputs.reason }}"
+
+      - name: Install deps
+        if: steps.release.outputs.skip != 'true'
+        run: npm ci
+
+      - name: Install Chromium
+        if: steps.release.outputs.skip != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Lint
+        if: steps.release.outputs.skip != 'true'
+        run: npm run lint
+
+      - name: Typecheck
+        if: steps.release.outputs.skip != 'true'
+        run: npm run typecheck
+
+      - name: Test
+        if: steps.release.outputs.skip != 'true'
+        run: npm test
+
+      - name: Fixture-backed E2E
+        if: steps.release.outputs.skip != 'true'
+        run: npm run test:e2e:fixtures
+
+      - name: Build
+        if: steps.release.outputs.skip != 'true'
+        run: npm run build
+
+      - name: Apply release version
+        if: steps.release.outputs.skip != 'true'
+        run: >
+          node ./scripts/prepare-release.mjs
+          --mode "$RELEASE_MODE"
+          --notes-file "${{ steps.release.outputs.release_notes_path }}"
+
+      - name: Create release commit and tag
+        if: steps.release.outputs.skip != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json packages/core/package.json packages/cli/package.json packages/mcp/package.json
+          git commit -m "chore(release): publish ${{ steps.release.outputs.version }} [skip ci]"
+          git tag -a "${{ steps.release.outputs.tag }}" -m "Release ${{ steps.release.outputs.tag }}"
+
+      - name: Publish core
+        if: steps.release.outputs.skip != 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish -w @linkedin-assistant/core --access public --provenance
+
+      - name: Publish CLI
+        if: steps.release.outputs.skip != 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish -w @linkedin-assistant/cli --access public --provenance
+
+      - name: Publish MCP
+        if: steps.release.outputs.skip != 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish -w @linkedin-assistant/mcp --access public --provenance
+
+      - name: Push release commit and tag
+        if: steps.release.outputs.skip != 'true'
+        run: |
+          git push origin HEAD:main
+          git push origin "${{ steps.release.outputs.tag }}"
+
+      - name: Create GitHub Release
+        if: steps.release.outputs.skip != 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: ${{ steps.release.outputs.release_notes_path }}
+          make_latest: true
+          name: ${{ steps.release.outputs.tag }}
+          tag_name: ${{ steps.release.outputs.tag }}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:e2e": "node ./scripts/run-e2e.js",
     "test:e2e:fixtures": "LINKEDIN_E2E=1 LINKEDIN_E2E_REPLAY=1 LINKEDIN_E2E_FIXTURE_MANIFEST=test/fixtures/manifest.json vitest run -c vitest.config.e2e.ts",
     "test:e2e:raw": "LINKEDIN_E2E=1 vitest run -c vitest.config.e2e.ts",
-    "build": "tsc -b --pretty false"
+    "build": "tsc -b --pretty false",
+    "release:prepare": "node ./scripts/prepare-release.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,10 +4,31 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "bin": {
     "linkedin": "dist/bin/linkedin.js",
     "owa": "dist/bin/linkedin.js"
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sigvardt/linkedin-buddy.git",
+    "directory": "packages/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/sigvardt/linkedin-buddy/issues"
+  },
+  "homepage": "https://github.com/sigvardt/linkedin-buddy/tree/main/packages/cli",
+  "keywords": [
+    "linkedin",
+    "automation",
+    "cli",
+    "playwright"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc --noEmit -p tsconfig.json"

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -17,6 +17,7 @@ import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { Command } from "commander";
+import packageJson from "../../package.json" with { type: "json" };
 import {
   ACTIVITY_EVENT_TYPES,
   ACTIVITY_WATCH_KINDS,
@@ -6173,7 +6174,7 @@ export function createCliProgram(): Command {
   program
     .name("linkedin")
     .description("LinkedIn assistant CLI")
-    .version("0.1.0")
+    .version(packageJson.version)
     .option(
       "--cdp-url <url>",
       "Connect to existing browser via CDP endpoint (e.g., http://127.0.0.1:18800)"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,12 +4,33 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sigvardt/linkedin-buddy.git",
+    "directory": "packages/core"
+  },
+  "bugs": {
+    "url": "https://github.com/sigvardt/linkedin-buddy/issues"
+  },
+  "homepage": "https://github.com/sigvardt/linkedin-buddy/tree/main/packages/core",
+  "keywords": [
+    "linkedin",
+    "automation",
+    "playwright",
+    "library"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc --noEmit -p tsconfig.json",

--- a/packages/core/test/releaseUtils.test.ts
+++ b/packages/core/test/releaseUtils.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReleaseNotes,
+  formatCalver,
+  groupCommitsBySection,
+  selectReleaseVersion
+} from "../../../scripts/release-utils.mjs";
+
+describe("release-utils", () => {
+  describe("formatCalver", () => {
+    it("formats UTC calendar versions without zero-padding", () => {
+      expect(formatCalver(new Date("2026-03-10T06:00:00Z"))).toBe("2026.3.10");
+    });
+  });
+
+  describe("selectReleaseVersion", () => {
+    it("uses the bare date for scheduled releases", () => {
+      expect(
+        selectReleaseVersion({
+          date: new Date("2026-03-10T06:00:00Z"),
+          existingVersions: ["2026.3.9", "2026.3.10", "2026.3.10-1"],
+          mode: "scheduled"
+        })
+      ).toBe("2026.3.10");
+    });
+
+    it("keeps the bare date for manual releases when that day has no release yet", () => {
+      expect(
+        selectReleaseVersion({
+          date: new Date("2026-03-10T06:00:00Z"),
+          existingVersions: ["2026.3.9", "2026.3.9-1"],
+          mode: "manual"
+        })
+      ).toBe("2026.3.10");
+    });
+
+    it("increments the same-day manual hotfix suffix", () => {
+      expect(
+        selectReleaseVersion({
+          date: new Date("2026-03-10T06:00:00Z"),
+          existingVersions: [
+            "2026.3.10",
+            "2026.3.10-1",
+            "2026.3.10-2",
+            "2026.3.9"
+          ],
+          mode: "manual"
+        })
+      ).toBe("2026.3.10-3");
+    });
+  });
+
+  describe("groupCommitsBySection", () => {
+    it("groups feat and fix commits while leaving other commits in the fallback bucket", () => {
+      const sections = groupCommitsBySection([
+        {
+          sha: "1111111111111111111111111111111111111111",
+          subject: "feat: automate releases"
+        },
+        {
+          sha: "2222222222222222222222222222222222222222",
+          subject: "fix #250: handle same-day hotfix suffixes"
+        },
+        {
+          sha: "3333333333333333333333333333333333333333",
+          subject: "docs: explain npm release token setup"
+        }
+      ]);
+
+      expect(sections.features).toHaveLength(1);
+      expect(sections.fixes).toHaveLength(1);
+      expect(sections.other).toHaveLength(1);
+    });
+  });
+
+  describe("buildReleaseNotes", () => {
+    it("renders grouped changelog sections with compare links", () => {
+      const notes = buildReleaseNotes({
+        version: "2026.3.10",
+        previousTag: "v2026.3.9",
+        compareUrl:
+          "https://github.com/sigvardt/linkedin-buddy/compare/v2026.3.9...abcdef0",
+        repository: "sigvardt/linkedin-buddy",
+        commits: [
+          {
+            sha: "abcdef0123456789abcdef0123456789abcdef01",
+            subject: "feat: automate the npm release workflow"
+          },
+          {
+            sha: "1234567890abcdef1234567890abcdef12345678",
+            subject: "fix: skip daily releases when nothing changed"
+          },
+          {
+            sha: "fedcba9876543210fedcba9876543210fedcba98",
+            subject: "chore: refresh package metadata for npm"
+          }
+        ]
+      });
+
+      expect(notes).toContain("# v2026.3.10");
+      expect(notes).toContain("## Features");
+      expect(notes).toContain("## Fixes");
+      expect(notes).toContain("## Other");
+      expect(notes).toContain("Compare: https://github.com/sigvardt/linkedin-buddy/compare/v2026.3.9...abcdef0");
+      expect(notes).toContain("[abcdef0](https://github.com/sigvardt/linkedin-buddy/commit/abcdef0123456789abcdef0123456789abcdef01)");
+    });
+  });
+});

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -4,9 +4,30 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "bin": {
     "linkedin-mcp": "dist/bin/linkedin-mcp.js"
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sigvardt/linkedin-buddy.git",
+    "directory": "packages/mcp"
+  },
+  "bugs": {
+    "url": "https://github.com/sigvardt/linkedin-buddy/issues"
+  },
+  "homepage": "https://github.com/sigvardt/linkedin-buddy/tree/main/packages/mcp",
+  "keywords": [
+    "linkedin",
+    "automation",
+    "mcp",
+    "playwright"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc --noEmit -p tsconfig.json"

--- a/packages/mcp/src/bin/linkedin-mcp.ts
+++ b/packages/mcp/src/bin/linkedin-mcp.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { pathToFileURL } from "node:url";
+import packageJson from "../../package.json" with { type: "json" };
 import {
   ACTIVITY_EVENT_TYPES,
   ACTIVITY_WATCH_KINDS,
@@ -2531,7 +2532,7 @@ async function handleConfirm(args: ToolArgs): Promise<ToolResult> {
 const server = new Server(
   {
     name: "linkedin-mcp",
-    version: "0.1.0"
+    version: packageJson.version
   },
   {
     capabilities: {

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -1,0 +1,459 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildReleaseNotes,
+  formatCalver,
+  selectReleaseVersion
+} from "./release-utils.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const canonicalPackageName = "@linkedin-assistant/cli";
+const releaseTagPrefix = "v";
+const rootPackageJsonPath = path.join(repoRoot, "package.json");
+const workspacePackageJsonPaths = [
+  path.join(repoRoot, "packages/core/package.json"),
+  path.join(repoRoot, "packages/cli/package.json"),
+  path.join(repoRoot, "packages/mcp/package.json")
+];
+
+/**
+ * @typedef {{
+ *   checkOnly: boolean;
+ *   mode: "scheduled" | "manual";
+ *   notesFilePath: string;
+ *   today: Date;
+ * }} ParsedArgs
+ */
+
+/**
+ * @typedef {{
+ *   commitsSincePreviousRelease: number;
+ *   latestPublishedVersion: string | null;
+ *   previousReleaseTag: string | null;
+ *   reason: string | null;
+ *   releaseNotes: string | null;
+ *   releaseNotesPath: string;
+ *   skip: boolean;
+ *   version: string | null;
+ * }} ReleasePreparationResult
+ */
+
+const parsedArgs = parseArgs(process.argv.slice(2));
+const result = prepareRelease(parsedArgs);
+
+writeOutputs(result);
+
+if (!result.skip && !parsedArgs.checkOnly && result.version !== null) {
+  applyVersion(result.version);
+}
+
+if (!result.skip && result.releaseNotes !== null) {
+  writeReleaseNotes(parsedArgs.notesFilePath, result.releaseNotes);
+}
+
+if (result.skip) {
+  console.log(result.reason ?? "release skipped");
+} else {
+  console.log(`Prepared release ${String(result.version)}.`);
+}
+
+/**
+ * @param {ParsedArgs} args
+ * @returns {ReleasePreparationResult}
+ */
+function prepareRelease(args) {
+  const latestPublishedVersion = getLatestPublishedVersion(canonicalPackageName);
+  const sortedReleaseTags = getSortedReleaseTags();
+  const publishedTag = latestPublishedVersion === null
+    ? null
+    : `${releaseTagPrefix}${latestPublishedVersion}`;
+  const previousReleaseTag = resolvePreviousReleaseTag(sortedReleaseTags, publishedTag);
+  const commitsSincePreviousRelease = countCommitsSince(previousReleaseTag);
+
+  if (commitsSincePreviousRelease === 0) {
+    return {
+      commitsSincePreviousRelease,
+      latestPublishedVersion,
+      previousReleaseTag,
+      reason: "No commits since the previous release.",
+      releaseNotes: null,
+      releaseNotesPath: args.notesFilePath,
+      skip: true,
+      version: null
+    };
+  }
+
+  const existingVersions = new Set(
+    sortedReleaseTags.map((tag) => stripReleaseTagPrefix(tag))
+  );
+  const baseVersion = formatCalver(args.today);
+
+  if (args.mode === "scheduled" && existingVersions.has(baseVersion)) {
+    return {
+      commitsSincePreviousRelease,
+      latestPublishedVersion,
+      previousReleaseTag,
+      reason: `Scheduled release ${baseVersion} already exists.`,
+      releaseNotes: null,
+      releaseNotesPath: args.notesFilePath,
+      skip: true,
+      version: null
+    };
+  }
+
+  const version = selectReleaseVersion({
+    date: args.today,
+    existingVersions,
+    mode: args.mode
+  });
+  const commits = readCommits(previousReleaseTag);
+  const compareUrl = buildCompareUrl(previousReleaseTag);
+  const releaseNotes = buildReleaseNotes({
+    version,
+    commits,
+    repository: process.env.GITHUB_REPOSITORY,
+    previousTag: previousReleaseTag,
+    compareUrl
+  });
+
+  return {
+    commitsSincePreviousRelease,
+    latestPublishedVersion,
+    previousReleaseTag,
+    reason: null,
+    releaseNotes,
+    releaseNotesPath: args.notesFilePath,
+    skip: false,
+    version
+  };
+}
+
+/**
+ * @param {string} version
+ */
+function applyVersion(version) {
+  const rootPackageJson = readJson(rootPackageJsonPath);
+  rootPackageJson.version = version;
+  writeJson(rootPackageJsonPath, rootPackageJson);
+
+  for (const workspacePath of workspacePackageJsonPaths) {
+    const packageJson = readJson(workspacePath);
+    packageJson.version = version;
+
+    if (workspacePath.endsWith("/packages/cli/package.json")) {
+      packageJson.dependencies["@linkedin-assistant/core"] = version;
+    }
+
+    if (workspacePath.endsWith("/packages/mcp/package.json")) {
+      packageJson.dependencies["@linkedin-assistant/core"] = version;
+    }
+
+    writeJson(workspacePath, packageJson);
+  }
+
+  execFileSync(
+    "npm",
+    ["install", "--package-lock-only", "--ignore-scripts"],
+    {
+      cwd: repoRoot,
+      stdio: "inherit"
+    }
+  );
+}
+
+/**
+ * @param {string} notesFilePath
+ * @param {string} releaseNotes
+ */
+function writeReleaseNotes(notesFilePath, releaseNotes) {
+  mkdirSync(path.dirname(notesFilePath), { recursive: true });
+  writeFileSync(notesFilePath, releaseNotes, "utf8");
+}
+
+/**
+ * @param {ReleasePreparationResult} result
+ */
+function writeOutputs(result) {
+  const githubOutputPath = process.env.GITHUB_OUTPUT;
+  if (typeof githubOutputPath === "string" && githubOutputPath.length > 0) {
+    appendGitHubOutput(githubOutputPath, "skip", result.skip ? "true" : "false");
+    appendGitHubOutput(
+      githubOutputPath,
+      "commits_since_previous_release",
+      String(result.commitsSincePreviousRelease)
+    );
+    appendGitHubOutput(
+      githubOutputPath,
+      "latest_published_version",
+      result.latestPublishedVersion ?? ""
+    );
+    appendGitHubOutput(
+      githubOutputPath,
+      "previous_release_tag",
+      result.previousReleaseTag ?? ""
+    );
+    appendGitHubOutput(githubOutputPath, "reason", result.reason ?? "");
+    appendGitHubOutput(
+      githubOutputPath,
+      "release_notes_path",
+      result.releaseNotesPath
+    );
+    appendGitHubOutput(githubOutputPath, "version", result.version ?? "");
+    appendGitHubOutput(
+      githubOutputPath,
+      "tag",
+      result.version === null ? "" : `${releaseTagPrefix}${result.version}`
+    );
+  }
+}
+
+/**
+ * @param {string[]} sortedReleaseTags
+ * @param {string | null} publishedTag
+ * @returns {string | null}
+ */
+function resolvePreviousReleaseTag(sortedReleaseTags, publishedTag) {
+  if (publishedTag !== null && !sortedReleaseTags.includes(publishedTag)) {
+    throw new Error(
+      `Latest published version tag ${publishedTag} is missing from the repository.`
+    );
+  }
+
+  if (sortedReleaseTags.length > 0) {
+    return sortedReleaseTags[0];
+  }
+
+  return publishedTag;
+}
+
+/**
+ * @returns {string[]}
+ */
+function getSortedReleaseTags() {
+  const rawOutput = runGit(["tag", "--sort=-v:refname", "--list", `${releaseTagPrefix}*`]);
+  if (rawOutput.length === 0) {
+    return [];
+  }
+
+  return rawOutput
+    .split("\n")
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.length > 0);
+}
+
+/**
+ * @param {string | null} previousReleaseTag
+ * @returns {number}
+ */
+function countCommitsSince(previousReleaseTag) {
+  if (previousReleaseTag === null) {
+    return Number.parseInt(runGit(["rev-list", "--count", "HEAD"]), 10);
+  }
+
+  return Number.parseInt(
+    runGit(["rev-list", "--count", `${previousReleaseTag}..HEAD`]),
+    10
+  );
+}
+
+/**
+ * @param {string | null} previousReleaseTag
+ * @returns {{ sha: string; subject: string }[]}
+ */
+function readCommits(previousReleaseTag) {
+  const range = previousReleaseTag === null ? "HEAD" : `${previousReleaseTag}..HEAD`;
+  const rawOutput = runGit([
+    "log",
+    "--reverse",
+    "--format=%H%x09%s",
+    range
+  ]);
+
+  if (rawOutput.length === 0) {
+    return [];
+  }
+
+  return rawOutput
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const [sha, ...subjectParts] = line.split("\t");
+      return {
+        sha,
+        subject: subjectParts.join("\t")
+      };
+    });
+}
+
+/**
+ * @param {string | null} previousReleaseTag
+ * @returns {string | null}
+ */
+function buildCompareUrl(previousReleaseTag) {
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (typeof repository !== "string" || repository.length === 0) {
+    return null;
+  }
+
+  if (previousReleaseTag === null) {
+    return null;
+  }
+
+  const headSha = runGit(["rev-parse", "HEAD"]);
+  return `https://github.com/${repository}/compare/${previousReleaseTag}...${headSha}`;
+}
+
+/**
+ * @param {string} packageName
+ * @returns {string | null}
+ */
+function getLatestPublishedVersion(packageName) {
+  try {
+    const rawOutput = runCommand("npm", ["view", packageName, "version", "--json"]);
+    if (rawOutput.length === 0) {
+      return null;
+    }
+
+    const parsedOutput = JSON.parse(rawOutput);
+    return typeof parsedOutput === "string" ? parsedOutput : null;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      typeof error.message === "string" &&
+      error.message.includes("E404")
+    ) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+/**
+ * @param {string[]} args
+ * @returns {ParsedArgs}
+ */
+function parseArgs(args) {
+  /** @type {ParsedArgs} */
+  const parsedArgs = {
+    checkOnly: false,
+    mode: "scheduled",
+    notesFilePath: path.join(repoRoot, ".release-notes.md"),
+    today: new Date()
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+
+    if (argument === "--check-only") {
+      parsedArgs.checkOnly = true;
+      continue;
+    }
+
+    if (argument === "--mode") {
+      const mode = args[index + 1];
+      if (mode !== "manual" && mode !== "scheduled") {
+        throw new Error(`Unsupported release mode: ${String(mode)}`);
+      }
+
+      parsedArgs.mode = mode;
+      index += 1;
+      continue;
+    }
+
+    if (argument === "--notes-file") {
+      const notesFilePath = args[index + 1];
+      if (typeof notesFilePath !== "string" || notesFilePath.length === 0) {
+        throw new Error("Expected a path after --notes-file.");
+      }
+
+      parsedArgs.notesFilePath = path.resolve(repoRoot, notesFilePath);
+      index += 1;
+      continue;
+    }
+
+    if (argument === "--today") {
+      const todayValue = args[index + 1];
+      if (typeof todayValue !== "string" || todayValue.length === 0) {
+        throw new Error("Expected an ISO date after --today.");
+      }
+
+      const parsedDate = new Date(todayValue);
+      if (Number.isNaN(parsedDate.getTime())) {
+        throw new Error(`Invalid date passed to --today: ${todayValue}`);
+      }
+
+      parsedArgs.today = parsedDate;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${argument}`);
+  }
+
+  return parsedArgs;
+}
+
+/**
+ * @param {string} outputPath
+ * @param {string} key
+ * @param {string} value
+ */
+function appendGitHubOutput(outputPath, key, value) {
+  const multilineMarker = "EOF_RELEASE_OUTPUT";
+  appendFileSync(
+    outputPath,
+    `${key}<<${multilineMarker}\n${value}\n${multilineMarker}\n`,
+    "utf8"
+  );
+}
+
+/**
+ * @param {string[]} args
+ * @returns {string}
+ */
+function runGit(args) {
+  return runCommand("git", args);
+}
+
+/**
+ * @param {string} command
+ * @param {string[]} args
+ * @returns {string}
+ */
+function runCommand(command, args) {
+  return execFileSync(command, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}
+
+/**
+ * @param {string} tag
+ * @returns {string}
+ */
+function stripReleaseTagPrefix(tag) {
+  return tag.startsWith(releaseTagPrefix) ? tag.slice(releaseTagPrefix.length) : tag;
+}
+
+/**
+ * @param {string} filePath
+ * @returns {Record<string, unknown>}
+ */
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+/**
+ * @param {string} filePath
+ * @param {Record<string, unknown>} value
+ */
+function writeJson(filePath, value) {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}

--- a/scripts/release-utils.mjs
+++ b/scripts/release-utils.mjs
@@ -1,0 +1,205 @@
+/**
+ * @typedef {{
+ *   sha: string;
+ *   subject: string;
+ * }} ReleaseCommit
+ */
+
+/**
+ * @typedef {"scheduled" | "manual"} ReleaseMode
+ */
+
+const CONVENTIONAL_FEATURE_TYPES = new Set(["feat"]);
+const CONVENTIONAL_FIX_TYPES = new Set(["fix"]);
+
+/**
+ * Formats a UTC calendar version using the repository's `YYYY.M.D` scheme.
+ *
+ * @param {Date} date
+ * @returns {string}
+ */
+export function formatCalver(date) {
+  return `${date.getUTCFullYear()}.${date.getUTCMonth() + 1}.${date.getUTCDate()}`;
+}
+
+/**
+ * Returns the release version for the given mode and existing release history.
+ *
+ * Scheduled releases always use the bare date. Manual releases append `-N`
+ * only when the same-day base version already exists.
+ *
+ * @param {{
+ *   date: Date;
+ *   existingVersions: Iterable<string>;
+ *   mode: ReleaseMode;
+ * }} input
+ * @returns {string}
+ */
+export function selectReleaseVersion({ date, existingVersions, mode }) {
+  const baseVersion = formatCalver(date);
+
+  if (mode === "scheduled") {
+    return baseVersion;
+  }
+
+  let highestPatch = -1;
+  const patchPattern = new RegExp(`^${escapeRegExp(baseVersion)}-(\\d+)$`);
+
+  for (const version of existingVersions) {
+    if (version === baseVersion) {
+      highestPatch = Math.max(highestPatch, 0);
+      continue;
+    }
+
+    const match = patchPattern.exec(version);
+    if (!match) {
+      continue;
+    }
+
+    const patchNumber = Number.parseInt(match[1], 10);
+    if (Number.isNaN(patchNumber)) {
+      continue;
+    }
+
+    highestPatch = Math.max(highestPatch, patchNumber);
+  }
+
+  if (highestPatch < 0) {
+    return baseVersion;
+  }
+
+  return `${baseVersion}-${highestPatch + 1}`;
+}
+
+/**
+ * Groups commits into conventional-commit-inspired release sections.
+ *
+ * @param {ReleaseCommit[]} commits
+ * @returns {{
+ *   features: ReleaseCommit[];
+ *   fixes: ReleaseCommit[];
+ *   other: ReleaseCommit[];
+ * }}
+ */
+export function groupCommitsBySection(commits) {
+  return commits.reduce(
+    (sections, commit) => {
+      const type = readConventionalCommitType(commit.subject);
+
+      if (type !== null && CONVENTIONAL_FEATURE_TYPES.has(type)) {
+        sections.features.push(commit);
+        return sections;
+      }
+
+      if (type !== null && CONVENTIONAL_FIX_TYPES.has(type)) {
+        sections.fixes.push(commit);
+        return sections;
+      }
+
+      sections.other.push(commit);
+      return sections;
+    },
+    /** @type {{
+     *   features: ReleaseCommit[];
+     *   fixes: ReleaseCommit[];
+     *   other: ReleaseCommit[];
+     * }} */ ({
+      features: [],
+      fixes: [],
+      other: []
+    })
+  );
+}
+
+/**
+ * Builds the GitHub Release body for a release candidate.
+ *
+ * @param {{
+ *   version: string;
+ *   commits: ReleaseCommit[];
+ *   repository?: string;
+ *   previousTag?: string | null;
+ *   compareUrl?: string | null;
+ * }} input
+ * @returns {string}
+ */
+export function buildReleaseNotes({
+  version,
+  commits,
+  repository,
+  previousTag = null,
+  compareUrl = null
+}) {
+  const lines = [`# v${version}`, ""];
+  const sections = groupCommitsBySection(commits);
+
+  if (previousTag !== null) {
+    lines.push(`Changes since \`${previousTag}\`.`, "");
+  } else {
+    lines.push("Initial automated release.", "");
+  }
+
+  appendReleaseSection(lines, "Features", sections.features, repository);
+  appendReleaseSection(lines, "Fixes", sections.fixes, repository);
+  appendReleaseSection(lines, "Other", sections.other, repository);
+
+  if (commits.length === 0) {
+    lines.push("## Other", "", "- Maintenance release with no grouped commits.");
+  }
+
+  if (compareUrl !== null) {
+    lines.push("", `Compare: ${compareUrl}`);
+  }
+
+  return `${lines.join("\n").trim()}\n`;
+}
+
+/**
+ * @param {string[]} lines
+ * @param {string} heading
+ * @param {ReleaseCommit[]} commits
+ * @param {string | undefined} repository
+ */
+function appendReleaseSection(lines, heading, commits, repository) {
+  if (commits.length === 0) {
+    return;
+  }
+
+  lines.push(`## ${heading}`, "");
+  for (const commit of commits) {
+    lines.push(formatCommitLine(commit, repository));
+  }
+  lines.push("");
+}
+
+/**
+ * @param {ReleaseCommit} commit
+ * @param {string | undefined} repository
+ * @returns {string}
+ */
+function formatCommitLine(commit, repository) {
+  const shortSha = commit.sha.slice(0, 7);
+
+  if (typeof repository === "string" && repository.length > 0) {
+    return `- ${commit.subject} ([${shortSha}](https://github.com/${repository}/commit/${commit.sha}))`;
+  }
+
+  return `- ${commit.subject} (${shortSha})`;
+}
+
+/**
+ * @param {string} subject
+ * @returns {string | null}
+ */
+function readConventionalCommitType(subject) {
+  const match = /^(?<type>[a-z]+)(?:\([^)]*\))?(?:!)?(?::|\s)/i.exec(subject.trim());
+  return match?.groups?.type?.toLowerCase() ?? null;
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
## Summary
- add a dedicated release workflow that runs daily at 06:00 UTC and can also be triggered manually for same-day hotfix releases
- add release preparation scripts that detect no-op runs, compute CalVer versions, rewrite workspace package versions, and generate grouped GitHub release notes from conventional commits
- make the CLI and MCP server read their runtime version from package metadata and add npm publishing metadata to the workspace packages

## Testing
- npm run lint
- npm run typecheck
- npm test
- npm run build
- npm run test:e2e:fixtures

Closes #250