### PR TITLE
fix: surface authenticated account identity in session diagnostics

### DIFF
--- a/docs/issue-214-ux-pass.md
+++ b/docs/issue-214-ux-pass.md
@@ -1,0 +1,52 @@
+# Issue 214 UX Pass Notes
+
+Date: 2026-03-10
+
+## Summary
+
+The March 10, 2026 preflight for issue #214 could not proceed to a full live MCP
+tool pass because the available authenticated browser state did not match the
+required test account.
+
+Observed state:
+
+- `linkedin status --profile default` reported an authenticated session.
+- `linkedin profile editable --profile default` resolved to Joakim Sigvardt's
+  personal LinkedIn profile, which must not be used for issue #214.
+- `linkedin status --profile fresh-test`,
+  `linkedin status --profile recovery-20260223`, and
+  `linkedin status --profile default-backup-1771831535` all returned LinkedIn
+  checkpoint/login-wall states instead of an authenticated test session.
+- No stored-session directory existed under the default assistant home, so
+  `linkedin auth session` had not already captured a reusable encrypted session
+  for the test account.
+
+## Why This Matters
+
+Issue #214 explicitly requires exercising the MCP and CLI surfaces against the
+test account `linkedin-mcp@signikant.com`. As of 2026-03-10, the locally
+authenticated `default` browser profile is not that account, so continuing would
+risk running automation against a real personal LinkedIn profile.
+
+## UX Improvement Shipped In This PR
+
+Session-oriented outputs now include a best-effort authenticated member
+identity:
+
+- `linkedin status`
+- `linkedin health`
+- `linkedin.session.status`
+- `linkedin.session.open_login`
+- `linkedin.session.health`
+
+This makes it much easier to confirm which LinkedIn account is active before any
+read or write validation starts.
+
+## Next Safe Step
+
+Re-run the issue-214 pass only after one of these is true:
+
+- the persistent `default` profile is re-authenticated as the test account, or
+- a dedicated test profile is authenticated and selected for the run, or
+- a stored encrypted session for the test account is captured for the
+  stored-session validation flows.

