### PR TITLE
feat: add MCP company discovery coverage

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -36,6 +36,7 @@ import {
   buildLinkedInImagePersonaFromProfileSeed,
   evaluateDraftQuality,
   getLinkedInSelectorLocaleConfigWarning,
+  isSearchCategory,
   isInRateLimitCooldown,
   isLinkedInFixtureReplayUrl,
   LINKEDIN_REPLAY_PAGE_TYPES,
@@ -47,6 +48,7 @@ import {
   LINKEDIN_PRIVACY_SETTING_KEYS,
   LINKEDIN_SELECTOR_LOCALES,
   LINKEDIN_WRITE_VALIDATION_ACTIONS,
+  SEARCH_CATEGORIES,
   LinkedInAssistantError,
   LinkedInSchedulerService,
   DEFAULT_FIXTURE_STALENESS_DAYS,
@@ -294,13 +296,13 @@ function coerceNonNegativeInt(value: string, label: string): number {
 }
 
 function coerceSearchCategory(value: string): SearchCategory {
-  if (value === "people" || value === "companies" || value === "jobs") {
+  if (isSearchCategory(value)) {
     return value;
   }
 
   throw new LinkedInAssistantError(
     "ACTION_PRECONDITION_FAILED",
-    "category must be one of: people, companies, jobs."
+    `category must be one of: ${SEARCH_CATEGORIES.join(", ")}.`
   );
 }
 
@@ -5734,6 +5736,106 @@ async function runProfileView(input: {
   }
 }
 
+async function runCompanyPageView(input: {
+  profileName: string;
+  target: string;
+}, cdpUrl?: string): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.company.view.start", {
+      profileName: input.profileName,
+      target: input.target
+    });
+
+    const company = await runtime.companyPages.viewCompanyPage({
+      profileName: input.profileName,
+      target: input.target
+    });
+
+    runtime.logger.log("info", "cli.company.view.done", {
+      profileName: input.profileName,
+      companyName: company.name
+    });
+
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      company
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function runCompanyPrepareFollow(input: {
+  profileName: string;
+  targetCompany: string;
+  operatorNote?: string;
+}, cdpUrl?: string): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.company.prepare_follow.start", {
+      profileName: input.profileName,
+      targetCompany: input.targetCompany
+    });
+
+    const prepared = runtime.companyPages.prepareFollowCompanyPage({
+      profileName: input.profileName,
+      targetCompany: input.targetCompany,
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+    });
+
+    runtime.logger.log("info", "cli.company.prepare_follow.done", {
+      profileName: input.profileName,
+      preparedActionId: prepared.preparedActionId
+    });
+
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      ...prepared
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function runCompanyPrepareUnfollow(input: {
+  profileName: string;
+  targetCompany: string;
+  operatorNote?: string;
+}, cdpUrl?: string): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.company.prepare_unfollow.start", {
+      profileName: input.profileName,
+      targetCompany: input.targetCompany
+    });
+
+    const prepared = runtime.companyPages.prepareUnfollowCompanyPage({
+      profileName: input.profileName,
+      targetCompany: input.targetCompany,
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+    });
+
+    runtime.logger.log("info", "cli.company.prepare_unfollow.done", {
+      profileName: input.profileName,
+      preparedActionId: prepared.preparedActionId
+    });
+
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      ...prepared
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
 async function runProfileViewEditable(input: {
   profileName: string;
 }, cdpUrl?: string): Promise<void> {
@@ -8416,7 +8518,7 @@ export function createCliProgram(): Command {
     .option("-p, --profile <profile>", "Profile name", "default")
     .option(
       "-c, --category <category>",
-      "Search category: people, companies, or jobs",
+      `Search category: ${SEARCH_CATEGORIES.join(", ")}`,
       "people"
     )
     .option("-l, --limit <limit>", "Max results", "10")
@@ -9050,6 +9152,60 @@ export function createCliProgram(): Command {
         target
       }, readCdpUrl());
     });
+
+  const companyCommand = program
+    .command("company")
+    .description("View LinkedIn company pages and prepare follow changes");
+
+  companyCommand
+    .command("view")
+    .description("View a LinkedIn company page")
+    .argument("<target>", "Company slug, /company/ path, or company URL")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .action(async (target: string, options: { profile: string }) => {
+      await runCompanyPageView({
+        profileName: options.profile,
+        target
+      }, readCdpUrl());
+    });
+
+  companyCommand
+    .command("follow")
+    .description("Prepare to follow a LinkedIn company page (two-phase)")
+    .argument("<target>", "Company slug, /company/ path, or company URL")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .option("--operator-note <note>", "Optional note attached to the prepared action")
+    .action(
+      async (
+        target: string,
+        options: { operatorNote?: string; profile: string }
+      ) => {
+        await runCompanyPrepareFollow({
+          profileName: options.profile,
+          targetCompany: target,
+          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
+        }, readCdpUrl());
+      }
+    );
+
+  companyCommand
+    .command("unfollow")
+    .description("Prepare to unfollow a LinkedIn company page (two-phase)")
+    .argument("<target>", "Company slug, /company/ path, or company URL")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .option("--operator-note <note>", "Optional note attached to the prepared action")
+    .action(
+      async (
+        target: string,
+        options: { operatorNote?: string; profile: string }
+      ) => {
+        await runCompanyPrepareUnfollow({
+          profileName: options.profile,
+          targetCompany: target,
+          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
+        }, readCdpUrl());
+      }
+    );
 
   profileCommand
     .command("editable")

--- a/packages/core/src/__tests__/linkedinCompanyPages.test.ts
+++ b/packages/core/src/__tests__/linkedinCompanyPages.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeLinkedInCompanyPageUrl,
+  resolveCompanyPageUrl
+} from "../linkedinCompanyPages.js";
+
+describe("resolveCompanyPageUrl", () => {
+  it("accepts company slugs", () => {
+    expect(resolveCompanyPageUrl("openai")).toBe(
+      "https://www.linkedin.com/company/openai/"
+    );
+  });
+
+  it("normalizes /company paths", () => {
+    expect(resolveCompanyPageUrl("/company/microsoft/about/")).toBe(
+      "https://www.linkedin.com/company/microsoft/"
+    );
+  });
+
+  it("normalizes absolute LinkedIn company URLs", () => {
+    expect(
+      resolveCompanyPageUrl("https://www.linkedin.com/company/microsoft/jobs/")
+    ).toBe("https://www.linkedin.com/company/microsoft/");
+  });
+
+  it("rejects non-company LinkedIn URLs", () => {
+    expect(() =>
+      resolveCompanyPageUrl("https://www.linkedin.com/in/someone/")
+    ).toThrow("Company page URL must point to linkedin.com/company/.");
+  });
+});
+
+describe("normalizeLinkedInCompanyPageUrl", () => {
+  it("strips query strings and hashes", () => {
+    expect(
+      normalizeLinkedInCompanyPageUrl(
+        "https://www.linkedin.com/company/openai/about/?foo=bar#fragment"
+      )
+    ).toBe("https://www.linkedin.com/company/openai/");
+  });
+});

