### PR TITLE
feat: add LinkedIn notification actions and preference support

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -438,6 +438,57 @@ function collectNonEmptyStrings(value: string, previous: string[]): string[] {
   return [...previous, ...nextValues];
 }
 
+function parseNotificationPreferenceAssignments(
+  values: string[]
+): Array<{ preference: string; enabled: boolean }> {
+  if (values.length === 0) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "At least one --set preference=on|off assignment is required."
+    );
+  }
+
+  return values.map((value) => {
+    const assignment = value.trim();
+    const equalsIndex = assignment.indexOf("=");
+    if (equalsIndex <= 0 || equalsIndex === assignment.length - 1) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `Invalid --set assignment "${value}". Use preference=on|off.`
+      );
+    }
+
+    const preference = assignment.slice(0, equalsIndex).trim();
+    const rawEnabled = assignment.slice(equalsIndex + 1).trim().toLowerCase();
+    const enabled =
+      rawEnabled === "true" ||
+      rawEnabled === "on" ||
+      rawEnabled === "enable" ||
+      rawEnabled === "enabled" ||
+      rawEnabled === "yes" ||
+      rawEnabled === "1";
+    const disabled =
+      rawEnabled === "false" ||
+      rawEnabled === "off" ||
+      rawEnabled === "disable" ||
+      rawEnabled === "disabled" ||
+      rawEnabled === "no" ||
+      rawEnabled === "0";
+
+    if (!preference || (!enabled && !disabled)) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `Invalid --set assignment "${value}". Use preference=on|off.`
+      );
+    }
+
+    return {
+      preference,
+      enabled
+    };
+  });
+}
+
 function uniqueFixtureReplayPageTypes(
   pageTypes: LinkedInReplayPageType[]
 ): LinkedInReplayPageType[] {
@@ -6695,6 +6746,143 @@ async function runNotificationsList(input: {
   }
 }
 
+async function runNotificationsMarkRead(input: {
+  profileName: string;
+  notification: string;
+}, cdpUrl?: string): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.notifications.mark_read.start", {
+      profileName: input.profileName,
+      notification: input.notification
+    });
+
+    const result = await runtime.notifications.markRead({
+      profileName: input.profileName,
+      notification: input.notification
+    });
+
+    runtime.logger.log("info", "cli.notifications.mark_read.done", {
+      profileName: input.profileName,
+      notificationId: result.notification.id,
+      status: result.status
+    });
+
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      ...result
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function runNotificationsDismiss(input: {
+  profileName: string;
+  notification: string;
+  operatorNote?: string;
+}, cdpUrl?: string): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.notifications.dismiss.start", {
+      profileName: input.profileName,
+      notification: input.notification
+    });
+
+    const prepared = await runtime.notifications.prepareDismiss({
+      profileName: input.profileName,
+      notification: input.notification,
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+    });
+
+    runtime.logger.log("info", "cli.notifications.dismiss.done", {
+      profileName: input.profileName,
+      preparedActionId: prepared.preparedActionId
+    });
+
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      ...prepared
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function runNotificationPreferencesGet(input: {
+  profileName: string;
+  notification: string;
+}, cdpUrl?: string): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.notifications.preferences.get.start", {
+      profileName: input.profileName,
+      notification: input.notification
+    });
+
+    const preferences = await runtime.notifications.getPreferences({
+      profileName: input.profileName,
+      notification: input.notification
+    });
+
+    runtime.logger.log("info", "cli.notifications.preferences.get.done", {
+      profileName: input.profileName,
+      notificationId: preferences.notification.id,
+      count: preferences.preferences.length
+    });
+
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      ...preferences
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function runNotificationPreferencesPrepareUpdate(input: {
+  profileName: string;
+  notification: string;
+  changes: Array<{ preference: string; enabled: boolean }>;
+  operatorNote?: string;
+}, cdpUrl?: string): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.notifications.preferences.prepare_update.start", {
+      profileName: input.profileName,
+      notification: input.notification,
+      changeCount: input.changes.length
+    });
+
+    const prepared = await runtime.notifications.prepareUpdatePreferences({
+      profileName: input.profileName,
+      notification: input.notification,
+      changes: input.changes,
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+    });
+
+    runtime.logger.log("info", "cli.notifications.preferences.prepare_update.done", {
+      profileName: input.profileName,
+      preparedActionId: prepared.preparedActionId
+    });
+
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      ...prepared
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
 async function runJobsSearch(input: {
   profileName: string;
   query: string;
@@ -8990,6 +9178,102 @@ export function createCliProgram(): Command {
         await runNotificationsList({
           profileName: options.profile,
           limit: coercePositiveInt(options.limit, "limit")
+        }, readCdpUrl());
+      }
+    );
+
+  notificationsCommand
+    .command("mark-read")
+    .description("Mark one LinkedIn notification as read")
+    .requiredOption(
+      "--notification <notification>",
+      "Notification id, full link, or a unique message fragment"
+    )
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .action(
+      async (options: { profile: string; notification: string }) => {
+        await runNotificationsMarkRead({
+          profileName: options.profile,
+          notification: options.notification
+        }, readCdpUrl());
+      }
+    );
+
+  notificationsCommand
+    .command("dismiss")
+    .description(
+      "Prepare a two-phase dismiss for one LinkedIn notification (confirm with actions confirm)"
+    )
+    .requiredOption(
+      "--notification <notification>",
+      "Notification id, full link, or a unique message fragment"
+    )
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .option("--operator-note <note>", "Internal note for audit")
+    .action(
+      async (options: {
+        profile: string;
+        notification: string;
+        operatorNote?: string;
+      }) => {
+        await runNotificationsDismiss({
+          profileName: options.profile,
+          notification: options.notification,
+          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
+        }, readCdpUrl());
+      }
+    );
+
+  const notificationPreferencesCommand = notificationsCommand
+    .command("preferences")
+    .description("Read and prepare notification preference updates");
+
+  notificationPreferencesCommand
+    .command("get")
+    .description("Read the preference toggles for one LinkedIn notification")
+    .requiredOption(
+      "--notification <notification>",
+      "Notification id, full link, or a unique message fragment"
+    )
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .action(
+      async (options: { profile: string; notification: string }) => {
+        await runNotificationPreferencesGet({
+          profileName: options.profile,
+          notification: options.notification
+        }, readCdpUrl());
+      }
+    );
+
+  notificationPreferencesCommand
+    .command("prepare-update")
+    .description(
+      "Prepare a two-phase notification preference update (confirm with actions confirm)"
+    )
+    .requiredOption(
+      "--notification <notification>",
+      "Notification id, full link, or a unique message fragment"
+    )
+    .requiredOption(
+      "--set <assignment>",
+      "Preference assignment in the form preference=on|off",
+      collectNonEmptyStrings,
+      [] as string[]
+    )
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .option("--operator-note <note>", "Internal note for audit")
+    .action(
+      async (options: {
+        profile: string;
+        notification: string;
+        set: string[];
+        operatorNote?: string;
+      }) => {
+        await runNotificationPreferencesPrepareUpdate({
+          profileName: options.profile,
+          notification: options.notification,
+          changes: parseNotificationPreferenceAssignments(options.set),
+          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
         }, readCdpUrl());
       }
     );

--- a/packages/core/src/__tests__/e2e/cli.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/cli.e2e.test.ts
@@ -586,5 +586,84 @@ describe.sequential("CLI E2E", () => {
       profile_name: profileName,
       notifications: expect.any(Array)
     });
+
+    const notificationPreferences = await runCliCommand([
+      "notifications",
+      "preferences",
+      "get",
+      "--profile",
+      profileName,
+      "--notification",
+      fixtures.notificationId
+    ]);
+    expect(notificationPreferences.error).toBeUndefined();
+    expect(getLastJsonObject(notificationPreferences.stdout)).toMatchObject({
+      profile_name: profileName,
+      notification: {
+        id: fixtures.notificationId
+      },
+      preferences: expect.any(Array)
+    });
+    const notificationPreferencesPayload = getLastJsonObject(notificationPreferences.stdout);
+    const notificationPreferenceItems = notificationPreferencesPayload
+      .preferences as Array<Record<string, unknown>>;
+    const notificationPreferenceKey = notificationPreferenceItems[0]?.key as
+      | string
+      | undefined;
+    const notificationPreferenceEnabled = notificationPreferenceItems[0]?.enabled as
+      | boolean
+      | undefined;
+    expect(typeof notificationPreferenceKey).toBe("string");
+    expect(typeof notificationPreferenceEnabled).toBe("boolean");
+    if (
+      typeof notificationPreferenceKey !== "string" ||
+      typeof notificationPreferenceEnabled !== "boolean"
+    ) {
+      throw new Error("Expected at least one notification preference entry.");
+    }
+
+    const dismissNotification = await runCliCommand([
+      "notifications",
+      "dismiss",
+      "--profile",
+      profileName,
+      "--notification",
+      fixtures.notificationId
+    ]);
+    expect(dismissNotification.error).toBeUndefined();
+    expect(getLastJsonObject(dismissNotification.stdout)).toMatchObject({
+      profile_name: profileName,
+      preparedActionId: expect.stringMatching(/^pa_/),
+      confirmToken: expect.stringMatching(/^ct_/),
+      preview: {
+        notification: {
+          id: fixtures.notificationId
+        }
+      }
+    });
+
+    const prepareNotificationPreferenceUpdate = await runCliCommand([
+      "notifications",
+      "preferences",
+      "prepare-update",
+      "--profile",
+      profileName,
+      "--notification",
+      fixtures.notificationId,
+      "--set",
+      `${notificationPreferenceKey}=${notificationPreferenceEnabled ? "off" : "on"}`
+    ]);
+    expect(prepareNotificationPreferenceUpdate.error).toBeUndefined();
+    expect(getLastJsonObject(prepareNotificationPreferenceUpdate.stdout)).toMatchObject({
+      profile_name: profileName,
+      preparedActionId: expect.stringMatching(/^pa_/),
+      confirmToken: expect.stringMatching(/^ct_/),
+      preview: {
+        notification: {
+          id: fixtures.notificationId
+        },
+        changes: expect.any(Array)
+      }
+    });
   }, 240_000);
 });

--- a/packages/core/src/__tests__/e2e/helpers.ts
+++ b/packages/core/src/__tests__/e2e/helpers.ts
@@ -39,7 +39,11 @@ import {
   LINKEDIN_MEMBERS_PREPARE_BLOCK_TOOL,
   LINKEDIN_MEMBERS_PREPARE_REPORT_TOOL,
   LINKEDIN_MEMBERS_PREPARE_UNBLOCK_TOOL,
+  LINKEDIN_NOTIFICATIONS_DISMISS_TOOL,
   LINKEDIN_NOTIFICATIONS_LIST_TOOL,
+  LINKEDIN_NOTIFICATIONS_MARK_READ_TOOL,
+  LINKEDIN_NOTIFICATIONS_PREFERENCES_GET_TOOL,
+  LINKEDIN_NOTIFICATIONS_PREFERENCES_PREPARE_UPDATE_TOOL,
   LINKEDIN_POST_PREPARE_CREATE_TOOL,
   LINKEDIN_POST_PREPARE_CREATE_MEDIA_TOOL,
   LINKEDIN_POST_PREPARE_CREATE_POLL_TOOL,
@@ -94,6 +98,8 @@ export interface CliCoverageFixtures {
   postUrl: string;
   jobId: string;
   connectionTarget: string;
+  notificationId: string;
+  notificationLink: string;
 }
 
 /** Optional execution controls shared by the CLI and MCP wrapper helpers. */
@@ -310,6 +316,14 @@ function parseCliCoverageFixtures(
     connectionTarget: assertNonEmptyString(
       record.connectionTarget,
       `${sourceLabel}.connectionTarget`
+    ),
+    notificationId: assertNonEmptyString(
+      record.notificationId,
+      `${sourceLabel}.notificationId`
+    ),
+    notificationLink: assertNonEmptyString(
+      record.notificationLink,
+      `${sourceLabel}.notificationLink`
     )
   };
 }