--- a/packages/core/src/__tests__/healthCheck.test.ts
+++ b/packages/core/src/__tests__/healthCheck.test.ts
@@ -4,9 +4,11 @@ import { resolveEvasionConfig } from "../config.js";
 import { checkBrowserHealth, checkLinkedInSession } from "../healthCheck.js";
 
 function createMockPage(opts: {
+  getAttribute?: (selector: string, name: string, currentUrl: string) => string | null;
   url: string;
   evaluateResult?: unknown;
   isVisible?: (selector: string) => boolean;
+  textContent?: (selector: string, currentUrl: string) => string | null;
 }): Page {
   let currentUrl = opts.url;
 
@@ -18,16 +20,25 @@ function createMockPage(opts: {
       return opts.evaluateResult ?? 2;
     }),
     url: vi.fn(() => currentUrl),
-    goto: vi.fn(async () => {
-      currentUrl = opts.url;
+    goto: vi.fn(async (url: string) => {
+      currentUrl =
+        url === "https://www.linkedin.com/in/me/"
+          ? "https://www.linkedin.com/in/test-health/"
+          : opts.url;
     }),
     locator: vi.fn((selector: string) => {
       const visible = opts.isVisible?.(selector) ?? false;
       const isVisible = vi.fn(async () => visible);
+      const textContent = vi.fn(async () => opts.textContent?.(selector, currentUrl) ?? null);
+      const getAttribute = vi.fn(async (name: string) => {
+        return opts.getAttribute?.(selector, name, currentUrl) ?? null;
+      });
       const first = vi.fn();
       const mockLocator = {
         first,
-        isVisible
+        getAttribute,
+        isVisible,
+        textContent
       } as unknown as Locator;
       first.mockReturnValue(mockLocator);
       return mockLocator;
@@ -215,5 +226,42 @@ describe("checkLinkedInSession", () => {
     const status = await checkLinkedInSession(context, { evasion });
 
     expect(status.evasion).toBe(evasion);
+  });
+
+  it("includes the authenticated member identity when the profile page resolves", async () => {
+    const page = createMockPage({
+      url: "https://www.linkedin.com/feed/",
+      getAttribute: (selector, name, currentUrl) => {
+        if (
+          selector === "link[rel='canonical']" &&
+          name === "href" &&
+          currentUrl.includes("/in/test-health/")
+        ) {
+          return "https://www.linkedin.com/in/test-health/";
+        }
+
+        return null;
+      },
+      isVisible: (selector) => selector === "nav.global-nav",
+      textContent: (selector, currentUrl) => {
+        if (selector === "main h1" && currentUrl.includes("/in/test-health/")) {
+          return "Health Check User";
+        }
+
+        return null;
+      }
+    });
+    const context = createMockContext({
+      connected: true,
+      pages: [page]
+    });
+
+    const status = await checkLinkedInSession(context);
+
+    expect(status.identity).toEqual({
+      fullName: "Health Check User",
+      profileUrl: "https://www.linkedin.com/in/test-health/",
+      vanityName: "test-health"
+    });
   });
 });

--- a/packages/core/src/__tests__/sessionAuth.test.ts
+++ b/packages/core/src/__tests__/sessionAuth.test.ts
@@ -21,8 +21,14 @@ vi.mock("../auth/rateLimitState.js", () => ({
 
 function createMockPage(options: {
   initialUrl: string;
+  getAttribute?: (
+    selector: string,
+    name: string,
+    currentUrl: string
+  ) => string | null;
   onWait?: () => void;
   isVisible: (selector: string, currentUrl: string) => boolean;
+  textContent?: (selector: string, currentUrl: string) => string | null;
 }): { page: Page; gotoCalls: string[]; setUrl: (url: string) => void } {
   let currentUrl = options.initialUrl;
   const gotoCalls: string[] = [];
@@ -30,7 +36,10 @@ function createMockPage(options: {
   const page = {
     url: vi.fn(() => currentUrl),
     goto: vi.fn(async (url: string) => {
-      currentUrl = url;
+      currentUrl =
+        url === "https://www.linkedin.com/in/me/"
+          ? "https://www.linkedin.com/in/test-operator/"
+          : url;
       gotoCalls.push(url);
     }),
     waitForTimeout: vi.fn(async () => {
@@ -39,10 +48,18 @@ function createMockPage(options: {
     locator: vi.fn((selector: string) => {
       const visible = options.isVisible(selector, currentUrl);
       const isVisible = vi.fn(async () => visible);
+      const textContent = vi.fn(async () => {
+        return options.textContent?.(selector, currentUrl) ?? null;
+      });
+      const getAttribute = vi.fn(async (name: string) => {
+        return options.getAttribute?.(selector, name, currentUrl) ?? null;
+      });
       const first = vi.fn();
       const mockLocator = {
         first,
-        isVisible
+        getAttribute,
+        isVisible,
+        textContent
       } as unknown as Locator;
       first.mockReturnValue(mockLocator);
       return mockLocator;
@@ -116,7 +133,10 @@ describe("LinkedInAuthService auth flow", () => {
 
     expect(result.authenticated).toBe(true);
     expect(result.timedOut).toBe(false);
-    expect(gotoCalls).toEqual(["https://www.linkedin.com/login"]);
+    expect(gotoCalls).toEqual([
+      "https://www.linkedin.com/login",
+      "https://www.linkedin.com/in/me/"
+    ]);
     expect(rateLimitStateMocks.clearRateLimitState).toHaveBeenCalledTimes(1);
   });
 
@@ -151,6 +171,45 @@ describe("LinkedInAuthService auth flow", () => {
     });
     expect(status.rateLimitActive).toBeUndefined();
     expect(rateLimitStateMocks.clearRateLimitState).toHaveBeenCalledTimes(1);
+  });
+
+  it("status enriches authenticated sessions with member identity", async () => {
+    const { page } = createMockPage({
+      initialUrl: "https://www.linkedin.com/feed/",
+      getAttribute: (selector, name, currentUrl) => {
+        if (
+          selector === "link[rel='canonical']" &&
+          name === "href" &&
+          currentUrl.includes("/in/test-operator/")
+        ) {
+          return "https://www.linkedin.com/in/test-operator/";
+        }
+
+        return null;
+      },
+      isVisible: (selector) => selector === "nav.global-nav",
+      textContent: (selector, currentUrl) => {
+        if (selector === "main h1" && currentUrl.includes("/in/test-operator/")) {
+          return "Test Operator";
+        }
+
+        return null;
+      }
+    });
+
+    const context = createContextWithPage(page);
+    const profileManager = {
+      runWithContext: vi.fn(async (_options, callback) => callback(context))
+    } as const;
+    const auth = new LinkedInAuthService(profileManager as unknown as ProfileManager);
+
+    const status = await auth.status({ profileName: "default" });
+
+    expect(status.identity).toEqual({
+      fullName: "Test Operator",
+      profileUrl: "https://www.linkedin.com/in/test-operator/",
+      vanityName: "test-operator"
+    });
   });
 
   it("ensureAuthenticated throws RATE_LIMITED when session is unauthenticated during cooldown", async () => {

--- a/packages/core/src/__tests__/sessionInspection.test.ts
+++ b/packages/core/src/__tests__/sessionInspection.test.ts
@@ -1,21 +1,39 @@
 import { describe, expect, it, vi } from "vitest";
 import type { BrowserContext, Locator, Page } from "playwright-core";
-import { inspectLinkedInSession } from "../auth/sessionInspection.js";
+import {
+  inspectAuthenticatedLinkedInIdentity,
+  inspectLinkedInSession
+} from "../auth/sessionInspection.js";
 
 function createMockPage(options: {
   url: string;
   cookies?: readonly { name: string; value: string }[];
+  getAttribute?: (selector: string, name: string, currentUrl: string) => string | null;
   isVisible?: (selector: string) => boolean;
+  textContent?: (selector: string, currentUrl: string) => string | null;
 }): Page {
+  let currentUrl = options.url;
+
   return {
-    url: vi.fn(() => options.url),
+    goto: vi.fn(async (url: string) => {
+      currentUrl = url === "https://www.linkedin.com/in/me/"
+        ? "https://www.linkedin.com/in/test-member/"
+        : url;
+    }),
+    url: vi.fn(() => currentUrl),
     locator: vi.fn((selector: string) => {
       const visible = options.isVisible?.(selector) ?? false;
       const isVisible = vi.fn(async () => visible);
+      const textContent = vi.fn(async () => options.textContent?.(selector, currentUrl) ?? null);
+      const getAttribute = vi.fn(async (name: string) => {
+        return options.getAttribute?.(selector, name, currentUrl) ?? null;
+      });
       const first = vi.fn();
       const mockLocator = {
         first,
-        isVisible
+        getAttribute,
+        isVisible,
+        textContent
       } as unknown as Locator;
       first.mockReturnValue(mockLocator);
       return mockLocator;
@@ -138,5 +156,37 @@ describe("inspectLinkedInSession", () => {
 
     expect(status.authenticated).toBe(true);
     expect(status.reason).toContain("authenticated");
+  });
+
+  it("extracts the authenticated member identity from the self profile page", async () => {
+    const page = createMockPage({
+      url: "https://www.linkedin.com/feed/",
+      getAttribute: (selector, name, currentUrl) => {
+        if (
+          selector === "link[rel='canonical']" &&
+          name === "href" &&
+          currentUrl.includes("/in/test-member/")
+        ) {
+          return "https://www.linkedin.com/in/test-member/";
+        }
+
+        return null;
+      },
+      textContent: (selector, currentUrl) => {
+        if (selector === "main h1" && currentUrl.includes("/in/test-member/")) {
+          return " Test   Member ";
+        }
+
+        return null;
+      }
+    });
+
+    const identity = await inspectAuthenticatedLinkedInIdentity(page);
+
+    expect(identity).toEqual({
+      fullName: "Test Member",
+      profileUrl: "https://www.linkedin.com/in/test-member/",
+      vanityName: "test-member"
+    });
   });
 });

--- a/packages/core/src/auth/session.ts
+++ b/packages/core/src/auth/session.ts
@@ -5,8 +5,10 @@ import { attachHumanizeLogger, detachHumanizeLogger, humanize } from "../humaniz
 import type { JsonEventLogger } from "../logging.js";
 import { ProfileManager } from "../profileManager.js";
 import {
+  inspectAuthenticatedLinkedInIdentity,
   inspectLinkedInSession,
-  isRateLimitedChallengeUrl
+  isRateLimitedChallengeUrl,
+  type LinkedInSessionIdentity
 } from "./sessionInspection.js";
 import {
   DEFAULT_LINKEDIN_SELECTOR_LOCALE,
@@ -27,6 +29,7 @@ export interface SessionStatus {
   currentUrl: string;
   /** Resolved anti-bot evasion status when available. */
   evasion?: EvasionConfig;
+  identity?: LinkedInSessionIdentity;
   loginWallDetected?: boolean;
   reason: string;
   rateLimitActive?: boolean;
@@ -101,6 +104,23 @@ async function sleep(ms: number): Promise<void> {
   });
 }
 
+async function enrichAuthenticatedSessionStatus<T extends { authenticated: boolean }>(
+  page: Page,
+  status: T
+): Promise<T & { identity?: LinkedInSessionIdentity }> {
+  if (!status.authenticated) {
+    return status;
+  }
+
+  const identity = await inspectAuthenticatedLinkedInIdentity(page);
+  return identity
+    ? {
+        ...status,
+        identity
+      }
+    : status;
+}
+
 export class LinkedInAuthService {
   constructor(
     private readonly profileManager: ProfileManager,
@@ -133,7 +153,7 @@ export class LinkedInAuthService {
         if (status.authenticated) {
           await clearRateLimitState();
         }
-        return status;
+        return enrichAuthenticatedSessionStatus(page, status);
       }
     );
 
@@ -305,8 +325,12 @@ export class LinkedInAuthService {
           });
           if (earlyStatus.authenticated) {
             await clearRateLimitState();
+            const resolvedEarlyStatus = await enrichAuthenticatedSessionStatus(
+              page,
+              earlyStatus
+            );
             return {
-              ...earlyStatus,
+              ...resolvedEarlyStatus,
               timedOut: false,
               checkpoint: false
             };
@@ -347,8 +371,12 @@ export class LinkedInAuthService {
 
           if (status.authenticated) {
             await clearRateLimitState();
+            const resolvedStatus = await enrichAuthenticatedSessionStatus(
+              page,
+              status
+            );
             return {
-              ...status,
+              ...resolvedStatus,
               timedOut: false,
               checkpoint: false
             };
@@ -541,11 +569,15 @@ export class LinkedInAuthService {
         const finalStatus = await inspectLinkedInSession(page, {
           selectorLocale: this.selectorLocale
         });
-        if (finalStatus.authenticated) {
+        const resolvedFinalStatus = await enrichAuthenticatedSessionStatus(
+          page,
+          finalStatus
+        );
+        if (resolvedFinalStatus.authenticated) {
           await clearRateLimitState();
         }
         return {
-          ...finalStatus,
+          ...resolvedFinalStatus,
           timedOut: true,
           checkpoint: false
         };
@@ -598,13 +630,15 @@ export class LinkedInAuthService {
           });
         }
 
-        if (status.authenticated) {
+        const resolvedStatus = await enrichAuthenticatedSessionStatus(page, status);
+
+        if (resolvedStatus.authenticated) {
           await clearRateLimitState();
         }
 
         return {
-          ...status,
-          timedOut: !status.authenticated
+          ...resolvedStatus,
+          timedOut: !resolvedStatus.authenticated
         };
       }
     );

--- a/packages/core/src/auth/sessionInspection.ts
+++ b/packages/core/src/auth/sessionInspection.ts
@@ -20,16 +20,29 @@ export interface LinkedInSessionInspection {
   sessionCookiePresent: boolean;
 }
 
+/** Best-effort identity snapshot for the authenticated LinkedIn member. */
+export interface LinkedInSessionIdentity {
+  fullName: string | null;
+  profileUrl: string | null;
+  vanityName: string | null;
+}
+
 const LOGIN_FORM_SELECTOR = "input[name='session_key'], input#username";
 const CHECKPOINT_FORM_SELECTOR = "form[action*='checkpoint']";
 const AUTH_NAV_SELECTOR = "nav.global-nav";
 const AUTH_PROFILE_MENU_SELECTOR = "[data-control-name='nav.settings_view_profile']";
+const PROFILE_HEADING_SELECTORS = [
+  "main h1",
+  ".pv-text-details__left-panel h1",
+  "h1"
+];
 const LOGIN_WALL_SELECTOR = [
   "[data-test-id='sign-in-form']",
   ".authwall",
   "form[action*='login-submit']",
   "a[href*='/login'][data-tracking-control-name]"
 ].join(", ");
+const LINKEDIN_PROFILE_SELF_URL = "https://www.linkedin.com/in/me/";
 
 async function isVisibleSafe(page: Page, selector: string): Promise<boolean> {
   try {
@@ -63,6 +76,82 @@ function isCheckpointUrl(url: string): boolean {
     url.includes("/challenge") ||
     isRateLimitedChallengeUrl(url)
   );
+}
+
+function normalizeWhitespace(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.replace(/\s+/g, " ").trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeLinkedInProfileUrl(value: string | null): string | null {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(value, "https://www.linkedin.com");
+    const vanityMatch = parsed.pathname.match(/^\/in\/([^/?#]+)\/?$/u);
+    if (!vanityMatch) {
+      return null;
+    }
+
+    parsed.hash = "";
+    parsed.search = "";
+    parsed.pathname = `/in/${vanityMatch[1]}/`;
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+function extractLinkedInVanityName(profileUrl: string | null): string | null {
+  if (!profileUrl) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(profileUrl);
+    const vanityMatch = parsed.pathname.match(/^\/in\/([^/]+)\/$/u);
+    return vanityMatch?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function readFirstNonEmptyText(
+  page: Page,
+  selectors: string[]
+): Promise<string | null> {
+  for (const selector of selectors) {
+    try {
+      const rawText = await page.locator(selector).first().textContent();
+      const normalized = normalizeWhitespace(rawText);
+      if (normalized) {
+        return normalized;
+      }
+    } catch {
+      // Best effort.
+    }
+  }
+
+  return null;
+}
+
+async function readFirstAttribute(
+  page: Page,
+  selector: string,
+  attribute: string
+): Promise<string | null> {
+  try {
+    const value = await page.locator(selector).first().getAttribute(attribute);
+    return normalizeWhitespace(value);
+  } catch {
+    return null;
+  }
 }
 
 async function hasSessionCookie(page: Page): Promise<boolean> {
@@ -159,5 +248,43 @@ export async function inspectLinkedInSession(
     loginWallDetected: false,
     rateLimited: false,
     sessionCookiePresent
+  };
+}
+
+/**
+ * Best-effort extraction of the currently authenticated LinkedIn member's
+ * public identity. This intentionally prefers a stable public profile URL plus
+ * the visible H1 so operators can confirm they are using the intended account.
+ */
+export async function inspectAuthenticatedLinkedInIdentity(
+  page: Page
+): Promise<LinkedInSessionIdentity | undefined> {
+  try {
+    await page.goto(LINKEDIN_PROFILE_SELF_URL, {
+      waitUntil: "domcontentloaded"
+    });
+  } catch {
+    return undefined;
+  }
+
+  const currentUrl = page.url();
+  if (isLoginUrl(currentUrl) || isCheckpointUrl(currentUrl)) {
+    return undefined;
+  }
+
+  const fullName = await readFirstNonEmptyText(page, PROFILE_HEADING_SELECTORS);
+  const profileUrl =
+    normalizeLinkedInProfileUrl(
+      await readFirstAttribute(page, "link[rel='canonical']", "href")
+    ) ?? normalizeLinkedInProfileUrl(currentUrl);
+
+  if (!fullName && !profileUrl) {
+    return undefined;
+  }
+
+  return {
+    fullName,
+    profileUrl,
+    vanityName: extractLinkedInVanityName(profileUrl)
   };
 }

--- a/packages/core/src/healthCheck.ts
+++ b/packages/core/src/healthCheck.ts
@@ -1,5 +1,9 @@
 import type { BrowserContext, Page } from "playwright-core";
-import { inspectLinkedInSession } from "./auth/sessionInspection.js";
+import {
+  inspectAuthenticatedLinkedInIdentity,
+  inspectLinkedInSession,
+  type LinkedInSessionIdentity
+} from "./auth/sessionInspection.js";
 import { resolveEvasionConfig, type EvasionConfig } from "./config.js";
 import {
   getLinkedInSessionFingerprint,
@@ -27,6 +31,7 @@ export interface SessionHealthStatus {
   cookieExpiringSoon: boolean;
   /** Resolved anti-bot evasion status for the current runtime. */
   evasion: EvasionConfig;
+  identity?: LinkedInSessionIdentity;
   loginWallDetected: boolean;
   nextCookieExpiryAt: string | null;
   rateLimited: boolean;
@@ -95,6 +100,9 @@ export async function checkLinkedInSession(
     });
 
     const inspection = await inspectLinkedInSession(page);
+    const identity = inspection.authenticated
+      ? await inspectAuthenticatedLinkedInIdentity(page)
+      : undefined;
     const cookies = await context.cookies("https://www.linkedin.com");
     const sessionCookies = summarizeLinkedInSessionCookies(cookies);
     const nextCookieExpiryAt = sessionCookies.find(
@@ -111,6 +119,7 @@ export async function checkLinkedInSession(
       ...inspection,
       cookieExpiringSoon,
       evasion,
+      ...(identity ? { identity } : {}),
       nextCookieExpiryAt,
       sessionCookieFingerprint:
         sessionCookies.length > 0


### PR DESCRIPTION
## Summary

This PR makes the session-oriented UX safer for issue #214 style live validation by surfacing the authenticated LinkedIn member identity in session status and health output.

It also records the March 10, 2026 issue-214 preflight blocker we hit locally: the authenticated `default` browser profile resolved to Joakim's personal account, while the other local profiles were checkpointed and no stored test-account session was available.

## What Changed

- add best-effort authenticated member identity to core session status output
- propagate that identity into health checks and session/open-login flows
- cover the new identity extraction behavior with unit tests
- add `docs/issue-214-ux-pass.md` with the blocker notes and safe next steps

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

## Follow-up

- blocker tracked in #267

Closes #214