--- a/packages/core/src/__tests__/linkedinSearch.test.ts
+++ b/packages/core/src/__tests__/linkedinSearch.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildSearchUrl } from "../linkedinSearch.js";
+import {
+  SEARCH_CATEGORIES,
+  buildSearchUrl,
+  isSearchCategory
+} from "../linkedinSearch.js";
 
 describe("buildSearchUrl", () => {
   it("builds people search URL", () => {
@@ -20,6 +24,24 @@ describe("buildSearchUrl", () => {
     );
   });
 
+  it("builds posts search URL", () => {
+    expect(buildSearchUrl("OpenAI", "posts")).toBe(
+      "https://www.linkedin.com/search/results/posts/?keywords=OpenAI&skipRedirect=true"
+    );
+  });
+
+  it("builds groups search URL", () => {
+    expect(buildSearchUrl("marketing", "groups")).toBe(
+      "https://www.linkedin.com/search/results/groups/?keywords=marketing"
+    );
+  });
+
+  it("builds events search URL", () => {
+    expect(buildSearchUrl("AI", "events")).toBe(
+      "https://www.linkedin.com/search/results/events/?keywords=AI"
+    );
+  });
+
   it("defaults to people when no category given", () => {
     expect(buildSearchUrl("test")).toBe(
       "https://www.linkedin.com/search/results/people/?keywords=test"
@@ -29,5 +51,21 @@ describe("buildSearchUrl", () => {
   it("encodes special characters", () => {
     const url = buildSearchUrl("C++ developer", "people");
     expect(url).toContain("C%2B%2B");
+  });
+
+  it("exports the supported search categories", () => {
+    expect(SEARCH_CATEGORIES).toEqual([
+      "people",
+      "companies",
+      "jobs",
+      "posts",
+      "groups",
+      "events"
+    ]);
+  });
+
+  it("detects supported search categories", () => {
+    expect(isSearchCategory("groups")).toBe(true);
+    expect(isSearchCategory("topics")).toBe(false);
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export * from "./keepAlive.js";
 export * from "./localData.js";
 export * from "./liveValidation.js";
 export * from "./linkedinConnections.js";
+export * from "./linkedinCompanyPages.js";
 export * from "./linkedinFeed.js";
 export * from "./linkedinFollowups.js";
 export * from "./linkedinImageAssets.js";

--- a/packages/core/src/linkedinCompanyPages.ts
+++ b/packages/core/src/linkedinCompanyPages.ts
@@ -1,0 +1,830 @@
+import { type BrowserContext, type Locator, type Page } from "playwright-core";
+import type { ArtifactHelpers } from "./artifacts.js";
+import type { LinkedInAuthService } from "./auth/session.js";
+import { executeConfirmActionWithArtifacts } from "./confirmArtifacts.js";
+import type { ConfirmFailureArtifactConfig } from "./config.js";
+import { LinkedInAssistantError, asLinkedInAssistantError } from "./errors.js";
+import type { JsonEventLogger } from "./logging.js";
+import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
+import type { ProfileManager } from "./profileManager.js";
+import {
+  buildLinkedInAriaLabelContainsSelector,
+  buildLinkedInSelectorPhraseRegex,
+  formatLinkedInSelectorRegexHint,
+  type LinkedInSelectorLocale,
+  type LinkedInSelectorPhraseKey
+} from "./selectorLocale.js";
+import type {
+  ActionExecutor,
+  ActionExecutorInput,
+  ActionExecutorResult,
+  TwoPhaseCommitService
+} from "./twoPhaseCommit.js";
+
+/* eslint-disable no-undef -- DOM types are valid inside page.evaluate() */
+
+export interface LinkedInCompanyPage {
+  company_url: string;
+  about_url: string;
+  slug: string | null;
+  name: string;
+  industry: string;
+  location: string;
+  follower_count: string;
+  employee_count: string;
+  associated_members: string;
+  website: string;
+  verified_on: string;
+  headquarters: string;
+  specialties: string;
+  overview: string;
+  follow_state: "following" | "not_following" | "unknown";
+}
+
+export interface ViewCompanyPageInput {
+  profileName?: string;
+  target: string;
+}
+
+interface PrepareCompanyPageActionInput {
+  profileName?: string;
+  targetCompany: string;
+  operatorNote?: string;
+}
+
+export type PrepareFollowCompanyPageInput = PrepareCompanyPageActionInput;
+
+export type PrepareUnfollowCompanyPageInput = PrepareCompanyPageActionInput;
+
+interface LinkedInCompanyPagesRuntimeBase {
+  auth: LinkedInAuthService;
+  cdpUrl?: string | undefined;
+  selectorLocale: LinkedInSelectorLocale;
+  profileManager: ProfileManager;
+  logger: JsonEventLogger;
+}
+
+export interface LinkedInCompanyPagesExecutorRuntime
+  extends LinkedInCompanyPagesRuntimeBase {
+  artifacts: ArtifactHelpers;
+  confirmFailureArtifacts: ConfirmFailureArtifactConfig;
+}
+
+export interface LinkedInCompanyPagesRuntime
+  extends LinkedInCompanyPagesExecutorRuntime {
+  twoPhaseCommit: Pick<
+    TwoPhaseCommitService<LinkedInCompanyPagesExecutorRuntime>,
+    "prepare"
+  >;
+}
+
+export const FOLLOW_COMPANY_PAGE_ACTION_TYPE = "company.follow";
+export const UNFOLLOW_COMPANY_PAGE_ACTION_TYPE = "company.unfollow";
+
+function normalizeText(value: string | null | undefined): string {
+  return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function isAbsoluteUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value);
+}
+
+export function resolveCompanyPageUrl(target: string): string {
+  const trimmedTarget = normalizeText(target);
+  if (!trimmedTarget) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "Company page target is required."
+    );
+  }
+
+  if (isAbsoluteUrl(trimmedTarget)) {
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(trimmedTarget);
+    } catch (error) {
+      throw asLinkedInAssistantError(
+        error,
+        "ACTION_PRECONDITION_FAILED",
+        "Company page URL must be a valid URL."
+      );
+    }
+
+    const hostname = parsedUrl.hostname.toLowerCase();
+    const isLinkedInDomain =
+      hostname === "linkedin.com" || hostname.endsWith(".linkedin.com");
+    const segments = parsedUrl.pathname.split("/").filter((segment) => segment.length > 0);
+    if (!isLinkedInDomain || segments[0] !== "company" || !segments[1]) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        "Company page URL must point to linkedin.com/company/.",
+        { target: trimmedTarget }
+      );
+    }
+
+    const slug = decodeURIComponent(segments[1]);
+    return `https://www.linkedin.com/company/${encodeURIComponent(slug)}/`;
+  }
+
+  if (trimmedTarget.startsWith("/company/")) {
+    const [, , slug = ""] = trimmedTarget.split("/");
+    const normalizedSlug = normalizeText(slug);
+    if (!normalizedSlug) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        "Company page target is required."
+      );
+    }
+    return `https://www.linkedin.com/company/${encodeURIComponent(normalizedSlug)}/`;
+  }
+
+  return `https://www.linkedin.com/company/${encodeURIComponent(trimmedTarget)}/`;
+}
+
+export function normalizeLinkedInCompanyPageUrl(target: string): string {
+  const resolved = resolveCompanyPageUrl(target);
+
+  try {
+    const parsedUrl = new URL(resolved);
+    parsedUrl.search = "";
+    parsedUrl.hash = "";
+
+    const pathname = parsedUrl.pathname.endsWith("/")
+      ? parsedUrl.pathname
+      : `${parsedUrl.pathname}/`;
+
+    return `${parsedUrl.origin}${pathname}`;
+  } catch {
+    return resolved;
+  }
+}
+
+function buildCompanyPageAboutUrl(target: string): string {
+  return `${normalizeLinkedInCompanyPageUrl(target)}about/`;
+}
+
+function extractCompanySlug(url: string): string | null {
+  const match = /\/company\/([^/?#]+)/i.exec(url);
+  const slug = match?.[1];
+  if (!slug) {
+    return null;
+  }
+
+  try {
+    return decodeURIComponent(slug);
+  } catch {
+    return slug;
+  }
+}
+
+async function getOrCreatePage(context: BrowserContext): Promise<Page> {
+  const existing = context.pages()[0];
+  if (existing) {
+    return existing;
+  }
+  return context.newPage();
+}
+
+async function waitForCompanyPageReady(page: Page): Promise<void> {
+  await page
+    .locator("main h1")
+    .first()
+    .waitFor({ state: "visible", timeout: 10_000 })
+    .catch(() => undefined);
+}
+
+type LocatorRoot = Page | Locator;
+
+interface VisibleLocatorCandidate {
+  key: string;
+  selectorHint: string;
+  locatorFactory: (root: LocatorRoot) => Locator;
+}
+
+async function findVisibleLocator(
+  root: LocatorRoot,
+  candidates: VisibleLocatorCandidate[]
+): Promise<{ locator: Locator; key: string } | null> {
+  for (const candidate of candidates) {
+    const locator = candidate.locatorFactory(root).first();
+    if (await locator.isVisible().catch(() => false)) {
+      return { locator, key: candidate.key };
+    }
+  }
+
+  return null;
+}
+
+async function waitForCondition(
+  condition: () => Promise<boolean>,
+  timeoutMs: number,
+  intervalMs = 250
+): Promise<boolean> {
+  const deadline = Date.now() + Math.max(0, timeoutMs);
+  while (Date.now() < deadline) {
+    if (await condition()) {
+      return true;
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, intervalMs);
+    });
+  }
+
+  return condition();
+}
+
+function buildCompanyActionButtonCandidates(input: {
+  root: Locator;
+  selectorLocale: LinkedInSelectorLocale;
+  selectorKeys: LinkedInSelectorPhraseKey | readonly LinkedInSelectorPhraseKey[];
+  candidateKeyPrefix: string;
+}): VisibleLocatorCandidate[] {
+  const exactRegex = buildLinkedInSelectorPhraseRegex(
+    input.selectorKeys,
+    input.selectorLocale,
+    { exact: true }
+  );
+  const exactRegexHint = formatLinkedInSelectorRegexHint(
+    input.selectorKeys,
+    input.selectorLocale,
+    { exact: true }
+  );
+  const ariaSelector = buildLinkedInAriaLabelContainsSelector(
+    "button",
+    input.selectorKeys,
+    input.selectorLocale
+  );
+
+  return [
+    {
+      key: `${input.candidateKeyPrefix}-root-role`,
+      selectorHint: `root.getByRole(button, ${exactRegexHint})`,
+      locatorFactory: () =>
+        input.root.getByRole("button", {
+          name: exactRegex
+        })
+    },
+    {
+      key: `${input.candidateKeyPrefix}-root-aria`,
+      selectorHint: `root ${ariaSelector}`,
+      locatorFactory: () => input.root.locator(ariaSelector)
+    },
+    {
+      key: `${input.candidateKeyPrefix}-page-role`,
+      selectorHint: `page.getByRole(button, ${exactRegexHint})`,
+      locatorFactory: (pageRoot) =>
+        pageRoot.getByRole("button", {
+          name: exactRegex
+        })
+    },
+    {
+      key: `${input.candidateKeyPrefix}-page-aria`,
+      selectorHint: ariaSelector,
+      locatorFactory: (pageRoot) => pageRoot.locator(ariaSelector)
+    }
+  ];
+}
+
+async function readCompanyFollowState(
+  page: Page,
+  selectorLocale: LinkedInSelectorLocale
+): Promise<LinkedInCompanyPage["follow_state"]> {
+  const root = page.locator("main").first();
+  const followingCandidates = buildCompanyActionButtonCandidates({
+    root,
+    selectorLocale,
+    selectorKeys: "following",
+    candidateKeyPrefix: "company-following"
+  });
+  if (await findVisibleLocator(page, followingCandidates)) {
+    return "following";
+  }
+
+  const followCandidates = buildCompanyActionButtonCandidates({
+    root,
+    selectorLocale,
+    selectorKeys: "follow",
+    candidateKeyPrefix: "company-follow"
+  });
+  if (await findVisibleLocator(page, followCandidates)) {
+    return "not_following";
+  }
+
+  return "unknown";
+}
+
+async function clickCompanyAction(input: {
+  page: Page;
+  selectorLocale: LinkedInSelectorLocale;
+  selectorKeys: LinkedInSelectorPhraseKey | readonly LinkedInSelectorPhraseKey[];
+  actionLabel: string;
+  targetCompany: string;
+  candidateKeyPrefix: string;
+}): Promise<string> {
+  const root = input.page.locator("main").first();
+  const candidates = buildCompanyActionButtonCandidates({
+    root,
+    selectorLocale: input.selectorLocale,
+    selectorKeys: input.selectorKeys,
+    candidateKeyPrefix: input.candidateKeyPrefix
+  });
+  const found = await findVisibleLocator(input.page, candidates);
+
+  if (!found) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${input.actionLabel} action is not available for "${input.targetCompany}".`,
+      {
+        target_company: input.targetCompany,
+        selector_candidates: candidates.map((candidate) => ({
+          key: candidate.key,
+          selector_hint: candidate.selectorHint
+        }))
+      }
+    );
+  }
+
+  await found.locator.click({ timeout: 5_000 });
+  return found.key;
+}
+
+async function extractCompanyPageData(page: Page): Promise<
+  Omit<LinkedInCompanyPage, "follow_state">
+> {
+  return page.evaluate(() => {
+    const normalize = (value: string | null | undefined): string =>
+      (value ?? "").replace(/\s+/g, " ").trim();
+
+    const main = globalThis.document.querySelector("main");
+    const companyUrl = normalize(globalThis.location.href);
+    const slug = (() => {
+      const match = /\/company\/([^/?#]+)/i.exec(companyUrl);
+      const value = match?.[1];
+      if (!value) {
+        return null;
+      }
+      try {
+        return decodeURIComponent(value);
+      } catch {
+        return value;
+      }
+    })();
+
+    const firstSection = main?.querySelector("section");
+    const topLines = (
+      (firstSection as HTMLElement | null)?.innerText ?? firstSection?.textContent ?? ""
+    )
+      .split(/\n+/)
+      .map((value) => normalize(value))
+      .filter((value) => value.length > 0);
+    const summaryLine =
+      topLines.find(
+        (line) => /\bfollowers\b/i.test(line) && /\bemployees\b/i.test(line)
+      ) ??
+      topLines[1] ??
+      "";
+
+    const overviewSection = Array.from(
+      main?.querySelectorAll("section") ?? []
+    ).find((section) => normalize(section.querySelector("h2, h3")?.textContent) === "Overview");
+    const overview = normalize(overviewSection?.querySelector("p")?.textContent);
+
+    const detailMap = new Map<string, string[]>();
+    for (const dt of Array.from(main?.querySelectorAll("dt") ?? [])) {
+      const label = normalize(dt.textContent);
+      if (!label) {
+        continue;
+      }
+
+      const values: string[] = [];
+      let sibling = dt.nextElementSibling;
+      while (sibling && sibling.tagName === "DD") {
+        const value = normalize(sibling.textContent);
+        if (value) {
+          values.push(value);
+        }
+        sibling = sibling.nextElementSibling;
+      }
+
+      detailMap.set(label, values);
+    }
+
+    const industry = detailMap.get("Industry")?.[0] ?? "";
+    const followerMatch = /([0-9][\w.,+]*\s+followers)/i.exec(summaryLine);
+    const followerCount = normalize(followerMatch?.[1] ?? "");
+    const employeeCount =
+      detailMap.get("Company size")?.[0] ??
+      normalize(/([0-9][\w.,+-]*\s+employees)$/i.exec(summaryLine)?.[1] ?? "");
+    const locationPrefix = followerMatch
+      ? normalize(summaryLine.slice(0, followerMatch.index))
+      : "";
+    const location = industry && locationPrefix.startsWith(industry)
+      ? normalize(locationPrefix.slice(industry.length))
+      : locationPrefix;
+
+    return {
+      company_url: slug
+        ? `https://www.linkedin.com/company/${encodeURIComponent(slug)}/`
+        : companyUrl,
+      about_url: slug
+        ? `https://www.linkedin.com/company/${encodeURIComponent(slug)}/about/`
+        : companyUrl,
+      slug,
+      name: normalize(main?.querySelector("h1")?.textContent),
+      industry,
+      location,
+      follower_count: followerCount,
+      employee_count: employeeCount,
+      associated_members: detailMap.get("Company size")?.[1] ?? "",
+      website: detailMap.get("Website")?.[0] ?? "",
+      verified_on: detailMap.get("Verified page")?.[0] ?? "",
+      headquarters: detailMap.get("Headquarters")?.[0] ?? "",
+      specialties: detailMap.get("Specialties")?.[0] ?? "",
+      overview
+    };
+  });
+}
+
+async function executeFollowCompanyPage(
+  runtime: LinkedInCompanyPagesExecutorRuntime,
+  actionId: string,
+  target: Record<string, unknown>
+): Promise<{ result: Record<string, unknown>; artifacts: string[] }> {
+  const targetCompany = String(target.target_company ?? "");
+  const profileName = String(target.profile_name ?? "default");
+  const companyUrl = normalizeLinkedInCompanyPageUrl(
+    String(target.company_url ?? targetCompany)
+  );
+
+  return runtime.profileManager.runWithContext(
+    {
+      cdpUrl: runtime.cdpUrl,
+      profileName,
+      headless: true
+    },
+    async (context) => {
+      const page = await getOrCreatePage(context);
+      return executeConfirmActionWithArtifacts({
+        runtime,
+        context,
+        page,
+        actionId,
+        actionType: FOLLOW_COMPANY_PAGE_ACTION_TYPE,
+        profileName,
+        targetUrl: companyUrl,
+        metadata: {
+          target_company: targetCompany,
+          company_url: companyUrl
+        },
+        errorDetails: {
+          target_company: targetCompany,
+          company_url: companyUrl
+        },
+        mapError: (error) =>
+          asLinkedInAssistantError(
+            error,
+            "UNKNOWN",
+            "Failed to execute LinkedIn company follow action."
+          ),
+        execute: async () => {
+          await page.goto(buildCompanyPageAboutUrl(companyUrl), {
+            waitUntil: "domcontentloaded"
+          });
+          await waitForNetworkIdleBestEffort(page);
+          await waitForCompanyPageReady(page);
+
+          const followState = await readCompanyFollowState(
+            page,
+            runtime.selectorLocale
+          );
+          if (followState === "following") {
+            throw new LinkedInAssistantError(
+              "ACTION_PRECONDITION_FAILED",
+              `Already following company "${targetCompany}".`,
+              {
+                target_company: targetCompany,
+                company_url: companyUrl
+              }
+            );
+          }
+
+          const selectorKey = await clickCompanyAction({
+            page,
+            selectorLocale: runtime.selectorLocale,
+            selectorKeys: "follow",
+            actionLabel: "Follow",
+            targetCompany,
+            candidateKeyPrefix: "company-follow"
+          });
+
+          const followed = await waitForCondition(async () => {
+            const nextState = await readCompanyFollowState(
+              page,
+              runtime.selectorLocale
+            );
+            return nextState === "following";
+          }, 5_000);
+
+          if (!followed) {
+            throw new LinkedInAssistantError(
+              "UNKNOWN",
+              "Company follow action could not be verified after clicking the control.",
+              {
+                target_company: targetCompany,
+                company_url: companyUrl,
+                follow_selector_key: selectorKey
+              }
+            );
+          }
+
+          return {
+            ok: true,
+            result: {
+              status: "company_followed",
+              target_company: targetCompany,
+              company_url: companyUrl,
+              follow_selector_key: selectorKey
+            },
+            artifacts: []
+          };
+        }
+      });
+    }
+  );
+}
+
+async function executeUnfollowCompanyPage(
+  runtime: LinkedInCompanyPagesExecutorRuntime,
+  actionId: string,
+  target: Record<string, unknown>
+): Promise<{ result: Record<string, unknown>; artifacts: string[] }> {
+  const targetCompany = String(target.target_company ?? "");
+  const profileName = String(target.profile_name ?? "default");
+  const companyUrl = normalizeLinkedInCompanyPageUrl(
+    String(target.company_url ?? targetCompany)
+  );
+
+  return runtime.profileManager.runWithContext(
+    {
+      cdpUrl: runtime.cdpUrl,
+      profileName,
+      headless: true
+    },
+    async (context) => {
+      const page = await getOrCreatePage(context);
+      return executeConfirmActionWithArtifacts({
+        runtime,
+        context,
+        page,
+        actionId,
+        actionType: UNFOLLOW_COMPANY_PAGE_ACTION_TYPE,
+        profileName,
+        targetUrl: companyUrl,
+        metadata: {
+          target_company: targetCompany,
+          company_url: companyUrl
+        },
+        errorDetails: {
+          target_company: targetCompany,
+          company_url: companyUrl
+        },
+        mapError: (error) =>
+          asLinkedInAssistantError(
+            error,
+            "UNKNOWN",
+            "Failed to execute LinkedIn company unfollow action."
+          ),
+        execute: async () => {
+          await page.goto(buildCompanyPageAboutUrl(companyUrl), {
+            waitUntil: "domcontentloaded"
+          });
+          await waitForNetworkIdleBestEffort(page);
+          await waitForCompanyPageReady(page);
+
+          const followState = await readCompanyFollowState(
+            page,
+            runtime.selectorLocale
+          );
+          if (followState === "not_following") {
+            throw new LinkedInAssistantError(
+              "ACTION_PRECONDITION_FAILED",
+              `Already not following company "${targetCompany}".`,
+              {
+                target_company: targetCompany,
+                company_url: companyUrl
+              }
+            );
+          }
+
+          const selectorKey = await clickCompanyAction({
+            page,
+            selectorLocale: runtime.selectorLocale,
+            selectorKeys: "following",
+            actionLabel: "Unfollow",
+            targetCompany,
+            candidateKeyPrefix: "company-unfollow"
+          });
+
+          const unfollowed = await waitForCondition(async () => {
+            const nextState = await readCompanyFollowState(
+              page,
+              runtime.selectorLocale
+            );
+            return nextState === "not_following";
+          }, 5_000);
+
+          if (!unfollowed) {
+            throw new LinkedInAssistantError(
+              "UNKNOWN",
+              "Company unfollow action could not be verified after clicking the control.",
+              {
+                target_company: targetCompany,
+                company_url: companyUrl,
+                unfollow_selector_key: selectorKey
+              }
+            );
+          }
+
+          return {
+            ok: true,
+            result: {
+              status: "company_unfollowed",
+              target_company: targetCompany,
+              company_url: companyUrl,
+              unfollow_selector_key: selectorKey
+            },
+            artifacts: []
+          };
+        }
+      });
+    }
+  );
+}
+
+export class FollowCompanyPageActionExecutor
+  implements ActionExecutor<LinkedInCompanyPagesExecutorRuntime>
+{
+  async execute(
+    input: ActionExecutorInput<LinkedInCompanyPagesExecutorRuntime>
+  ): Promise<ActionExecutorResult> {
+    const { result, artifacts } = await executeFollowCompanyPage(
+      input.runtime,
+      input.action.id,
+      input.action.target
+    );
+    return { ok: true, result, artifacts };
+  }
+}
+
+export class UnfollowCompanyPageActionExecutor
+  implements ActionExecutor<LinkedInCompanyPagesExecutorRuntime>
+{
+  async execute(
+    input: ActionExecutorInput<LinkedInCompanyPagesExecutorRuntime>
+  ): Promise<ActionExecutorResult> {
+    const { result, artifacts } = await executeUnfollowCompanyPage(
+      input.runtime,
+      input.action.id,
+      input.action.target
+    );
+    return { ok: true, result, artifacts };
+  }
+}
+
+export function createCompanyPageActionExecutors(): Record<
+  string,
+  ActionExecutor<LinkedInCompanyPagesExecutorRuntime>
+> {
+  return {
+    [FOLLOW_COMPANY_PAGE_ACTION_TYPE]: new FollowCompanyPageActionExecutor(),
+    [UNFOLLOW_COMPANY_PAGE_ACTION_TYPE]: new UnfollowCompanyPageActionExecutor()
+  };
+}
+
+export class LinkedInCompanyPagesService {
+  constructor(private readonly runtime: LinkedInCompanyPagesRuntime) {}
+
+  private prepareCompanyPageAction(input: {
+    actionType: string;
+    profileName?: string | undefined;
+    targetCompany: string;
+    operatorNote?: string | undefined;
+    summary: string;
+  }): {
+    preparedActionId: string;
+    confirmToken: string;
+    expiresAtMs: number;
+    preview: Record<string, unknown>;
+  } {
+    const profileName = input.profileName ?? "default";
+    const targetCompany = normalizeText(input.targetCompany);
+    if (!targetCompany) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        "targetCompany is required."
+      );
+    }
+
+    const companyUrl = normalizeLinkedInCompanyPageUrl(targetCompany);
+    const target = {
+      profile_name: profileName,
+      target_company: targetCompany,
+      company_url: companyUrl
+    };
+
+    return this.runtime.twoPhaseCommit.prepare({
+      actionType: input.actionType,
+      target,
+      payload: {},
+      preview: {
+        summary: input.summary,
+        target
+      },
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+    });
+  }
+
+  async viewCompanyPage(input: ViewCompanyPageInput): Promise<LinkedInCompanyPage> {
+    const profileName = input.profileName ?? "default";
+    const companyUrl = normalizeLinkedInCompanyPageUrl(input.target);
+    const aboutUrl = buildCompanyPageAboutUrl(companyUrl);
+
+    await this.runtime.auth.ensureAuthenticated({
+      profileName,
+      cdpUrl: this.runtime.cdpUrl
+    });
+
+    try {
+      return await this.runtime.profileManager.runWithContext(
+        {
+          cdpUrl: this.runtime.cdpUrl,
+          profileName,
+          headless: true
+        },
+        async (context) => {
+          const page = await getOrCreatePage(context);
+          await page.goto(aboutUrl, { waitUntil: "domcontentloaded" });
+          await waitForNetworkIdleBestEffort(page);
+          await waitForCompanyPageReady(page);
+
+          const company = await extractCompanyPageData(page);
+          const followState = await readCompanyFollowState(
+            page,
+            this.runtime.selectorLocale
+          );
+
+          return {
+            ...company,
+            company_url: normalizeLinkedInCompanyPageUrl(
+              company.company_url || companyUrl
+            ),
+            about_url: buildCompanyPageAboutUrl(
+              company.company_url || companyUrl
+            ),
+            slug: company.slug ?? extractCompanySlug(companyUrl),
+            follow_state: followState
+          };
+        }
+      );
+    } catch (error) {
+      if (error instanceof LinkedInAssistantError) {
+        throw error;
+      }
+      throw asLinkedInAssistantError(
+        error,
+        "UNKNOWN",
+        "Failed to view LinkedIn company page."
+      );
+    }
+  }
+
+  prepareFollowCompanyPage(input: PrepareFollowCompanyPageInput): {
+    preparedActionId: string;
+    confirmToken: string;
+    expiresAtMs: number;
+    preview: Record<string, unknown>;
+  } {
+    return this.prepareCompanyPageAction({
+      actionType: FOLLOW_COMPANY_PAGE_ACTION_TYPE,
+      operatorNote: input.operatorNote,
+      profileName: input.profileName,
+      targetCompany: input.targetCompany,
+      summary: `Follow company ${normalizeText(input.targetCompany)}`
+    });
+  }
+
+  prepareUnfollowCompanyPage(input: PrepareUnfollowCompanyPageInput): {
+    preparedActionId: string;
+    confirmToken: string;
+    expiresAtMs: number;
+    preview: Record<string, unknown>;
+  } {
+    return this.prepareCompanyPageAction({
+      actionType: UNFOLLOW_COMPANY_PAGE_ACTION_TYPE,
+      operatorNote: input.operatorNote,
+      profileName: input.profileName,
+      targetCompany: input.targetCompany,
+      summary: `Unfollow company ${normalizeText(input.targetCompany)}`
+    });
+  }
+}