@@ -895,16 +909,45 @@ export async function getJob(runtime: CoreRuntime): Promise<{
   };
 }
 
+/** Discovers one notification target used by the CLI and MCP contract suites. */
+export async function getNotification(runtime: CoreRuntime): Promise<{
+  id: string;
+  link: string;
+  message: string;
+}> {
+  const profileName = getDefaultProfileName();
+  const notifications = await runtime.notifications.listNotifications({
+    profileName,
+    limit: 10
+  });
+
+  const notification = notifications[0];
+  if (!notification) {
+    throw new Error(
+      "No LinkedIn notification was available for E2E coverage. Refresh the test account activity or saved fixtures."
+    );
+  }
+
+  return {
+    id: notification.id,
+    link: notification.link,
+    message: notification.message
+  };
+}
+
 async function discoverCliCoverageFixtures(runtime: CoreRuntime): Promise<CliCoverageFixtures> {
   const thread = await getMessageThread(runtime);
   const post = await getFeedPost(runtime);
   const job = await getJob(runtime);
+  const notification = await getNotification(runtime);
 
   return {
     threadId: thread.thread_id,
     postUrl: post.post_url,
     jobId: job.job_id,
-    connectionTarget: getDefaultConnectionTarget()
+    connectionTarget: getDefaultConnectionTarget(),
+    notificationId: notification.id,
+    notificationLink: notification.link
   };
 }
 
@@ -984,6 +1027,11 @@ export const MCP_TOOL_NAMES = {
   postPrepareEdit: LINKEDIN_POST_PREPARE_EDIT_TOOL,
   postPrepareDelete: LINKEDIN_POST_PREPARE_DELETE_TOOL,
   notificationsList: LINKEDIN_NOTIFICATIONS_LIST_TOOL,
+  notificationsMarkRead: LINKEDIN_NOTIFICATIONS_MARK_READ_TOOL,
+  notificationsDismiss: LINKEDIN_NOTIFICATIONS_DISMISS_TOOL,
+  notificationsPreferencesGet: LINKEDIN_NOTIFICATIONS_PREFERENCES_GET_TOOL,
+  notificationsPreferencesPrepareUpdate:
+    LINKEDIN_NOTIFICATIONS_PREFERENCES_PREPARE_UPDATE_TOOL,
   jobsSearch: LINKEDIN_JOBS_SEARCH_TOOL,
   jobsView: LINKEDIN_JOBS_VIEW_TOOL,
   actionsConfirm: LINKEDIN_ACTIONS_CONFIRM_TOOL

--- a/packages/core/src/__tests__/e2e/mcp.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/mcp.e2e.test.ts
@@ -358,6 +358,80 @@ describe.sequential("MCP E2E", () => {
       profile_name: profileName,
       notifications: expect.any(Array)
     });
+
+    const notificationPreferences = await callMcpTool(
+      MCP_TOOL_NAMES.notificationsPreferencesGet,
+      {
+        profileName,
+        notification: fixtures.notificationId
+      }
+    );
+    expect(notificationPreferences.isError).toBe(false);
+    expect(notificationPreferences.payload).toMatchObject({
+      profile_name: profileName,
+      notification: {
+        id: fixtures.notificationId
+      },
+      preferences: expect.any(Array)
+    });
+    const notificationPreferenceItems = notificationPreferences.payload
+      .preferences as Array<Record<string, unknown>>;
+    const notificationPreferenceKey = notificationPreferenceItems[0]?.key as
+      | string
+      | undefined;
+    const notificationPreferenceEnabled = notificationPreferenceItems[0]?.enabled as
+      | boolean
+      | undefined;
+    expect(typeof notificationPreferenceKey).toBe("string");
+    expect(typeof notificationPreferenceEnabled).toBe("boolean");
+    if (
+      typeof notificationPreferenceKey !== "string" ||
+      typeof notificationPreferenceEnabled !== "boolean"
+    ) {
+      throw new Error("Expected at least one notification preference entry.");
+    }
+
+    const notificationDismiss = await callMcpTool(MCP_TOOL_NAMES.notificationsDismiss, {
+      profileName,
+      notification: fixtures.notificationId
+    });
+    expect(notificationDismiss.isError).toBe(false);
+    expect(notificationDismiss.payload).toMatchObject({
+      profile_name: profileName,
+      preparedActionId: expect.stringMatching(/^pa_/),
+      confirmToken: expect.stringMatching(/^ct_/),
+      preview: {
+        notification: {
+          id: fixtures.notificationId
+        }
+      }
+    });
+
+    const notificationPreferenceUpdate = await callMcpTool(
+      MCP_TOOL_NAMES.notificationsPreferencesPrepareUpdate,
+      {
+        profileName,
+        notification: fixtures.notificationId,
+        changes: [
+          {
+            preference: notificationPreferenceKey,
+            enabled: !notificationPreferenceEnabled
+          }
+        ]
+      }
+    );
+    expect(notificationPreferenceUpdate.isError).toBe(false);
+    expect(notificationPreferenceUpdate.payload).toMatchObject({
+      profile_name: profileName,
+      preparedActionId: expect.stringMatching(/^pa_/),
+      confirmToken: expect.stringMatching(/^ct_/),
+      preview: {
+        notification: {
+          id: fixtures.notificationId
+        },
+        changes: expect.any(Array)
+      }
+    });
   }, 180_000);
 
   it("covers profile, search, and jobs tools", async (context) => {

--- a/packages/core/src/__tests__/e2e/notifications.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/notifications.e2e.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { getNotification } from "./helpers.js";
 import { setupE2ESuite, skipIfE2EUnavailable } from "./setup.js";
 
 describe("Notifications E2E", () => {
@@ -10,5 +11,59 @@ describe("Notifications E2E", () => {
     const notifications = await runtime.notifications.listNotifications({ limit: 5 });
 
     expect(Array.isArray(notifications)).toBe(true);
+  });
+
+  it("reads notification preferences and prepares notification actions", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
+    const runtime = e2e.runtime();
+    const notification = await getNotification(runtime);
+
+    const preferences = await runtime.notifications.getPreferences({
+      notification: notification.id
+    });
+    expect(preferences).toMatchObject({
+      notification: {
+        id: notification.id
+      },
+      preferences: expect.any(Array)
+    });
+    const firstPreference = preferences.preferences[0];
+    expect(firstPreference).toBeDefined();
+    if (!firstPreference) {
+      throw new Error("Expected at least one notification preference.");
+    }
+
+    const dismiss = await runtime.notifications.prepareDismiss({
+      notification: notification.id
+    });
+    expect(dismiss).toMatchObject({
+      preparedActionId: expect.stringMatching(/^pa_/),
+      confirmToken: expect.stringMatching(/^ct_/),
+      preview: {
+        notification: {
+          id: notification.id
+        }
+      }
+    });
+
+    const update = await runtime.notifications.prepareUpdatePreferences({
+      notification: notification.id,
+      changes: [
+        {
+          preference: firstPreference.key,
+          enabled: !firstPreference.enabled
+        }
+      ]
+    });
+    expect(update).toMatchObject({
+      preparedActionId: expect.stringMatching(/^pa_/),
+      confirmToken: expect.stringMatching(/^ct_/),
+      preview: {
+        notification: {
+          id: notification.id
+        },
+        changes: expect.any(Array)
+      }
+    });
   });
 });

--- a/packages/core/src/__tests__/e2eHelpers.test.ts
+++ b/packages/core/src/__tests__/e2eHelpers.test.ts
@@ -55,6 +55,18 @@ function createFixtureRuntime() {
           }
         ]
       }))
+    },
+    notifications: {
+      listNotifications: vi.fn(async () => [
+        {
+          id: "notif-123",
+          type: "reaction",
+          message: "Fixture notification",
+          timestamp: "1h",
+          link: "https://www.linkedin.com/feed/update/notif-123",
+          is_read: false
+        }
+      ])
     }
   } as unknown as Parameters<typeof getCliCoverageFixtures>[0];
 }
@@ -240,7 +252,9 @@ describe("E2E fixture helpers", () => {
           threadId: "thread-from-file",
           postUrl: "https://www.linkedin.com/feed/update/from-file",
           jobId: "job-from-file",
-          connectionTarget: "fixture-target"
+          connectionTarget: "fixture-target",
+          notificationId: "notif-from-file",
+          notificationLink: "https://www.linkedin.com/feed/update/notif-from-file"
         },
         null,
         2
@@ -255,11 +269,14 @@ describe("E2E fixture helpers", () => {
       threadId: "thread-from-file",
       postUrl: "https://www.linkedin.com/feed/update/from-file",
       jobId: "job-from-file",
-      connectionTarget: "fixture-target"
+      connectionTarget: "fixture-target",
+      notificationId: "notif-from-file",
+      notificationLink: "https://www.linkedin.com/feed/update/notif-from-file"
     });
     expect(runtime.inbox.listThreads).not.toHaveBeenCalled();
     expect(runtime.feed.viewFeed).not.toHaveBeenCalled();
     expect(runtime.jobs.searchJobs).not.toHaveBeenCalled();
+    expect(runtime.notifications.listNotifications).not.toHaveBeenCalled();
   });
 
   it("refreshes and rewrites the coverage fixture file when requested", async () => {
@@ -277,7 +294,9 @@ describe("E2E fixture helpers", () => {
       threadId: "thread-123",
       postUrl: "https://www.linkedin.com/feed/update/post-123",
       jobId: "job-123",
-      connectionTarget: "refresh-target"
+      connectionTarget: "refresh-target",
+      notificationId: "notif-123",
+      notificationLink: "https://www.linkedin.com/feed/update/notif-123"
     });
 
     const savedFixtures = JSON.parse(readFileSync(fixturePath, "utf8")) as Record<string, unknown>;
@@ -287,7 +306,9 @@ describe("E2E fixture helpers", () => {
       threadId: "thread-123",
       postUrl: "https://www.linkedin.com/feed/update/post-123",
       jobId: "job-123",
-      connectionTarget: "refresh-target"
+      connectionTarget: "refresh-target",
+      notificationId: "notif-123",
+      notificationLink: "https://www.linkedin.com/feed/update/notif-123"
     });
     expect(typeof savedFixtures.capturedAt).toBe("string");
   });

--- a/packages/core/src/__tests__/linkedinNotifications.test.ts
+++ b/packages/core/src/__tests__/linkedinNotifications.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  createNotificationActionExecutors,
+  DISMISS_NOTIFICATION_ACTION_TYPE,
   LinkedInNotificationsService,
   type LinkedInNotification,
+  type LinkedInNotificationPreference,
+  type LinkedInNotificationPreferenceChangeInput,
   type ListNotificationsInput,
   type LinkedInNotificationsRuntime
 } from "../linkedinNotifications.js";
