### PR TITLE
feat: add issue #212 activity seeding workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,18 @@ npm exec -w @linkedin-assistant/cli -- linkedin assets generate-profile-images -
 - `--upload-profile-media` reuses the existing profile photo/banner upload flow and paces the two uploads to avoid back-to-back updates.
 - See `docs/profile-image-generation.md` for the end-to-end workflow and the matching MCP tool.
 
+Activity seeding command:
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin seed activity --profile default --spec docs/profile-seeds/issue-212-signikant-test-activity.json --delay-ms 4500 --yes --output reports/activity-seed.json
+```
+
+- `seed activity` applies a paced issue-212 activity spec for connections, posts, feed engagement, job browsing, messaging, and notifications.
+- Image-backed posts can reuse the issue-211 report through `assets.generatedImageManifestPath`.
+- The bundled spec is a starter template: replace the curated social targets before running it against the real test account.
+- Because it batches multiple real outbound actions, this workflow remains CLI-only; use the existing MCP read tools for verification after the run.
+- See `docs/activity-seeding.md` for the full workflow, keep-alive guidance, and verification steps.
+
 Confirm prepared actions by token:
 
 ```bash

--- a/docs/activity-seeding.md
+++ b/docs/activity-seeding.md
@@ -1,0 +1,75 @@
+# Activity seeding workflow
+
+Issue #212 adds a reusable CLI workflow for populating the dedicated test
+account with paced LinkedIn activity after the profile itself is seeded (#210)
+and the image bundle is generated (#211).
+
+## Requirements
+
+- The target LinkedIn browser profile must already be authenticated.
+- For longer runs, start the keep-alive daemon first:
+  ```bash
+  npm exec -w @linkedin-assistant/cli -- linkedin keepalive start --profile <profile>
+  ```
+- If you want image-backed posts, run issue #211 first and keep its JSON report
+  available so the activity seed can reuse the generated post images.
+
+## CLI command
+
+```bash
+npm exec -w @linkedin-assistant/cli -- linkedin seed activity \
+  --profile <profile> \
+  --spec docs/profile-seeds/issue-212-signikant-test-activity.json \
+  --delay-ms 4500 \
+  --yes \
+  --output reports/activity-seed.json
+```
+
+## Intended issue-212 flow
+
+1. Complete the issue-210 profile seeding workflow.
+2. Generate the issue-211 image bundle and save the report, for example:
+   `reports/profile-images.json`
+3. Open `docs/profile-seeds/issue-212-signikant-test-activity.json` and
+   replace the operator-curated social targets before running:
+   - `connections.invites`
+   - `feed.likes`
+   - `feed.comments`
+   - `messaging.replies`
+4. Start keep-alive in another terminal.
+5. Run `linkedin seed activity`.
+6. Verify the resulting state with either the CLI or the existing MCP read
+   tools:
+   - `linkedin.connections.list`
+   - `linkedin.feed.list`
+   - `linkedin.inbox.list_threads`
+   - `linkedin.notifications.list`
+   - `linkedin.jobs.search`
+   - `linkedin.jobs.view`
+
+## What the command does
+
+`seed activity` reads the JSON spec and then:
+
+1. accepts up to the configured number of pending invitations
+2. sends any curated connection invites that are not already connected or
+   already pending
+3. publishes the configured posts, defaulting to `connections` visibility when
+   a post omits `visibility`
+4. reuses issue-211 post images when a post references
+   `generatedImageIndex`
+5. confirms likes, comments, new threads, and replies one action at a time
+6. runs the configured read-only job and notification checks
+7. emits a final JSON report with end-of-run verification for connections,
+   feed, and inbox threads
+
+## Notes
+
+- This workflow is intentionally CLI-only because it batches multiple real
+  outbound actions in one run.
+- Every write still goes through the existing two-phase action surface under
+  the hood and is confirmed sequentially.
+- The configured delay is randomized slightly between write actions so the run
+  does not fire a rigid fixed cadence.
+- Image-backed posts only require the issue-211 report path; the command reads
+  `post_images[*].absolute_path` from that report or manifest automatically.

--- a/docs/profile-seeds/issue-212-signikant-test-activity.json
+++ b/docs/profile-seeds/issue-212-signikant-test-activity.json
@@ -1,0 +1,70 @@
+{
+  "metadata": {
+    "issue": 212,
+    "notes": [
+      "This is a starter template for realistic issue-212 activity seeding.",
+      "Replace connections.invites, feed.likes, feed.comments, and messaging.replies with curated real targets before execution.",
+      "generatedImageManifestPath should point at the issue-211 image report for the same persona."
+    ]
+  },
+  "assets": {
+    "generatedImageManifestPath": "../../reports/profile-images.json"
+  },
+  "connections": {
+    "acceptPending": {
+      "limit": 10
+    },
+    "invites": []
+  },
+  "posts": [
+    {
+      "text": "One thing I keep returning to in AI product work: evaluation is only useful when the team can act on it. The hard part is rarely collecting another metric. It is building feedback loops that fit the way engineers and product teams already work.\n\nI have been thinking a lot about lightweight regression checks, trace-linked examples, and making model changes easier to review before they surprise users.",
+      "visibility": "connections"
+    },
+    {
+      "text": "A small lesson from recent internal tooling work: the most helpful AI developer tools are usually the ones that make context visible, not the ones that try to hide complexity.\n\nI would rather give a team better observability, clearer diffs, and faster iteration than promise full autonomy too early.",
+      "generatedImageIndex": 0,
+      "visibility": "connections"
+    },
+    {
+      "text": "I enjoyed this piece on practical AI engineering tradeoffs. The framing around quality, instrumentation, and product discipline lines up with a lot of what smaller teams wrestle with in production: https://example.com/practical-ai-engineering",
+      "generatedImageIndex": 1,
+      "visibility": "connections"
+    }
+  ],
+  "feed": {
+    "discoveryLimit": 15,
+    "likes": [],
+    "comments": []
+  },
+  "jobs": {
+    "searches": [
+      {
+        "query": "AI engineer",
+        "location": "Copenhagen, Denmark",
+        "limit": 5,
+        "viewTop": 2
+      },
+      {
+        "query": "Developer tools engineer",
+        "location": "Remote",
+        "limit": 5,
+        "viewTop": 2
+      }
+    ]
+  },
+  "messaging": {
+    "newThreads": [
+      {
+        "recipients": [
+          "Simon Miller"
+        ],
+        "text": "Hi Simon, I have been refreshing a test LinkedIn account for tooling validation and thought I would say hello. Hope things are going well on your side."
+      }
+    ],
+    "replies": []
+  },
+  "notifications": {
+    "limit": 20
+  }
+}

--- a/packages/cli/src/activitySeed.ts
+++ b/packages/cli/src/activitySeed.ts
@@ -1,0 +1,536 @@
+import { LinkedInAssistantError } from "@linkedin-assistant/core";
+
+export interface ActivitySeedGeneratedPostImage {
+  absolutePath: string;
+  conceptKey: string;
+  fileName: string;
+  title: string;
+}
+
+export interface ActivitySeedGeneratedImageManifest {
+  postImages: ActivitySeedGeneratedPostImage[];
+}
+
+export interface ActivitySeedAssetsSpec {
+  generatedImageManifestPath?: string;
+}
+
+export interface ActivitySeedAcceptPendingSpec {
+  limit: number;
+}
+
+export interface ActivitySeedInviteSpec {
+  note?: string;
+  operatorNote?: string;
+  targetProfile: string;
+}
+
+export interface ActivitySeedConnectionsSpec {
+  acceptPending?: ActivitySeedAcceptPendingSpec;
+  invites: ActivitySeedInviteSpec[];
+}
+
+export interface ActivitySeedPostSpec {
+  generatedImageIndex?: number;
+  mediaPath?: string;
+  operatorNote?: string;
+  text: string;
+  visibility?: string;
+}
+
+export interface ActivitySeedFeedLikeSpec {
+  operatorNote?: string;
+  postUrl: string;
+  reaction?: string;
+}
+
+export interface ActivitySeedFeedCommentSpec {
+  operatorNote?: string;
+  postUrl: string;
+  text: string;
+}
+
+export interface ActivitySeedFeedSpec {
+  comments: ActivitySeedFeedCommentSpec[];
+  discoveryLimit?: number;
+  likes: ActivitySeedFeedLikeSpec[];
+}
+
+export interface ActivitySeedJobSearchSpec {
+  limit?: number;
+  location?: string;
+  query: string;
+  viewTop?: number;
+}
+
+export interface ActivitySeedJobsSpec {
+  searches: ActivitySeedJobSearchSpec[];
+}
+
+export interface ActivitySeedNewThreadSpec {
+  operatorNote?: string;
+  recipients: string[];
+  text: string;
+}
+
+export interface ActivitySeedReplySpec {
+  operatorNote?: string;
+  text: string;
+  thread: string;
+}
+
+export interface ActivitySeedMessagingSpec {
+  newThreads: ActivitySeedNewThreadSpec[];
+  replies: ActivitySeedReplySpec[];
+}
+
+export interface ActivitySeedNotificationsSpec {
+  limit?: number;
+}
+
+export interface ActivitySeedSpec {
+  assets?: ActivitySeedAssetsSpec;
+  connections: ActivitySeedConnectionsSpec;
+  feed: ActivitySeedFeedSpec;
+  jobs: ActivitySeedJobsSpec;
+  messaging: ActivitySeedMessagingSpec;
+  notifications?: ActivitySeedNotificationsSpec;
+  posts: ActivitySeedPostSpec[];
+}
+
+export function parseActivitySeedSpec(input: unknown): ActivitySeedSpec {
+  if (!isRecord(input)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "Activity seed spec must be a JSON object."
+    );
+  }
+
+  return {
+    ...(input.assets !== undefined ? { assets: normalizeAssetsSpec(input.assets) } : {}),
+    connections: normalizeConnectionsSpec(input.connections),
+    posts: normalizePostsSpec(input.posts),
+    feed: normalizeFeedSpec(input.feed),
+    jobs: normalizeJobsSpec(input.jobs),
+    messaging: normalizeMessagingSpec(input.messaging),
+    ...(input.notifications !== undefined
+      ? { notifications: normalizeNotificationsSpec(input.notifications) }
+      : {})
+  };
+}
+
+export function parseActivitySeedGeneratedImageManifest(
+  input: unknown
+): ActivitySeedGeneratedImageManifest {
+  if (!isRecord(input)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "Generated image manifest must be a JSON object."
+    );
+  }
+
+  const rawPostImages = input.post_images;
+  if (!Array.isArray(rawPostImages)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      'Generated image manifest must include a "post_images" array.'
+    );
+  }
+
+  return {
+    postImages: rawPostImages.map((entry, index) =>
+      normalizeGeneratedPostImage(entry, `post_images[${index}]`)
+    )
+  };
+}
+
+function normalizeAssetsSpec(value: unknown): ActivitySeedAssetsSpec {
+  if (!isRecord(value)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "activity seed assets must be a JSON object."
+    );
+  }
+
+  const generatedImageManifestPath = readOptionalString(value.generatedImageManifestPath);
+
+  return {
+    ...(generatedImageManifestPath ? { generatedImageManifestPath } : {})
+  };
+}
+
+function normalizeConnectionsSpec(value: unknown): ActivitySeedConnectionsSpec {
+  const record = normalizeOptionalRecord(value);
+
+  return {
+    ...(record.acceptPending !== undefined
+      ? { acceptPending: normalizeAcceptPendingSpec(record.acceptPending) }
+      : {}),
+    invites: Array.isArray(record.invites)
+      ? record.invites.map((entry, index) =>
+          normalizeInviteSpec(entry, `connections.invites[${index}]`)
+        )
+      : []
+  };
+}
+
+function normalizeAcceptPendingSpec(value: unknown): ActivitySeedAcceptPendingSpec {
+  if (!isRecord(value)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "connections.acceptPending must be a JSON object."
+    );
+  }
+
+  return {
+    limit: readPositiveInt(value.limit, "connections.acceptPending.limit")
+  };
+}
+
+function normalizeInviteSpec(value: unknown, label: string): ActivitySeedInviteSpec {
+  if (!isRecord(value)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must be a JSON object.`
+    );
+  }
+
+  const targetProfile = readRequiredString(value.targetProfile, `${label}.targetProfile`);
+  const note = readOptionalString(value.note);
+  const operatorNote = readOptionalString(value.operatorNote);
+
+  return {
+    targetProfile,
+    ...(note ? { note } : {}),
+    ...(operatorNote ? { operatorNote } : {})
+  };
+}
+
+function normalizePostsSpec(value: unknown): ActivitySeedPostSpec[] {
+  if (value === undefined) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "posts must be a JSON array."
+    );
+  }
+
+  return value.map((entry, index) => normalizePostSpec(entry, `posts[${index}]`));
+}
+
+function normalizePostSpec(value: unknown, label: string): ActivitySeedPostSpec {
+  if (!isRecord(value)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must be a JSON object.`
+    );
+  }
+
+  const text = readRequiredString(value.text, `${label}.text`);
+  const mediaPath = readOptionalString(value.mediaPath);
+  const operatorNote = readOptionalString(value.operatorNote);
+  const visibility = readOptionalString(value.visibility);
+  const generatedImageIndex = readOptionalNonNegativeInt(
+    value.generatedImageIndex,
+    `${label}.generatedImageIndex`
+  );
+
+  if (mediaPath && generatedImageIndex !== undefined) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} cannot include both mediaPath and generatedImageIndex.`
+    );
+  }
+
+  return {
+    text,
+    ...(mediaPath ? { mediaPath } : {}),
+    ...(operatorNote ? { operatorNote } : {}),
+    ...(visibility ? { visibility } : {}),
+    ...(generatedImageIndex !== undefined ? { generatedImageIndex } : {})
+  };
+}
+
+function normalizeFeedSpec(value: unknown): ActivitySeedFeedSpec {
+  const record = normalizeOptionalRecord(value);
+  const discoveryLimit = readOptionalPositiveInt(
+    record.discoveryLimit,
+    "feed.discoveryLimit"
+  );
+
+  return {
+    ...(discoveryLimit !== undefined ? { discoveryLimit } : {}),
+    likes: Array.isArray(record.likes)
+      ? record.likes.map((entry, index) =>
+          normalizeFeedLikeSpec(entry, `feed.likes[${index}]`)
+        )
+      : [],
+    comments: Array.isArray(record.comments)
+      ? record.comments.map((entry, index) =>
+          normalizeFeedCommentSpec(entry, `feed.comments[${index}]`)
+        )
+      : []
+  };
+}
+
+function normalizeFeedLikeSpec(
+  value: unknown,
+  label: string
+): ActivitySeedFeedLikeSpec {
+  if (!isRecord(value)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must be a JSON object.`
+    );
+  }
+
+  const postUrl = readRequiredString(value.postUrl, `${label}.postUrl`);
+  const reaction = readOptionalString(value.reaction);
+  const operatorNote = readOptionalString(value.operatorNote);
+
+  return {
+    postUrl,
+    ...(reaction ? { reaction } : {}),
+    ...(operatorNote ? { operatorNote } : {})
+  };
+}
+
+function normalizeFeedCommentSpec(
+  value: unknown,
+  label: string
+): ActivitySeedFeedCommentSpec {
+  if (!isRecord(value)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must be a JSON object.`
+    );
+  }
+
+  const postUrl = readRequiredString(value.postUrl, `${label}.postUrl`);
+  const text = readRequiredString(value.text, `${label}.text`);
+  const operatorNote = readOptionalString(value.operatorNote);
+
+  return {
+    postUrl,
+    text,
+    ...(operatorNote ? { operatorNote } : {})
+  };
+}
+
+function normalizeJobsSpec(value: unknown): ActivitySeedJobsSpec {
+  const record = normalizeOptionalRecord(value);
+
+  return {
+    searches: Array.isArray(record.searches)
+      ? record.searches.map((entry, index) =>
+          normalizeJobSearchSpec(entry, `jobs.searches[${index}]`)
+        )
+      : []
+  };
+}
+
+function normalizeJobSearchSpec(
+  value: unknown,
+  label: string
+): ActivitySeedJobSearchSpec {
+  if (!isRecord(value)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must be a JSON object.`
+    );
+  }
+
+  const query = readRequiredString(value.query, `${label}.query`);
+  const location = readOptionalString(value.location);
+  const limit = readOptionalPositiveInt(value.limit, `${label}.limit`);
+  const viewTop = readOptionalPositiveInt(value.viewTop, `${label}.viewTop`);
+
+  return {
+    query,
+    ...(location ? { location } : {}),
+    ...(limit !== undefined ? { limit } : {}),
+    ...(viewTop !== undefined ? { viewTop } : {})
+  };
+}
+
+function normalizeMessagingSpec(value: unknown): ActivitySeedMessagingSpec {
+  const record = normalizeOptionalRecord(value);
+
+  return {
+    newThreads: Array.isArray(record.newThreads)
+      ? record.newThreads.map((entry, index) =>
+          normalizeNewThreadSpec(entry, `messaging.newThreads[${index}]`)
+        )
+      : [],
+    replies: Array.isArray(record.replies)
+      ? record.replies.map((entry, index) =>
+          normalizeReplySpec(entry, `messaging.replies[${index}]`)
+        )
+      : []
+  };
+}
+
+function normalizeNewThreadSpec(
+  value: unknown,
+  label: string
+): ActivitySeedNewThreadSpec {
+  if (!isRecord(value)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must be a JSON object.`
+    );
+  }
+
+  const recipients = readStringArray(value.recipients, `${label}.recipients`);
+  const text = readRequiredString(value.text, `${label}.text`);
+  const operatorNote = readOptionalString(value.operatorNote);
+
+  if (recipients.length === 0) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label}.recipients must include at least one recipient.`
+    );
+  }
+
+  return {
+    recipients,
+    text,
+    ...(operatorNote ? { operatorNote } : {})
+  };
+}
+
+function normalizeReplySpec(value: unknown, label: string): ActivitySeedReplySpec {
+  if (!isRecord(value)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must be a JSON object.`
+    );
+  }
+
+  const thread = readRequiredString(value.thread, `${label}.thread`);
+  const text = readRequiredString(value.text, `${label}.text`);
+  const operatorNote = readOptionalString(value.operatorNote);
+
+  return {
+    thread,
+    text,
+    ...(operatorNote ? { operatorNote } : {})
+  };
+}
+
+function normalizeNotificationsSpec(value: unknown): ActivitySeedNotificationsSpec {
+  const record = normalizeOptionalRecord(value);
+  const limit = readOptionalPositiveInt(record.limit, "notifications.limit");
+  return {
+    ...(limit !== undefined ? { limit } : {})
+  };
+}
+
+function normalizeGeneratedPostImage(
+  value: unknown,
+  label: string
+): ActivitySeedGeneratedPostImage {
+  if (!isRecord(value)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must be a JSON object.`
+    );
+  }
+
+  return {
+    absolutePath: readRequiredString(value.absolute_path, `${label}.absolute_path`),
+    conceptKey: readRequiredString(value.concept_key, `${label}.concept_key`),
+    fileName: readRequiredString(value.file_name, `${label}.file_name`),
+    title: readRequiredString(value.title, `${label}.title`)
+  };
+}
+
+function normalizeOptionalRecord(value: unknown): Record<string, unknown> {
+  if (value === undefined) {
+    return {};
+  }
+
+  if (isRecord(value)) {
+    return value;
+  }
+
+  throw new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    "Expected a JSON object."
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeText(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  const normalized = normalizeText(value);
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function readRequiredString(value: unknown, label: string): string {
+  const normalized = normalizeText(value);
+  if (normalized.length === 0) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must be a non-empty string.`
+    );
+  }
+
+  return normalized;
+}
+
+function readPositiveInt(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must be a whole number greater than 0.`
+    );
+  }
+
+  return value;
+}
+
+function readOptionalPositiveInt(value: unknown, label: string): number | undefined {
+  if (typeof value === "undefined") {
+    return undefined;
+  }
+
+  return readPositiveInt(value, label);
+}
+
+function readOptionalNonNegativeInt(value: unknown, label: string): number | undefined {
+  if (typeof value === "undefined") {
+    return undefined;
+  }
+
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must be a whole number greater than or equal to 0.`
+    );
+  }
+
+  return value;
+}
+
+function readStringArray(value: unknown, label: string): string[] {
+  if (!Array.isArray(value)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} must be an array of strings.`
+    );
+  }
+
+  return value.map((entry, index) =>
+    readRequiredString(entry, `${label}[${index}]`)
+  );
+}

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -192,6 +192,14 @@ import {
   type KeepAliveStopReport
 } from "../keepAliveOutput.js";
 import {
+  parseActivitySeedGeneratedImageManifest,
+  parseActivitySeedSpec,
+  type ActivitySeedGeneratedPostImage,
+  type ActivitySeedSpec,
+  type ActivitySeedPostSpec,
+  type ActivitySeedJobSearchSpec
+} from "../activitySeed.js";
+import {
   createProfileSeedPlan,
   parseProfileSeedSpec,
   type ProfileSeedPlanAction,
@@ -5605,7 +5613,9 @@ function createProfileSeedUnsupportedFieldsError(
   );
 }
 