--- a/packages/core/src/linkedinSearch.ts
+++ b/packages/core/src/linkedinSearch.ts
@@ -34,7 +34,48 @@ export interface LinkedInJobResult {
   employment_type: string;
 }
 
-export type SearchCategory = "people" | "companies" | "jobs";
+export interface LinkedInPostSearchResult {
+  author: string;
+  author_headline: string;
+  posted_at: string;
+  text: string;
+  post_url: string;
+  reaction_count: string;
+  comment_count: string;
+}
+
+export interface LinkedInGroupSearchResult {
+  name: string;
+  group_type: string;
+  member_count: string;
+  description: string;
+  group_url: string;
+}
+
+export interface LinkedInEventSearchResult {
+  title: string;
+  date: string;
+  location: string;
+  organizer: string;
+  description: string;
+  attendee_count: string;
+  event_url: string;
+}
+
+export const SEARCH_CATEGORIES = [
+  "people",
+  "companies",
+  "jobs",
+  "posts",
+  "groups",
+  "events"
+] as const;
+
+export type SearchCategory = (typeof SEARCH_CATEGORIES)[number];
+
+export function isSearchCategory(value: string): value is SearchCategory {
+  return (SEARCH_CATEGORIES as readonly string[]).includes(value);
+}
 
 export interface SearchInput {
   profileName?: string;
@@ -64,10 +105,34 @@ export interface SearchJobsResult {
   count: number;
 }
 
+export interface SearchPostsResult {
+  query: string;
+  category: "posts";
+  results: LinkedInPostSearchResult[];
+  count: number;
+}
+
+export interface SearchGroupsResult {
+  query: string;
+  category: "groups";
+  results: LinkedInGroupSearchResult[];
+  count: number;
+}
+
+export interface SearchEventsResult {
+  query: string;
+  category: "events";
+  results: LinkedInEventSearchResult[];
+  count: number;
+}
+
 export type SearchResult =
   | SearchPeopleResult
   | SearchCompaniesResult
-  | SearchJobsResult;
+  | SearchJobsResult
+  | SearchPostsResult
+  | SearchGroupsResult
+  | SearchEventsResult;
 
 export interface LinkedInSearchRuntime {
   auth: LinkedInAuthService;
@@ -121,6 +186,12 @@ export function buildSearchUrl(
       return `https://www.linkedin.com/search/results/companies/?keywords=${encodedQuery}`;
     case "jobs":
       return `https://www.linkedin.com/search/results/jobs/?keywords=${encodedQuery}`;
+    case "posts":
+      return `https://www.linkedin.com/search/results/posts/?keywords=${encodedQuery}&skipRedirect=true`;
+    case "groups":
+      return `https://www.linkedin.com/search/results/groups/?keywords=${encodedQuery}`;
+    case "events":
+      return `https://www.linkedin.com/search/results/events/?keywords=${encodedQuery}`;
   }
 }
 
@@ -137,6 +208,12 @@ export class LinkedInSearchService {
         return this.searchCompanies(input);
       case "jobs":
         return this.searchJobs(input);
+      case "posts":
+        return this.searchPosts(input);
+      case "groups":
+        return this.searchGroups(input);
+      case "events":
+        return this.searchEvents(input);
     }
   }
 