@@ -44,9 +48,35 @@ describe("LinkedInNotificationsService", () => {
     const runtimeKeys: (keyof LinkedInNotificationsRuntime)[] = [
       "auth",
       "cdpUrl",
+      "selectorLocale",
       "profileManager",
-      "logger"
+      "logger",
+      "rateLimiter",
+      "artifacts",
+      "confirmFailureArtifacts",
+      "twoPhaseCommit"
     ];
-    expect(runtimeKeys).toHaveLength(4);
+    expect(runtimeKeys).toHaveLength(9);
+  });
+
+  it("exports notification action executors", () => {
+    const executors = createNotificationActionExecutors();
+    expect(executors).toHaveProperty(DISMISS_NOTIFICATION_ACTION_TYPE);
+    expect(Object.keys(executors)).toContain("notifications.update_preferences");
+  });
+
+  it("notification preference interfaces are importable", () => {
+    const preference: LinkedInNotificationPreference = {
+      key: "this-post",
+      label: "This post",
+      enabled: true
+    };
+    const change: LinkedInNotificationPreferenceChangeInput = {
+      preference: "this-post",
+      enabled: false
+    };
+
+    expect(preference.key).toBe("this-post");
+    expect(change.enabled).toBe(false);
   });
 });

--- a/packages/core/src/linkedinNotifications.ts
+++ b/packages/core/src/linkedinNotifications.ts
@@ -1,5 +1,8 @@
-import { type BrowserContext, type Page } from "playwright-core";
+import { type BrowserContext, type Locator, type Page, errors as playwrightErrors } from "playwright-core";
+import type { ArtifactHelpers } from "./artifacts.js";
 import type { LinkedInAuthService } from "./auth/session.js";
+import { executeConfirmActionWithArtifacts } from "./confirmArtifacts.js";
+import type { ConfirmFailureArtifactConfig } from "./config.js";
 import {
   LinkedInAssistantError,
   asLinkedInAssistantError
@@ -7,6 +10,22 @@ import {
 import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
+import type {
+  ConsumeRateLimitInput,
+  RateLimiter,
+  RateLimiterState
+} from "./rateLimiter.js";
+import type { LinkedInSelectorLocale } from "./selectorLocale.js";
+import {
+  buildLinkedInSelectorPhraseRegex,
+  formatLinkedInSelectorRegexHint
+} from "./selectorLocale.js";
+import type {
+  ActionExecutor,
+  ActionExecutorInput,
+  ActionExecutorResult,
+  TwoPhaseCommitService
+} from "./twoPhaseCommit.js";
 
 export interface LinkedInNotification {
   id: string;
@@ -22,26 +41,167 @@ export interface ListNotificationsInput {
   limit?: number;
 }
 
-export interface LinkedInNotificationsRuntime {
+export interface NotificationActionInput {
+  profileName?: string;
+  notification: string;
+  operatorNote?: string;
+}
+
+export interface GetNotificationPreferencesInput {
+  profileName?: string;
+  notification: string;
+}
+
+export interface LinkedInNotificationPreference {
+  key: string;
+  label: string;
+  enabled: boolean;
+}
+
+export interface LinkedInNotificationPreferences {
+  notification: LinkedInNotification;
+  heading: string;
+  settings_url: string | null;
+  preferences: LinkedInNotificationPreference[];
+}
+
+export interface LinkedInNotificationPreferenceChangeInput {
+  preference: string;
+  enabled: boolean;
+}
+
+export interface PrepareUpdateNotificationPreferencesInput {
+  profileName?: string;
+  notification: string;
+  changes: LinkedInNotificationPreferenceChangeInput[];
+  operatorNote?: string;
+}
+
+export interface MarkReadNotificationResult {
+  notification: LinkedInNotification;
+  status: "marked_read" | "already_read";
+  artifacts: string[];
+  rate_limit: Record<string, boolean | number | string>;
+}
+
+export interface LinkedInNotificationsExecutorRuntime {
   auth: LinkedInAuthService;
   cdpUrl?: string | undefined;
+  selectorLocale: LinkedInSelectorLocale;
   profileManager: ProfileManager;
   logger: JsonEventLogger;
+  rateLimiter: RateLimiter;
+  artifacts: ArtifactHelpers;
+  confirmFailureArtifacts: ConfirmFailureArtifactConfig;
 }
 
-interface NotificationSnapshot {
-  id: string;
-  type: string;
-  message: string;
-  timestamp: string;
-  link: string;
-  is_read: boolean;
+export interface LinkedInNotificationsRuntime
+  extends LinkedInNotificationsExecutorRuntime {
+  twoPhaseCommit: Pick<
+    TwoPhaseCommitService<LinkedInNotificationsExecutorRuntime>,
+    "prepare"
+  >;
 }
+
+type NotificationSnapshot = LinkedInNotification;
+
+interface ResolvedNotificationTarget {
+  snapshot: NotificationSnapshot;
+  locator: Locator;
+}
+
+interface NotificationPreferencesDialogState {
+  heading: string;
+  settingsUrl: string | null;
+  preferences: LinkedInNotificationPreference[];
+}
+
+interface PreparedNotificationPreferenceChange {
+  key: string;
+  label: string;
+  previous_enabled: boolean;
+  enabled: boolean;
+}
+
+type NotificationUiPhraseKey =
+  | "change_preferences"
+  | "delete_notification"
+  | "show_less_like_this";
+
+const NOTIFICATION_UI_PHRASES: Record<
+  LinkedInSelectorLocale,
+  Record<NotificationUiPhraseKey, readonly string[]>
+> = {
+  en: {
+    change_preferences: ["Change notification preferences"],
+    delete_notification: ["Delete notification"],
+    show_less_like_this: ["Show less like this"]
+  },
+  da: {
+    change_preferences: ["Skift notifikationspræferencer"],
+    delete_notification: ["Slet notifikation"],
+    show_less_like_this: ["Vis færre som dette"]
+  }
+};
 
 const LINKEDIN_NOTIFICATIONS_URL = "https://www.linkedin.com/notifications/";
+const MARK_READ_RATE_LIMIT_CONFIG = {
+  counterKey: "linkedin.notifications.mark_read",
+  windowSizeMs: 60 * 60 * 1000,
+  limit: 40
+} satisfies ConsumeRateLimitInput;
+const DISMISS_NOTIFICATION_RATE_LIMIT_CONFIG = {
+  counterKey: "linkedin.notifications.dismiss",
+  windowSizeMs: 60 * 60 * 1000,
+  limit: 25
+} satisfies ConsumeRateLimitInput;
+const UPDATE_NOTIFICATION_PREFERENCES_RATE_LIMIT_CONFIG = {
+  counterKey: "linkedin.notifications.update_preferences",
+  windowSizeMs: 60 * 60 * 1000,
+  limit: 20
+} satisfies ConsumeRateLimitInput;
+
+export const DISMISS_NOTIFICATION_ACTION_TYPE = "notifications.dismiss";
+export const UPDATE_NOTIFICATION_PREFERENCES_ACTION_TYPE =
+  "notifications.update_preferences";
 
 function normalizeText(value: string | null | undefined): string {
   return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function buildPhraseRegex(
+  phrases: readonly string[],
+  options: { exact?: boolean } = {}
+): RegExp {
+  const body = phrases.map((phrase) => escapeRegExp(phrase)).join("|") || "^$";
+  const pattern = options.exact ? `^(?:${body})$` : `(?:${body})`;
+  return new RegExp(pattern, "iu");
+}
+
+function buildNotificationPhraseRegex(
+  key: NotificationUiPhraseKey,
+  selectorLocale: LinkedInSelectorLocale,
+  options: { exact?: boolean } = {}
+): RegExp {
+  return buildPhraseRegex(
+    NOTIFICATION_UI_PHRASES[selectorLocale]?.[key] ??
+      NOTIFICATION_UI_PHRASES.en[key],
+    options
+  );
+}
+
+function buildNotificationPhraseHint(
+  key: NotificationUiPhraseKey,
+  selectorLocale: LinkedInSelectorLocale
+): string {
+  const phrases =
+    NOTIFICATION_UI_PHRASES[selectorLocale]?.[key] ??
+    NOTIFICATION_UI_PHRASES.en[key];
+  return phrases.map((phrase) => JSON.stringify(phrase)).join(" | ");
 }
 
 function readNotificationsLimit(value: number | undefined): number {
@@ -50,6 +210,200 @@ function readNotificationsLimit(value: number | undefined): number {
   }
 
   return Math.max(1, Math.floor(value));
+}
+
+function toAbsoluteUrl(value: string): string {
+  const normalizedValue = normalizeText(value);
+  if (!normalizedValue) {
+    return "";
+  }
+
+  try {
+    return new URL(normalizedValue, LINKEDIN_NOTIFICATIONS_URL).toString();
+  } catch {
+    return normalizedValue;
+  }
+}
+
+function canonicalizeComparableUrl(value: string): string {
+  const absoluteValue = toAbsoluteUrl(value);
+  if (!absoluteValue) {
+    return "";
+  }
+
+  try {
+    const url = new URL(absoluteValue);
+    url.hash = "";
+    return url.toString().replace(/\/$/u, "");
+  } catch {
+    return absoluteValue.replace(/\/$/u, "");
+  }
+}
+
+function slugifyNotificationPreference(label: string, fallbackIndex: number): string {
+  const normalizedLabel = normalizeText(label).toLowerCase();
+  const slug = normalizedLabel
+    .replace(/[^a-z0-9]+/gu, "-")
+    .replace(/^-+|-+$/gu, "");
+  return slug || `preference-${fallbackIndex + 1}`;
+}
+
+function getProfileName(target: Record<string, unknown>): string {
+  const value = target.profile_name;
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  return "default";
+}
+
+function getRequiredStringField(
+  source: Record<string, unknown>,
+  key: string,
+  actionId: string,
+  location: "target" | "payload"
+): string {
+  const value = source[key];
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  throw new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    `Prepared action ${actionId} is missing ${location}.${key}.`,
+    {
+      action_id: actionId,
+      location,
+      key
+    }
+  );
+}
+
+function getRequiredPreparedPreferenceChanges(
+  payload: Record<string, unknown>,
+  actionId: string
+): PreparedNotificationPreferenceChange[] {
+  const value = payload.changes;
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `Prepared action ${actionId} is missing payload.changes.`,
+      {
+        action_id: actionId,
+        key: "changes",
+        location: "payload"
+      }
+    );
+  }
+
+  return value.map((item, index) => {
+    if (typeof item !== "object" || item === null || Array.isArray(item)) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `Prepared action ${actionId} has invalid payload.changes[${index}].`,
+        {
+          action_id: actionId,
+          key: "changes",
+          index,
+          location: "payload"
+        }
+      );
+    }
+
+    const record = item as Record<string, unknown>;
+    const key = record.key;
+    const label = record.label;
+    const enabled = record.enabled;
+    const previousEnabled = record.previous_enabled;
+
+    if (
+      typeof key !== "string" ||
+      key.trim().length === 0 ||
+      typeof label !== "string" ||
+      label.trim().length === 0 ||
+      typeof enabled !== "boolean" ||
+      typeof previousEnabled !== "boolean"
+    ) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `Prepared action ${actionId} has invalid payload.changes[${index}].`,
+        {
+          action_id: actionId,
+          key: "changes",
+          index,
+          location: "payload"
+        }
+      );
+    }
+
+    return {
+      key: key.trim(),
+      label: label.trim(),
+      enabled,
+      previous_enabled: previousEnabled
+    };
+  });
+}
+
+function toAutomationError(
+  error: unknown,
+  message: string,
+  details: Record<string, unknown>
+): LinkedInAssistantError {
+  if (error instanceof LinkedInAssistantError) {
+    return error;
+  }
+
+  if (error instanceof playwrightErrors.TimeoutError) {
+    return new LinkedInAssistantError("TIMEOUT", message, details, {
+      cause: error
+    });
+  }
+
+  if (
+    error instanceof Error &&
+    /(net::|ERR_|ECONN|ENOTFOUND|EAI_AGAIN|socket hang up)/iu.test(error.message)
+  ) {
+    return new LinkedInAssistantError("NETWORK_ERROR", message, details, {
+      cause: error
+    });
+  }
+
+  return asLinkedInAssistantError(error, "UNKNOWN", message);
+}
+
+function formatRateLimitState(
+  state: RateLimiterState
+): Record<string, boolean | number | string> {
+  return {
+    counter_key: state.counterKey,
+    window_start_ms: state.windowStartMs,
+    window_size_ms: state.windowSizeMs,
+    count: state.count,
+    limit: state.limit,
+    remaining: state.remaining,
+    allowed: state.allowed
+  };
+}
+
+async function waitForCondition(
+  condition: () => Promise<boolean>,
+  timeoutMs: number,
+  intervalMs: number = 250
+): Promise<boolean> {
+  const deadline = Date.now() + Math.max(0, timeoutMs);
+
+  while (Date.now() < deadline) {
+    if (await condition()) {
+      return true;
+    }
+
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, intervalMs);
+    });
+  }
+
+  return condition();
 }
 
 async function getOrCreatePage(context: BrowserContext): Promise<Page> {
@@ -91,11 +445,19 @@ async function waitForNotificationsSurface(page: Page): Promise<void> {
   );
 }
 