-function sampleProfileSeedDelay(baseDelayMs: number): number {
+type CliRuntime = ReturnType<typeof createRuntime>;
+
+function sampleSeedDelay(baseDelayMs: number): number {
   if (baseDelayMs <= 0) {
     return 0;
   }
@@ -5617,7 +5627,7 @@ function sampleProfileSeedDelay(baseDelayMs: number): number {
 }
 
 function prepareProfileSeedAction(
-  runtime: ReturnType<typeof createRuntime>,
+  runtime: CliRuntime,
   action: ProfileSeedPlanAction
 ) {
   switch (action.kind) {
@@ -5628,6 +5638,179 @@ function prepareProfileSeedAction(
     case "remove_section_item":
       return runtime.profile.prepareRemoveSectionItem(action.input);
   }
+}
+
+interface ActivitySeedPlanSummary {
+  acceptPendingCount: number;
+  commentCount: number;
+  inviteCount: number;
+  jobSearchCount: number;
+  jobViewCount: number;
+  likeCount: number;
+  newThreadCount: number;
+  notificationCheckCount: number;
+  postCount: number;
+  replyCount: number;
+  totalReadSteps: number;
+  totalWriteActions: number;
+}
+
+function createActivitySeedPlanSummary(spec: ActivitySeedSpec): ActivitySeedPlanSummary {
+  const jobViewCount = spec.jobs.searches.reduce(
+    (total, search) => total + (search.viewTop ?? 0),
+    0
+  );
+  const totalWriteActions =
+    spec.connections.invites.length +
+    (spec.connections.acceptPending ? spec.connections.acceptPending.limit : 0) +
+    spec.posts.length +
+    spec.feed.likes.length +
+    spec.feed.comments.length +
+    spec.messaging.newThreads.length +
+    spec.messaging.replies.length;
+  const totalReadSteps =
+    spec.jobs.searches.length + (spec.notifications ? 1 : 0) + 3;
+
+  return {
+    acceptPendingCount: spec.connections.acceptPending?.limit ?? 0,
+    commentCount: spec.feed.comments.length,
+    inviteCount: spec.connections.invites.length,
+    jobSearchCount: spec.jobs.searches.length,
+    jobViewCount,
+    likeCount: spec.feed.likes.length,
+    newThreadCount: spec.messaging.newThreads.length,
+    notificationCheckCount: spec.notifications ? 1 : 0,
+    postCount: spec.posts.length,
+    replyCount: spec.messaging.replies.length,
+    totalReadSteps,
+    totalWriteActions
+  };
+}
+
+async function resolveActivitySeedGeneratedPostImages(
+  spec: ActivitySeedSpec,
+  resolvedSpecPath: string
+): Promise<{
+  manifestPath: string;
+  postImages: ActivitySeedGeneratedPostImage[];
+} | null> {
+  const manifestPathInput = spec.assets?.generatedImageManifestPath;
+  if (!manifestPathInput) {
+    return null;
+  }
+
+  const resolvedManifestPath = path.resolve(
+    path.dirname(resolvedSpecPath),
+    manifestPathInput
+  );
+  const rawManifest = await readJsonInputFile(
+    resolvedManifestPath,
+    "activity seed generated image manifest"
+  );
+  const manifest = parseActivitySeedGeneratedImageManifest(rawManifest);
+
+  return {
+    manifestPath: resolvedManifestPath,
+    postImages: manifest.postImages
+  };
+}
+
+function resolveActivitySeedPostMediaPath(
+  post: ActivitySeedPostSpec,
+  resolvedSpecPath: string,
+  generatedImages: readonly ActivitySeedGeneratedPostImage[]
+): string | undefined {
+  if (post.mediaPath) {
+    return path.resolve(path.dirname(resolvedSpecPath), post.mediaPath);
+  }
+
+  if (post.generatedImageIndex === undefined) {
+    return undefined;
+  }
+
+  if (generatedImages.length === 0) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "posts.generatedImageIndex requires assets.generatedImageManifestPath to be configured."
+    );
+  }
+
+  const generatedImage = generatedImages[post.generatedImageIndex];
+  if (!generatedImage) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `posts.generatedImageIndex ${post.generatedImageIndex} is out of range for the configured generated image manifest.`
+    );
+  }
+
+  return generatedImage.absolutePath;
+}
+
+function normalizeComparableLinkedInIdentity(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (normalized.length === 0) {
+    return "";
+  }
+
+  try {
+    const parsed = new URL(normalized);
+    const cleanPath = parsed.pathname.replace(/\/+$/u, "");
+    return `${parsed.origin}${cleanPath}`;
+  } catch {
+    return normalized.replace(/\/+$/u, "");
+  }
+}
+
+function createActivitySeedOperatorNote(
+  resolvedSpecPath: string,
+  sectionLabel: string,
+  explicitNote?: string
+): string {
+  const baseNote = explicitNote?.trim();
+  if (baseNote) {
+    return baseNote;
+  }
+
+  return `activity seed: ${path.basename(resolvedSpecPath)} / ${sectionLabel}`;
+}
+
+function summarizeConfirmedAction(confirmed: {
+  actionType: string;
+  preparedActionId: string;
+  status: string;
+  result: Record<string, unknown>;
+  artifacts: string[];
+}): Record<string, unknown> {
+  return {
+    action_type: confirmed.actionType,
+    prepared_action_id: confirmed.preparedActionId,
+    status: confirmed.status,
+    result: confirmed.result,
+    artifacts: confirmed.artifacts
+  };
+}
+
+async function maybeSleepSeedDelay(delayMs: number): Promise<void> {
+  if (delayMs <= 0) {
+    return;
+  }
+
+  await sleep(sampleSeedDelay(delayMs));
+}
+
+async function maybeWarnAboutKeepAliveForSeeding(): Promise<number[]> {
+  const runningKeepAlivePids = await findRunningKeepAlivePids();
+  if (runningKeepAlivePids.length === 0) {
+    writeCliWarning(
+      "No running keepalive daemon was detected. For long issue-212 seeding runs, start `linkedin keepalive start` in another terminal first."
+    );
+  } else {
+    writeCliNotice(
+      `Detected keepalive daemon PID${runningKeepAlivePids.length === 1 ? "" : "s"}: ${runningKeepAlivePids.join(", ")}.`
+    );
+  }
+
+  return runningKeepAlivePids;
 }
 
 async function runProfileApplySpec(input: {
@@ -5718,7 +5901,7 @@ async function runProfileApplySpec(input: {
       });
 
       if (index < plan.actions.length - 1 && input.delayMs > 0) {
-        await sleep(sampleProfileSeedDelay(input.delayMs));
+        await sleep(sampleSeedDelay(input.delayMs));
       }
     }
 
@@ -5751,6 +5934,455 @@ async function runProfileApplySpec(input: {
       plannedActionCount: plan.actions.length,
       executedActionCount: actionResults.length,
       unsupportedFieldCount: plan.unsupportedFields.length
+    });
+
+    printJson(report);
+  } finally {
+    runtime.close();
+  }
+}
+
+async function runActivitySeedJobSearch(
+  runtime: CliRuntime,
+  profileName: string,
+  search: ActivitySeedJobSearchSpec
+): Promise<Record<string, unknown>> {
+  const searchResult = await runtime.jobs.searchJobs({
+    profileName,
+    query: search.query,
+    ...(search.location ? { location: search.location } : {}),
+    ...(search.limit ? { limit: search.limit } : {})
+  });
+  const viewCount = Math.min(search.viewTop ?? 0, searchResult.results.length);
+  const viewedJobs: Record<string, unknown>[] = [];
+
+  for (const job of searchResult.results.slice(0, viewCount)) {
+    const detail = await runtime.jobs.viewJob({
+      profileName,
+      jobId: job.job_id
+    });
+    viewedJobs.push(detail as unknown as Record<string, unknown>);
+  }
+
+  return {
+    query: searchResult.query,
+    location: searchResult.location,
+    count: searchResult.count,
+    results: searchResult.results,
+    viewed_jobs: viewedJobs
+  };
+}
+
+async function runSeedActivity(input: {
+  profileName: string;
+  specPath: string;
+  delayMs: number;
+  yes: boolean;
+  outputPath?: string;
+}, cdpUrl?: string): Promise<void> {
+  const resolvedSpecPath = path.resolve(input.specPath);
+  const rawSpec = await readJsonInputFile(resolvedSpecPath, "activity seed spec");
+  const spec = parseActivitySeedSpec(rawSpec);
+  const planSummary = createActivitySeedPlanSummary(spec);
+  const generatedImages = await resolveActivitySeedGeneratedPostImages(spec, resolvedSpecPath);
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.seed.activity.start", {
+      profileName: input.profileName,
+      specPath: resolvedSpecPath,
+      delayMs: input.delayMs,
+      totalWriteActions: planSummary.totalWriteActions,
+      totalReadSteps: planSummary.totalReadSteps
+    });
+
+    const keepAlivePids = await maybeWarnAboutKeepAliveForSeeding();
+
+    if (planSummary.totalWriteActions > 0) {
+      writeCliNotice(
+        `Loaded ${resolvedSpecPath} with ${planSummary.totalWriteActions} write ${planSummary.totalWriteActions === 1 ? "action" : "actions"} and ${planSummary.totalReadSteps} read-only verification ${planSummary.totalReadSteps === 1 ? "step" : "steps"}.`
+      );
+    } else {
+      writeCliNotice(
+        `Loaded ${resolvedSpecPath}; no write actions are configured, so this run will only perform read-only checks.`
+      );
+    }
+
+    if (!input.yes && planSummary.totalWriteActions > 0) {
+      if (!stdin.isTTY || !stdout.isTTY) {
+        throw new LinkedInAssistantError(
+          "ACTION_PRECONDITION_FAILED",
+          "Refusing to apply an activity seed spec without --yes in non-interactive mode."
+        );
+      }
+
+      const confirmed = await promptYesNo(
+        `Execute ${planSummary.totalWriteActions} LinkedIn write ${planSummary.totalWriteActions === 1 ? "action" : "actions"} from this activity seed spec?`,
+        process.stderr
+      );
+      if (!confirmed) {
+        throw new LinkedInAssistantError(
+          "ACTION_PRECONDITION_FAILED",
+          "Operator declined activity seed execution."
+        );
+      }
+    }
+
+    const report: Record<string, unknown> = {
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      spec_path: resolvedSpecPath,
+      delay_ms: input.delayMs,
+      keep_alive_pids: keepAlivePids,
+      keep_alive_running: keepAlivePids.length > 0,
+      plan: planSummary,
+      evasion: runtime.evasion,
+      ...(generatedImages ? { generated_image_manifest_path: generatedImages.manifestPath } : {})
+    };
+
+    const connectionsSection: Record<string, unknown> = {
+      accepted_pending: [] as Record<string, unknown>[],
+      invites: [] as Record<string, unknown>[],
+      skipped_invites: [] as Record<string, unknown>[]
+    };
+
+    if (spec.connections.acceptPending) {
+      const pendingReceived = await runtime.connections.listPendingInvitations({
+        profileName: input.profileName,
+        filter: "received"
+      });
+      const pendingToAccept = pendingReceived.slice(0, spec.connections.acceptPending.limit);
+      connectionsSection.pending_received = pendingReceived;
+
+      for (const [index, invitation] of pendingToAccept.entries()) {
+        const prepared = runtime.connections.prepareAcceptInvitation({
+          profileName: input.profileName,
+          targetProfile: invitation.profile_url,
+          operatorNote: createActivitySeedOperatorNote(
+            resolvedSpecPath,
+            `accept pending ${index + 1}`,
+            undefined
+          )
+        });
+        const confirmed = await runtime.twoPhaseCommit.confirmByToken({
+          confirmToken: prepared.confirmToken
+        });
+        (connectionsSection.accepted_pending as Record<string, unknown>[]).push({
+          target_profile: invitation.profile_url,
+          full_name: invitation.full_name,
+          ...summarizeConfirmedAction(confirmed)
+        });
+        await maybeSleepSeedDelay(input.delayMs);
+      }
+    }
+
+    if (spec.connections.invites.length > 0) {
+      const [existingConnections, pendingSent] = await Promise.all([
+        runtime.connections.listConnections({
+          profileName: input.profileName,
+          limit: Math.max(40, spec.connections.invites.length + 20)
+        }),
+        runtime.connections.listPendingInvitations({
+          profileName: input.profileName,
+          filter: "sent"
+        })
+      ]);
+      const existingTargets = new Set(
+        existingConnections
+          .map((connection) => normalizeComparableLinkedInIdentity(connection.profile_url))
+          .filter((value) => value.length > 0)
+      );
+      const pendingTargets = new Set(
+        pendingSent
+          .map((invitation) => normalizeComparableLinkedInIdentity(invitation.profile_url))
+          .filter((value) => value.length > 0)
+      );
+
+      connectionsSection.connections_before = existingConnections;
+      connectionsSection.pending_sent = pendingSent;
+
+      for (const [index, invite] of spec.connections.invites.entries()) {
+        const normalizedTarget = normalizeComparableLinkedInIdentity(invite.targetProfile);
+        if (existingTargets.has(normalizedTarget)) {
+          (connectionsSection.skipped_invites as Record<string, unknown>[]).push({
+            target_profile: invite.targetProfile,
+            reason: "already_connected"
+          });
+          continue;
+        }
+        if (pendingTargets.has(normalizedTarget)) {
+          (connectionsSection.skipped_invites as Record<string, unknown>[]).push({
+            target_profile: invite.targetProfile,
+            reason: "invitation_already_pending"
+          });
+          continue;
+        }
+
+        const prepared = runtime.connections.prepareSendInvitation({
+          profileName: input.profileName,
+          targetProfile: invite.targetProfile,
+          ...(invite.note ? { note: invite.note } : {}),
+          operatorNote: createActivitySeedOperatorNote(
+            resolvedSpecPath,
+            `invite ${index + 1}`,
+            invite.operatorNote
+          )
+        });
+        const confirmed = await runtime.twoPhaseCommit.confirmByToken({
+          confirmToken: prepared.confirmToken
+        });
+        (connectionsSection.invites as Record<string, unknown>[]).push({
+          target_profile: invite.targetProfile,
+          ...(invite.note ? { note: invite.note } : {}),
+          ...summarizeConfirmedAction(confirmed)
+        });
+        pendingTargets.add(normalizedTarget);
+        await maybeSleepSeedDelay(input.delayMs);
+      }
+    }
+
+    report.connections = connectionsSection;
+
+    const postsSection: Record<string, unknown>[] = [];
+    for (const [index, post] of spec.posts.entries()) {
+      const mediaPath = resolveActivitySeedPostMediaPath(
+        post,
+        resolvedSpecPath,
+        generatedImages?.postImages ?? []
+      );
+      const visibility = post.visibility ?? "connections";
+      const operatorNote = createActivitySeedOperatorNote(
+        resolvedSpecPath,
+        `post ${index + 1}`,
+        post.operatorNote
+      );
+
+      const prepared = mediaPath
+        ? await runtime.posts.prepareCreateMedia({
+            profileName: input.profileName,
+            text: post.text,
+            mediaPaths: [mediaPath],
+            visibility,
+            operatorNote
+          })
+        : await runtime.posts.prepareCreate({
+            profileName: input.profileName,
+            text: post.text,
+            visibility,
+            operatorNote
+          });
+      const confirmed = await runtime.twoPhaseCommit.confirmByToken({
+        confirmToken: prepared.confirmToken
+      });
+      const publishedPostUrl =
+        typeof confirmed.result.published_post_url === "string" &&
+        confirmed.result.published_post_url.trim().length > 0
+          ? confirmed.result.published_post_url.trim()
+          : undefined;
+      const verification = publishedPostUrl
+        ? await runtime.feed.viewPost({
+            profileName: input.profileName,
+            postUrl: publishedPostUrl
+          })
+        : undefined;
+
+      postsSection.push({
+        text: post.text,
+        visibility,
+        ...(mediaPath ? { media_path: mediaPath } : {}),
+        ...summarizeConfirmedAction(confirmed),
+        ...(verification ? { verification } : {})
+      });
+      await maybeSleepSeedDelay(input.delayMs);
+    }
+    report.posts = postsSection;
+
+    const feedSection: Record<string, unknown> = {
+      liked: [] as Record<string, unknown>[],
+      commented: [] as Record<string, unknown>[]
+    };
+    if (
+      spec.feed.discoveryLimit ||
+      spec.feed.likes.length > 0 ||
+      spec.feed.comments.length > 0
+    ) {
+      const discoveryLimit =
+        spec.feed.discoveryLimit ??
+        Math.max(10, spec.feed.likes.length + spec.feed.comments.length + 3);
+      feedSection.feed_snapshot = await runtime.feed.viewFeed({
+        profileName: input.profileName,
+        limit: discoveryLimit
+      });
+    }
+
+    for (const [index, like] of spec.feed.likes.entries()) {
+      const prepared = runtime.feed.prepareLikePost({
+        profileName: input.profileName,
+        postUrl: like.postUrl,
+        ...(like.reaction ? { reaction: like.reaction } : {}),
+        operatorNote: createActivitySeedOperatorNote(
+          resolvedSpecPath,
+          `feed like ${index + 1}`,
+          like.operatorNote
+        )
+      });
+      const confirmed = await runtime.twoPhaseCommit.confirmByToken({
+        confirmToken: prepared.confirmToken
+      });
+      (feedSection.liked as Record<string, unknown>[]).push({
+        post_url: like.postUrl,
+        ...(like.reaction ? { reaction: like.reaction } : {}),
+        ...summarizeConfirmedAction(confirmed)
+      });
+      await maybeSleepSeedDelay(input.delayMs);
+    }
+
+    for (const [index, comment] of spec.feed.comments.entries()) {
+      const prepared = runtime.feed.prepareCommentOnPost({
+        profileName: input.profileName,
+        postUrl: comment.postUrl,
+        text: comment.text,
+        operatorNote: createActivitySeedOperatorNote(
+          resolvedSpecPath,
+          `feed comment ${index + 1}`,
+          comment.operatorNote
+        )
+      });
+      const confirmed = await runtime.twoPhaseCommit.confirmByToken({
+        confirmToken: prepared.confirmToken
+      });
+      (feedSection.commented as Record<string, unknown>[]).push({
+        post_url: comment.postUrl,
+        text: comment.text,
+        ...summarizeConfirmedAction(confirmed)
+      });
+      await maybeSleepSeedDelay(input.delayMs);
+    }
+
+    report.feed = feedSection;
+
+    const jobsSection: Record<string, unknown>[] = [];
+    for (const search of spec.jobs.searches) {
+      jobsSection.push(
+        await runActivitySeedJobSearch(runtime, input.profileName, search)
+      );
+    }
+    report.jobs = jobsSection;
+
+    const messagingSection: Record<string, unknown> = {
+      new_threads: [] as Record<string, unknown>[],
+      replies: [] as Record<string, unknown>[]
+    };
+    if (spec.messaging.newThreads.length > 0 || spec.messaging.replies.length > 0) {
+      messagingSection.threads_before = await runtime.inbox.listThreads({
+        profileName: input.profileName,
+        limit: 10
+      });
+    }
+
+    for (const [index, thread] of spec.messaging.newThreads.entries()) {
+      const prepared = await runtime.inbox.prepareNewThread({
+        profileName: input.profileName,
+        recipients: thread.recipients,
+        text: thread.text,
+        operatorNote: createActivitySeedOperatorNote(
+          resolvedSpecPath,
+          `new thread ${index + 1}`,
+          thread.operatorNote
+        )
+      });
+      const confirmed = await runtime.twoPhaseCommit.confirmByToken({
+        confirmToken: prepared.confirmToken
+      });
+      const threadUrl =
+        typeof confirmed.result.thread_url === "string" &&
+        confirmed.result.thread_url.trim().length > 0
+          ? confirmed.result.thread_url.trim()
+          : undefined;
+      const verification = threadUrl
+        ? await runtime.inbox.getThread({
+            profileName: input.profileName,
+            thread: threadUrl,
+            limit: 10
+          })
+        : undefined;
+      (messagingSection.new_threads as Record<string, unknown>[]).push({
+        recipients: thread.recipients,
+        text: thread.text,
+        ...summarizeConfirmedAction(confirmed),
+        ...(verification ? { verification } : {})
+      });
+      await maybeSleepSeedDelay(input.delayMs);
+    }
+
+    for (const [index, reply] of spec.messaging.replies.entries()) {
+      const prepared = await runtime.inbox.prepareReply({
+        profileName: input.profileName,
+        thread: reply.thread,
+        text: reply.text,
+        operatorNote: createActivitySeedOperatorNote(
+          resolvedSpecPath,
+          `reply ${index + 1}`,
+          reply.operatorNote
+        )
+      });
+      const confirmed = await runtime.twoPhaseCommit.confirmByToken({
+        confirmToken: prepared.confirmToken
+      });
+      const threadUrl =
+        typeof confirmed.result.thread_url === "string" &&
+        confirmed.result.thread_url.trim().length > 0
+          ? confirmed.result.thread_url.trim()
+          : reply.thread;
+      const verification = await runtime.inbox.getThread({
+        profileName: input.profileName,
+        thread: threadUrl,
+        limit: 10
+      });
+      (messagingSection.replies as Record<string, unknown>[]).push({
+        thread: reply.thread,
+        text: reply.text,
+        ...summarizeConfirmedAction(confirmed),
+        verification
+      });
+      await maybeSleepSeedDelay(input.delayMs);
+    }
+
+    report.messaging = messagingSection;
+
+    if (spec.notifications) {
+      report.notifications = await runtime.notifications.listNotifications({
+        profileName: input.profileName,
+        ...(typeof spec.notifications.limit === "number"
+          ? { limit: spec.notifications.limit }
+          : {})
+      });
+    }
+
+    report.verification = {
+      connections: await runtime.connections.listConnections({
+        profileName: input.profileName,
+        limit: Math.max(20, spec.connections.invites.length + 10)
+      }),
+      feed: await runtime.feed.viewFeed({
+        profileName: input.profileName,
+        limit: Math.max(10, spec.posts.length + 5)
+      }),
+      inbox_threads: await runtime.inbox.listThreads({
+        profileName: input.profileName,
+        limit: 10
+      })
+    };
+
+    if (input.outputPath) {
+      report.output_path = await writeOutputJsonFile(input.outputPath, report);
+    }
+
+    runtime.logger.log("info", "cli.seed.activity.done", {
+      profileName: input.profileName,
+      specPath: resolvedSpecPath,
+      totalWriteActions: planSummary.totalWriteActions,
+      totalReadSteps: planSummary.totalReadSteps
     });
 
     printJson(report);