@@ -525,6 +602,387 @@ export class LinkedInSearchService {
         error,
         "UNKNOWN",
         "Failed to search LinkedIn jobs."
+      );
+    }
+  }
+
+  private async searchPosts(input: SearchInput): Promise<SearchPostsResult> {
+    const profileName = input.profileName ?? "default";
+    const query = normalizeText(input.query);
+    const limit = readSearchLimit(input.limit);
+    if (!query) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        "query is required."
+      );
+    }
+
+    await this.runtime.auth.ensureAuthenticated({
+      profileName
+    });
+
+    try {
+      const snapshots = await this.runtime.profileManager.runWithPersistentContext(
+        profileName,
+        { headless: true },
+        async (context) => {
+          const page = await getOrCreatePage(context);
+          await page.goto(buildSearchUrl(query, "posts"), {
+            waitUntil: "domcontentloaded"
+          });
+          await waitForNetworkIdleBestEffort(page);
+          await page.waitForTimeout(2_000);
+
+          return page.evaluate((lim: number) => {
+            const normalize = (value: string | null | undefined): string =>
+              (value ?? "").replace(/\s+/g, " ").trim();
+            const origin = globalThis.window.location.origin;
+            const toAbsoluteHref = (value: string): string => {
+              if (!value) {
+                return "";
+              }
+              if (/^https?:\/\//i.test(value)) {
+                return value;
+              }
+              return value.startsWith("/") ? `${origin}${value}` : `${origin}/${value}`;
+            };
+
+            if (
+              normalize(globalThis.document.body?.innerText).includes(
+                "We've filed a report for this error."
+              )
+            ) {
+              return [] as Array<Record<string, string>>;
+            }
+
+            const anchors = Array.from(
+              globalThis.document.querySelectorAll(
+                "a[href*='/feed/update/'], a[href*='/posts/']"
+              )
+            ) as HTMLAnchorElement[];
+            const seen = new Set<string>();
+            const results: Array<Record<string, string>> = [];
+
+            for (const anchor of anchors) {
+              const href = toAbsoluteHref(
+                normalize(anchor.getAttribute("href")) || normalize(anchor.href)
+              );
+              if (!href || seen.has(href)) {
+                continue;
+              }
+              seen.add(href);
+
+              const container = anchor.closest("article, li, div") ?? anchor;
+              const lines = ((container as HTMLElement).innerText ?? container.textContent ?? "")
+                .split(/\n+/)
+                .map((value) => normalize(value))
+                .filter((value) => value.length > 0);
+              if (lines.length === 0) {
+                continue;
+              }
+
+              const postedAt =
+                lines.find((line) =>
+                  /\b(?:h|d|w|mo|yr|hour|day|week|month|year)s?\b/i.test(line)
+                ) ?? "";
+              const reactionCount =
+                lines.find((line) => /\breactions?\b/i.test(line)) ?? "";
+              const commentCount =
+                lines.find((line) => /\bcomments?\b/i.test(line)) ?? "";
+              const author =
+                container.querySelector("span[dir='ltr'], span[aria-hidden='true']")
+                  ?.textContent ??
+                lines[0] ??
+                "";
+
+              results.push({
+                author: normalize(author),
+                author_headline: "",
+                posted_at: postedAt,
+                text: lines.slice(0, 8).join(" "),
+                post_url: href,
+                reaction_count: reactionCount,
+                comment_count: commentCount
+              });
+
+              if (results.length >= lim) {
+                break;
+              }
+            }
+
+            return results;
+          }, limit);
+        }
+      );
+
+      const results = snapshots
+        .map((snapshot) => ({
+          author: normalizeText(snapshot.author),
+          author_headline: normalizeText(snapshot.author_headline),
+          posted_at: normalizeText(snapshot.posted_at),
+          text: normalizeText(snapshot.text),
+          post_url: normalizeText(snapshot.post_url),
+          reaction_count: normalizeText(snapshot.reaction_count),
+          comment_count: normalizeText(snapshot.comment_count)
+        }))
+        .filter((result) => result.text.length > 0 || result.post_url.length > 0)
+        .slice(0, limit);
+
+      return {
+        query,
+        category: "posts",
+        results,
+        count: results.length
+      };
+    } catch (error) {
+      if (error instanceof LinkedInAssistantError) {
+        throw error;
+      }
+      throw asLinkedInAssistantError(
+        error,
+        "UNKNOWN",
+        "Failed to search LinkedIn posts."
+      );
+    }
+  }
+
+  private async searchGroups(input: SearchInput): Promise<SearchGroupsResult> {
+    const profileName = input.profileName ?? "default";
+    const query = normalizeText(input.query);
+    const limit = readSearchLimit(input.limit);
+    if (!query) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        "query is required."
+      );
+    }
+
+    await this.runtime.auth.ensureAuthenticated({
+      profileName
+    });
+
+    try {
+      const snapshots = await this.runtime.profileManager.runWithPersistentContext(
+        profileName,
+        { headless: true },
+        async (context) => {
+          const page = await getOrCreatePage(context);
+          await page.goto(buildSearchUrl(query, "groups"), {
+            waitUntil: "domcontentloaded"
+          });
+          await waitForNetworkIdleBestEffort(page);
+          await page.waitForTimeout(2_000);
+
+          return page.evaluate((lim: number) => {
+            const normalize = (value: string | null | undefined): string =>
+              (value ?? "").replace(/\s+/g, " ").trim();
+            const origin = globalThis.window.location.origin;
+            const toAbsoluteHref = (value: string): string => {
+              if (!value) {
+                return "";
+              }
+              if (/^https?:\/\//i.test(value)) {
+                return value;
+              }
+              return value.startsWith("/") ? `${origin}${value}` : `${origin}/${value}`;
+            };
+
+            const anchors = Array.from(
+              globalThis.document.querySelectorAll("a[href*='/groups/']")
+            ) as HTMLAnchorElement[];
+            const seen = new Set<string>();
+            const results: Array<Record<string, string>> = [];
+
+            for (const anchor of anchors) {
+              const href = toAbsoluteHref(
+                normalize(anchor.getAttribute("href")) || normalize(anchor.href)
+              );
+              if (!href || seen.has(href)) {
+                continue;
+              }
+              seen.add(href);
+
+              const lines = (anchor.innerText ?? "")
+                .split(/\n+/)
+                .map((value) => normalize(value))
+                .filter((value) => value.length > 0);
+              if (lines.length < 2) {
+                continue;
+              }
+
+              const filteredLines = lines.filter(
+                (line) => !/^(Join|Requested|View)$/i.test(line)
+              );
+
+              results.push({
+                name: filteredLines[0] ?? "",
+                group_type: filteredLines[1] ?? "",
+                member_count: filteredLines[2] ?? "",
+                description: filteredLines.slice(3).join(" "),
+                group_url: href
+              });
+
+              if (results.length >= lim) {
+                break;
+              }
+            }
+
+            return results;
+          }, limit);
+        }
+      );
+
+      const results = snapshots
+        .map((snapshot) => ({
+          name: normalizeText(snapshot.name),
+          group_type: normalizeText(snapshot.group_type),
+          member_count: normalizeText(snapshot.member_count),
+          description: normalizeText(snapshot.description),
+          group_url: normalizeText(snapshot.group_url)
+        }))
+        .filter((result) => result.name.length > 0 || result.group_url.length > 0)
+        .slice(0, limit);
+
+      return {
+        query,
+        category: "groups",
+        results,
+        count: results.length
+      };
+    } catch (error) {
+      if (error instanceof LinkedInAssistantError) {
+        throw error;
+      }
+      throw asLinkedInAssistantError(
+        error,
+        "UNKNOWN",
+        "Failed to search LinkedIn groups."
+      );
+    }
+  }
+
+  private async searchEvents(input: SearchInput): Promise<SearchEventsResult> {
+    const profileName = input.profileName ?? "default";
+    const query = normalizeText(input.query);
+    const limit = readSearchLimit(input.limit);
+    if (!query) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        "query is required."
+      );
+    }
+
+    await this.runtime.auth.ensureAuthenticated({
+      profileName
+    });
+
+    try {
+      const snapshots = await this.runtime.profileManager.runWithPersistentContext(
+        profileName,
+        { headless: true },
+        async (context) => {
+          const page = await getOrCreatePage(context);
+          await page.goto(buildSearchUrl(query, "events"), {
+            waitUntil: "domcontentloaded"
+          });
+          await waitForNetworkIdleBestEffort(page);
+          await page.waitForTimeout(2_000);
+
+          return page.evaluate((lim: number) => {
+            const normalize = (value: string | null | undefined): string =>
+              (value ?? "").replace(/\s+/g, " ").trim();
+            const origin = globalThis.window.location.origin;
+            const toAbsoluteHref = (value: string): string => {
+              if (!value) {
+                return "";
+              }
+              if (/^https?:\/\//i.test(value)) {
+                return value;
+              }
+              return value.startsWith("/") ? `${origin}${value}` : `${origin}/${value}`;
+            };
+
+            const anchors = Array.from(
+              globalThis.document.querySelectorAll("a[href*='/events/']")
+            ) as HTMLAnchorElement[];
+            const seen = new Set<string>();
+            const results: Array<Record<string, string>> = [];
+
+            for (const anchor of anchors) {
+              const href = toAbsoluteHref(
+                normalize(anchor.getAttribute("href")) || normalize(anchor.href)
+              );
+              if (!href || seen.has(href)) {
+                continue;
+              }
+              seen.add(href);
+
+              const lines = (anchor.innerText ?? "")
+                .split(/\n+/)
+                .map((value) => normalize(value))
+                .filter((value) => value.length > 0);
+              if (lines.length < 2) {
+                continue;
+              }
+
+              const venueLine = lines[2] ?? "";
+              const organizerMatch = /^(.*)\s+.\s+By\s+(.*)$/.exec(venueLine);
+              const descriptionLines = lines.slice(3);
+              const attendeeIndex = descriptionLines.findIndex((line) =>
+                /\battendees?\b/i.test(line)
+              );
+
+              results.push({
+                title: lines[0] ?? "",
+                date: lines[1] ?? "",
+                location: normalize(organizerMatch?.[1] ?? venueLine),
+                organizer: normalize(organizerMatch?.[2] ?? ""),
+                description:
+                  attendeeIndex >= 0
+                    ? descriptionLines.slice(0, attendeeIndex).join(" ")
+                    : descriptionLines.join(" "),
+                attendee_count:
+                  attendeeIndex >= 0 ? descriptionLines[attendeeIndex] ?? "" : "",
+                event_url: href
+              });
+
+              if (results.length >= lim) {
+                break;
+              }
+            }
+
+            return results;
+          }, limit);
+        }
+      );
+
+      const results = snapshots
+        .map((snapshot) => ({
+          title: normalizeText(snapshot.title),
+          date: normalizeText(snapshot.date),
+          location: normalizeText(snapshot.location),
+          organizer: normalizeText(snapshot.organizer),
+          description: normalizeText(snapshot.description),
+          attendee_count: normalizeText(snapshot.attendee_count),
+          event_url: normalizeText(snapshot.event_url)
+        }))
+        .filter((result) => result.title.length > 0 || result.event_url.length > 0)
+        .slice(0, limit);
+
+      return {
+        query,
+        category: "events",
+        results,
+        count: results.length
+      };
+    } catch (error) {
+      if (error instanceof LinkedInAssistantError) {
+        throw error;
+      }
+      throw asLinkedInAssistantError(
+        error,
+        "UNKNOWN",
+        "Failed to search LinkedIn events."
       );
     }
   }

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -22,6 +22,11 @@ import {
   type LinkedInConnectionsRuntime
 } from "./linkedinConnections.js";
 import {
+  createCompanyPageActionExecutors,
+  LinkedInCompanyPagesService,
+  type LinkedInCompanyPagesRuntime
+} from "./linkedinCompanyPages.js";
+import {
   createMemberActionExecutors,
   LinkedInMembersService,
   type LinkedInMembersRuntime
@@ -161,6 +166,7 @@ export interface CoreRuntime {
   profileManager: ProfileManager;
   auth: LinkedInAuthService;
   profile: LinkedInProfileService;
+  companyPages: LinkedInCompanyPagesService;
   imageAssets: LinkedInImageAssetsService;
   search: LinkedInSearchService;
   jobs: LinkedInJobsService;
@@ -264,6 +270,10 @@ export function createCoreRuntime(
     string,
     import("./twoPhaseCommit.js").ActionExecutor<LinkedInMessagingRuntime>
   >;
+  const companyPageExecutors = createCompanyPageActionExecutors() as unknown as Record<
+    string,
+    import("./twoPhaseCommit.js").ActionExecutor<LinkedInMessagingRuntime>
+  >;
   const memberExecutors = createMemberActionExecutors() as unknown as Record<
     string,
     import("./twoPhaseCommit.js").ActionExecutor<LinkedInMessagingRuntime>
@@ -292,6 +302,7 @@ export function createCoreRuntime(
       ...linkedInExecutors,
       ...profileExecutors,
       ...connectionExecutors,
+      ...companyPageExecutors,
       ...memberExecutors,
       ...followupExecutors,
       ...feedExecutors,
@@ -326,6 +337,7 @@ export function createCoreRuntime(
       evasion
     ),
     profile: undefined as unknown as LinkedInProfileService,
+    companyPages: undefined as unknown as LinkedInCompanyPagesService,
     imageAssets: undefined as unknown as LinkedInImageAssetsService,
     search: undefined as unknown as LinkedInSearchService,
     jobs: undefined as unknown as LinkedInJobsService,
@@ -367,6 +379,8 @@ export function createCoreRuntime(
 
   const profileRuntime: LinkedInProfileRuntime = runtime;
   runtime.profile = new LinkedInProfileService(profileRuntime);
+  const companyPagesRuntime: LinkedInCompanyPagesRuntime = runtime;
+  runtime.companyPages = new LinkedInCompanyPagesService(companyPagesRuntime);
   runtime.imageAssets = new LinkedInImageAssetsService(
     {
       logger,

--- a/packages/mcp/src/__tests__/linkedinMcp.test.ts
+++ b/packages/mcp/src/__tests__/linkedinMcp.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  LINKEDIN_COMPANY_PREPARE_FOLLOW_TOOL,
+  LINKEDIN_COMPANY_VIEW_TOOL,
   LINKEDIN_MEMBERS_PREPARE_REPORT_TOOL,
   LINKEDIN_PRIVACY_GET_SETTINGS_TOOL
 } from "../index.js";
@@ -20,6 +22,10 @@ vi.mock("@linkedin-assistant/core", async () => {
 
 interface FakeRuntime {
   close: ReturnType<typeof vi.fn>;
+  companyPages: {
+    prepareFollowCompanyPage: ReturnType<typeof vi.fn>;
+    viewCompanyPage: ReturnType<typeof vi.fn>;
+  };
   logger: {
     log: ReturnType<typeof vi.fn>;
   };
@@ -36,6 +42,10 @@ function createFakeRuntime(): FakeRuntime {
   return {
     runId: "run_test",
     close: vi.fn(),
+    companyPages: {
+      prepareFollowCompanyPage: vi.fn(),
+      viewCompanyPage: vi.fn()
+    },
     logger: {
       log: vi.fn()
     },
@@ -133,6 +143,75 @@ describe("handleToolCall", () => {
       targetProfile: "target-user",
       reason: "spam",
       details: "Repeated unsolicited outreach."
+    });
+    expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns company page payloads through the MCP contract", async () => {
+    fakeRuntime.companyPages.viewCompanyPage.mockResolvedValue({
+      company_url: "https://www.linkedin.com/company/openai/",
+      about_url: "https://www.linkedin.com/company/openai/about/",
+      slug: "openai",
+      name: "OpenAI",
+      industry: "Research Services",
+      location: "San Francisco, CA",
+      follower_count: "10M followers",
+      employee_count: "201-500 employees",
+      associated_members: "7,548 associated members",
+      website: "https://openai.com/",
+      verified_on: "June 15, 2023",
+      headquarters: "San Francisco, CA",
+      specialties: "artificial intelligence and machine learning",
+      overview: "OpenAI is an AI research and deployment company.",
+      follow_state: "following"
+    });
+
+    const result = await handleToolCall(LINKEDIN_COMPANY_VIEW_TOOL, {
+      profileName: "default",
+      target: "openai"
+    });
+
+    expect("isError" in result && result.isError).toBe(false);
+    expect(parseToolPayload(result)).toMatchObject({
+      run_id: "run_test",
+      profile_name: "default",
+      company: {
+        name: "OpenAI",
+        follow_state: "following"
+      }
+    });
+    expect(fakeRuntime.companyPages.viewCompanyPage).toHaveBeenCalledWith({
+      profileName: "default",
+      target: "openai"
+    });
+    expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("prepares company follow actions through the MCP contract", async () => {
+    fakeRuntime.companyPages.prepareFollowCompanyPage.mockReturnValue({
+      preparedActionId: "pa_company",
+      confirmToken: "ct_company",
+      expiresAtMs: 456,
+      preview: {
+        summary: "Follow company openai"
+      }
+    });
+
+    const result = await handleToolCall(LINKEDIN_COMPANY_PREPARE_FOLLOW_TOOL, {
+      profileName: "default",
+      targetCompany: "openai"
+    });
+
+    expect("isError" in result && result.isError).toBe(false);
+    expect(parseToolPayload(result)).toMatchObject({
+      run_id: "run_test",
+      profile_name: "default",
+      preparedActionId: "pa_company",
+      confirmToken: "ct_company"
+    });
+    expect(fakeRuntime.companyPages.prepareFollowCompanyPage).toHaveBeenCalledWith({
+      profileName: "default",
+      targetCompany: "openai"
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });

--- a/packages/mcp/src/bin/linkedin-mcp.ts
+++ b/packages/mcp/src/bin/linkedin-mcp.ts
@@ -18,6 +18,7 @@ import {
   LinkedInAssistantError,
   buildLinkedInImagePersonaFromProfileSeed,
   createCoreRuntime,
+  isSearchCategory,
   normalizeLinkedInFeedReaction,
   normalizeLinkedInInboxReaction,
   normalizeLinkedInMemberReportReason,
@@ -27,6 +28,7 @@ import {
   resolveFollowupSinceWindow,
   redactStructuredValue,
   resolvePrivacyConfig,
+  SEARCH_CATEGORIES,
   toLinkedInAssistantErrorPayload,
   WEBHOOK_DELIVERY_ATTEMPT_STATUSES,
   WEBHOOK_SUBSCRIPTION_STATUSES,
@@ -60,6 +62,9 @@ import {
   LINKEDIN_ACTIVITY_WEBHOOK_PAUSE_TOOL,
   LINKEDIN_ACTIVITY_WEBHOOK_REMOVE_TOOL,
   LINKEDIN_ACTIVITY_WEBHOOK_RESUME_TOOL,
+  LINKEDIN_COMPANY_PREPARE_FOLLOW_TOOL,
+  LINKEDIN_COMPANY_PREPARE_UNFOLLOW_TOOL,
+  LINKEDIN_COMPANY_VIEW_TOOL,
   LINKEDIN_CONNECTIONS_ACCEPT_TOOL,
   LINKEDIN_CONNECTIONS_INVITE_TOOL,
   LINKEDIN_CONNECTIONS_LIST_TOOL,
@@ -425,13 +430,13 @@ function readSearchCategory(
   }
 
   const category = value.trim();
-  if (category === "people" || category === "companies" || category === "jobs") {
+  if (isSearchCategory(category)) {
     return category;
   }
 
   throw new LinkedInAssistantError(
     "ACTION_PRECONDITION_FAILED",
-    `${key} must be one of: people, companies, jobs.`
+    `${key} must be one of: ${SEARCH_CATEGORIES.join(", ")}.`
   );
 }
 
@@ -1052,6 +1057,38 @@ async function handleProfileView(args: ToolArgs): Promise<ToolResult> {
       run_id: runtime.runId,
       profile_name: profileName,
       profile
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function handleCompanyView(args: ToolArgs): Promise<ToolResult> {
+  const runtime = createRuntime(args);
+
+  try {
+    const profileName = readString(args, "profileName", "default");
+    const target = readRequiredString(args, "target");
+
+    runtime.logger.log("info", "mcp.company.view.start", {
+      profileName,
+      target
+    });
+
+    const company = await runtime.companyPages.viewCompanyPage({
+      profileName,
+      target
+    });
+
+    runtime.logger.log("info", "mcp.company.view.done", {
+      profileName,
+      companyName: company.name
+    });
+
+    return toToolResult({
+      run_id: runtime.runId,
+      profile_name: profileName,
+      company
     });
   } finally {
     runtime.close();
@@ -2149,6 +2186,76 @@ async function handleConnectionsPrepareUnfollow(
     });
 
     runtime.logger.log("info", "mcp.connections.prepare_unfollow.done", {
+      profileName,
+      preparedActionId: prepared.preparedActionId
+    });
+
+    return toToolResult({
+      run_id: runtime.runId,
+      profile_name: profileName,
+      ...prepared
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function handleCompanyPrepareFollow(args: ToolArgs): Promise<ToolResult> {
+  const runtime = createRuntime(args);
+
+  try {
+    const profileName = readString(args, "profileName", "default");
+    const targetCompany = readRequiredString(args, "targetCompany");
+    const operatorNote = readString(args, "operatorNote", "");
+
+    runtime.logger.log("info", "mcp.company.prepare_follow.start", {
+      profileName,
+      targetCompany
+    });
+
+    const prepared = runtime.companyPages.prepareFollowCompanyPage({
+      profileName,
+      targetCompany,
+      ...(operatorNote ? { operatorNote } : {})
+    });
+
+    runtime.logger.log("info", "mcp.company.prepare_follow.done", {
+      profileName,
+      preparedActionId: prepared.preparedActionId
+    });
+
+    return toToolResult({
+      run_id: runtime.runId,
+      profile_name: profileName,
+      ...prepared
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function handleCompanyPrepareUnfollow(
+  args: ToolArgs
+): Promise<ToolResult> {
+  const runtime = createRuntime(args);
+
+  try {
+    const profileName = readString(args, "profileName", "default");
+    const targetCompany = readRequiredString(args, "targetCompany");
+    const operatorNote = readString(args, "operatorNote", "");
+
+    runtime.logger.log("info", "mcp.company.prepare_unfollow.start", {
+      profileName,
+      targetCompany
+    });
+
+    const prepared = runtime.companyPages.prepareUnfollowCompanyPage({
+      profileName,
+      targetCompany,
+      ...(operatorNote ? { operatorNote } : {})
+    });
+
+    runtime.logger.log("info", "mcp.company.prepare_unfollow.done", {
       profileName,
       preparedActionId: prepared.preparedActionId
     });
@@ -3625,6 +3732,28 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         }
       },
       {
+        name: LINKEDIN_COMPANY_VIEW_TOOL,
+        description: withSelectorAuditHint(
+          "View a LinkedIn company page. Returns structured company overview, details, and current follow state."
+        ),
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+          required: ["target"],
+          properties: withCdpSchemaProperties({
+            profileName: {
+              type: "string",
+              description: "Persistent Playwright profile name. Defaults to default."
+            },
+            target: {
+              type: "string",
+              description:
+                "Company slug, /company/ path, or LinkedIn company URL."
+            }
+          })
+        }
+      },
+      {
         name: LINKEDIN_PROFILE_VIEW_TOOL,
         description:
           withSelectorAuditHint(
@@ -4157,7 +4286,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: LINKEDIN_SEARCH_TOOL,
         description: withSelectorAuditHint(
-          "Search LinkedIn for people, companies, or jobs."
+          `Search LinkedIn for ${SEARCH_CATEGORIES.join(", ")}.`
         ),
         inputSchema: {
           type: "object",
@@ -4175,7 +4304,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             category: {
               type: "string",
-              enum: ["people", "companies", "jobs"],
+              enum: [...SEARCH_CATEGORIES],
               description: "Search category. Defaults to people."
             },
             limit: {
@@ -4361,6 +4490,54 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             operatorNote: {
               type: "string",
               description: "Internal note for audit."
+            }
+          })
+        }
+      },
+      {
+        name: LINKEDIN_COMPANY_PREPARE_FOLLOW_TOOL,
+        description:
+          "Prepare to follow a LinkedIn company page (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+          required: ["targetCompany"],
+          properties: withCdpSchemaProperties({
+            profileName: {
+              type: "string",
+              description: "Persistent Playwright profile name. Defaults to default."
+            },
+            targetCompany: {
+              type: "string",
+              description: "Company slug, /company/ path, or company URL."
+            },
+            operatorNote: {
+              type: "string",
+              description: "Optional note attached to the prepared action."
+            }
+          })
+        }
+      },
+      {
+        name: LINKEDIN_COMPANY_PREPARE_UNFOLLOW_TOOL,
+        description:
+          "Prepare to unfollow a LinkedIn company page (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+          required: ["targetCompany"],
+          properties: withCdpSchemaProperties({
+            profileName: {
+              type: "string",
+              description: "Persistent Playwright profile name. Defaults to default."
+            },
+            targetCompany: {
+              type: "string",
+              description: "Company slug, /company/ path, or company URL."
+            },
+            operatorNote: {
+              type: "string",
+              description: "Optional note attached to the prepared action."
             }
           })
         }
@@ -5365,6 +5542,7 @@ const TOOL_HANDLERS: Record<string, ToolHandler> = {
   [LINKEDIN_INBOX_UNARCHIVE_THREAD_TOOL]: handleUnarchiveThread,
   [LINKEDIN_INBOX_MARK_UNREAD_TOOL]: handleMarkUnread,
   [LINKEDIN_INBOX_MUTE_THREAD_TOOL]: handleMuteThread,
+  [LINKEDIN_COMPANY_VIEW_TOOL]: handleCompanyView,
   [LINKEDIN_PROFILE_VIEW_TOOL]: handleProfileView,
   [LINKEDIN_PROFILE_VIEW_EDITABLE_TOOL]: handleProfileViewEditable,
   [LINKEDIN_PROFILE_PREPARE_UPDATE_INTRO_TOOL]: handleProfilePrepareUpdateIntro,
@@ -5398,6 +5576,8 @@ const TOOL_HANDLERS: Record<string, ToolHandler> = {
   [LINKEDIN_CONNECTIONS_WITHDRAW_TOOL]: handleConnectionsWithdraw,
   [LINKEDIN_CONNECTIONS_PREPARE_IGNORE_TOOL]: handleConnectionsPrepareIgnore,
   [LINKEDIN_CONNECTIONS_PREPARE_REMOVE_TOOL]: handleConnectionsPrepareRemove,
+  [LINKEDIN_COMPANY_PREPARE_FOLLOW_TOOL]: handleCompanyPrepareFollow,
+  [LINKEDIN_COMPANY_PREPARE_UNFOLLOW_TOOL]: handleCompanyPrepareUnfollow,
   [LINKEDIN_CONNECTIONS_PREPARE_FOLLOW_TOOL]: handleConnectionsPrepareFollow,
   [LINKEDIN_CONNECTIONS_PREPARE_UNFOLLOW_TOOL]: handleConnectionsPrepareUnfollow,
   [LINKEDIN_MEMBERS_PREPARE_BLOCK_TOOL]: handleMembersPrepareBlock,

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -17,6 +17,11 @@ export const LINKEDIN_INBOX_UNARCHIVE_THREAD_TOOL =
 export const LINKEDIN_INBOX_MARK_UNREAD_TOOL = "linkedin.inbox.mark_unread";
 export const LINKEDIN_INBOX_MUTE_THREAD_TOOL = "linkedin.inbox.mute_thread";
 export const LINKEDIN_ACTIONS_CONFIRM_TOOL = "linkedin.actions.confirm";
+export const LINKEDIN_COMPANY_VIEW_TOOL = "linkedin.company.view";
+export const LINKEDIN_COMPANY_PREPARE_FOLLOW_TOOL =
+  "linkedin.company.prepare_follow";
+export const LINKEDIN_COMPANY_PREPARE_UNFOLLOW_TOOL =
+  "linkedin.company.prepare_unfollow";
 export const LINKEDIN_PROFILE_VIEW_TOOL = "linkedin.profile.view";
 export const LINKEDIN_PROFILE_VIEW_EDITABLE_TOOL = "linkedin.profile.view_editable";
 export const LINKEDIN_PROFILE_PREPARE_UPDATE_INTRO_TOOL =


### PR DESCRIPTION
## Summary
- add a company page core service with read-only view support plus prepared follow and unfollow actions
- expose the new company capabilities through the CLI and MCP server entrypoint
- expand discovery search to cover posts, groups, and events with shared category validation and tests

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build
- live: `node packages/cli/dist/bin/linkedin.js company view microsoft --profile default`
- live: `node packages/cli/dist/bin/linkedin.js company view openai --profile default`
- live: `node packages/cli/dist/bin/linkedin.js search marketing --profile default --category groups --limit 2`
- live: `node packages/cli/dist/bin/linkedin.js search AI --profile default --category events --limit 2`
- live: `node packages/cli/dist/bin/linkedin.js search OpenAI --profile default --category posts --limit 2`
- live: built MCP `handleToolCall()` for `linkedin.company.view`, `linkedin.search`, and `linkedin.company.prepare_follow`

## Notes
- Topic follow flows were not added because the current member UI did not expose a usable topic surface during live verification.
- Company follow and unfollow were validated through the prepare phase only. The approved test account currently hits LinkedIn email verification, and the existing authenticated `default` profile in this workspace is a personal account, so I did not run visible confirm actions from that session.

Closes #236