+async function openNotificationsPage(page: Page): Promise<void> {
+  await page.goto(LINKEDIN_NOTIFICATIONS_URL, {
+    waitUntil: "domcontentloaded"
+  });
+  await waitForNetworkIdleBestEffort(page);
+  await waitForNotificationsSurface(page);
+}
+
 /* eslint-disable no-undef -- DOM types are valid inside page.evaluate() */
-async function extractNotifications(
+async function indexNotificationCards(
   page: Page,
   limit: number
-): Promise<LinkedInNotification[]> {
+): Promise<NotificationSnapshot[]> {
   const snapshots = await page.evaluate((maxNotifications: number) => {
     const normalize = (value: string | null | undefined): string =>
       (value ?? "").replace(/\s+/g, " ").trim();
@@ -111,6 +473,15 @@ async function extractNotifications(
       } catch {
         return href;
       }
+    };
+
+    const hashText = (value: string): string => {
+      let hash = 2166136261;
+      for (let index = 0; index < value.length; index += 1) {
+        hash ^= value.charCodeAt(index);
+        hash = Math.imul(hash, 16777619);
+      }
+      return `notif_${(hash >>> 0).toString(16).padStart(8, "0")}`;
     };
 
     const pickText = (root: ParentNode, selectors: string[]): string => {
@@ -143,40 +514,6 @@ async function extractNotifications(
         return "";
       }
       return normalize(node.getAttribute("class"));
-    };
-
-    const extractNotificationId = (
-      root: Element,
-      link: string,
-      index: number
-    ): string => {
-      const idCandidates = [
-        normalize(root.getAttribute("data-urn")),
-        normalize(root.getAttribute("data-id")),
-        normalize(root.getAttribute("data-notification-id")),
-        normalize(root.getAttribute("id")),
-        normalize(root.querySelector("[data-urn]")?.getAttribute("data-urn")),
-        normalize(root.querySelector("[data-id]")?.getAttribute("data-id"))
-      ];
-
-      for (const candidate of idCandidates) {
-        if (candidate) {
-          return candidate;
-        }
-      }
-
-      const linkMatch =
-        /\/notifications\/([^/?#]+)/i.exec(link) ??
-        /[?&]notificationId=([^&#]+)/i.exec(link);
-      if (linkMatch?.[1]) {
-        try {
-          return decodeURIComponent(linkMatch[1]);
-        } catch {
-          return linkMatch[1];
-        }
-      }
-
-      return `notification-${index + 1}`;
     };
 
     const inferType = (root: Element): string => {
@@ -217,15 +554,15 @@ async function extractNotifications(
 
     const inferReadState = (root: Element): boolean => {
       const classSignal = readClassName(root).toLowerCase();
-      if (/\bunread\b|\bnew\b|is-new/.test(classSignal)) {
+      if (/\bunread\b|\bnew\b|is-new/u.test(classSignal)) {
         return false;
       }
-      if (/\bread\b/.test(classSignal)) {
+      if (/\bread\b/u.test(classSignal)) {
         return true;
       }
 
       const unreadIndicator = root.querySelector(
-        ".notification-status--unread, .notification-card__unread, .notification-card__unread-dot, .nt-card__unread, [data-test-notification-unread], [aria-label*='Unread'], [aria-label*='unread']"
+        ".notification-status--unread, .notification-card__unread, .notification-card__unread-dot, .nt-card__unread, .nt-card__blue-dot, [data-test-notification-unread], [aria-label*='Unread'], [aria-label*='unread']"
       );
       if (unreadIndicator) {
         return false;
@@ -285,22 +622,24 @@ async function extractNotifications(
     }
 
     const notifications: NotificationSnapshot[] = [];
-    for (let i = 0; i < uniqueCards.length; i++) {
-      const card = uniqueCards[i];
+    for (let index = 0; index < uniqueCards.length; index += 1) {
+      const card = uniqueCards[index];
       if (!card) {
         continue;
       }
 
       const link = pickHref(card, [
+        "a.nt-card__headline",
         "a[href*='/notifications/']",
         "a[href*='/feed/update/']",
         "a[href*='/jobs/view/']",
+        "a[href*='/analytics/']",
         "a[href*='/in/']",
         "a"
       ]);
-      const id = extractNotificationId(card, link, i);
       const message =
         pickText(card, [
+          ".nt-card__headline",
           ".nt-card__content p",
           ".nt-card__content",
           ".notification-card__message",
@@ -309,7 +648,6 @@ async function extractNotifications(
           "p",
           "span[dir='ltr']"
         ]) || normalize(card.textContent);
-
       const timestamp =
         pickText(card, [
           "time",
@@ -319,6 +657,18 @@ async function extractNotifications(
           "[data-test-time-ago]"
         ]) ||
         normalize(card.querySelector("time")?.getAttribute("datetime"));
+
+      const rawIdentifierSeed =
+        normalize(card.getAttribute("data-urn")) ||
+        normalize(card.getAttribute("data-id")) ||
+        normalize(card.getAttribute("data-notification-id")) ||
+        normalize(card.getAttribute("id")) ||
+        normalize(card.querySelector("[data-urn]")?.getAttribute("data-urn")) ||
+        normalize(card.querySelector("[data-id]")?.getAttribute("data-id")) ||
+        link ||
+        `${message}|${timestamp}|${index}`;
+      const id = hashText(rawIdentifierSeed.toLowerCase());
+      card.setAttribute("data-linkedin-assistant-notification-key", id);
 
       notifications.push({
         id,
@@ -343,7 +693,7 @@ async function extractNotifications(
       type: normalizeText(snapshot.type) || "notification",
       message: normalizeText(snapshot.message),
       timestamp: normalizeText(snapshot.timestamp),
-      link: normalizeText(snapshot.link),
+      link: toAbsoluteUrl(snapshot.link),
       is_read: Boolean(snapshot.is_read)
     }))
     .filter(
@@ -356,21 +706,751 @@ async function extractNotifications(
 }
 /* eslint-enable no-undef */
 
-async function loadNotifications(
+async function collectNotifications(
   page: Page,
   limit: number
-): Promise<LinkedInNotification[]> {
-  let notifications = await extractNotifications(page, limit);
+): Promise<NotificationSnapshot[]> {
+  let notifications = await indexNotificationCards(page, limit);
 
-  for (let i = 0; i < 6 && notifications.length < limit; i++) {
+  for (let attempt = 0; attempt < 6 && notifications.length < limit; attempt += 1) {
     await page.evaluate(() => {
       globalThis.window.scrollTo(0, globalThis.document.body.scrollHeight);
     });
     await page.waitForTimeout(800);
-    notifications = await extractNotifications(page, limit);
+    notifications = await indexNotificationCards(page, limit);
   }
 
   return notifications.slice(0, Math.max(1, limit));
+}
+
+function getNotificationPreview(notification: LinkedInNotification): Record<string, unknown> {
+  return {
+    id: notification.id,
+    type: notification.type,
+    message: notification.message,
+    timestamp: notification.timestamp,
+    link: notification.link,
+    is_read: notification.is_read
+  };
+}
+
+function selectNotificationMatch(
+  notifications: readonly NotificationSnapshot[],
+  query: string
+): NotificationSnapshot | null {
+  const normalizedQuery = normalizeText(query);
+  const lowerQuery = normalizedQuery.toLowerCase();
+  const comparableQueryUrl = canonicalizeComparableUrl(normalizedQuery);
+
+  if (!normalizedQuery) {
+    return null;
+  }
+
+  const exactIdMatches = notifications.filter((notification) => {
+    return notification.id.toLowerCase() === lowerQuery;
+  });
+  if (exactIdMatches.length === 1) {
+    return exactIdMatches[0] ?? null;
+  }
+  if (exactIdMatches.length > 1) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `Notification query "${query}" matched multiple notification ids.`,
+      {
+        notification: query,
+        matches: exactIdMatches.map(getNotificationPreview)
+      }
+    );
+  }
+
+  if (comparableQueryUrl) {
+    const exactUrlMatches = notifications.filter((notification) => {
+      return canonicalizeComparableUrl(notification.link) === comparableQueryUrl;
+    });
+    if (exactUrlMatches.length === 1) {
+      return exactUrlMatches[0] ?? null;
+    }
+    if (exactUrlMatches.length > 1) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `Notification query "${query}" matched multiple notification links.`,
+        {
+          notification: query,
+          matches: exactUrlMatches.map(getNotificationPreview)
+        }
+      );
+    }
+  }
+
+  const exactMessageMatches = notifications.filter((notification) => {
+    return notification.message.toLowerCase() === lowerQuery;
+  });
+  if (exactMessageMatches.length === 1) {
+    return exactMessageMatches[0] ?? null;
+  }
+  if (exactMessageMatches.length > 1) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `Notification query "${query}" matched multiple notification messages.`,
+      {
+        notification: query,
+        matches: exactMessageMatches.map(getNotificationPreview)
+      }
+    );
+  }
+
+  const partialMatches = notifications.filter((notification) => {
+    return (
+      notification.message.toLowerCase().includes(lowerQuery) ||
+      notification.id.toLowerCase().includes(lowerQuery) ||
+      notification.link.toLowerCase().includes(lowerQuery)
+    );
+  });
+  if (partialMatches.length === 1) {
+    return partialMatches[0] ?? null;
+  }
+  if (partialMatches.length > 1) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `Notification query "${query}" was ambiguous. Use the notification id or full link instead.`,
+      {
+        notification: query,
+        matches: partialMatches.slice(0, 5).map(getNotificationPreview)
+      }
+    );
+  }
+
+  return null;
+}
+
+async function resolveNotificationTarget(
+  page: Page,
+  query: string
+): Promise<ResolvedNotificationTarget> {
+  let notifications = await indexNotificationCards(page, 40);
+  let match = selectNotificationMatch(notifications, query);
+
+  for (let attempt = 0; !match && attempt < 8; attempt += 1) {
+    await page.evaluate(() => {
+      globalThis.window.scrollTo(0, globalThis.document.body.scrollHeight);
+    });
+    await page.waitForTimeout(800);
+    notifications = await indexNotificationCards(page, 120);
+    match = selectNotificationMatch(notifications, query);
+  }
+
+  if (!match) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `Could not find a LinkedIn notification matching "${query}".`,
+      {
+        notification: query,
+        candidates: notifications.slice(0, 10).map(getNotificationPreview)
+      }
+    );
+  }
+
+  const locator = page
+    .locator(`[data-linkedin-assistant-notification-key="${match.id}"]`)
+    .first();
+
+  if (!(await locator.isVisible().catch(() => false))) {
+    throw new LinkedInAssistantError(
+      "UI_CHANGED_SELECTOR_FAILED",
+      `Matched LinkedIn notification "${query}" is no longer visible.`,
+      {
+        notification: query,
+        notification_id: match.id
+      }
+    );
+  }
+
+  return {
+    snapshot: match,
+    locator
+  };
+}
+
+async function openNotificationMenu(
+  page: Page,
+  card: Locator
+): Promise<Locator> {
+  const trigger = card.locator("button[data-nt-card-settings-dropdown-trigger]").first();
+  await trigger.waitFor({ state: "visible", timeout: 10_000 });
+  await trigger.click({ timeout: 10_000 });
+
+  const menu = page.locator(".nt-card-settings-dropdown__content[aria-hidden='false']").last();
+  await menu.waitFor({ state: "visible", timeout: 10_000 });
+  return menu;
+}
+
+async function openNotificationPreferencesDialog(
+  page: Page,
+  card: Locator,
+  selectorLocale: LinkedInSelectorLocale
+): Promise<Locator> {
+  const changePreferencesRegex = buildNotificationPhraseRegex(
+    "change_preferences",
+    selectorLocale
+  );
+  const changePreferencesRegexHint = buildNotificationPhraseHint(
+    "change_preferences",
+    selectorLocale
+  );
+  const menu = await openNotificationMenu(page, card);
+  const changePreferencesButton = menu.locator("button").filter({
+    hasText: changePreferencesRegex
+  }).first();
+
+  if (!(await changePreferencesButton.isVisible().catch(() => false))) {
+    throw new LinkedInAssistantError(
+      "UI_CHANGED_SELECTOR_FAILED",
+      "Could not locate the LinkedIn notification preferences action.",
+      {
+        selector_hint: `.nt-card-settings-dropdown__content button hasText ${changePreferencesRegexHint}`
+      }
+    );
+  }
+
+  await changePreferencesButton.click({ timeout: 10_000 });
+
+  const dialog = page.locator("[role='dialog']").filter({
+    has: page.locator(".props-s-multi-setting-toggle")
+  }).first();
+  await dialog.waitFor({ state: "visible", timeout: 10_000 });
+  return dialog;
+}
+
+async function readNotificationPreferencesDialog(
+  page: Page,
+  dialog: Locator
+): Promise<NotificationPreferencesDialogState> {
+  const heading = normalizeText(await dialog.locator("h1, h2").first().innerText());
+  const rows = dialog.locator(".props-s-multi-setting-toggle");
+  const count = await rows.count();
+
+  if (count === 0) {
+    throw new LinkedInAssistantError(
+      "UI_CHANGED_SELECTOR_FAILED",
+      "LinkedIn notification preferences dialog did not contain any toggle rows.",
+      {
+        selector_hint: ".props-s-multi-setting-toggle"
+      }
+    );
+  }
+
+  const preferences: LinkedInNotificationPreference[] = [];
+  const seenKeys = new Set<string>();
+  for (let index = 0; index < count; index += 1) {
+    const row = rows.nth(index);
+    const label = normalizeText(
+      await row.locator(".props-s-multi-setting-toggle__display-text").innerText()
+    );
+    const input = row.locator("input[type='checkbox']").first();
+    const enabled = await input.isChecked();
+    let key = slugifyNotificationPreference(label, index);
+    if (seenKeys.has(key)) {
+      key = `${key}-${index + 1}`;
+    }
+    seenKeys.add(key);
+
+    preferences.push({
+      key,
+      label,
+      enabled
+    });
+  }
+
+  const settingsUrlLocator = page
+    .locator("a[href*='/mypreferences/d/categories/notifications']")
+    .first();
+  const settingsUrl = await settingsUrlLocator
+    .getAttribute("href")
+    .then((value) => (typeof value === "string" ? toAbsoluteUrl(value) : null))
+    .catch(() => null);
+
+  return {
+    heading,
+    settingsUrl,
+    preferences
+  };
+}
+
+async function closeNotificationPreferencesDialog(
+  page: Page,
+  selectorLocale: LinkedInSelectorLocale
+): Promise<void> {
+  const dismissRegex = buildLinkedInSelectorPhraseRegex("dismiss", selectorLocale, {
+    exact: true
+  });
+  const dismissRegexHint = formatLinkedInSelectorRegexHint("dismiss", selectorLocale, {
+    exact: true
+  });
+  const dismissButton = page.locator(".artdeco-modal__dismiss").first();
+
+  if (!(await dismissButton.isVisible().catch(() => false))) {
+    throw new LinkedInAssistantError(
+      "UI_CHANGED_SELECTOR_FAILED",
+      "Could not locate the LinkedIn notification preferences close button.",
+      {
+        selector_hint: `button.artdeco-modal__dismiss or getByRole(button, ${dismissRegexHint})`
+      }
+    );
+  }
+
+  const ariaLabel = normalizeText(await dismissButton.getAttribute("aria-label"));
+  if (ariaLabel && !dismissRegex.test(ariaLabel)) {
+    throw new LinkedInAssistantError(
+      "UI_CHANGED_SELECTOR_FAILED",
+      "LinkedIn notification preferences close button no longer matches the expected label.",
+      {
+        expected: dismissRegex.source,
+        observed: ariaLabel
+      }
+    );
+  }
+
+  await dismissButton.click({ timeout: 10_000 });
+  await waitForCondition(
+    async () => !(await page.locator("[role='dialog']").first().isVisible().catch(() => false)),
+    10_000
+  );
+}
+
+function resolvePreferenceChanges(
+  preferences: readonly LinkedInNotificationPreference[],
+  changes: readonly LinkedInNotificationPreferenceChangeInput[]
+): PreparedNotificationPreferenceChange[] {
+  if (changes.length === 0) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "changes must include at least one notification preference update."
+    );
+  }
+
+  const resolved: PreparedNotificationPreferenceChange[] = [];
+  const seenKeys = new Set<string>();
+
+  for (const change of changes) {
+    const query = normalizeText(change.preference);
+    const slugQuery = slugifyNotificationPreference(query, 0);
+    const match = preferences.find((preference) => {
+      return (
+        preference.key === query ||
+        preference.key === slugQuery ||
+        preference.label.toLowerCase() === query.toLowerCase()
+      );
+    });
+
+    if (!match) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `Unknown notification preference "${change.preference}".`,
+        {
+          preference: change.preference,
+          available_preferences: preferences.map((preference) => ({
+            key: preference.key,
+            label: preference.label,
+            enabled: preference.enabled
+          }))
+        }
+      );
+    }
+
+    if (seenKeys.has(match.key)) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `Duplicate notification preference change for "${match.label}".`,
+        {
+          preference: change.preference,
+          key: match.key
+        }
+      );
+    }
+
+    seenKeys.add(match.key);
+    resolved.push({
+      key: match.key,
+      label: match.label,
+      previous_enabled: match.enabled,
+      enabled: change.enabled
+    });
+  }
+
+  return resolved;
+}
+
+async function applyNotificationPreferenceChanges(
+  dialog: Locator,
+  changes: readonly PreparedNotificationPreferenceChange[]
+): Promise<void> {
+  const rows = dialog.locator(".props-s-multi-setting-toggle");
+  const rowCount = await rows.count();
+  const seenKeys = new Set<string>();
+
+  for (let index = 0; index < rowCount; index += 1) {
+    const row = rows.nth(index);
+    const label = normalizeText(
+      await row.locator(".props-s-multi-setting-toggle__display-text").innerText()
+    );
+    let key = slugifyNotificationPreference(label, index);
+    if (seenKeys.has(key)) {
+      key = `${key}-${index + 1}`;
+    }
+    seenKeys.add(key);
+    const change = changes.find((candidate) => candidate.key === key);
+
+    if (!change) {
+      continue;
+    }
+
+    const input = row.locator("input[type='checkbox']").first();
+    const currentState = await input.isChecked();
+    if (currentState === change.enabled) {
+      continue;
+    }
+
+    const toggle = row.locator(".artdeco-toggle").first();
+    await toggle.click({ timeout: 10_000 });
+    const updated = await waitForCondition(
+      async () => (await input.isChecked()) === change.enabled,
+      10_000
+    );
+
+    if (!updated) {
+      throw new LinkedInAssistantError(
+        "UI_CHANGED_SELECTOR_FAILED",
+        `LinkedIn notification preference "${change.label}" did not update to the requested state.`,
+        {
+          preference_key: change.key,
+          preference_label: change.label,
+          requested_enabled: change.enabled
+        }
+      );
+    }
+
+    await pageWait();
+  }
+}
+
+async function pageWait(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 300);
+  });
+}
+
+async function captureNotificationScreenshot(
+  runtime: Pick<LinkedInNotificationsExecutorRuntime, "artifacts">,
+  page: Page,
+  actionType: string,
+  metadata: Record<string, unknown>
+): Promise<string> {
+  const relativePath = `linkedin/screenshot-${actionType}-${Date.now()}.png`;
+  await page.screenshot({
+    path: runtime.artifacts.resolve(relativePath),
+    fullPage: true
+  });
+  runtime.artifacts.registerArtifact(relativePath, "image/png", metadata);
+  return relativePath;
+}
+
+async function executeDismissNotification(
+  runtime: LinkedInNotificationsExecutorRuntime,
+  actionId: string,
+  target: Record<string, unknown>
+): Promise<{ result: Record<string, unknown>; artifacts: string[] }> {
+  const profileName = getProfileName(target);
+  const notificationQuery = getRequiredStringField(
+    target,
+    "notification_query",
+    actionId,
+    "target"
+  );
+
+  return runtime.profileManager.runWithContext(
+    {
+      cdpUrl: runtime.cdpUrl,
+      profileName,
+      headless: true
+    },
+    async (context) => {
+      const page = await getOrCreatePage(context);
+      return executeConfirmActionWithArtifacts({
+        runtime,
+        context,
+        page,
+        actionId,
+        actionType: DISMISS_NOTIFICATION_ACTION_TYPE,
+        profileName,
+        targetUrl: LINKEDIN_NOTIFICATIONS_URL,
+        metadata: {
+          notification: notificationQuery
+        },
+        errorDetails: {
+          notification: notificationQuery
+        },
+        mapError: (error) =>
+          toAutomationError(error, "Failed to dismiss the LinkedIn notification.", {
+            action_id: actionId,
+            notification: notificationQuery
+          }),
+        execute: async () => {
+          await openNotificationsPage(page);
+          const rateLimitState = runtime.rateLimiter.consume(
+            DISMISS_NOTIFICATION_RATE_LIMIT_CONFIG
+          );
+          if (!rateLimitState.allowed) {
+            throw new LinkedInAssistantError(
+              "RATE_LIMITED",
+              "LinkedIn notification dismiss is rate limited for the current window.",
+              {
+                action_id: actionId,
+                profile_name: profileName,
+                notification: notificationQuery,
+                rate_limit: formatRateLimitState(rateLimitState)
+              }
+            );
+          }
+
+          const targetNotification = await resolveNotificationTarget(
+            page,
+            notificationQuery
+          );
+          const menu = await openNotificationMenu(page, targetNotification.locator);
+          const deleteRegex = buildNotificationPhraseRegex(
+            "delete_notification",
+            runtime.selectorLocale
+          );
+          const deleteNotificationRegexHint = buildNotificationPhraseHint(
+            "delete_notification",
+            runtime.selectorLocale
+          );
+          const deleteButton = menu.locator("button").filter({
+            hasText: deleteRegex
+          }).first();
+
+          if (!(await deleteButton.isVisible().catch(() => false))) {
+            throw new LinkedInAssistantError(
+              "UI_CHANGED_SELECTOR_FAILED",
+              "Could not locate the LinkedIn dismiss notification action.",
+              {
+                selector_hint: `.nt-card-settings-dropdown__content button hasText ${deleteNotificationRegexHint}`
+              }
+            );
+          }
+
+          await deleteButton.click({ timeout: 10_000 });
+          await page.waitForTimeout(1_000);
+          await openNotificationsPage(page);
+          const remainingNotifications = await collectNotifications(page, 40);
+          const stillPresent = selectNotificationMatch(
+            remainingNotifications,
+            targetNotification.snapshot.id
+          );
+          if (stillPresent) {
+            throw new LinkedInAssistantError(
+              "ACTION_PRECONDITION_FAILED",
+              "LinkedIn still showed the notification after dismiss.",
+              {
+                action_id: actionId,
+                notification_id: targetNotification.snapshot.id
+              }
+            );
+          }
+
+          return {
+            ok: true,
+            result: {
+              status: "notification_dismissed",
+              dismissed: true,
+              notification: getNotificationPreview(targetNotification.snapshot),
+              rate_limit: formatRateLimitState(rateLimitState)
+            },
+            artifacts: []
+          };
+        }
+      });
+    }
+  );
+}
+
+async function executeUpdateNotificationPreferences(
+  runtime: LinkedInNotificationsExecutorRuntime,
+  actionId: string,
+  target: Record<string, unknown>,
+  payload: Record<string, unknown>
+): Promise<{ result: Record<string, unknown>; artifacts: string[] }> {
+  const profileName = getProfileName(target);
+  const notificationQuery = getRequiredStringField(
+    target,
+    "notification_query",
+    actionId,
+    "target"
+  );
+  const requestedChanges = getRequiredPreparedPreferenceChanges(payload, actionId);
+
+  return runtime.profileManager.runWithContext(
+    {
+      cdpUrl: runtime.cdpUrl,
+      profileName,
+      headless: true
+    },
+    async (context) => {
+      const page = await getOrCreatePage(context);
+      return executeConfirmActionWithArtifacts({
+        runtime,
+        context,
+        page,
+        actionId,
+        actionType: UPDATE_NOTIFICATION_PREFERENCES_ACTION_TYPE,
+        profileName,
+        targetUrl: LINKEDIN_NOTIFICATIONS_URL,
+        metadata: {
+          notification: notificationQuery,
+          changes: requestedChanges
+        },
+        errorDetails: {
+          notification: notificationQuery
+        },
+        mapError: (error) =>
+          toAutomationError(
+            error,
+            "Failed to update LinkedIn notification preferences.",
+            {
+              action_id: actionId,
+              notification: notificationQuery
+            }
+          ),
+        execute: async () => {
+          await openNotificationsPage(page);
+          const rateLimitState = runtime.rateLimiter.consume(
+            UPDATE_NOTIFICATION_PREFERENCES_RATE_LIMIT_CONFIG
+          );
+          if (!rateLimitState.allowed) {
+            throw new LinkedInAssistantError(
+              "RATE_LIMITED",
+              "LinkedIn notification preference updates are rate limited for the current window.",
+              {
+                action_id: actionId,
+                profile_name: profileName,
+                notification: notificationQuery,
+                rate_limit: formatRateLimitState(rateLimitState)
+              }
+            );
+          }
+
+          const targetNotification = await resolveNotificationTarget(
+            page,
+            notificationQuery
+          );
+          const dialog = await openNotificationPreferencesDialog(
+            page,
+            targetNotification.locator,
+            runtime.selectorLocale
+          );
+          const beforeState = await readNotificationPreferencesDialog(page, dialog);
+          const applicableChanges = resolvePreferenceChanges(
+            beforeState.preferences,
+            requestedChanges.map((change) => ({
+              preference: change.key,
+              enabled: change.enabled
+            }))
+          );
+
+          await applyNotificationPreferenceChanges(dialog, applicableChanges);
+          const afterState = await readNotificationPreferencesDialog(page, dialog);
+          await closeNotificationPreferencesDialog(page, runtime.selectorLocale);
+
+          const verifiedChanges = applicableChanges.map((change) => {
+            const updatedPreference = afterState.preferences.find(
+              (preference) => preference.key === change.key
+            );
+
+            if (!updatedPreference || updatedPreference.enabled !== change.enabled) {
+              throw new LinkedInAssistantError(
+                "ACTION_PRECONDITION_FAILED",
+                `LinkedIn notification preference "${change.label}" did not end in the requested state.`,
+                {
+                  action_id: actionId,
+                  preference_key: change.key,
+                  preference_label: change.label,
+                  requested_enabled: change.enabled
+                }
+              );
+            }
+
+            return {
+              ...change,
+              enabled: updatedPreference.enabled
+            };
+          });
+
+          return {
+            ok: true,
+            result: {
+              status: "notification_preferences_updated",
+              notification: getNotificationPreview(targetNotification.snapshot),
+              heading: afterState.heading,
+              settings_url: afterState.settingsUrl,
+              changes: verifiedChanges,
+              rate_limit: formatRateLimitState(rateLimitState)
+            },
+            artifacts: []
+          };
+        }
+      });
+    }
+  );
+}
+
+export class DismissNotificationActionExecutor
+  implements ActionExecutor<LinkedInNotificationsExecutorRuntime>
+{
+  async execute(
+    input: ActionExecutorInput<LinkedInNotificationsExecutorRuntime>
+  ): Promise<ActionExecutorResult> {
+    const { result, artifacts } = await executeDismissNotification(
+      input.runtime,
+      input.action.id,
+      input.action.target
+    );
+    return {
+      ok: true,
+      result,
+      artifacts
+    };
+  }
+}
+
+export class UpdateNotificationPreferencesActionExecutor
+  implements ActionExecutor<LinkedInNotificationsExecutorRuntime>
+{
+  async execute(
+    input: ActionExecutorInput<LinkedInNotificationsExecutorRuntime>
+  ): Promise<ActionExecutorResult> {
+    const { result, artifacts } = await executeUpdateNotificationPreferences(
+      input.runtime,
+      input.action.id,
+      input.action.target,
+      input.action.payload
+    );
+    return {
+      ok: true,
+      result,
+      artifacts
+    };
+  }
+}
+
+export function createNotificationActionExecutors(): Record<
+  string,
+  ActionExecutor<LinkedInNotificationsExecutorRuntime>
+> {
+  return {
+    [DISMISS_NOTIFICATION_ACTION_TYPE]: new DismissNotificationActionExecutor(),
+    [UPDATE_NOTIFICATION_PREFERENCES_ACTION_TYPE]:
+      new UpdateNotificationPreferencesActionExecutor()
+  };
 }
 
 export class LinkedInNotificationsService {
@@ -383,33 +1463,316 @@ export class LinkedInNotificationsService {
     const limit = readNotificationsLimit(input.limit);
 
     await this.runtime.auth.ensureAuthenticated({
-      profileName
+      profileName,
+      cdpUrl: this.runtime.cdpUrl
     });
 
     try {
-      return await this.runtime.profileManager.runWithPersistentContext(
-        profileName,
-        { headless: true },
+      return await this.runtime.profileManager.runWithContext(
+        {
+          cdpUrl: this.runtime.cdpUrl,
+          profileName,
+          headless: true
+        },
         async (context) => {
           const page = await getOrCreatePage(context);
-          await page.goto(LINKEDIN_NOTIFICATIONS_URL, {
-            waitUntil: "domcontentloaded"
-          });
-          await waitForNetworkIdleBestEffort(page);
-          await waitForNotificationsSurface(page);
-          const notifications = await loadNotifications(page, limit);
+          await openNotificationsPage(page);
+          const notifications = await collectNotifications(page, limit);
           return notifications.slice(0, limit);
         }
       );
     } catch (error) {
-      if (error instanceof LinkedInAssistantError) {
-        throw error;
-      }
-      throw asLinkedInAssistantError(
+      throw toAutomationError(error, "Failed to list LinkedIn notifications.", {
+        profile_name: profileName,
+        limit
+      });
+    }
+  }
+
+  async markRead(
+    input: NotificationActionInput
+  ): Promise<MarkReadNotificationResult> {
+    const profileName = input.profileName ?? "default";
+    const notificationQuery = normalizeText(input.notification);
+
+    await this.runtime.auth.ensureAuthenticated({
+      profileName,
+      cdpUrl: this.runtime.cdpUrl
+    });
+
+    try {
+      return await this.runtime.profileManager.runWithContext(
+        {
+          cdpUrl: this.runtime.cdpUrl,
+          profileName,
+          headless: true
+        },
+        async (context) => {
+          const page = await getOrCreatePage(context);
+          await openNotificationsPage(page);
+          const targetNotification = await resolveNotificationTarget(
+            page,
+            notificationQuery
+          );
+
+          if (targetNotification.snapshot.is_read) {
+            const artifact = await captureNotificationScreenshot(
+              this.runtime,
+              page,
+              "notifications-mark-read-already-read",
+              {
+                profile_name: profileName,
+                notification_id: targetNotification.snapshot.id
+              }
+            );
+            return {
+              notification: {
+                ...targetNotification.snapshot,
+                is_read: true
+              },
+              status: "already_read",
+              artifacts: [artifact],
+              rate_limit: formatRateLimitState(
+                this.runtime.rateLimiter.peek(MARK_READ_RATE_LIMIT_CONFIG)
+              )
+            };
+          }
+
+          const rateLimitState = this.runtime.rateLimiter.consume(
+            MARK_READ_RATE_LIMIT_CONFIG
+          );
+          if (!rateLimitState.allowed) {
+            throw new LinkedInAssistantError(
+              "RATE_LIMITED",
+              "LinkedIn notification mark_read is rate limited for the current window.",
+              {
+                profile_name: profileName,
+                notification: notificationQuery,
+                rate_limit: formatRateLimitState(rateLimitState)
+              }
+            );
+          }
+
+          const headlineLink = targetNotification.locator.locator("a.nt-card__headline").first();
+          if (!(await headlineLink.isVisible().catch(() => false))) {
+            throw new LinkedInAssistantError(
+              "UI_CHANGED_SELECTOR_FAILED",
+              "Could not locate the clickable LinkedIn notification headline.",
+              {
+                notification: notificationQuery,
+                notification_id: targetNotification.snapshot.id
+              }
+            );
+          }
+
+          const beforeUrl = page.url();
+          await headlineLink.click({ timeout: 10_000 });
+          await Promise.race([
+            page.waitForURL((url) => url.toString() !== beforeUrl, {
+              timeout: 7_500
+            }),
+            page.waitForTimeout(1_500)
+          ]).catch(() => undefined);
+
+          if (canonicalizeComparableUrl(page.url()) !== canonicalizeComparableUrl(beforeUrl)) {
+            await page.goBack({ waitUntil: "domcontentloaded", timeout: 30_000 }).catch(
+              () => openNotificationsPage(page)
+            );
+          }
+
+          await openNotificationsPage(page);
+          const updatedNotification = await resolveNotificationTarget(
+            page,
+            targetNotification.snapshot.id
+          );
+          if (!updatedNotification.snapshot.is_read) {
+            throw new LinkedInAssistantError(
+              "ACTION_PRECONDITION_FAILED",
+              "LinkedIn still showed the notification as unread after mark_read.",
+              {
+                notification: notificationQuery,
+                notification_id: targetNotification.snapshot.id
+              }
+            );
+          }
+
+          const artifact = await captureNotificationScreenshot(
+            this.runtime,
+            page,
+            "notifications-mark-read",
+            {
+              profile_name: profileName,
+              notification_id: updatedNotification.snapshot.id
+            }
+          );
+
+          return {
+            notification: updatedNotification.snapshot,
+            status: "marked_read",
+            artifacts: [artifact],
+            rate_limit: formatRateLimitState(rateLimitState)
+          };
+        }
+      );
+    } catch (error) {
+      throw toAutomationError(error, "Failed to mark the LinkedIn notification as read.", {
+        profile_name: profileName,
+        notification: notificationQuery
+      });
+    }
+  }
+
+  async getPreferences(
+    input: GetNotificationPreferencesInput
+  ): Promise<LinkedInNotificationPreferences> {
+    const profileName = input.profileName ?? "default";
+    const notificationQuery = normalizeText(input.notification);
+
+    await this.runtime.auth.ensureAuthenticated({
+      profileName,
+      cdpUrl: this.runtime.cdpUrl
+    });
+
+    try {
+      return await this.runtime.profileManager.runWithContext(
+        {
+          cdpUrl: this.runtime.cdpUrl,
+          profileName,
+          headless: true
+        },
+        async (context) => {
+          const page = await getOrCreatePage(context);
+          await openNotificationsPage(page);
+          const targetNotification = await resolveNotificationTarget(
+            page,
+            notificationQuery
+          );
+          const dialog = await openNotificationPreferencesDialog(
+            page,
+            targetNotification.locator,
+            this.runtime.selectorLocale
+          );
+          const preferences = await readNotificationPreferencesDialog(page, dialog);
+          await closeNotificationPreferencesDialog(page, this.runtime.selectorLocale);
+
+          return {
+            notification: targetNotification.snapshot,
+            heading: preferences.heading,
+            settings_url: preferences.settingsUrl,
+            preferences: preferences.preferences
+          };
+        }
+      );
+    } catch (error) {
+      throw toAutomationError(
         error,
-        "UNKNOWN",
-        "Failed to list LinkedIn notifications."
+        "Failed to read LinkedIn notification preferences.",
+        {
+          profile_name: profileName,
+          notification: notificationQuery
+        }
       );
     }
+  }
+
+  async prepareDismiss(
+    input: NotificationActionInput
+  ): Promise<{
+    preparedActionId: string;
+    confirmToken: string;
+    expiresAtMs: number;
+    preview: Record<string, unknown>;
+  }> {
+    const profileName = input.profileName ?? "default";
+    const notificationQuery = normalizeText(input.notification);
+
+    await this.runtime.auth.ensureAuthenticated({
+      profileName,
+      cdpUrl: this.runtime.cdpUrl
+    });
+
+    const notification = await this.runtime.profileManager.runWithContext(
+      {
+        cdpUrl: this.runtime.cdpUrl,
+        profileName,
+        headless: true
+      },
+      async (context) => {
+        const page = await getOrCreatePage(context);
+        await openNotificationsPage(page);
+        const targetNotification = await resolveNotificationTarget(page, notificationQuery);
+        return targetNotification.snapshot;
+      }
+    );
+
+    const target = {
+      profile_name: profileName,
+      notification_query: notificationQuery,
+      notification_id: notification.id,
+      notification_link: notification.link,
+      notification_message: notification.message
+    };
+
+    return this.runtime.twoPhaseCommit.prepare({
+      actionType: DISMISS_NOTIFICATION_ACTION_TYPE,
+      target,
+      payload: {},
+      preview: {
+        summary: `Dismiss LinkedIn notification: ${notification.message}`,
+        notification: getNotificationPreview(notification),
+        target
+      },
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+    });
+  }
+
+  async prepareUpdatePreferences(
+    input: PrepareUpdateNotificationPreferencesInput
+  ): Promise<{
+    preparedActionId: string;
+    confirmToken: string;
+    expiresAtMs: number;
+    preview: Record<string, unknown>;
+  }> {
+    const profileName = input.profileName ?? "default";
+    const notificationQuery = normalizeText(input.notification);
+    const normalizedChanges = input.changes.map((change) => ({
+      preference: normalizeText(change.preference),
+      enabled: change.enabled
+    }));
+
+    const currentPreferences = await this.getPreferences({
+      profileName,
+      notification: notificationQuery
+    });
+    const resolvedChanges = resolvePreferenceChanges(
+      currentPreferences.preferences,
+      normalizedChanges
+    );
+
+    const target = {
+      profile_name: profileName,
+      notification_query: notificationQuery,
+      notification_id: currentPreferences.notification.id,
+      notification_link: currentPreferences.notification.link,
+      notification_message: currentPreferences.notification.message
+    };
+
+    return this.runtime.twoPhaseCommit.prepare({
+      actionType: UPDATE_NOTIFICATION_PREFERENCES_ACTION_TYPE,
+      target,
+      payload: {
+        changes: resolvedChanges
+      },
+      preview: {
+        summary: `Update LinkedIn notification preferences for ${currentPreferences.notification.message}`,
+        notification: getNotificationPreview(currentPreferences.notification),
+        heading: currentPreferences.heading,
+        settings_url: currentPreferences.settings_url,
+        changes: resolvedChanges,
+        target
+      },
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+    });
   }
 }

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -52,6 +52,7 @@ import {
   type LinkedInJobsRuntime
 } from "./linkedinJobs.js";
 import {
+  createNotificationActionExecutors,
   LinkedInNotificationsService,
   type LinkedInNotificationsRuntime
 } from "./linkedinNotifications.js";
@@ -280,6 +281,11 @@ export function createCoreRuntime(
     string,
     import("./twoPhaseCommit.js").ActionExecutor<LinkedInMessagingRuntime>
   >;
+  const notificationExecutors =
+    createNotificationActionExecutors() as unknown as Record<
+      string,
+      import("./twoPhaseCommit.js").ActionExecutor<LinkedInMessagingRuntime>
+    >;
   const privacySettingExecutors =
     createPrivacySettingActionExecutors() as unknown as Record<
       string,
@@ -296,6 +302,7 @@ export function createCoreRuntime(
       ...followupExecutors,
       ...feedExecutors,
       ...postExecutors,
+      ...notificationExecutors,
       ...privacySettingExecutors,
       [TEST_ECHO_ACTION_TYPE]: testEchoExecutor
     },

--- a/packages/mcp/src/__tests__/linkedinMcp.test.ts
+++ b/packages/mcp/src/__tests__/linkedinMcp.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  LINKEDIN_NOTIFICATIONS_DISMISS_TOOL,
+  LINKEDIN_NOTIFICATIONS_PREFERENCES_GET_TOOL,
   LINKEDIN_MEMBERS_PREPARE_REPORT_TOOL,
   LINKEDIN_PRIVACY_GET_SETTINGS_TOOL
 } from "../index.js";
@@ -26,6 +28,10 @@ interface FakeRuntime {
   members: {
     prepareReportMember: ReturnType<typeof vi.fn>;
   };
+  notifications: {
+    getPreferences: ReturnType<typeof vi.fn>;
+    prepareDismiss: ReturnType<typeof vi.fn>;
+  };
   privacySettings: {
     getSettings: ReturnType<typeof vi.fn>;
   };
@@ -41,6 +47,10 @@ function createFakeRuntime(): FakeRuntime {
     },
     members: {
       prepareReportMember: vi.fn()
+    },
+    notifications: {
+      getPreferences: vi.fn(),
+      prepareDismiss: vi.fn()
     },
     privacySettings: {
       getSettings: vi.fn()
@@ -133,6 +143,85 @@ describe("handleToolCall", () => {
       targetProfile: "target-user",
       reason: "spam",
       details: "Repeated unsolicited outreach."
+    });
+    expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns notification preference payloads through the MCP contract", async () => {
+    fakeRuntime.notifications.getPreferences.mockResolvedValue({
+      notification: {
+        id: "notif-123",
+        type: "reaction",
+        message: "Fixture notification",
+        timestamp: "1h",
+        link: "https://www.linkedin.com/feed/update/notif-123",
+        is_read: false
+      },
+      heading: "Allow notifications about",
+      settings_url: "https://www.linkedin.com/mypreferences/d/categories/notifications",
+      preferences: [
+        {
+          key: "this-post",
+          label: "This post",
+          enabled: true
+        }
+      ]
+    });
+
+    const result = await handleToolCall(LINKEDIN_NOTIFICATIONS_PREFERENCES_GET_TOOL, {
+      profileName: "default",
+      notification: "notif-123"
+    });
+
+    expect("isError" in result && result.isError).toBe(false);
+    expect(parseToolPayload(result)).toMatchObject({
+      run_id: "run_test",
+      profile_name: "default",
+      notification: {
+        id: "notif-123"
+      },
+      preferences: [
+        expect.objectContaining({
+          key: "this-post",
+          enabled: true
+        })
+      ]
+    });
+    expect(fakeRuntime.notifications.getPreferences).toHaveBeenCalledWith({
+      profileName: "default",
+      notification: "notif-123"
+    });
+    expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("prepares dismiss notification actions through the MCP contract", async () => {
+    fakeRuntime.notifications.prepareDismiss.mockResolvedValue({
+      preparedActionId: "pa_test",
+      confirmToken: "ct_test",
+      expiresAtMs: 123,
+      preview: {
+        summary: "Dismiss LinkedIn notification",
+        notification: {
+          id: "notif-123"
+        }
+      }
+    });
+
+    const result = await handleToolCall(LINKEDIN_NOTIFICATIONS_DISMISS_TOOL, {
+      profileName: "default",
+      notification: "notif-123"
+    });
+
+    expect("isError" in result && result.isError).toBe(false);
+    expect(parseToolPayload(result)).toMatchObject({
+      run_id: "run_test",
+      profile_name: "default",
+      preparedActionId: "pa_test",
+      confirmToken: "ct_test"
+    });
+    expect(fakeRuntime.notifications.prepareDismiss).toHaveBeenCalledWith({
+      profileName: "default",
+      notification: "notif-123"
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });

--- a/packages/mcp/src/bin/linkedin-mcp.ts
+++ b/packages/mcp/src/bin/linkedin-mcp.ts
@@ -112,7 +112,11 @@ import {
   LINKEDIN_PRIVACY_PREPARE_UPDATE_SETTING_TOOL,
   LINKEDIN_JOBS_SEARCH_TOOL,
   LINKEDIN_JOBS_VIEW_TOOL,
+  LINKEDIN_NOTIFICATIONS_DISMISS_TOOL,
   LINKEDIN_NOTIFICATIONS_LIST_TOOL,
+  LINKEDIN_NOTIFICATIONS_MARK_READ_TOOL,
+  LINKEDIN_NOTIFICATIONS_PREFERENCES_GET_TOOL,
+  LINKEDIN_NOTIFICATIONS_PREFERENCES_PREPARE_UPDATE_TOOL,
   LINKEDIN_POST_PREPARE_CREATE_TOOL,
   LINKEDIN_POST_PREPARE_CREATE_MEDIA_TOOL,
   LINKEDIN_POST_PREPARE_CREATE_POLL_TOOL,
@@ -292,6 +296,47 @@ function readObject(
     "ACTION_PRECONDITION_FAILED",
     `${key} must be an object.`
   );
+}
+
+function readNotificationPreferenceChanges(
+  args: ToolArgs,
+  key: string
+): Array<{ preference: string; enabled: boolean }> {
+  const value = args[key];
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${key} must be a non-empty array of { preference, enabled } objects.`
+    );
+  }
+
+  return value.map((item, index) => {
+    if (typeof item !== "object" || item === null || Array.isArray(item)) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `${key}[${index}] must be an object.`
+      );
+    }
+
+    const record = item as Record<string, unknown>;
+    const preference = record.preference;
+    const enabled = record.enabled;
+    if (
+      typeof preference !== "string" ||
+      preference.trim().length === 0 ||
+      typeof enabled !== "boolean"
+    ) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `${key}[${index}] must include a non-empty string preference and boolean enabled.`
+      );
+    }
+
+    return {
+      preference: preference.trim(),
+      enabled
+    };
+  });
 }
 
 async function readJsonInputFile(
@@ -1730,6 +1775,147 @@ async function handleNotificationsList(args: ToolArgs): Promise<ToolResult> {
       profile_name: profileName,
       count: notifications.length,
       notifications
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function handleNotificationsMarkRead(args: ToolArgs): Promise<ToolResult> {
+  const runtime = createRuntime(args);
+
+  try {
+    const profileName = readString(args, "profileName", "default");
+    const notification = readRequiredString(args, "notification");
+
+    runtime.logger.log("info", "mcp.notifications.mark_read.start", {
+      profileName,
+      notification
+    });
+
+    const result = await runtime.notifications.markRead({
+      profileName,
+      notification
+    });
+
+    runtime.logger.log("info", "mcp.notifications.mark_read.done", {
+      profileName,
+      notificationId: result.notification.id,
+      status: result.status
+    });
+
+    return toToolResult({
+      run_id: runtime.runId,
+      profile_name: profileName,
+      ...result
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function handleNotificationsDismiss(args: ToolArgs): Promise<ToolResult> {
+  const runtime = createRuntime(args);
+
+  try {
+    const profileName = readString(args, "profileName", "default");
+    const notification = readRequiredString(args, "notification");
+    const operatorNote = readString(args, "operatorNote", "");
+
+    runtime.logger.log("info", "mcp.notifications.dismiss.start", {
+      profileName,
+      notification
+    });
+
+    const prepared = await runtime.notifications.prepareDismiss({
+      profileName,
+      notification,
+      ...(operatorNote ? { operatorNote } : {})
+    });
+
+    runtime.logger.log("info", "mcp.notifications.dismiss.done", {
+      profileName,
+      preparedActionId: prepared.preparedActionId
+    });
+
+    return toToolResult({
+      run_id: runtime.runId,
+      profile_name: profileName,
+      ...prepared
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function handleNotificationPreferencesGet(
+  args: ToolArgs
+): Promise<ToolResult> {
+  const runtime = createRuntime(args);
+
+  try {
+    const profileName = readString(args, "profileName", "default");
+    const notification = readRequiredString(args, "notification");
+
+    runtime.logger.log("info", "mcp.notifications.preferences.get.start", {
+      profileName,
+      notification
+    });
+
+    const preferences = await runtime.notifications.getPreferences({
+      profileName,
+      notification
+    });
+
+    runtime.logger.log("info", "mcp.notifications.preferences.get.done", {
+      profileName,
+      notificationId: preferences.notification.id,
+      count: preferences.preferences.length
+    });
+
+    return toToolResult({
+      run_id: runtime.runId,
+      profile_name: profileName,
+      ...preferences
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function handleNotificationPreferencesPrepareUpdate(
+  args: ToolArgs
+): Promise<ToolResult> {
+  const runtime = createRuntime(args);
+
+  try {
+    const profileName = readString(args, "profileName", "default");
+    const notification = readRequiredString(args, "notification");
+    const changes = readNotificationPreferenceChanges(args, "changes");
+    const operatorNote = readString(args, "operatorNote", "");
+
+    runtime.logger.log("info", "mcp.notifications.preferences.prepare_update.start", {
+      profileName,
+      notification,
+      changeCount: changes.length
+    });
+
+    const prepared = await runtime.notifications.prepareUpdatePreferences({
+      profileName,
+      notification,
+      changes,
+      ...(operatorNote ? { operatorNote } : {})
+    });
+
+    runtime.logger.log("info", "mcp.notifications.preferences.prepare_update.done", {
+      profileName,
+      preparedActionId: prepared.preparedActionId
+    });
+
+    return toToolResult({
+      run_id: runtime.runId,
+      profile_name: profileName,
+      ...prepared
     });
   } finally {
     runtime.close();
@@ -5000,6 +5186,130 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         }
       },
       {
+        name: LINKEDIN_NOTIFICATIONS_MARK_READ_TOOL,
+        description:
+          withSelectorAuditHint(
+            "Mark one LinkedIn notification as read immediately. Accepts a notification id, full notification link, or unique message text."
+          ),
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+          required: ["notification"],
+          properties: withCdpSchemaProperties({
+            profileName: {
+              type: "string",
+              description:
+                "Persistent Playwright profile name. Defaults to default."
+            },
+            notification: {
+              type: "string",
+              description:
+                "Notification id from linkedin.notifications.list, the notification link, or a unique message fragment."
+            }
+          })
+        }
+      },
+      {
+        name: LINKEDIN_NOTIFICATIONS_DISMISS_TOOL,
+        description:
+          withSelectorAuditHint(
+            "Prepare a two-phase dismiss for one LinkedIn notification. Returns a confirm token; use linkedin.actions.confirm to execute."
+          ),
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+          required: ["notification"],
+          properties: withCdpSchemaProperties({
+            profileName: {
+              type: "string",
+              description:
+                "Persistent Playwright profile name. Defaults to default."
+            },
+            notification: {
+              type: "string",
+              description:
+                "Notification id from linkedin.notifications.list, the notification link, or a unique message fragment."
+            },
+            operatorNote: {
+              type: "string",
+              description: "Internal note for audit."
+            }
+          })
+        }
+      },
+      {
+        name: LINKEDIN_NOTIFICATIONS_PREFERENCES_GET_TOOL,
+        description:
+          withSelectorAuditHint(
+            "Read the notification preference toggles exposed for one LinkedIn notification."
+          ),
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+          required: ["notification"],
+          properties: withCdpSchemaProperties({
+            profileName: {
+              type: "string",
+              description:
+                "Persistent Playwright profile name. Defaults to default."
+            },
+            notification: {
+              type: "string",
+              description:
+                "Notification id from linkedin.notifications.list, the notification link, or a unique message fragment."
+            }
+          })
+        }
+      },
+      {
+        name: LINKEDIN_NOTIFICATIONS_PREFERENCES_PREPARE_UPDATE_TOOL,
+        description:
+          withSelectorAuditHint(
+            "Prepare a two-phase update for one notification's preference toggles. Returns a confirm token; use linkedin.actions.confirm to execute."
+          ),
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+          required: ["notification", "changes"],
+          properties: withCdpSchemaProperties({
+            profileName: {
+              type: "string",
+              description:
+                "Persistent Playwright profile name. Defaults to default."
+            },
+            notification: {
+              type: "string",
+              description:
+                "Notification id from linkedin.notifications.list, the notification link, or a unique message fragment."
+            },
+            changes: {
+              type: "array",
+              description:
+                "Requested notification preference changes as [{ preference, enabled }]. Use linkedin.notifications.preferences.get to discover preference keys first.",
+              items: {
+                type: "object",
+                additionalProperties: false,
+                required: ["preference", "enabled"],
+                properties: {
+                  preference: {
+                    type: "string",
+                    description: "Preference key or exact label."
+                  },
+                  enabled: {
+                    type: "boolean",
+                    description: "Desired on/off state."
+                  }
+                }
+              }
+            },
+            operatorNote: {
+              type: "string",
+              description: "Internal note for audit."
+            }
+          })
+        }
+      },
+      {
         name: LINKEDIN_JOBS_SEARCH_TOOL,
         description:
           withSelectorAuditHint(
@@ -5422,6 +5732,11 @@ const TOOL_HANDLERS: Record<string, ToolHandler> = {
   [LINKEDIN_POST_PREPARE_EDIT_TOOL]: handlePostPrepareEdit,
   [LINKEDIN_POST_PREPARE_DELETE_TOOL]: handlePostPrepareDelete,
   [LINKEDIN_NOTIFICATIONS_LIST_TOOL]: handleNotificationsList,
+  [LINKEDIN_NOTIFICATIONS_MARK_READ_TOOL]: handleNotificationsMarkRead,
+  [LINKEDIN_NOTIFICATIONS_DISMISS_TOOL]: handleNotificationsDismiss,
+  [LINKEDIN_NOTIFICATIONS_PREFERENCES_GET_TOOL]: handleNotificationPreferencesGet,
+  [LINKEDIN_NOTIFICATIONS_PREFERENCES_PREPARE_UPDATE_TOOL]:
+    handleNotificationPreferencesPrepareUpdate,
   [LINKEDIN_JOBS_SEARCH_TOOL]: handleJobsSearch,
   [LINKEDIN_JOBS_VIEW_TOOL]: handleJobsView,
   [LINKEDIN_ACTIVITY_WATCH_CREATE_TOOL]: handleActivityWatchCreate,

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -91,6 +91,13 @@ export const LINKEDIN_POST_PREPARE_CREATE_POLL_TOOL =
 export const LINKEDIN_POST_PREPARE_EDIT_TOOL = "linkedin.post.prepare_edit";
 export const LINKEDIN_POST_PREPARE_DELETE_TOOL = "linkedin.post.prepare_delete";
 export const LINKEDIN_NOTIFICATIONS_LIST_TOOL = "linkedin.notifications.list";
+export const LINKEDIN_NOTIFICATIONS_MARK_READ_TOOL =
+  "linkedin.notifications.mark_read";
+export const LINKEDIN_NOTIFICATIONS_DISMISS_TOOL = "linkedin.notifications.dismiss";
+export const LINKEDIN_NOTIFICATIONS_PREFERENCES_GET_TOOL =
+  "linkedin.notifications.preferences.get";
+export const LINKEDIN_NOTIFICATIONS_PREFERENCES_PREPARE_UPDATE_TOOL =
+  "linkedin.notifications.preferences.prepare_update";
 export const LINKEDIN_JOBS_SEARCH_TOOL = "linkedin.jobs.search";
 export const LINKEDIN_JOBS_VIEW_TOOL = "linkedin.jobs.view";
 export const LINKEDIN_ACTIVITY_WATCH_CREATE_TOOL = "linkedin.activity_watch.create";


### PR DESCRIPTION
## Summary
- extend the core notifications service with notification target resolution, direct mark-read, two-phase dismiss, and notification preference read/update preview flows
- expose the new notification actions through MCP tool registrations and matching CLI commands
- add notification fixtures plus unit, runtime E2E, CLI E2E, MCP E2E, and MCP contract coverage

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

## Live validation
- attempted a fresh isolated test-account login with `node packages/cli/dist/bin/linkedin.js login --profile default --headless --email "$LINKEDIN_TEST_EMAIL" --password "$LINKEDIN_TEST_PASSWORD"`
- the isolated test-account login was redirected to `https://www.linkedin.com/checkpoint/lg/login-submit`, so I did not execute mutation flows against the existing on-disk personal session

Closes #240