@@ -8270,6 +8902,52 @@ export function createCliProgram(): Command {
           uploadProfileMedia: options.uploadProfileMedia,
           uploadDelayMs: coerceNonNegativeInt(options.uploadDelayMs, "upload-delay-ms"),
           ...(options.model ? { model: options.model } : {}),
+          ...(options.output ? { outputPath: options.output } : {})
+        }, readCdpUrl());
+      }
+    );
+
+  const seedCommand = program
+    .command("seed")
+    .description("Run reusable LinkedIn profile and activity seeding workflows");
+
+  seedCommand
+    .command("activity")
+    .description("Apply a paced activity seed spec for connections, posts, engagement, jobs, messaging, and notifications")
+    .requiredOption("--spec <path>", "Path to a JSON activity seed spec")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .option(
+      "--delay-ms <ms>",
+      "Base delay between confirmed write actions",
+      "4500"
+    )
+    .option("-y, --yes", "Skip the interactive confirmation prompt", false)
+    .option("--output <path>", "Write the final JSON report to a file")
+    .addHelpText(
+      "after",
+      [
+        "",
+        "Notes:",
+        "  - this command batches real LinkedIn actions, so it stays CLI-only and asks for confirmation unless you pass --yes",
+        "  - start `linkedin keepalive start` first for longer seeding sessions",
+        "  - posts default to `connections` visibility when the spec omits visibility",
+        "  - generated-image posts can reuse the issue-211 image manifest via assets.generatedImageManifestPath",
+        "  - verification re-reads connections, feed, and inbox state at the end of the run"
+      ].join("\n")
+    )
+    .action(
+      async (options: {
+        profile: string;
+        spec: string;
+        delayMs: string;
+        yes: boolean;
+        output?: string;
+      }) => {
+        await runSeedActivity({
+          profileName: options.profile,
+          specPath: options.spec,
+          delayMs: coerceNonNegativeInt(options.delayMs, "delay-ms"),
+          yes: options.yes,
           ...(options.output ? { outputPath: options.output } : {})
         }, readCdpUrl());
       }

--- a/packages/cli/test/activitySeed.test.ts
+++ b/packages/cli/test/activitySeed.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseActivitySeedGeneratedImageManifest,
+  parseActivitySeedSpec
+} from "../src/activitySeed.js";
+
+describe("activity seed spec parser", () => {
+  it("parses issue-212 style sections and defaults", () => {
+    const spec = parseActivitySeedSpec({
+      assets: {
+        generatedImageManifestPath: "reports/profile-images.json"
+      },
+      connections: {
+        acceptPending: {
+          limit: 5
+        },
+        invites: [
+          {
+            targetProfile: "https://www.linkedin.com/in/example-person/",
+            note: "Thought your recent post on developer tools was excellent."
+          }
+        ]
+      },
+      posts: [
+        {
+          text: "A text-only update about AI evaluation loops."
+        },
+        {
+          text: "A media post about shipping practical developer tools.",
+          generatedImageIndex: 1,
+          visibility: "connections"
+        }
+      ],
+      feed: {
+        discoveryLimit: 12,
+        likes: [
+          {
+            postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/"
+          }
+        ],
+        comments: [
+          {
+            postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:456/",
+            text: "Really like the emphasis on closing the feedback loop here."
+          }
+        ]
+      },
+      jobs: {
+        searches: [
+          {
+            query: "AI engineer",
+            location: "Copenhagen, Denmark",
+            limit: 5,
+            viewTop: 2
+          }
+        ]
+      },
+      messaging: {
+        newThreads: [
+          {
+            recipients: ["Simon Miller"],
+            text: "Hi Simon, hope you are doing well."
+          }
+        ],
+        replies: [
+          {
+            thread: "thread-123",
+            text: "Thanks for the note."
+          }
+        ]
+      },
+      notifications: {
+        limit: 15
+      }
+    });
+
+    expect(spec.assets?.generatedImageManifestPath).toBe("reports/profile-images.json");
+    expect(spec.connections.acceptPending?.limit).toBe(5);
+    expect(spec.connections.invites).toHaveLength(1);
+    expect(spec.posts[0]).toMatchObject({
+      text: "A text-only update about AI evaluation loops."
+    });
+    expect(spec.posts[1]).toMatchObject({
+      generatedImageIndex: 1,
+      visibility: "connections"
+    });
+    expect(spec.feed.discoveryLimit).toBe(12);
+    expect(spec.jobs.searches[0]).toMatchObject({
+      query: "AI engineer",
+      viewTop: 2
+    });
+    expect(spec.messaging.newThreads[0]?.recipients).toEqual(["Simon Miller"]);
+    expect(spec.notifications?.limit).toBe(15);
+  });
+
+  it("rejects posts that mix direct media paths and generated image indexes", () => {
+    expect(() =>
+      parseActivitySeedSpec({
+        posts: [
+          {
+            text: "Conflicting post media config",
+            mediaPath: "./local.png",
+            generatedImageIndex: 0
+          }
+        ]
+      })
+    ).toThrow("posts[0] cannot include both mediaPath and generatedImageIndex");
+  });
+});
+
+describe("activity seed generated image manifest parser", () => {
+  it("extracts generated post image metadata from an issue-211 report", () => {
+    const manifest = parseActivitySeedGeneratedImageManifest({
+      generated_at: "2026-03-10T10:00:00.000Z",
+      post_images: [
+        {
+          absolute_path: "/tmp/post-01.png",
+          file_name: "post-01.png",
+          concept_key: "copenhagen-workspace",
+          title: "Workspace"
+        }
+      ]
+    });
+
+    expect(manifest.postImages).toEqual([
+      {
+        absolutePath: "/tmp/post-01.png",
+        fileName: "post-01.png",
+        conceptKey: "copenhagen-workspace",
+        title: "Workspace"
+      }
+    ]);
+  });
+});

--- a/packages/cli/test/activitySeedCli.test.ts
+++ b/packages/cli/test/activitySeedCli.test.ts
@@ -1,0 +1,534 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const activitySeedCliMocks = vi.hoisted(() => ({
+  close: vi.fn(),
+  confirmByToken: vi.fn(),
+  createCoreRuntime: vi.fn(),
+  getThread: vi.fn(),
+  jobsSearchJobs: vi.fn(),
+  jobsViewJob: vi.fn(),
+  listConnections: vi.fn(),
+  listNotifications: vi.fn(),
+  listPendingInvitations: vi.fn(),
+  listThreads: vi.fn(),
+  loggerLog: vi.fn(),
+  prepareAcceptInvitation: vi.fn(),
+  prepareCommentOnPost: vi.fn(),
+  prepareCreate: vi.fn(),
+  prepareCreateMedia: vi.fn(),
+  prepareLikePost: vi.fn(),
+  prepareNewThread: vi.fn(),
+  prepareReply: vi.fn(),
+  prepareSendInvitation: vi.fn(),
+  viewFeed: vi.fn(),
+  viewPost: vi.fn()
+}));
+
+vi.mock("@linkedin-assistant/core", async () => {
+  const actual = await import("../../core/src/index.js");
+  return {
+    ...actual,
+    createCoreRuntime: activitySeedCliMocks.createCoreRuntime
+  };
+});
+
+import { runCli } from "../src/bin/linkedin.js";
+
+describe("CLI activity seed workflow", () => {
+  let tempDir = "";
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let stderrWriteSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutChunks: string[] = [];
+  let stderrChunks: string[] = [];
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-cli-activity-seed-"));
+    process.env.LINKEDIN_ASSISTANT_HOME = path.join(tempDir, "assistant-home");
+    process.exitCode = undefined;
+    stdoutChunks = [];
+    stderrChunks = [];
+    vi.clearAllMocks();
+
+    activitySeedCliMocks.createCoreRuntime.mockImplementation(() => ({
+      runId: "run-activity-seed-cli",
+      evasion: {
+        level: "moderate",
+        diagnosticsEnabled: false
+      },
+      logger: {
+        log: activitySeedCliMocks.loggerLog
+      },
+      connections: {
+        listPendingInvitations: activitySeedCliMocks.listPendingInvitations,
+        listConnections: activitySeedCliMocks.listConnections,
+        prepareAcceptInvitation: activitySeedCliMocks.prepareAcceptInvitation,
+        prepareSendInvitation: activitySeedCliMocks.prepareSendInvitation
+      },
+      posts: {
+        prepareCreate: activitySeedCliMocks.prepareCreate,
+        prepareCreateMedia: activitySeedCliMocks.prepareCreateMedia
+      },
+      feed: {
+        viewFeed: activitySeedCliMocks.viewFeed,
+        viewPost: activitySeedCliMocks.viewPost,
+        prepareLikePost: activitySeedCliMocks.prepareLikePost,
+        prepareCommentOnPost: activitySeedCliMocks.prepareCommentOnPost
+      },
+      jobs: {
+        searchJobs: activitySeedCliMocks.jobsSearchJobs,
+        viewJob: activitySeedCliMocks.jobsViewJob
+      },
+      inbox: {
+        listThreads: activitySeedCliMocks.listThreads,
+        getThread: activitySeedCliMocks.getThread,
+        prepareNewThread: activitySeedCliMocks.prepareNewThread,
+        prepareReply: activitySeedCliMocks.prepareReply
+      },
+      notifications: {
+        listNotifications: activitySeedCliMocks.listNotifications
+      },
+      twoPhaseCommit: {
+        confirmByToken: activitySeedCliMocks.confirmByToken
+      },
+      close: activitySeedCliMocks.close
+    }));
+
+    activitySeedCliMocks.listPendingInvitations.mockImplementation(
+      async (input: { filter?: string }) => {
+        if (input.filter === "received") {
+          return [
+            {
+              vanity_name: "pending-person",
+              full_name: "Pending Person",
+              headline: "Staff Engineer",
+              profile_url: "https://www.linkedin.com/in/pending-person/",
+              sent_or_received: "received"
+            }
+          ];
+        }
+
+        return [];
+      }
+    );
+
+    activitySeedCliMocks.listConnections
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          vanity_name: "new-person",
+          full_name: "New Person",
+          headline: "Applied AI Engineer",
+          profile_url: "https://www.linkedin.com/in/new-person/",
+          connected_since: "Today"
+        }
+      ]);
+
+    activitySeedCliMocks.prepareAcceptInvitation.mockReturnValue({
+      preparedActionId: "pa-accept",
+      confirmToken: "ct-accept",
+      expiresAtMs: 1,
+      preview: { summary: "Accept invitation" }
+    });
+    activitySeedCliMocks.prepareSendInvitation.mockReturnValue({
+      preparedActionId: "pa-invite",
+      confirmToken: "ct-invite",
+      expiresAtMs: 1,
+      preview: { summary: "Invite connection" }
+    });
+    activitySeedCliMocks.prepareCreate.mockResolvedValue({
+      preparedActionId: "pa-post-1",
+      confirmToken: "ct-post-1",
+      expiresAtMs: 1,
+      preview: { summary: "Create post" }
+    });
+    activitySeedCliMocks.prepareCreateMedia.mockResolvedValue({
+      preparedActionId: "pa-post-2",
+      confirmToken: "ct-post-2",
+      expiresAtMs: 1,
+      preview: { summary: "Create media post" }
+    });
+    activitySeedCliMocks.prepareLikePost.mockReturnValue({
+      preparedActionId: "pa-like",
+      confirmToken: "ct-like",
+      expiresAtMs: 1,
+      preview: { summary: "Like post" }
+    });
+    activitySeedCliMocks.prepareCommentOnPost.mockReturnValue({
+      preparedActionId: "pa-comment",
+      confirmToken: "ct-comment",
+      expiresAtMs: 1,
+      preview: { summary: "Comment on post" }
+    });
+    activitySeedCliMocks.prepareNewThread.mockResolvedValue({
+      preparedActionId: "pa-thread",
+      confirmToken: "ct-thread",
+      expiresAtMs: 1,
+      preview: { summary: "New thread" }
+    });
+    activitySeedCliMocks.prepareReply.mockResolvedValue({
+      preparedActionId: "pa-reply",
+      confirmToken: "ct-reply",
+      expiresAtMs: 1,
+      preview: { summary: "Reply" }
+    });
+
+    activitySeedCliMocks.confirmByToken
+      .mockResolvedValueOnce({
+        preparedActionId: "pa-accept",
+        status: "executed",
+        actionType: "connections.accept_invitation",
+        result: {
+          status: "invitation_accepted",
+          target_profile: "https://www.linkedin.com/in/pending-person/"
+        },
+        artifacts: []
+      })
+      .mockResolvedValueOnce({
+        preparedActionId: "pa-invite",
+        status: "executed",
+        actionType: "connections.send_invitation",
+        result: {
+          status: "invitation_sent",
+          target_profile: "https://www.linkedin.com/in/new-person/"
+        },
+        artifacts: []
+      })
+      .mockResolvedValueOnce({
+        preparedActionId: "pa-post-1",
+        status: "executed",
+        actionType: "post.create",
+        result: {
+          posted: true,
+          published_post_url: "https://www.linkedin.com/feed/update/urn:li:activity:post-1/"
+        },
+        artifacts: []
+      })
+      .mockResolvedValueOnce({
+        preparedActionId: "pa-post-2",
+        status: "executed",
+        actionType: "post.create_media",
+        result: {
+          posted: true,
+          published_post_url: "https://www.linkedin.com/feed/update/urn:li:activity:post-2/"
+        },
+        artifacts: []
+      })
+      .mockResolvedValueOnce({
+        preparedActionId: "pa-like",
+        status: "executed",
+        actionType: "feed.like_post",
+        result: {
+          reacted: true,
+          post_url: "https://www.linkedin.com/feed/update/urn:li:activity:feed-1/"
+        },
+        artifacts: []
+      })
+      .mockResolvedValueOnce({
+        preparedActionId: "pa-comment",
+        status: "executed",
+        actionType: "feed.comment_on_post",
+        result: {
+          commented: true,
+          post_url: "https://www.linkedin.com/feed/update/urn:li:activity:feed-2/"
+        },
+        artifacts: []
+      })
+      .mockResolvedValueOnce({
+        preparedActionId: "pa-thread",
+        status: "executed",
+        actionType: "inbox.send_new_thread",
+        result: {
+          sent: true,
+          thread_url: "https://www.linkedin.com/messaging/thread/thread-1/"
+        },
+        artifacts: []
+      })
+      .mockResolvedValueOnce({
+        preparedActionId: "pa-reply",
+        status: "executed",
+        actionType: "send_message",
+        result: {
+          sent: true,
+          thread_url: "https://www.linkedin.com/messaging/thread/thread-2/"
+        },
+        artifacts: []
+      });
+
+    activitySeedCliMocks.viewPost
+      .mockResolvedValueOnce({
+        post_id: "post-1",
+        author_name: "Emil Sorensen",
+        author_headline: "AI/ML Engineer",
+        author_profile_url: "https://www.linkedin.com/in/emil-sorensen/",
+        posted_at: "Now",
+        text: "Text-only post",
+        reactions_count: "0",
+        comments_count: "0",
+        reposts_count: "0",
+        post_url: "https://www.linkedin.com/feed/update/urn:li:activity:post-1/"
+      })
+      .mockResolvedValueOnce({
+        post_id: "post-2",
+        author_name: "Emil Sorensen",
+        author_headline: "AI/ML Engineer",
+        author_profile_url: "https://www.linkedin.com/in/emil-sorensen/",
+        posted_at: "Now",
+        text: "Media post",
+        reactions_count: "0",
+        comments_count: "0",
+        reposts_count: "0",
+        post_url: "https://www.linkedin.com/feed/update/urn:li:activity:post-2/"
+      });
+
+    activitySeedCliMocks.viewFeed.mockResolvedValue([
+      {
+        post_id: "feed-1",
+        author_name: "Someone Else",
+        author_headline: "AI Engineer",
+        author_profile_url: "https://www.linkedin.com/in/someone-else/",
+        posted_at: "1h",
+        text: "A post about evaluation loops.",
+        reactions_count: "12",
+        comments_count: "3",
+        reposts_count: "1",
+        post_url: "https://www.linkedin.com/feed/update/urn:li:activity:feed-1/"
+      }
+    ]);
+
+    activitySeedCliMocks.jobsSearchJobs.mockResolvedValue({
+      query: "AI engineer",
+      location: "Copenhagen, Denmark",
+      count: 1,
+      results: [
+        {
+          job_id: "job-1",
+          title: "AI Engineer",
+          company: "Signikant",
+          location: "Copenhagen, Denmark",
+          posted_at: "1d",
+          job_url: "https://www.linkedin.com/jobs/view/job-1/",
+          salary_range: "",
+          employment_type: "Full-time"
+        }
+      ]
+    });
+    activitySeedCliMocks.jobsViewJob.mockResolvedValue({
+      job_id: "job-1",
+      title: "AI Engineer",
+      company: "Signikant",
+      company_url: "https://www.linkedin.com/company/signikant/",
+      location: "Copenhagen, Denmark",
+      posted_at: "1d",
+      description: "Build AI systems.",
+      salary_range: "",
+      employment_type: "Full-time",
+      job_url: "https://www.linkedin.com/jobs/view/job-1/",
+      applicant_count: "5 applicants",
+      seniority_level: "Mid-Senior",
+      is_remote: false
+    });
+
+    activitySeedCliMocks.listThreads.mockResolvedValue([
+      {
+        thread_id: "thread-1",
+        title: "Simon Miller",
+        unread_count: 0,
+        snippet: "Latest message",
+        thread_url: "https://www.linkedin.com/messaging/thread/thread-1/"
+      }
+    ]);
+    activitySeedCliMocks.getThread.mockResolvedValue({
+      thread_id: "thread-1",
+      title: "Simon Miller",
+      unread_count: 0,
+      snippet: "Latest message",
+      thread_url: "https://www.linkedin.com/messaging/thread/thread-1/",
+      messages: [
+        {
+          author: "Emil Sorensen",
+          sent_at: "Now",
+          text: "Hi Simon"
+        }
+      ]
+    });
+
+    activitySeedCliMocks.listNotifications.mockResolvedValue([
+      {
+        id: "notification-1",
+        type: "connection",
+        message: "Someone viewed your profile",
+        timestamp: "1h",
+        link: "https://www.linkedin.com/notifications/",
+        is_read: false
+      }
+    ]);
+
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation((value?: unknown) => {
+      stdoutChunks.push(String(value ?? ""));
+    });
+    stderrWriteSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((...args: Parameters<typeof process.stderr.write>) => {
+        stderrChunks.push(String(args[0]));
+        return true;
+      });
+  });
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore();
+    stderrWriteSpy.mockRestore();
+    process.exitCode = undefined;
+    delete process.env.LINKEDIN_ASSISTANT_HOME;
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("runs an issue-212 style seed spec and reuses generated media assets", async () => {
+    const specPath = path.join(tempDir, "activity-spec.json");
+    const imageReportPath = path.join(tempDir, "profile-images.json");
+    await writeFile(
+      imageReportPath,
+      JSON.stringify(
+        {
+          post_images: [
+            {
+              absolute_path: path.join(tempDir, "generated-post-01.png"),
+              file_name: "generated-post-01.png",
+              concept_key: "copenhagen-workspace",
+              title: "Workspace"
+            }
+          ]
+        },
+        null,
+        2
+      )
+    );
+    await writeFile(
+      specPath,
+      JSON.stringify(
+        {
+          assets: {
+            generatedImageManifestPath: path.basename(imageReportPath)
+          },
+          connections: {
+            acceptPending: {
+              limit: 1
+            },
+            invites: [
+              {
+                targetProfile: "https://www.linkedin.com/in/new-person/",
+                note: "Thought your recent AI platform post was excellent."
+              }
+            ]
+          },
+          posts: [
+            {
+              text: "A text-only update about practical AI evaluation loops."
+            },
+            {
+              text: "A media update about grounded developer tooling.",
+              generatedImageIndex: 0
+            }
+          ],
+          feed: {
+            discoveryLimit: 8,
+            likes: [
+              {
+                postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:feed-1/",
+                reaction: "insightful"
+              }
+            ],
+            comments: [
+              {
+                postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:feed-2/",
+                text: "Really like the focus on instrumentation here."
+              }
+            ]
+          },
+          jobs: {
+            searches: [
+              {
+                query: "AI engineer",
+                location: "Copenhagen, Denmark",
+                limit: 5,
+                viewTop: 1
+              }
+            ]
+          },
+          messaging: {
+            newThreads: [
+              {
+                recipients: ["Simon Miller"],
+                text: "Hi Simon, hope your week is going well."
+              }
+            ],
+            replies: [
+              {
+                thread: "https://www.linkedin.com/messaging/thread/thread-2/",
+                text: "Thanks for the note."
+              }
+            ]
+          },
+          notifications: {
+            limit: 5
+          }
+        },
+        null,
+        2
+      )
+    );
+
+    await runCli([
+      "node",
+      "linkedin",
+      "seed",
+      "activity",
+      "--profile",
+      "smoke",
+      "--spec",
+      specPath,
+      "--delay-ms",
+      "0",
+      "--yes"
+    ]);
+
+    const output = JSON.parse(stdoutChunks.join("\n")) as {
+      generated_image_manifest_path: string;
+      plan: {
+        totalWriteActions: number;
+      };
+      posts: Array<{
+        action_type: string;
+        media_path?: string;
+      }>;
+      verification: {
+        inbox_threads: Array<{ thread_id: string }>;
+      };
+    };
+
+    expect(output.generated_image_manifest_path).toBe(path.resolve(imageReportPath));
+    expect(output.plan.totalWriteActions).toBe(8);
+    expect(output.posts.map((post) => post.action_type)).toEqual([
+      "post.create",
+      "post.create_media"
+    ]);
+    expect(output.posts[1]?.media_path).toBe(path.join(tempDir, "generated-post-01.png"));
+    expect(output.verification.inbox_threads[0]?.thread_id).toBe("thread-1");
+    expect(activitySeedCliMocks.prepareCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profileName: "smoke",
+        visibility: "connections"
+      })
+    );
+    expect(activitySeedCliMocks.prepareCreateMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profileName: "smoke",
+        mediaPaths: [path.join(tempDir, "generated-post-01.png")],
+        visibility: "connections"
+      })
+    );
+    expect(stderrChunks.join("")).toContain("No running keepalive daemon was detected");
+  });
+});


### PR DESCRIPTION
## Summary
- add the CLI activity seed parser and  workflow for issue #212
- support reusable issue-211 generated image manifests plus a starter issue-212 activity seed spec
- document the workflow and cover the parser + CLI execution path with tests

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #212