### PR TITLE
feat: add MCP support for job saves, alerts, and Easy Apply prep

### DIFF
--- a/packages/core/src/__tests__/linkedinJobs.test.ts
+++ b/packages/core/src/__tests__/linkedinJobs.test.ts
@@ -1,14 +1,119 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  CREATE_JOB_ALERT_ACTION_TYPE,
+  EASY_APPLY_ACTION_TYPE,
+  LINKEDIN_JOB_ALERT_FREQUENCIES,
+  LINKEDIN_JOB_ALERT_NOTIFICATION_TYPES,
   LinkedInJobsService,
+  REMOVE_JOB_ALERT_ACTION_TYPE,
+  SAVE_JOB_ACTION_TYPE,
+  UNSAVE_JOB_ACTION_TYPE,
   buildJobSearchUrl,
   buildJobViewUrl,
-  type LinkedInJobSearchResult,
+  createJobActionExecutors,
+  normalizeLinkedInJobAlertFrequency,
+  normalizeLinkedInJobAlertNotificationType,
+  resolveLinkedInJobId,
   type LinkedInJobPosting,
+  type LinkedInJobsRuntime,
+  type LinkedInJobSearchResult,
   type SearchJobsInput,
-  type ViewJobInput,
-  type LinkedInJobsRuntime
+  type ViewJobInput
 } from "../linkedinJobs.js";
+
+function createRateLimitState(counterKey: string) {
+  return {
+    counterKey,
+    windowStartMs: 0,
+    windowSizeMs: 60_000,
+    count: 0,
+    limit: 10,
+    remaining: 10,
+    allowed: true
+  };
+}
+
+function createPrepareResult(preview: Record<string, unknown>) {
+  return {
+    preparedActionId: "pa_test",
+    confirmToken: "ct_test",
+    expiresAtMs: 123,
+    preview
+  };
+}
+
+function createJobsServiceRuntime() {
+  const prepare = vi.fn((input: { preview: Record<string, unknown> }) =>
+    createPrepareResult(input.preview)
+  );
+  const ensureAuthenticated = vi.fn().mockResolvedValue(undefined);
+  const runWithContext = vi.fn().mockResolvedValue({
+    readyToConfirm: false,
+    steps: [
+      {
+        stepIndex: 0,
+        stepTitle: "Contact info",
+        fields: [],
+        availableActions: ["Continue to next step"]
+      }
+    ],
+    fields: [
+      {
+        field_key: "resume",
+        label: "Resume",
+        input_type: "file",
+        required: true,
+        step_index: 0,
+        step_title: "Contact info",
+        supplied: false
+      }
+    ],
+    blockingFields: [
+      {
+        field_key: "resume",
+        label: "Resume",
+        input_type: "file",
+        required: true,
+        step_index: 0,
+        step_title: "Contact info",
+        supplied: false
+      }
+    ]
+  });
+  const peek = vi.fn((input: { counterKey: string }) =>
+    createRateLimitState(input.counterKey)
+  );
+
+  const runtime = {
+    auth: {
+      ensureAuthenticated
+    },
+    cdpUrl: undefined,
+    selectorLocale: "en",
+    profileManager: {
+      runWithContext
+    },
+    logger: {
+      log: vi.fn()
+    },
+    rateLimiter: {
+      peek
+    },
+    artifacts: {},
+    confirmFailureArtifacts: {},
+    twoPhaseCommit: {
+      prepare
+    }
+  } as unknown as LinkedInJobsRuntime;
+
+  return {
+    runtime,
+    prepare,
+    ensureAuthenticated,
+    runWithContext,
+    peek
+  };
+}
 
 describe("buildJobSearchUrl", () => {
   it("builds a job search URL with query only", () => {
@@ -34,15 +139,13 @@ describe("buildJobSearchUrl", () => {
   });
 
   it("ignores empty location", () => {
-    const url = buildJobSearchUrl("tester", "");
-    expect(url).toBe(
+    expect(buildJobSearchUrl("tester", "")).toBe(
       "https://www.linkedin.com/jobs/search/?keywords=tester"
     );
   });
 
   it("ignores whitespace-only location", () => {
-    const url = buildJobSearchUrl("tester", "   ");
-    expect(url).toBe(
+    expect(buildJobSearchUrl("tester", "   ")).toBe(
       "https://www.linkedin.com/jobs/search/?keywords=tester"
     );
   });
@@ -58,6 +161,79 @@ describe("buildJobViewUrl", () => {
   it("encodes special characters in job ID", () => {
     const url = buildJobViewUrl("abc/def");
     expect(url).toContain("abc%2Fdef");
+  });
+});
+
+describe("Job action types and executors", () => {
+  it("exports the expected action type constants", () => {
+    expect(SAVE_JOB_ACTION_TYPE).toBe("jobs.save_job");
+    expect(UNSAVE_JOB_ACTION_TYPE).toBe("jobs.unsave_job");
+    expect(CREATE_JOB_ALERT_ACTION_TYPE).toBe("jobs.create_alert");
+    expect(REMOVE_JOB_ALERT_ACTION_TYPE).toBe("jobs.remove_alert");
+    expect(EASY_APPLY_ACTION_TYPE).toBe("jobs.easy_apply");
+  });
+
+  it("registers all five job action executors", () => {
+    const executors = createJobActionExecutors();
+
+    expect(Object.keys(executors)).toHaveLength(5);
+    expect(executors[SAVE_JOB_ACTION_TYPE]).toBeDefined();
+    expect(executors[UNSAVE_JOB_ACTION_TYPE]).toBeDefined();
+    expect(executors[CREATE_JOB_ALERT_ACTION_TYPE]).toBeDefined();
+    expect(executors[REMOVE_JOB_ALERT_ACTION_TYPE]).toBeDefined();
+    expect(executors[EASY_APPLY_ACTION_TYPE]).toBeDefined();
+  });
+
+  it("exposes execute methods for every job action executor", () => {
+    const executors = createJobActionExecutors();
+
+    for (const executor of Object.values(executors)) {
+      expect(typeof executor.execute).toBe("function");
+    }
+  });
+});
+
+describe("Job alert normalization", () => {
+  it("exports the supported alert frequency and notification enums", () => {
+    expect(LINKEDIN_JOB_ALERT_FREQUENCIES).toEqual(["daily", "weekly"]);
+    expect(LINKEDIN_JOB_ALERT_NOTIFICATION_TYPES).toEqual([
+      "email_and_notification",
+      "email",
+      "notification"
+    ]);
+  });
+
+  it("normalizes friendly job alert values", () => {
+    expect(normalizeLinkedInJobAlertFrequency("weekly")).toBe("weekly");
+    expect(normalizeLinkedInJobAlertFrequency("day")).toBe("daily");
+    expect(normalizeLinkedInJobAlertNotificationType("both")).toBe(
+      "email_and_notification"
+    );
+    expect(normalizeLinkedInJobAlertNotificationType("notification_only")).toBe(
+      "notification"
+    );
+  });
+});
+
+describe("resolveLinkedInJobId", () => {
+  it("keeps numeric job IDs intact", () => {
+    expect(resolveLinkedInJobId("1234567890")).toBe("1234567890");
+  });
+
+  it("extracts the job ID from a LinkedIn job URL", () => {
+    expect(
+      resolveLinkedInJobId(
+        "https://www.linkedin.com/jobs/view/1234567890/?trackingId=test"
+      )
+    ).toBe("1234567890");
+  });
+
+  it("falls back to currentJobId query parameters when needed", () => {
+    expect(
+      resolveLinkedInJobId(
+        "https://www.linkedin.com/jobs/search/?currentJobId=987654321"
+      )
+    ).toBe("987654321");
   });
 });
 
@@ -121,13 +297,162 @@ describe("LinkedInJobsService", () => {
     expect(input.profileName).toBeUndefined();
   });
 
-  it("runtime interface shape is correct", () => {
+  it("runtime interface shape includes confirm, locale, rate limit, and artifact dependencies", () => {
     const runtimeKeys: (keyof LinkedInJobsRuntime)[] = [
       "auth",
       "cdpUrl",
+      "selectorLocale",
       "profileManager",
-      "logger"
+      "logger",
+      "rateLimiter",
+      "artifacts",
+      "confirmFailureArtifacts",
+      "twoPhaseCommit"
     ];
-    expect(runtimeKeys).toHaveLength(4);
+    expect(runtimeKeys).toHaveLength(9);
+  });
+
+  it("prepares save, unsave, create-alert, and remove-alert actions with targeted previews", () => {
+    const { runtime, prepare, peek } = createJobsServiceRuntime();
+    const service = new LinkedInJobsService(runtime);
+
+    const savePrepared = service.prepareSaveJob({
+      jobId: "1234567890"
+    });
+    const unsavePrepared = service.prepareUnsaveJob({
+      profileName: "jobs-profile",
+      jobId: "https://www.linkedin.com/jobs/view/1234567890/"
+    });
+    const createAlertPrepared = service.prepareCreateJobAlert({
+      query: "software engineer",
+      location: "Copenhagen",
+      frequency: "weekly",
+      notificationType: "email",
+      includeSimilarJobs: true
+    });
+    const removeAlertPrepared = service.prepareRemoveJobAlert({
+      alertId: "ja_abc123"
+    });
+
+    expect(savePrepared.preview).toMatchObject({
+      summary: "Save LinkedIn job 1234567890 for later",
+      target: {
+        profile_name: "default",
+        job_id: "1234567890"
+      },
+      outbound: {
+        action: "save"
+      }
+    });
+    expect(unsavePrepared.preview).toMatchObject({
+      summary: "Unsave LinkedIn job 1234567890",
+      target: {
+        profile_name: "jobs-profile",
+        job_id: "1234567890"
+      },
+      outbound: {
+        action: "unsave"
+      }
+    });
+    expect(createAlertPrepared.preview).toMatchObject({
+      summary: "Create a LinkedIn job alert for software engineer in Copenhagen",
+      target: {
+        profile_name: "default",
+        query: "software engineer",
+        location: "Copenhagen"
+      },
+      outbound: {
+        action: "create_alert",
+        frequency: "weekly",
+        notification_type: "email",
+        include_similar_jobs: true
+      }
+    });
+    expect(removeAlertPrepared.preview).toMatchObject({
+      summary: "Remove LinkedIn job alert ja_abc123",
+      target: {
+        profile_name: "default",
+        alert_id: "ja_abc123"
+      },
+      outbound: {
+        action: "remove_alert"
+      }
+    });
+
+    expect(prepare).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ actionType: SAVE_JOB_ACTION_TYPE })
+    );
+    expect(prepare).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ actionType: UNSAVE_JOB_ACTION_TYPE })
+    );
+    expect(prepare).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ actionType: CREATE_JOB_ALERT_ACTION_TYPE })
+    );
+    expect(prepare).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({ actionType: REMOVE_JOB_ALERT_ACTION_TYPE })
+    );
+    expect(peek).toHaveBeenCalledTimes(4);
+  });
+
+  it("prepares Easy Apply previews with surfaced blocking fields", async () => {
+    const { runtime, prepare, ensureAuthenticated, runWithContext } =
+      createJobsServiceRuntime();
+    const service = new LinkedInJobsService(runtime);
+
+    const prepared = await service.prepareEasyApply({
+      profileName: "jobs-profile",
+      jobId: "1234567890",
+      application: {
+        email: "person@example.com",
+        answers: {
+          sponsorship_required: false
+        }
+      }
+    });
+
+    expect(prepared.preview).toMatchObject({
+      summary: "Prepare LinkedIn Easy Apply for job 1234567890",
+      target: {
+        profile_name: "jobs-profile",
+        job_id: "1234567890"
+      },
+      outbound: {
+        action: "easy_apply"
+      },
+      ready_to_confirm: false,
+      blocking_fields: [
+        expect.objectContaining({
+          field_key: "resume",
+          label: "Resume"
+        })
+      ],
+      application_inputs_present: {
+        email: true,
+        phone_country_code: false,
+        phone_number: false,
+        resume_path: false,
+        cover_letter_path: false,
+        answer_count: 1
+      }
+    });
+
+    expect(ensureAuthenticated).toHaveBeenCalledWith({
+      profileName: "jobs-profile",
+      cdpUrl: undefined
+    });
+    expect(runWithContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profileName: "jobs-profile",
+        headless: true
+      }),
+      expect.any(Function)
+    );
+    expect(prepare).toHaveBeenCalledWith(
+      expect.objectContaining({ actionType: EASY_APPLY_ACTION_TYPE })
+    );
   });
 });

--- a/packages/core/src/linkedinJobs.ts
+++ b/packages/core/src/linkedinJobs.ts
@@ -1,5 +1,11 @@
-import { type BrowserContext, type Page } from "playwright-core";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { type BrowserContext, type Locator, type Page } from "playwright-core";
+import type { ArtifactHelpers } from "./artifacts.js";
 import type { LinkedInAuthService } from "./auth/session.js";
+import { executeConfirmActionWithArtifacts } from "./confirmArtifacts.js";
+import type { ConfirmFailureArtifactConfig } from "./config.js";
 import {
   LinkedInAssistantError,
   asLinkedInAssistantError
@@ -7,6 +13,15 @@ import {
 import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
+import type { RateLimiter, RateLimiterState } from "./rateLimiter.js";
+import type { LinkedInSelectorLocale } from "./selectorLocale.js";
+import { valueContainsLinkedInSelectorPhrase } from "./selectorLocale.js";
+import type {
+  ActionExecutor,
+  ActionExecutorInput,
+  ActionExecutorResult,
+  TwoPhaseCommitService
+} from "./twoPhaseCommit.js";
 
 export interface LinkedInJobSearchResult {
   job_id: string;
@@ -57,8 +72,197 @@ export interface SearchJobsOutput {
 export interface LinkedInJobsRuntime {
   auth: LinkedInAuthService;
   cdpUrl?: string | undefined;
+  selectorLocale: LinkedInSelectorLocale;
   profileManager: ProfileManager;
   logger: JsonEventLogger;
+  rateLimiter: RateLimiter;
+  artifacts: ArtifactHelpers;
+  confirmFailureArtifacts: ConfirmFailureArtifactConfig;
+  twoPhaseCommit: Pick<TwoPhaseCommitService<LinkedInJobsExecutorRuntime>, "prepare">;
+}
+
+export interface LinkedInJobsExecutorRuntime {
+  auth: LinkedInAuthService;
+  cdpUrl?: string | undefined;
+  selectorLocale: LinkedInSelectorLocale;
+  profileManager: ProfileManager;
+  logger: JsonEventLogger;
+  rateLimiter: RateLimiter;
+  artifacts: ArtifactHelpers;
+  confirmFailureArtifacts: ConfirmFailureArtifactConfig;
+}
+
+export interface SaveJobInput {
+  profileName?: string;
+  jobId: string;
+  operatorNote?: string;
+}
+
+export interface UnsaveJobInput {
+  profileName?: string;
+  jobId: string;
+  operatorNote?: string;
+}
+
+export const LINKEDIN_JOB_ALERT_FREQUENCIES = ["daily", "weekly"] as const;
+export type LinkedInJobAlertFrequency =
+  (typeof LINKEDIN_JOB_ALERT_FREQUENCIES)[number];
+
+export const LINKEDIN_JOB_ALERT_NOTIFICATION_TYPES = [
+  "email_and_notification",
+  "email",
+  "notification"
+] as const;
+export type LinkedInJobAlertNotificationType =
+  (typeof LINKEDIN_JOB_ALERT_NOTIFICATION_TYPES)[number];
+
+export interface CreateJobAlertInput {
+  profileName?: string;
+  query: string;
+  location?: string;
+  frequency?: LinkedInJobAlertFrequency | string;
+  notificationType?: LinkedInJobAlertNotificationType | string;
+  includeSimilarJobs?: boolean;
+  operatorNote?: string;
+}
+
+export interface ListJobAlertsInput {
+  profileName?: string;
+}
+
+export interface RemoveJobAlertInput {
+  profileName?: string;
+  alertId: string;
+  operatorNote?: string;
+}
+
+export interface LinkedInJobAlert {
+  alert_id: string;
+  query: string;
+  location: string;
+  search_url: string;
+  filters_text: string;
+  frequency: LinkedInJobAlertFrequency;
+  notification_type: LinkedInJobAlertNotificationType;
+  frequency_text: string;
+  include_similar_jobs: boolean;
+}
+
+export interface ListJobAlertsOutput {
+  alerts: LinkedInJobAlert[];
+  count: number;
+}
+
+export interface LinkedInEasyApplyApplicationDraft {
+  email?: string;
+  phoneCountryCode?: string;
+  phoneNumber?: string;
+  resumePath?: string;
+  coverLetterPath?: string;
+  answers?: Record<string, string | boolean>;
+}
+
+export interface PrepareEasyApplyInput {
+  profileName?: string;
+  jobId: string;
+  application?: LinkedInEasyApplyApplicationDraft;
+  operatorNote?: string;
+}
+
+export const SAVE_JOB_ACTION_TYPE = "jobs.save_job";
+export const UNSAVE_JOB_ACTION_TYPE = "jobs.unsave_job";
+export const CREATE_JOB_ALERT_ACTION_TYPE = "jobs.create_alert";
+export const REMOVE_JOB_ALERT_ACTION_TYPE = "jobs.remove_alert";
+export const EASY_APPLY_ACTION_TYPE = "jobs.easy_apply";
+
+const JOB_ALERTS_URL = "https://www.linkedin.com/jobs/jam/";
+
+const SAVE_JOB_RATE_LIMIT_CONFIG = {
+  counterKey: "linkedin.jobs.save_job",
+  windowSizeMs: 60 * 60 * 1000,
+  limit: 40
+} as const;
+
+const UNSAVE_JOB_RATE_LIMIT_CONFIG = {
+  counterKey: "linkedin.jobs.unsave_job",
+  windowSizeMs: 60 * 60 * 1000,
+  limit: 40
+} as const;
+
+const CREATE_JOB_ALERT_RATE_LIMIT_CONFIG = {
+  counterKey: "linkedin.jobs.create_alert",
+  windowSizeMs: 60 * 60 * 1000,
+  limit: 20
+} as const;
+
+const REMOVE_JOB_ALERT_RATE_LIMIT_CONFIG = {
+  counterKey: "linkedin.jobs.remove_alert",
+  windowSizeMs: 60 * 60 * 1000,
+  limit: 20
+} as const;
+
+const EASY_APPLY_RATE_LIMIT_CONFIG = {
+  counterKey: "linkedin.jobs.easy_apply",
+  windowSizeMs: 24 * 60 * 60 * 1000,
+  limit: 5
+} as const;
+
+interface ExtractedJobAlertRow {
+  alertId: string;
+  query: string;
+  location: string;
+  searchUrl: string;
+  filtersText: string;
+  frequencyText: string;
+  rowIndex: number;
+}
+
+interface JobAlertEditSettings {
+  frequency: LinkedInJobAlertFrequency;
+  notificationType: LinkedInJobAlertNotificationType;
+  includeSimilarJobs: boolean;
+}
+
+interface EasyApplyFieldOption {
+  value: string;
+  label: string;
+  id: string;
+}
+
+interface EasyApplyFieldSnapshot {
+  fieldKey: string;
+  id: string;
+  name: string;
+  label: string;
+  inputType: string;
+  required: boolean;
+  currentValue: string | boolean | null;
+  options: EasyApplyFieldOption[];
+}
+
+interface EasyApplyStepSnapshot {
+  stepIndex: number;
+  stepTitle: string;
+  fields: EasyApplyFieldSnapshot[];
+  availableActions: string[];
+}
+
+interface EasyApplyPreparedField {
+  field_key: string;
+  label: string;
+  input_type: string;
+  required: boolean;
+  step_index: number;
+  step_title: string;
+  options?: string[];
+  supplied: boolean;
+}
+
+interface EasyApplyInspectionResult {
+  readyToConfirm: boolean;
+  steps: EasyApplyStepSnapshot[];
+  fields: EasyApplyPreparedField[];
+  blockingFields: EasyApplyPreparedField[];
 }
 
 function normalizeText(value: string | null | undefined): string {
@@ -513,6 +717,2130 @@ async function loadJobSearchResults(
 }
 /* eslint-enable no-undef */
 
+function formatRateLimitState(
+  state: RateLimiterState
+): Record<string, number | boolean | string> {
+  return {
+    counter_key: state.counterKey,
+    window_start_ms: state.windowStartMs,
+    window_size_ms: state.windowSizeMs,
+    count: state.count,
+    limit: state.limit,
+    remaining: state.remaining,
+    allowed: state.allowed
+  };
+}
+
+function getProfileName(target: Record<string, unknown>): string {
+  const value = target.profile_name;
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  return "default";
+}
+
+function getRequiredStringField(
+  source: Record<string, unknown>,
+  key: string,
+  actionId: string,
+  location: "target" | "payload"
+): string {
+  const value = source[key];
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  throw new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    `Prepared action ${actionId} is missing ${location}.${key}.`,
+    {
+      action_id: actionId,
+      location,
+      key
+    }
+  );
+}
+
+function normalizeComparisonText(value: string | null | undefined): string {
+  return normalizeText(value).toLowerCase();
+}
+
+function dedupeRepeatedText(value: string): string {
+  const normalized = normalizeText(value);
+  if (!normalized) {
+    return "";
+  }
+
+  const duplicateMatch = /^(.+?)\s*\1$/iu.exec(normalized);
+  if (duplicateMatch?.[1]) {
+    return normalizeText(duplicateMatch[1]);
+  }
+
+  return normalized;
+}
+
+function buildJobAlertId(searchUrl: string): string {
+  const digest = createHash("sha256")
+    .update(normalizeText(searchUrl))
+    .digest("hex")
+    .slice(0, 16);
+  return `ja_${digest}`;
+}
+
+export function normalizeLinkedInJobAlertFrequency(
+  value: string | undefined,
+  fallback: LinkedInJobAlertFrequency = "daily"
+): LinkedInJobAlertFrequency {
+  const normalized = normalizeComparisonText(value).replace(/[\s-]+/gu, "_");
+  if (!normalized) {
+    return fallback;
+  }
+
+  if (normalized === "daily" || normalized === "day") {
+    return "daily";
+  }
+  if (normalized === "weekly" || normalized === "week") {
+    return "weekly";
+  }
+
+  throw new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    `frequency must be one of: ${LINKEDIN_JOB_ALERT_FREQUENCIES.join(", ")}.`
+  );
+}
+
+export function normalizeLinkedInJobAlertNotificationType(
+  value: string | undefined,
+  fallback: LinkedInJobAlertNotificationType = "email_and_notification"
+): LinkedInJobAlertNotificationType {
+  const normalized = normalizeComparisonText(value).replace(/[\s-]+/gu, "_");
+  if (!normalized) {
+    return fallback;
+  }
+
+  if (
+    normalized === "email_and_notification" ||
+    normalized === "both" ||
+    normalized === "email_notification"
+  ) {
+    return "email_and_notification";
+  }
+  if (normalized === "email" || normalized === "email_only") {
+    return "email";
+  }
+  if (normalized === "notification" || normalized === "notification_only") {
+    return "notification";
+  }
+
+  throw new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    `notificationType must be one of: ${LINKEDIN_JOB_ALERT_NOTIFICATION_TYPES.join(", ")}.`
+  );
+}
+
+function parseJobAlertFrequencyText(value: string): {
+  frequency: LinkedInJobAlertFrequency;
+  notificationType: LinkedInJobAlertNotificationType;
+} {
+  const normalized = normalizeComparisonText(value);
+  const frequency: LinkedInJobAlertFrequency = normalized.includes("weekly")
+    ? "weekly"
+    : "daily";
+
+  if (normalized.includes("email and notification")) {
+    return {
+      frequency,
+      notificationType: "email_and_notification"
+    };
+  }
+
+  if (
+    normalized.includes("notification only") ||
+    normalized.endsWith("via notification") ||
+    normalized.includes(" via notification ")
+  ) {
+    return {
+      frequency,
+      notificationType: "notification"
+    };
+  }
+
+  return {
+    frequency,
+    notificationType: "email"
+  };
+}
+
+export function resolveLinkedInJobId(value: string): string {
+  const normalized = normalizeText(value);
+  if (!normalized) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "jobId is required."
+    );
+  }
+
+  if (/^\d+$/.test(normalized)) {
+    return normalized;
+  }
+
+  try {
+    const parsedUrl = new URL(
+      normalized.startsWith("http")
+        ? normalized
+        : normalized.startsWith("/")
+          ? `https://www.linkedin.com${normalized}`
+          : `https://www.linkedin.com/jobs/view/${encodeURIComponent(normalized)}/`
+    );
+    const viewMatch = /\/jobs\/view\/(\d+)/iu.exec(parsedUrl.pathname);
+    if (viewMatch?.[1]) {
+      return viewMatch[1];
+    }
+
+    const currentJobId = normalizeText(parsedUrl.searchParams.get("currentJobId"));
+    if (/^\d+$/.test(currentJobId)) {
+      return currentJobId;
+    }
+  } catch {
+    // Fall through to pattern matching on the raw string.
+  }
+
+  const rawMatch = /(\d{6,})/u.exec(normalized);
+  if (rawMatch?.[1]) {
+    return rawMatch[1];
+  }
+
+  return normalized;
+}
+
+function escapeCssAttributeValue(value: string): string {
+  return value.replace(/\\/gu, "\\\\").replace(/"/gu, '\\"');
+}
+
+function normalizeEasyApplyKey(value: string): string {
+  return normalizeComparisonText(value)
+    .replace(/[^a-z0-9]+/gu, "_")
+    .replace(/^_+|_+$/gu, "");
+}
+
+function ensureLocalFileExists(filePath: string, label: string): string {
+  const resolvedPath = path.resolve(filePath);
+  if (!existsSync(resolvedPath)) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} does not exist.`,
+      {
+        path: resolvedPath
+      }
+    );
+  }
+
+  return resolvedPath;
+}
+
+function normalizeEasyApplyApplicationDraft(
+  application: LinkedInEasyApplyApplicationDraft | undefined
+): LinkedInEasyApplyApplicationDraft {
+  if (!application) {
+    return {};
+  }
+
+  const normalizedAnswers: Record<string, string | boolean> = {};
+  if (application.answers) {
+    for (const [rawKey, rawValue] of Object.entries(application.answers)) {
+      const normalizedKey = normalizeEasyApplyKey(rawKey);
+      if (!normalizedKey) {
+        continue;
+      }
+
+      if (typeof rawValue === "boolean") {
+        normalizedAnswers[normalizedKey] = rawValue;
+        continue;
+      }
+
+      if (typeof rawValue === "string") {
+        const normalizedValue = normalizeText(rawValue);
+        if (normalizedValue) {
+          normalizedAnswers[normalizedKey] = normalizedValue;
+        }
+      }
+    }
+  }
+
+  const normalizedApplication: LinkedInEasyApplyApplicationDraft = {
+    ...(application.email
+      ? {
+          email: normalizeText(application.email)
+        }
+      : {}),
+    ...(application.phoneCountryCode
+      ? {
+          phoneCountryCode: normalizeText(application.phoneCountryCode)
+        }
+      : {}),
+    ...(application.phoneNumber
+      ? {
+          phoneNumber: normalizeText(application.phoneNumber)
+        }
+      : {}),
+    ...(application.resumePath
+      ? {
+          resumePath: ensureLocalFileExists(application.resumePath, "resumePath")
+        }
+      : {}),
+    ...(application.coverLetterPath
+      ? {
+          coverLetterPath: ensureLocalFileExists(
+            application.coverLetterPath,
+            "coverLetterPath"
+          )
+        }
+      : {}),
+    ...(Object.keys(normalizedAnswers).length > 0
+      ? {
+          answers: normalizedAnswers
+        }
+      : {})
+  };
+
+  return normalizedApplication;
+}
+
+function lookupEasyApplyAnswer(
+  field: EasyApplyFieldSnapshot,
+  application: LinkedInEasyApplyApplicationDraft
+): string | boolean | undefined {
+  const label = normalizeComparisonText(field.label);
+
+  if (field.inputType === "file") {
+    if (label.includes("resume")) {
+      return application.resumePath;
+    }
+    if (label.includes("cover")) {
+      return application.coverLetterPath;
+    }
+  }
+
+  if (label.includes("email")) {
+    return application.email;
+  }
+  if (label.includes("phone country")) {
+    return application.phoneCountryCode;
+  }
+  if (label.includes("phone")) {
+    return application.phoneNumber;
+  }
+
+  return application.answers?.[field.fieldKey];
+}
+
+function isEasyApplyFieldRequired(field: EasyApplyFieldSnapshot): boolean {
+  const label = normalizeComparisonText(field.label);
+  return (
+    field.required ||
+    (field.inputType === "file" && label.includes("resume"))
+  );
+}
+
+function isEasyApplyFieldSatisfied(
+  field: EasyApplyFieldSnapshot,
+  application: LinkedInEasyApplyApplicationDraft
+): boolean {
+  const providedValue = lookupEasyApplyAnswer(field, application);
+  if (typeof providedValue === "boolean") {
+    return true;
+  }
+  if (typeof providedValue === "string" && normalizeText(providedValue).length > 0) {
+    return true;
+  }
+  if (typeof field.currentValue === "boolean") {
+    return true;
+  }
+  return normalizeText(
+    typeof field.currentValue === "string" ? field.currentValue : ""
+  ).length > 0;
+}
+
+function toPreparedEasyApplyField(
+  field: EasyApplyFieldSnapshot,
+  step: EasyApplyStepSnapshot,
+  application: LinkedInEasyApplyApplicationDraft
+): EasyApplyPreparedField {
+  return {
+    field_key: field.fieldKey,
+    label: field.label,
+    input_type: field.inputType,
+    required: isEasyApplyFieldRequired(field),
+    step_index: step.stepIndex,
+    step_title: step.stepTitle,
+    ...(field.options.length > 0
+      ? {
+          options: field.options.map((option) => option.label || option.value)
+        }
+      : {}),
+    supplied: isEasyApplyFieldSatisfied(field, application)
+  };
+}
+
+async function captureScreenshotArtifact(
+  runtime: LinkedInJobsExecutorRuntime,
+  page: Page,
+  relativePath: string,
+  metadata: Record<string, unknown> = {}
+): Promise<string> {
+  const absolutePath = runtime.artifacts.resolve(relativePath);
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
+  await page.screenshot({ path: absolutePath, fullPage: true });
+  runtime.artifacts.registerArtifact(relativePath, "image/png", metadata);
+  return relativePath;
+}
+
+async function waitForCondition(
+  predicate: () => Promise<boolean>,
+  timeoutMs: number,
+  intervalMs: number = 250
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) {
+      return true;
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, intervalMs);
+    });
+  }
+
+  return false;
+}
+
+async function waitForJobAlertsSurface(page: Page): Promise<void> {
+  const selectors = [
+    ".jam-index-modal--body ul li",
+    ".jam-index-modal",
+    "main"
+  ];
+
+  for (const selector of selectors) {
+    try {
+      await page.locator(selector).first().waitFor({
+        state: "visible",
+        timeout: 5_000
+      });
+      return;
+    } catch {
+      // Try next selector.
+    }
+  }
+
+  throw new LinkedInAssistantError(
+    "UI_CHANGED_SELECTOR_FAILED",
+    "Could not locate LinkedIn job alerts content.",
+    {
+      current_url: page.url(),
+      attempted_selectors: selectors
+    }
+  );
+}
+
+async function waitForJobAlertEditSurface(page: Page): Promise<void> {
+  const selectors = [
+    "input[name='notificationFrequency']",
+    "input[name='notificationPlatform']",
+    ".artdeco-modal"
+  ];
+
+  for (const selector of selectors) {
+    try {
+      await page.locator(selector).first().waitFor({
+        state: "visible",
+        timeout: 5_000
+      });
+      return;
+    } catch {
+      // Try next selector.
+    }
+  }
+
+  throw new LinkedInAssistantError(
+    "UI_CHANGED_SELECTOR_FAILED",
+    "Could not locate the LinkedIn job alert editor.",
+    {
+      current_url: page.url(),
+      attempted_selectors: selectors
+    }
+  );
+}
+
+async function waitForEasyApplyModal(page: Page): Promise<void> {
+  const selectors = [
+    ".artdeco-modal button",
+    ".jobs-easy-apply-modal",
+    "[role='dialog']"
+  ];
+
+  for (const selector of selectors) {
+    try {
+      await page.locator(selector).first().waitFor({
+        state: "visible",
+        timeout: 5_000
+      });
+      return;
+    } catch {
+      // Try next selector.
+    }
+  }
+
+  throw new LinkedInAssistantError(
+    "UI_CHANGED_SELECTOR_FAILED",
+    "Could not locate the LinkedIn Easy Apply modal.",
+    {
+      current_url: page.url(),
+      attempted_selectors: selectors
+    }
+  );
+}
+
+async function resolveJobSaveButton(page: Page): Promise<Locator> {
+  const locator = page.locator(".jobs-save-button").first();
+  if ((await locator.count()) === 0) {
+    throw new LinkedInAssistantError(
+      "UI_CHANGED_SELECTOR_FAILED",
+      "Could not locate the LinkedIn save job button.",
+      {
+        current_url: page.url(),
+        attempted_selectors: [".jobs-save-button"]
+      }
+    );
+  }
+
+  await locator.waitFor({
+    state: "visible",
+    timeout: 5_000
+  });
+
+  return locator;
+}
+
+async function readJobSavedState(
+  page: Page,
+  selectorLocale: LinkedInSelectorLocale
+): Promise<boolean> {
+  const button = await resolveJobSaveButton(page);
+  const textLocator = button.locator(".jobs-save-button__text").first();
+  const label =
+    normalizeText(
+      (await textLocator.count()) > 0
+        ? await textLocator.textContent()
+        : await button.textContent()
+    ) || normalizeText(await button.getAttribute("aria-label"));
+
+  if (!label) {
+    throw new LinkedInAssistantError(
+      "UI_CHANGED_SELECTOR_FAILED",
+      "Could not determine the LinkedIn save job button state.",
+      {
+        current_url: page.url()
+      }
+    );
+  }
+
+  if (
+    valueContainsLinkedInSelectorPhrase(label, "saved", selectorLocale) ||
+    /^saved\b/iu.test(label)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+async function readJobAlertToggleState(page: Page): Promise<boolean> {
+  const locator = page
+    .locator(".jobs-search-create-alert__artdeco-toggle input[type='checkbox']")
+    .first();
+  if ((await locator.count()) === 0) {
+    throw new LinkedInAssistantError(
+      "UI_CHANGED_SELECTOR_FAILED",
+      "Could not locate the LinkedIn job alert toggle on the search page.",
+      {
+        current_url: page.url(),
+        attempted_selectors: [
+          ".jobs-search-create-alert__artdeco-toggle input[type='checkbox']"
+        ]
+      }
+    );
+  }
+
+  return locator.isChecked();
+}
+
+/* eslint-disable no-undef -- DOM globals and element types are valid inside page.evaluate() */
+async function extractJobAlertRows(page: Page): Promise<ExtractedJobAlertRow[]> {
+  const rows = await page.evaluate(() => {
+    const normalize = (value: string | null | undefined): string =>
+      (value ?? "").replace(/\s+/g, " ").trim();
+
+    return Array.from(
+      document.querySelectorAll(".jam-index-modal--body ul li")
+    ).map((row, rowIndex) => {
+      const linkElement = row.querySelector("a[href*='/jobs/search']");
+      const query = normalize(linkElement?.textContent);
+      const searchUrl =
+        normalize((linkElement as HTMLAnchorElement | null)?.href) ||
+        normalize(linkElement?.getAttribute("href"));
+      const location = normalize(
+        row.querySelector(".display-flex > div > span")?.textContent
+      );
+      const detailBlocks = Array.from(row.querySelectorAll(".t-12")).map((block) =>
+        normalize(block.textContent)
+      );
+
+      return {
+        query,
+        location,
+        searchUrl,
+        filtersText: detailBlocks.find((block) => block.startsWith("Filters:")) ?? "",
+        frequencyText:
+          detailBlocks.find((block) => block.startsWith("Frequency:")) ?? "",
+        rowIndex
+      };
+    });
+  });
+
+  return rows
+    .map((row) => ({
+      ...row,
+      alertId: buildJobAlertId(row.searchUrl)
+    }))
+    .filter((row) => row.query.length > 0 && row.searchUrl.length > 0);
+}
+
+async function openJobAlertEditModal(
+  page: Page,
+  rowIndex: number
+): Promise<void> {
+  const locator = page.locator(`#editAlertIndex__${rowIndex}`).first();
+  if ((await locator.count()) === 0) {
+    throw new LinkedInAssistantError(
+      "TARGET_NOT_FOUND",
+      "Could not locate the requested LinkedIn job alert row.",
+      {
+        row_index: rowIndex,
+        current_url: page.url()
+      }
+    );
+  }
+
+  await locator.click({
+    timeout: 5_000
+  });
+  await waitForJobAlertEditSurface(page);
+}
+
+async function readJobAlertEditSettings(
+  page: Page
+): Promise<JobAlertEditSettings> {
+  const state = await page.evaluate(() => {
+    const dialog =
+      Array.from(document.querySelectorAll(".artdeco-modal")).at(-1) ??
+      document.body;
+
+    const frequencyId = (
+      dialog.querySelector(
+        "input[name='notificationFrequency']:checked"
+      ) as HTMLInputElement | null
+    )?.id;
+    const notificationValue = (
+      dialog.querySelector(
+        "input[name='notificationPlatform']:checked"
+      ) as HTMLInputElement | null
+    )?.value;
+    const includeSimilarJobs = Boolean(
+      (
+        dialog.querySelector(
+          "input[type='checkbox'].artdeco-toggle__button"
+        ) as HTMLInputElement | null
+      )?.checked
+    );
+
+    return {
+      frequencyId: frequencyId ?? "",
+      notificationValue: notificationValue ?? "",
+      includeSimilarJobs
+    };
+  });
+
+  return {
+    frequency:
+      state.frequencyId === "alert-frequency-weekly" ? "weekly" : "daily",
+    notificationType:
+      state.notificationValue === "notificationOnly"
+        ? "notification"
+        : state.notificationValue === "emailOnly"
+          ? "email"
+          : "email_and_notification",
+    includeSimilarJobs: state.includeSimilarJobs
+  };
+}
+
+function toLinkedInJobAlert(
+  row: ExtractedJobAlertRow,
+  settings?: JobAlertEditSettings
+): LinkedInJobAlert {
+  const parsed = parseJobAlertFrequencyText(row.frequencyText);
+  const resolvedSettings = settings ?? {
+    frequency: parsed.frequency,
+    notificationType: parsed.notificationType,
+    includeSimilarJobs: false
+  };
+
+  return {
+    alert_id: row.alertId,
+    query: row.query,
+    location: row.location,
+    search_url: row.searchUrl,
+    filters_text: row.filtersText,
+    frequency: resolvedSettings.frequency,
+    notification_type: resolvedSettings.notificationType,
+    frequency_text: row.frequencyText,
+    include_similar_jobs: resolvedSettings.includeSimilarJobs
+  };
+}
+
+function findMatchingJobAlertRow(
+  rows: ExtractedJobAlertRow[],
+  query: string,
+  location: string
+): ExtractedJobAlertRow | undefined {
+  const normalizedQuery = normalizeComparisonText(query);
+  const normalizedLocation = normalizeComparisonText(location);
+
+  return rows.find((row) => {
+    if (normalizeComparisonText(row.query) !== normalizedQuery) {
+      return false;
+    }
+
+    if (!normalizedLocation) {
+      return true;
+    }
+
+    const rowLocation = normalizeComparisonText(row.location);
+    return (
+      rowLocation.includes(normalizedLocation) ||
+      normalizedLocation.includes(rowLocation)
+    );
+  });
+}
+
+async function closeJobAlertEditModal(page: Page, save: boolean): Promise<void> {
+  const selector = save
+    ? ".artdeco-modal button.artdeco-button--primary"
+    : ".artdeco-modal button.artdeco-button--secondary";
+  const button = page.locator(selector).last();
+  if ((await button.count()) === 0) {
+    throw new LinkedInAssistantError(
+      "UI_CHANGED_SELECTOR_FAILED",
+      "Could not locate the expected LinkedIn job alert modal footer button.",
+      {
+        current_url: page.url(),
+        selector
+      }
+    );
+  }
+
+  await button.click({
+    timeout: 5_000
+  });
+
+  await waitForCondition(async () => {
+    const editorCount = await page
+      .locator("input[name='notificationFrequency']")
+      .count();
+    return editorCount === 0;
+  }, 5_000);
+  await waitForJobAlertsSurface(page);
+}
+
+async function updateJobAlertSettings(
+  page: Page,
+  desired: JobAlertEditSettings
+): Promise<JobAlertEditSettings> {
+  const current = await readJobAlertEditSettings(page);
+  let changed = false;
+
+  if (current.frequency !== desired.frequency) {
+    await page
+      .locator(
+        desired.frequency === "weekly"
+          ? "#alert-frequency-weekly"
+          : "#alert-frequency-daily"
+      )
+      .check({
+        timeout: 5_000
+      });
+    changed = true;
+  }
+
+  if (current.notificationType !== desired.notificationType) {
+    const notificationSelector =
+      desired.notificationType === "notification"
+        ? "#alert-notification-preference-in-app"
+        : desired.notificationType === "email"
+          ? "#alert-notification-preference-email"
+          : "#alert-notification-preference-both";
+    await page.locator(notificationSelector).check({
+      timeout: 5_000
+    });
+    changed = true;
+  }
+
+  if (current.includeSimilarJobs !== desired.includeSimilarJobs) {
+    await page
+      .locator(".artdeco-modal input[type='checkbox'].artdeco-toggle__button")
+      .last()
+      .setChecked(desired.includeSimilarJobs, {
+        timeout: 5_000
+      });
+    changed = true;
+  }
+
+  await closeJobAlertEditModal(page, changed);
+  return changed ? desired : current;
+}
+
+async function openEasyApplyModal(page: Page): Promise<void> {
+  const locator = page.locator(".jobs-apply-button").filter({
+    hasText: /Easy Apply/iu
+  });
+
+  if ((await locator.count()) === 0) {
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      "This job does not currently expose an Easy Apply flow.",
+      {
+        current_url: page.url()
+      }
+    );
+  }
+
+  await locator.first().click({
+    timeout: 5_000
+  });
+  await waitForEasyApplyModal(page);
+}
+
+interface EasyApplyButtonSnapshot {
+  text: string;
+  aria: string;
+  disabled: boolean;
+}
+
+async function extractCurrentEasyApplyStep(
+  page: Page,
+  stepIndex: number
+): Promise<EasyApplyStepSnapshot & { buttons: EasyApplyButtonSnapshot[] }> {
+  const step = await page.evaluate((currentStepIndex: number) => {
+    const normalize = (value: string | null | undefined): string =>
+      (value ?? "").replace(/\s+/g, " ").trim();
+
+    const dedupeRepeated = (value: string): string => {
+      const normalized = normalize(value);
+      if (!normalized) {
+        return "";
+      }
+
+      const duplicateMatch = /^(.+?)\s*\1$/iu.exec(normalized);
+      return normalize(duplicateMatch?.[1] ?? normalized);
+    };
+
+    const normalizeSelectValue = (selectElement: HTMLSelectElement): string => {
+      const selectedOption =
+        selectElement.selectedOptions[0] ??
+        selectElement.options[selectElement.selectedIndex] ??
+        null;
+      const label = normalize(selectedOption?.textContent);
+      if (label === "Select an option") {
+        return "";
+      }
+      return label || normalize(selectElement.value);
+    };
+
+    const getLabelText = (element: Element): string => {
+      const inputElement = element as HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
+      const id = normalize(inputElement.id);
+      if (id) {
+        const linkedLabel = document.querySelector(`label[for="${id}"]`);
+        if (linkedLabel) {
+          return dedupeRepeated(linkedLabel.textContent ?? "");
+        }
+      }
+
+      const parentLabel = inputElement.closest("label");
+      if (parentLabel) {
+        return dedupeRepeated(parentLabel.textContent ?? "");
+      }
+
+      const fieldset = inputElement.closest("fieldset");
+      const legend = fieldset?.querySelector("legend");
+      if (legend) {
+        return dedupeRepeated(legend.textContent ?? "");
+      }
+
+      return "";
+    };
+
+    const dialog =
+      Array.from(document.querySelectorAll(".artdeco-modal, [role='dialog']")).at(-1) ??
+      document.body;
+    const headings = Array.from(
+      dialog.querySelectorAll("h1, h2, h3, h4, legend")
+    )
+      .map((heading) => dedupeRepeated(heading.textContent ?? ""))
+      .filter((heading) => heading.length > 0);
+    const stepTitle =
+      headings.find((heading) => !/^apply to\b/iu.test(heading)) ??
+      `Step ${currentStepIndex + 1}`;
+
+    const radioGroups = new Map<
+      string,
+      {
+        fieldKey: string;
+        id: string;
+        name: string;
+        label: string;
+        inputType: string;
+        required: boolean;
+        currentValue: string | boolean | null;
+        options: Array<{ value: string; label: string; id: string }>;
+      }
+    >();
+    const fields: Array<{
+      fieldKey: string;
+      id: string;
+      name: string;
+      label: string;
+      inputType: string;
+      required: boolean;
+      currentValue: string | boolean | null;
+      options: Array<{ value: string; label: string; id: string }>;
+    }> = [];
+
+    const controls = Array.from(
+      dialog.querySelectorAll("input, select, textarea")
+    ).filter((control) => {
+      const type = normalize(control.getAttribute("type")).toLowerCase();
+      return type !== "hidden";
+    });
+
+    for (const control of controls) {
+      const inputElement = control as
+        | HTMLInputElement
+        | HTMLSelectElement
+        | HTMLTextAreaElement;
+      const type =
+        control.tagName === "SELECT"
+          ? "select"
+          : control.tagName === "TEXTAREA"
+            ? "textarea"
+            : normalize((control as HTMLInputElement).type).toLowerCase() || "text";
+      const id = normalize(inputElement.id);
+      const name = normalize((inputElement as HTMLInputElement).name);
+      const label = getLabelText(control);
+      const fieldKey = (() => {
+        const base = label || id || name || `${type}_${fields.length + radioGroups.size}`;
+        return base
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/gu, "_")
+          .replace(/^_+|_+$/gu, "");
+      })();
+      const required =
+        inputElement.required ||
+        inputElement.getAttribute("aria-required") === "true" ||
+        /\brequired\b/iu.test(label);
+
+      if (type === "radio") {
+        const groupKey = name || fieldKey;
+        const group = radioGroups.get(groupKey) ?? {
+          fieldKey,
+          id: "",
+          name,
+          label,
+          inputType: "radio",
+          required,
+          currentValue: null,
+          options: []
+        };
+        const optionLabel = label;
+        const optionValue = normalize((inputElement as HTMLInputElement).value);
+        if ((inputElement as HTMLInputElement).checked) {
+          group.currentValue = optionLabel || optionValue;
+        }
+        group.options.push({
+          value: optionValue,
+          label: optionLabel,
+          id
+        });
+        radioGroups.set(groupKey, group);
+        continue;
+      }
+
+      const currentValue =
+        type === "checkbox"
+          ? Boolean((inputElement as HTMLInputElement).checked)
+          : type === "select"
+            ? normalizeSelectValue(inputElement as HTMLSelectElement)
+            : normalize(inputElement.value);
+
+      const options =
+        type === "select"
+          ? Array.from((inputElement as HTMLSelectElement).options).map((option) => ({
+              value: normalize(option.value),
+              label: normalize(option.textContent),
+              id: ""
+            }))
+          : [];
+
+      fields.push({
+        fieldKey,
+        id,
+        name,
+        label,
+        inputType: type,
+        required,
+        currentValue,
+        options
+      });
+    }
+
+    for (const group of radioGroups.values()) {
+      fields.push(group);
+    }
+
+    const buttons = Array.from(dialog.querySelectorAll("button")).map((button) => ({
+      text: dedupeRepeated(button.textContent ?? ""),
+      aria: dedupeRepeated(button.getAttribute("aria-label") ?? ""),
+      disabled:
+        button.hasAttribute("disabled") ||
+        button.getAttribute("aria-disabled") === "true"
+    }));
+
+    return {
+      stepIndex: currentStepIndex,
+      stepTitle,
+      fields,
+      buttons,
+      availableActions: buttons
+        .map((button) => `${button.text} ${button.aria}`.trim())
+        .filter((value) => value.length > 0)
+    };
+  }, stepIndex);
+
+  return {
+    stepIndex: step.stepIndex,
+    stepTitle: step.stepTitle,
+    fields: step.fields.map((field) => ({
+      fieldKey: field.fieldKey || normalizeEasyApplyKey(field.label || field.id || field.name),
+      id: field.id,
+      name: field.name,
+      label: dedupeRepeatedText(field.label),
+      inputType: field.inputType,
+      required: Boolean(field.required),
+      currentValue:
+        typeof field.currentValue === "string"
+          ? normalizeText(field.currentValue)
+          : typeof field.currentValue === "boolean"
+            ? field.currentValue
+            : null,
+      options: field.options.map((option) => ({
+        value: normalizeText(option.value),
+        label: dedupeRepeatedText(option.label),
+        id: normalizeText(option.id)
+      }))
+    })),
+    availableActions: step.availableActions.map((value) => normalizeText(value)),
+    buttons: step.buttons.map((button) => ({
+      text: normalizeText(button.text),
+      aria: normalizeText(button.aria),
+      disabled: Boolean(button.disabled)
+    }))
+  };
+}
+/* eslint-enable no-undef */
+
+function resolveEasyApplyPrimaryAction(
+  buttons: EasyApplyButtonSnapshot[]
+): "submit" | "review" | "next" | null {
+  const enabledButtons = buttons.filter((button) => !button.disabled);
+
+  if (
+    enabledButtons.some((button) =>
+      /submit application|submit/iu.test(`${button.text} ${button.aria}`)
+    )
+  ) {
+    return "submit";
+  }
+  if (
+    enabledButtons.some((button) =>
+      /review your application|review/iu.test(`${button.text} ${button.aria}`)
+    )
+  ) {
+    return "review";
+  }
+  if (
+    enabledButtons.some((button) =>
+      /continue to next step|next/iu.test(`${button.text} ${button.aria}`)
+    )
+  ) {
+    return "next";
+  }
+
+  return null;
+}
+
+function matchEasyApplyOption(
+  field: EasyApplyFieldSnapshot,
+  desiredValue: string | boolean
+): EasyApplyFieldOption | undefined {
+  const normalizedDesired = normalizeComparisonText(
+    typeof desiredValue === "boolean"
+      ? desiredValue
+        ? "yes"
+        : "no"
+      : desiredValue
+  );
+
+  return field.options.find((option) => {
+    const normalizedLabel = normalizeComparisonText(option.label);
+    const normalizedValue = normalizeComparisonText(option.value);
+    return (
+      normalizedLabel === normalizedDesired ||
+      normalizedValue === normalizedDesired ||
+      normalizedLabel.includes(normalizedDesired) ||
+      normalizedDesired.includes(normalizedLabel)
+    );
+  });
+}
+
+function getEasyApplyFieldLocator(
+  page: Page,
+  field: EasyApplyFieldSnapshot
+): Locator {
+  const modal = page.locator(".artdeco-modal").last();
+  if (field.id) {
+    return modal.locator(`[id="${escapeCssAttributeValue(field.id)}"]`).first();
+  }
+  if (field.name) {
+    return modal.locator(`[name="${escapeCssAttributeValue(field.name)}"]`).first();
+  }
+
+  throw new LinkedInAssistantError(
+    "ACTION_PRECONDITION_FAILED",
+    `Could not resolve a DOM locator for Easy Apply field ${field.fieldKey}.`,
+    {
+      field_key: field.fieldKey,
+      label: field.label
+    }
+  );
+}
+
+async function fillEasyApplyField(
+  page: Page,
+  field: EasyApplyFieldSnapshot,
+  application: LinkedInEasyApplyApplicationDraft
+): Promise<void> {
+  const providedValue = lookupEasyApplyAnswer(field, application);
+  if (providedValue === undefined) {
+    return;
+  }
+
+  if (field.inputType === "radio") {
+    const matchedOption = matchEasyApplyOption(field, providedValue);
+    if (!matchedOption) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        `No matching option was found for Easy Apply field ${field.label}.`,
+        {
+          field_key: field.fieldKey,
+          provided_value: String(providedValue)
+        }
+      );
+    }
+
+    const modal = page.locator(".artdeco-modal").last();
+    const radioLocator = matchedOption.id
+      ? modal.locator(`[id="${escapeCssAttributeValue(matchedOption.id)}"]`).first()
+      : modal
+          .locator(
+            `input[type="radio"][name="${escapeCssAttributeValue(field.name)}"][value="${escapeCssAttributeValue(matchedOption.value)}"]`
+          )
+          .first();
+    await radioLocator.check({
+      timeout: 5_000
+    });
+    return;
+  }
+
+  const locator = getEasyApplyFieldLocator(page, field);
+
+  if (field.inputType === "file") {
+    if (typeof providedValue !== "string") {
+      return;
+    }
+    await locator.setInputFiles(providedValue);
+    return;
+  }
+
+  if (field.inputType === "checkbox") {
+    await locator.setChecked(Boolean(providedValue), {
+      timeout: 5_000
+    });
+    return;
+  }
+
+  if (field.inputType === "select") {
+    const desiredString = normalizeText(String(providedValue));
+    const matchedOption = matchEasyApplyOption(field, desiredString);
+    if (matchedOption?.label) {
+      try {
+        await locator.selectOption({
+          label: matchedOption.label
+        });
+        return;
+      } catch {
+        // Fall through to value-based selection.
+      }
+    }
+    if (matchedOption?.value) {
+      await locator.selectOption({
+        value: matchedOption.value
+      });
+      return;
+    }
+
+    throw new LinkedInAssistantError(
+      "ACTION_PRECONDITION_FAILED",
+      `No matching select option was found for Easy Apply field ${field.label}.`,
+      {
+        field_key: field.fieldKey,
+        provided_value: desiredString
+      }
+    );
+  }
+
+  await locator.fill(String(providedValue), {
+    timeout: 5_000
+  });
+}
+
+async function advanceEasyApplyModal(
+  page: Page,
+  action: "review" | "next" | "submit"
+): Promise<void> {
+  const modal = page.locator(".artdeco-modal").last();
+  const buttons = modal.locator("button");
+  const buttonCount = await buttons.count();
+
+  for (let index = 0; index < buttonCount; index += 1) {
+    const button = buttons.nth(index);
+    const combinedText = normalizeText(
+      `${(await button.textContent()) ?? ""} ${(await button.getAttribute("aria-label")) ?? ""}`
+    );
+    const matches =
+      action === "submit"
+        ? /submit application|submit/iu.test(combinedText)
+        : action === "review"
+          ? /review your application|review/iu.test(combinedText)
+          : /continue to next step|next/iu.test(combinedText);
+
+    if (!matches) {
+      continue;
+    }
+
+    await button.click({
+      timeout: 5_000
+    });
+    return;
+  }
+
+  throw new LinkedInAssistantError(
+    "UI_CHANGED_SELECTOR_FAILED",
+    `Could not locate the Easy Apply ${action} button.`,
+    {
+      current_url: page.url(),
+      action
+    }
+  );
+}
+
+async function inspectEasyApplyFlow(
+  page: Page,
+  application: LinkedInEasyApplyApplicationDraft,
+  options: {
+    submitOnFinalStep: boolean;
+  }
+): Promise<
+  EasyApplyInspectionResult & {
+    submitted: boolean;
+  }
+> {
+  const steps: EasyApplyStepSnapshot[] = [];
+  const fields: EasyApplyPreparedField[] = [];
+  const blockingFields: EasyApplyPreparedField[] = [];
+  let submitted = false;
+
+  for (let stepIndex = 0; stepIndex < 8; stepIndex += 1) {
+    await waitForEasyApplyModal(page);
+    let step = await extractCurrentEasyApplyStep(page, stepIndex);
+
+    for (const field of step.fields) {
+      const providedValue = lookupEasyApplyAnswer(field, application);
+      if (providedValue !== undefined) {
+        await fillEasyApplyField(page, field, application);
+      }
+    }
+
+    step = await extractCurrentEasyApplyStep(page, stepIndex);
+    steps.push(step);
+
+    for (const field of step.fields) {
+      const preparedField = toPreparedEasyApplyField(field, step, application);
+      fields.push(preparedField);
+      if (preparedField.required && !preparedField.supplied) {
+        blockingFields.push(preparedField);
+      }
+    }
+
+    if (blockingFields.length > 0) {
+      return {
+        readyToConfirm: false,
+        steps,
+        fields,
+        blockingFields,
+        submitted
+      };
+    }
+
+    const action = resolveEasyApplyPrimaryAction(step.buttons);
+    if (!action) {
+      return {
+        readyToConfirm: true,
+        steps,
+        fields,
+        blockingFields,
+        submitted
+      };
+    }
+
+    if (action === "submit") {
+      if (options.submitOnFinalStep) {
+        await advanceEasyApplyModal(page, "submit");
+        submitted = true;
+      }
+
+      return {
+        readyToConfirm: true,
+        steps,
+        fields,
+        blockingFields,
+        submitted
+      };
+    }
+
+    await advanceEasyApplyModal(page, action);
+    await page.waitForTimeout(1_250);
+  }
+
+  return {
+    readyToConfirm: false,
+    steps,
+    fields,
+    blockingFields:
+      blockingFields.length > 0
+        ? blockingFields
+        : [
+            {
+              field_key: "unknown",
+              label: "Easy Apply flow exceeded the supported step limit.",
+              input_type: "unknown",
+              required: true,
+              step_index: steps.length,
+              step_title: "Unknown",
+              supplied: false
+            }
+          ],
+    submitted
+  };
+}
+
+export class SaveJobActionExecutor
+  implements ActionExecutor<LinkedInJobsExecutorRuntime>
+{
+  async execute(
+    input: ActionExecutorInput<LinkedInJobsExecutorRuntime>
+  ): Promise<ActionExecutorResult> {
+    const runtime = input.runtime;
+    const action = input.action;
+    const profileName = getProfileName(action.target);
+    const jobId = resolveLinkedInJobId(
+      getRequiredStringField(action.target, "job_id", action.id, "target")
+    );
+    const jobUrl = buildJobViewUrl(jobId);
+
+    await runtime.auth.ensureAuthenticated({
+      profileName,
+      cdpUrl: runtime.cdpUrl
+    });
+
+    return runtime.profileManager.runWithContext(
+      {
+        cdpUrl: runtime.cdpUrl,
+        profileName,
+        headless: true
+      },
+      async (context) => {
+        const page = await getOrCreatePage(context);
+
+        return executeConfirmActionWithArtifacts({
+          runtime,
+          context,
+          page,
+          actionId: action.id,
+          actionType: SAVE_JOB_ACTION_TYPE,
+          profileName,
+          targetUrl: jobUrl,
+          metadata: {
+            job_id: jobId,
+            job_url: jobUrl
+          },
+          errorDetails: {
+            job_id: jobId,
+            job_url: jobUrl
+          },
+          mapError: (error) =>
+            asLinkedInAssistantError(
+              error,
+              "UNKNOWN",
+              "Failed to execute LinkedIn save job action."
+            ),
+          execute: async () => {
+            const rateLimitState = runtime.rateLimiter.consume(
+              SAVE_JOB_RATE_LIMIT_CONFIG
+            );
+            if (!rateLimitState.allowed) {
+              throw new LinkedInAssistantError(
+                "RATE_LIMITED",
+                "LinkedIn save job confirm is rate limited for the current window.",
+                {
+                  action_id: action.id,
+                  profile_name: profileName,
+                  job_id: jobId,
+                  rate_limit: formatRateLimitState(rateLimitState)
+                }
+              );
+            }
+
+            await page.goto(jobUrl, { waitUntil: "domcontentloaded" });
+            await waitForNetworkIdleBestEffort(page);
+            await waitForJobDetailSurface(page);
+
+            const initialSaved = await readJobSavedState(
+              page,
+              runtime.selectorLocale
+            );
+
+            if (!initialSaved) {
+              await (await resolveJobSaveButton(page)).click({
+                timeout: 5_000
+              });
+            }
+
+            let saved = initialSaved;
+            if (!saved) {
+              saved = await waitForCondition(async () => {
+                try {
+                  return await readJobSavedState(page, runtime.selectorLocale);
+                } catch {
+                  return false;
+                }
+              }, 6_000);
+            }
+
+            if (!saved) {
+              await page.reload({ waitUntil: "domcontentloaded" });
+              await waitForNetworkIdleBestEffort(page);
+              await waitForJobDetailSurface(page);
+              saved = await readJobSavedState(page, runtime.selectorLocale);
+            }
+
+            if (!saved) {
+              throw new LinkedInAssistantError(
+                "UNKNOWN",
+                "Save job action could not be verified on the target job.",
+                {
+                  action_id: action.id,
+                  profile_name: profileName,
+                  job_id: jobId,
+                  job_url: jobUrl
+                }
+              );
+            }
+
+            const screenshotPath = `linkedin/screenshot-job-save-${Date.now()}.png`;
+            await captureScreenshotArtifact(runtime, page, screenshotPath, {
+              action: SAVE_JOB_ACTION_TYPE,
+              action_id: action.id,
+              profile_name: profileName,
+              job_id: jobId,
+              job_url: jobUrl
+            });
+
+            return {
+              ok: true,
+              result: {
+                saved: true,
+                already_saved: initialSaved,
+                job_id: jobId,
+                job_url: jobUrl,
+                rate_limit: formatRateLimitState(rateLimitState)
+              },
+              artifacts: [screenshotPath]
+            };
+          }
+        });
+      }
+    );
+  }
+}
+
+export class UnsaveJobActionExecutor
+  implements ActionExecutor<LinkedInJobsExecutorRuntime>
+{
+  async execute(
+    input: ActionExecutorInput<LinkedInJobsExecutorRuntime>
+  ): Promise<ActionExecutorResult> {
+    const runtime = input.runtime;
+    const action = input.action;
+    const profileName = getProfileName(action.target);
+    const jobId = resolveLinkedInJobId(
+      getRequiredStringField(action.target, "job_id", action.id, "target")
+    );
+    const jobUrl = buildJobViewUrl(jobId);
+
+    await runtime.auth.ensureAuthenticated({
+      profileName,
+      cdpUrl: runtime.cdpUrl
+    });
+
+    return runtime.profileManager.runWithContext(
+      {
+        cdpUrl: runtime.cdpUrl,
+        profileName,
+        headless: true
+      },
+      async (context) => {
+        const page = await getOrCreatePage(context);
+
+        return executeConfirmActionWithArtifacts({
+          runtime,
+          context,
+          page,
+          actionId: action.id,
+          actionType: UNSAVE_JOB_ACTION_TYPE,
+          profileName,
+          targetUrl: jobUrl,
+          metadata: {
+            job_id: jobId,
+            job_url: jobUrl
+          },
+          errorDetails: {
+            job_id: jobId,
+            job_url: jobUrl
+          },
+          mapError: (error) =>
+            asLinkedInAssistantError(
+              error,
+              "UNKNOWN",
+              "Failed to execute LinkedIn unsave job action."
+            ),
+          execute: async () => {
+            const rateLimitState = runtime.rateLimiter.consume(
+              UNSAVE_JOB_RATE_LIMIT_CONFIG
+            );
+            if (!rateLimitState.allowed) {
+              throw new LinkedInAssistantError(
+                "RATE_LIMITED",
+                "LinkedIn unsave job confirm is rate limited for the current window.",
+                {
+                  action_id: action.id,
+                  profile_name: profileName,
+                  job_id: jobId,
+                  rate_limit: formatRateLimitState(rateLimitState)
+                }
+              );
+            }
+
+            await page.goto(jobUrl, { waitUntil: "domcontentloaded" });
+            await waitForNetworkIdleBestEffort(page);
+            await waitForJobDetailSurface(page);
+
+            const initialSaved = await readJobSavedState(
+              page,
+              runtime.selectorLocale
+            );
+
+            if (initialSaved) {
+              await (await resolveJobSaveButton(page)).click({
+                timeout: 5_000
+              });
+            }
+
+            let saved = initialSaved;
+            if (initialSaved) {
+              saved = await waitForCondition(async () => {
+                try {
+                  return await readJobSavedState(page, runtime.selectorLocale);
+                } catch {
+                  return true;
+                }
+              }, 6_000);
+            }
+
+            if (initialSaved && saved) {
+              await page.reload({ waitUntil: "domcontentloaded" });
+              await waitForNetworkIdleBestEffort(page);
+              await waitForJobDetailSurface(page);
+              saved = await readJobSavedState(page, runtime.selectorLocale);
+            }
+
+            if (saved) {
+              throw new LinkedInAssistantError(
+                "UNKNOWN",
+                "Unsave job action could not be verified on the target job.",
+                {
+                  action_id: action.id,
+                  profile_name: profileName,
+                  job_id: jobId,
+                  job_url: jobUrl
+                }
+              );
+            }
+
+            const screenshotPath = `linkedin/screenshot-job-unsave-${Date.now()}.png`;
+            await captureScreenshotArtifact(runtime, page, screenshotPath, {
+              action: UNSAVE_JOB_ACTION_TYPE,
+              action_id: action.id,
+              profile_name: profileName,
+              job_id: jobId,
+              job_url: jobUrl
+            });
+
+            return {
+              ok: true,
+              result: {
+                saved: false,
+                already_unsaved: !initialSaved,
+                job_id: jobId,
+                job_url: jobUrl,
+                rate_limit: formatRateLimitState(rateLimitState)
+              },
+              artifacts: [screenshotPath]
+            };
+          }
+        });
+      }
+    );
+  }
+}
+
+export class CreateJobAlertActionExecutor
+  implements ActionExecutor<LinkedInJobsExecutorRuntime>
+{
+  async execute(
+    input: ActionExecutorInput<LinkedInJobsExecutorRuntime>
+  ): Promise<ActionExecutorResult> {
+    const runtime = input.runtime;
+    const action = input.action;
+    const profileName = getProfileName(action.target);
+    const query = getRequiredStringField(action.target, "query", action.id, "target");
+    const location = normalizeText(
+      getRequiredStringField(action.target, "location", action.id, "target")
+    );
+    const searchUrl = getRequiredStringField(
+      action.target,
+      "search_url",
+      action.id,
+      "target"
+    );
+    const desiredSettings: JobAlertEditSettings = {
+      frequency: normalizeLinkedInJobAlertFrequency(
+        typeof action.payload.frequency === "string"
+          ? action.payload.frequency
+          : undefined
+      ),
+      notificationType: normalizeLinkedInJobAlertNotificationType(
+        typeof action.payload.notification_type === "string"
+          ? action.payload.notification_type
+          : undefined
+      ),
+      includeSimilarJobs:
+        typeof action.payload.include_similar_jobs === "boolean"
+          ? action.payload.include_similar_jobs
+          : false
+    };
+
+    await runtime.auth.ensureAuthenticated({
+      profileName,
+      cdpUrl: runtime.cdpUrl
+    });
+
+    return runtime.profileManager.runWithContext(
+      {
+        cdpUrl: runtime.cdpUrl,
+        profileName,
+        headless: true
+      },
+      async (context) => {
+        const page = await getOrCreatePage(context);
+
+        return executeConfirmActionWithArtifacts({
+          runtime,
+          context,
+          page,
+          actionId: action.id,
+          actionType: CREATE_JOB_ALERT_ACTION_TYPE,
+          profileName,
+          targetUrl: searchUrl,
+          metadata: {
+            query,
+            location,
+            search_url: searchUrl
+          },
+          errorDetails: {
+            query,
+            location,
+            search_url: searchUrl
+          },
+          mapError: (error) =>
+            asLinkedInAssistantError(
+              error,
+              "UNKNOWN",
+              "Failed to execute LinkedIn create job alert action."
+            ),
+          execute: async () => {
+            const rateLimitState = runtime.rateLimiter.consume(
+              CREATE_JOB_ALERT_RATE_LIMIT_CONFIG
+            );
+            if (!rateLimitState.allowed) {
+              throw new LinkedInAssistantError(
+                "RATE_LIMITED",
+                "LinkedIn create job alert confirm is rate limited for the current window.",
+                {
+                  action_id: action.id,
+                  profile_name: profileName,
+                  query,
+                  location,
+                  rate_limit: formatRateLimitState(rateLimitState)
+                }
+              );
+            }
+
+            await page.goto(searchUrl, { waitUntil: "domcontentloaded" });
+            await waitForNetworkIdleBestEffort(page);
+            await waitForJobSearchSurface(page);
+
+            const alreadyEnabled = await readJobAlertToggleState(page);
+            if (!alreadyEnabled) {
+              await page
+                .locator(".jobs-search-create-alert__artdeco-toggle")
+                .first()
+                .click({
+                  timeout: 5_000
+                });
+
+              const enabled = await waitForCondition(async () => {
+                try {
+                  return await readJobAlertToggleState(page);
+                } catch {
+                  return false;
+                }
+              }, 5_000);
+
+              if (!enabled) {
+                throw new LinkedInAssistantError(
+                  "UNKNOWN",
+                  "Job alert creation could not be verified on the search page.",
+                  {
+                    query,
+                    location,
+                    search_url: searchUrl
+                  }
+                );
+              }
+            }
+
+            await page.goto(JOB_ALERTS_URL, {
+              waitUntil: "domcontentloaded"
+            });
+            await waitForNetworkIdleBestEffort(page);
+            await waitForJobAlertsSurface(page);
+
+            const rows = await extractJobAlertRows(page);
+            const matchedRow = findMatchingJobAlertRow(rows, query, location);
+            if (!matchedRow) {
+              throw new LinkedInAssistantError(
+                "TARGET_NOT_FOUND",
+                "The newly created LinkedIn job alert could not be found in alert management.",
+                {
+                  query,
+                  location
+                }
+              );
+            }
+
+            await openJobAlertEditModal(page, matchedRow.rowIndex);
+            const resolvedSettings = await updateJobAlertSettings(
+              page,
+              desiredSettings
+            );
+
+            const screenshotPath = `linkedin/screenshot-job-alert-create-${Date.now()}.png`;
+            await captureScreenshotArtifact(runtime, page, screenshotPath, {
+              action: CREATE_JOB_ALERT_ACTION_TYPE,
+              action_id: action.id,
+              profile_name: profileName,
+              query,
+              location,
+              search_url: matchedRow.searchUrl
+            });
+
+            return {
+              ok: true,
+              result: {
+                created: !alreadyEnabled,
+                alert: toLinkedInJobAlert(matchedRow, resolvedSettings),
+                rate_limit: formatRateLimitState(rateLimitState)
+              },
+              artifacts: [screenshotPath]
+            };
+          }
+        });
+      }
+    );
+  }
+}
+
+export class RemoveJobAlertActionExecutor
+  implements ActionExecutor<LinkedInJobsExecutorRuntime>
+{
+  async execute(
+    input: ActionExecutorInput<LinkedInJobsExecutorRuntime>
+  ): Promise<ActionExecutorResult> {
+    const runtime = input.runtime;
+    const action = input.action;
+    const profileName = getProfileName(action.target);
+    const alertId = getRequiredStringField(
+      action.target,
+      "alert_id",
+      action.id,
+      "target"
+    );
+
+    await runtime.auth.ensureAuthenticated({
+      profileName,
+      cdpUrl: runtime.cdpUrl
+    });
+
+    return runtime.profileManager.runWithContext(
+      {
+        cdpUrl: runtime.cdpUrl,
+        profileName,
+        headless: true
+      },
+      async (context) => {
+        const page = await getOrCreatePage(context);
+
+        return executeConfirmActionWithArtifacts({
+          runtime,
+          context,
+          page,
+          actionId: action.id,
+          actionType: REMOVE_JOB_ALERT_ACTION_TYPE,
+          profileName,
+          targetUrl: JOB_ALERTS_URL,
+          metadata: {
+            alert_id: alertId
+          },
+          errorDetails: {
+            alert_id: alertId
+          },
+          mapError: (error) =>
+            asLinkedInAssistantError(
+              error,
+              "UNKNOWN",
+              "Failed to execute LinkedIn remove job alert action."
+            ),
+          execute: async () => {
+            const rateLimitState = runtime.rateLimiter.consume(
+              REMOVE_JOB_ALERT_RATE_LIMIT_CONFIG
+            );
+            if (!rateLimitState.allowed) {
+              throw new LinkedInAssistantError(
+                "RATE_LIMITED",
+                "LinkedIn remove job alert confirm is rate limited for the current window.",
+                {
+                  action_id: action.id,
+                  profile_name: profileName,
+                  alert_id: alertId,
+                  rate_limit: formatRateLimitState(rateLimitState)
+                }
+              );
+            }
+
+            await page.goto(JOB_ALERTS_URL, {
+              waitUntil: "domcontentloaded"
+            });
+            await waitForNetworkIdleBestEffort(page);
+            await waitForJobAlertsSurface(page);
+
+            const rows = await extractJobAlertRows(page);
+            const matchedRow = rows.find((row) => row.alertId === alertId);
+            if (!matchedRow) {
+              throw new LinkedInAssistantError(
+                "TARGET_NOT_FOUND",
+                "Could not find the requested LinkedIn job alert.",
+                {
+                  alert_id: alertId
+                }
+              );
+            }
+
+            const parsedSettings = parseJobAlertFrequencyText(
+              matchedRow.frequencyText
+            );
+            await openJobAlertEditModal(page, matchedRow.rowIndex);
+
+            const deleteButton = page
+              .locator(".artdeco-modal button.artdeco-button--tertiary")
+              .last();
+            if ((await deleteButton.count()) === 0) {
+              throw new LinkedInAssistantError(
+                "UI_CHANGED_SELECTOR_FAILED",
+                "Could not locate the LinkedIn delete job alert button.",
+                {
+                  alert_id: alertId,
+                  current_url: page.url()
+                }
+              );
+            }
+
+            await deleteButton.click({
+              timeout: 5_000
+            });
+
+            const removed = await waitForCondition(async () => {
+              await waitForJobAlertsSurface(page);
+              const refreshedRows = await extractJobAlertRows(page);
+              return !refreshedRows.some((row) => row.alertId === alertId);
+            }, 7_500);
+
+            if (!removed) {
+              throw new LinkedInAssistantError(
+                "UNKNOWN",
+                "The LinkedIn job alert removal could not be verified.",
+                {
+                  alert_id: alertId
+                }
+              );
+            }
+
+            const screenshotPath = `linkedin/screenshot-job-alert-remove-${Date.now()}.png`;
+            await captureScreenshotArtifact(runtime, page, screenshotPath, {
+              action: REMOVE_JOB_ALERT_ACTION_TYPE,
+              action_id: action.id,
+              profile_name: profileName,
+              alert_id: alertId
+            });
+
+            return {
+              ok: true,
+              result: {
+                removed: true,
+                alert: toLinkedInJobAlert(matchedRow, {
+                  frequency: parsedSettings.frequency,
+                  notificationType: parsedSettings.notificationType,
+                  includeSimilarJobs: false
+                }),
+                rate_limit: formatRateLimitState(rateLimitState)
+              },
+              artifacts: [screenshotPath]
+            };
+          }
+        });
+      }
+    );
+  }
+}
+
+export class EasyApplyActionExecutor
+  implements ActionExecutor<LinkedInJobsExecutorRuntime>
+{
+  async execute(
+    input: ActionExecutorInput<LinkedInJobsExecutorRuntime>
+  ): Promise<ActionExecutorResult> {
+    const runtime = input.runtime;
+    const action = input.action;
+    const profileName = getProfileName(action.target);
+    const jobId = resolveLinkedInJobId(
+      getRequiredStringField(action.target, "job_id", action.id, "target")
+    );
+    const jobUrl = getRequiredStringField(
+      action.target,
+      "job_url",
+      action.id,
+      "target"
+    );
+    const application = normalizeEasyApplyApplicationDraft(
+      (action.payload.application ?? undefined) as
+        | LinkedInEasyApplyApplicationDraft
+        | undefined
+    );
+
+    await runtime.auth.ensureAuthenticated({
+      profileName,
+      cdpUrl: runtime.cdpUrl
+    });
+
+    return runtime.profileManager.runWithContext(
+      {
+        cdpUrl: runtime.cdpUrl,
+        profileName,
+        headless: true
+      },
+      async (context) => {
+        const page = await getOrCreatePage(context);
+
+        return executeConfirmActionWithArtifacts({
+          runtime,
+          context,
+          page,
+          actionId: action.id,
+          actionType: EASY_APPLY_ACTION_TYPE,
+          profileName,
+          targetUrl: jobUrl,
+          metadata: {
+            job_id: jobId,
+            job_url: jobUrl
+          },
+          errorDetails: {
+            job_id: jobId,
+            job_url: jobUrl
+          },
+          mapError: (error) =>
+            asLinkedInAssistantError(
+              error,
+              "UNKNOWN",
+              "Failed to execute LinkedIn Easy Apply action."
+            ),
+          execute: async () => {
+            const rateLimitState = runtime.rateLimiter.consume(
+              EASY_APPLY_RATE_LIMIT_CONFIG
+            );
+            if (!rateLimitState.allowed) {
+              throw new LinkedInAssistantError(
+                "RATE_LIMITED",
+                "LinkedIn Easy Apply confirm is rate limited for the current window.",
+                {
+                  action_id: action.id,
+                  profile_name: profileName,
+                  job_id: jobId,
+                  rate_limit: formatRateLimitState(rateLimitState)
+                }
+              );
+            }
+
+            await page.goto(jobUrl, { waitUntil: "domcontentloaded" });
+            await waitForNetworkIdleBestEffort(page);
+            await waitForJobDetailSurface(page);
+            await openEasyApplyModal(page);
+
+            const inspection = await inspectEasyApplyFlow(page, application, {
+              submitOnFinalStep: true
+            });
+
+            if (!inspection.readyToConfirm || !inspection.submitted) {
+              throw new LinkedInAssistantError(
+                "ACTION_PRECONDITION_FAILED",
+                "Easy Apply confirmation is missing required application inputs.",
+                {
+                  job_id: jobId,
+                  blocking_fields: inspection.blockingFields.map((field) => field.label)
+                }
+              );
+            }
+
+            const submitted = await waitForCondition(async () => {
+              const modalCount = await page.locator(".artdeco-modal").count();
+              if (modalCount === 0) {
+                return true;
+              }
+
+              const bodyText = normalizeText(await page.textContent("body"));
+              return /application submitted|your application was sent/iu.test(
+                bodyText
+              );
+            }, 10_000);
+
+            if (!submitted) {
+              throw new LinkedInAssistantError(
+                "UNKNOWN",
+                "LinkedIn Easy Apply submission could not be verified.",
+                {
+                  action_id: action.id,
+                  job_id: jobId
+                }
+              );
+            }
+
+            const screenshotPath = `linkedin/screenshot-job-easy-apply-${Date.now()}.png`;
+            await captureScreenshotArtifact(runtime, page, screenshotPath, {
+              action: EASY_APPLY_ACTION_TYPE,
+              action_id: action.id,
+              profile_name: profileName,
+              job_id: jobId,
+              job_url: jobUrl
+            });
+
+            return {
+              ok: true,
+              result: {
+                submitted: true,
+                job_id: jobId,
+                job_url: jobUrl,
+                rate_limit: formatRateLimitState(rateLimitState)
+              },
+              artifacts: [screenshotPath]
+            };
+          }
+        });
+      }
+    );
+  }
+}
+
+export function createJobActionExecutors(): Record<
+  string,
+  ActionExecutor<LinkedInJobsExecutorRuntime>
+> {
+  return {
+    [SAVE_JOB_ACTION_TYPE]: new SaveJobActionExecutor(),
+    [UNSAVE_JOB_ACTION_TYPE]: new UnsaveJobActionExecutor(),
+    [CREATE_JOB_ALERT_ACTION_TYPE]: new CreateJobAlertActionExecutor(),
+    [REMOVE_JOB_ALERT_ACTION_TYPE]: new RemoveJobAlertActionExecutor(),
+    [EASY_APPLY_ACTION_TYPE]: new EasyApplyActionExecutor()
+  };
+}
+
 export class LinkedInJobsService {
   constructor(private readonly runtime: LinkedInJobsRuntime) {}
 
@@ -530,13 +2858,17 @@ export class LinkedInJobsService {
     }
 
     await this.runtime.auth.ensureAuthenticated({
-      profileName
+      profileName,
+      cdpUrl: this.runtime.cdpUrl
     });
 
     try {
-      const results = await this.runtime.profileManager.runWithPersistentContext(
-        profileName,
-        { headless: true },
+      const results = await this.runtime.profileManager.runWithContext(
+        {
+          cdpUrl: this.runtime.cdpUrl,
+          profileName,
+          headless: true
+        },
         async (context) => {
           const page = await getOrCreatePage(context);
           await page.goto(buildJobSearchUrl(query, location || undefined), {
@@ -568,23 +2900,20 @@ export class LinkedInJobsService {
 
   async viewJob(input: ViewJobInput): Promise<LinkedInJobPosting> {
     const profileName = input.profileName ?? "default";
-    const jobId = normalizeText(input.jobId);
-
-    if (!jobId) {
-      throw new LinkedInAssistantError(
-        "ACTION_PRECONDITION_FAILED",
-        "jobId is required."
-      );
-    }
+    const jobId = resolveLinkedInJobId(input.jobId);
 
     await this.runtime.auth.ensureAuthenticated({
-      profileName
+      profileName,
+      cdpUrl: this.runtime.cdpUrl
     });
 
     try {
-      return await this.runtime.profileManager.runWithPersistentContext(
-        profileName,
-        { headless: true },
+      return await this.runtime.profileManager.runWithContext(
+        {
+          cdpUrl: this.runtime.cdpUrl,
+          profileName,
+          headless: true
+        },
         async (context) => {
           const page = await getOrCreatePage(context);
           await page.goto(buildJobViewUrl(jobId), {
@@ -605,5 +2934,296 @@ export class LinkedInJobsService {
         "Failed to view LinkedIn job posting."
       );
     }
+  }
+
+  listJobAlerts(input: ListJobAlertsInput = {}): Promise<ListJobAlertsOutput> {
+    const profileName = input.profileName ?? "default";
+
+    return this.runtime.profileManager.runWithContext(
+      {
+        cdpUrl: this.runtime.cdpUrl,
+        profileName,
+        headless: true
+      },
+      async (context) => {
+        await this.runtime.auth.ensureAuthenticated({
+          profileName,
+          cdpUrl: this.runtime.cdpUrl
+        });
+
+        try {
+          const page = await getOrCreatePage(context);
+          await page.goto(JOB_ALERTS_URL, {
+            waitUntil: "domcontentloaded"
+          });
+          await waitForNetworkIdleBestEffort(page);
+          await waitForJobAlertsSurface(page);
+
+          const rows = await extractJobAlertRows(page);
+          const alerts: LinkedInJobAlert[] = [];
+
+          for (const row of rows) {
+            await openJobAlertEditModal(page, row.rowIndex);
+            const settings = await readJobAlertEditSettings(page);
+            alerts.push(toLinkedInJobAlert(row, settings));
+            await closeJobAlertEditModal(page, false);
+          }
+
+          return {
+            alerts,
+            count: alerts.length
+          };
+        } catch (error) {
+          if (error instanceof LinkedInAssistantError) {
+            throw error;
+          }
+          throw asLinkedInAssistantError(
+            error,
+            "UNKNOWN",
+            "Failed to list LinkedIn job alerts."
+          );
+        }
+      }
+    );
+  }
+
+  prepareSaveJob(input: SaveJobInput): {
+    preparedActionId: string;
+    confirmToken: string;
+    expiresAtMs: number;
+    preview: Record<string, unknown>;
+  } {
+    const profileName = input.profileName ?? "default";
+    const jobId = resolveLinkedInJobId(input.jobId);
+    const jobUrl = buildJobViewUrl(jobId);
+    const rateLimitState = this.runtime.rateLimiter.peek(SAVE_JOB_RATE_LIMIT_CONFIG);
+
+    const target = {
+      profile_name: profileName,
+      job_id: jobId,
+      job_url: jobUrl
+    };
+
+    return this.runtime.twoPhaseCommit.prepare({
+      actionType: SAVE_JOB_ACTION_TYPE,
+      target,
+      payload: {},
+      preview: {
+        summary: `Save LinkedIn job ${jobId} for later`,
+        target,
+        outbound: {
+          action: "save"
+        },
+        rate_limit: formatRateLimitState(rateLimitState)
+      },
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+    });
+  }
+
+  prepareUnsaveJob(input: UnsaveJobInput): {
+    preparedActionId: string;
+    confirmToken: string;
+    expiresAtMs: number;
+    preview: Record<string, unknown>;
+  } {
+    const profileName = input.profileName ?? "default";
+    const jobId = resolveLinkedInJobId(input.jobId);
+    const jobUrl = buildJobViewUrl(jobId);
+    const rateLimitState = this.runtime.rateLimiter.peek(
+      UNSAVE_JOB_RATE_LIMIT_CONFIG
+    );
+
+    const target = {
+      profile_name: profileName,
+      job_id: jobId,
+      job_url: jobUrl
+    };
+
+    return this.runtime.twoPhaseCommit.prepare({
+      actionType: UNSAVE_JOB_ACTION_TYPE,
+      target,
+      payload: {},
+      preview: {
+        summary: `Unsave LinkedIn job ${jobId}`,
+        target,
+        outbound: {
+          action: "unsave"
+        },
+        rate_limit: formatRateLimitState(rateLimitState)
+      },
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+    });
+  }
+
+  prepareCreateJobAlert(input: CreateJobAlertInput): {
+    preparedActionId: string;
+    confirmToken: string;
+    expiresAtMs: number;
+    preview: Record<string, unknown>;
+  } {
+    const profileName = input.profileName ?? "default";
+    const query = normalizeText(input.query);
+    const location = normalizeText(input.location);
+
+    if (!query) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        "query is required."
+      );
+    }
+
+    const rateLimitState = this.runtime.rateLimiter.peek(
+      CREATE_JOB_ALERT_RATE_LIMIT_CONFIG
+    );
+    const frequency = normalizeLinkedInJobAlertFrequency(input.frequency);
+    const notificationType = normalizeLinkedInJobAlertNotificationType(
+      input.notificationType
+    );
+    const includeSimilarJobs = Boolean(input.includeSimilarJobs);
+    const target = {
+      profile_name: profileName,
+      query,
+      location,
+      search_url: buildJobSearchUrl(query, location || undefined)
+    };
+
+    return this.runtime.twoPhaseCommit.prepare({
+      actionType: CREATE_JOB_ALERT_ACTION_TYPE,
+      target,
+      payload: {
+        frequency,
+        notification_type: notificationType,
+        include_similar_jobs: includeSimilarJobs
+      },
+      preview: {
+        summary: `Create a LinkedIn job alert for ${query}${location ? ` in ${location}` : ""}`,
+        target,
+        outbound: {
+          action: "create_alert",
+          frequency,
+          notification_type: notificationType,
+          include_similar_jobs: includeSimilarJobs
+        },
+        rate_limit: formatRateLimitState(rateLimitState)
+      },
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+    });
+  }
+
+  prepareRemoveJobAlert(input: RemoveJobAlertInput): {
+    preparedActionId: string;
+    confirmToken: string;
+    expiresAtMs: number;
+    preview: Record<string, unknown>;
+  } {
+    const profileName = input.profileName ?? "default";
+    const alertId = normalizeText(input.alertId);
+
+    if (!alertId) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        "alertId is required."
+      );
+    }
+
+    const rateLimitState = this.runtime.rateLimiter.peek(
+      REMOVE_JOB_ALERT_RATE_LIMIT_CONFIG
+    );
+    const target = {
+      profile_name: profileName,
+      alert_id: alertId
+    };
+
+    return this.runtime.twoPhaseCommit.prepare({
+      actionType: REMOVE_JOB_ALERT_ACTION_TYPE,
+      target,
+      payload: {},
+      preview: {
+        summary: `Remove LinkedIn job alert ${alertId}`,
+        target,
+        outbound: {
+          action: "remove_alert"
+        },
+        rate_limit: formatRateLimitState(rateLimitState)
+      },
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+    });
+  }
+
+  async prepareEasyApply(input: PrepareEasyApplyInput): Promise<{
+    preparedActionId: string;
+    confirmToken: string;
+    expiresAtMs: number;
+    preview: Record<string, unknown>;
+  }> {
+    const profileName = input.profileName ?? "default";
+    const jobId = resolveLinkedInJobId(input.jobId);
+    const jobUrl = buildJobViewUrl(jobId);
+    const application = normalizeEasyApplyApplicationDraft(input.application);
+    const rateLimitState = this.runtime.rateLimiter.peek(EASY_APPLY_RATE_LIMIT_CONFIG);
+
+    await this.runtime.auth.ensureAuthenticated({
+      profileName,
+      cdpUrl: this.runtime.cdpUrl
+    });
+
+    const inspection = await this.runtime.profileManager.runWithContext(
+      {
+        cdpUrl: this.runtime.cdpUrl,
+        profileName,
+        headless: true
+      },
+      async (context) => {
+        const page = await getOrCreatePage(context);
+        await page.goto(jobUrl, { waitUntil: "domcontentloaded" });
+        await waitForNetworkIdleBestEffort(page);
+        await waitForJobDetailSurface(page);
+        await openEasyApplyModal(page);
+        return inspectEasyApplyFlow(page, application, {
+          submitOnFinalStep: false
+        });
+      }
+    );
+
+    const target = {
+      profile_name: profileName,
+      job_id: jobId,
+      job_url: jobUrl
+    };
+
+    const preview = {
+      summary: `Prepare LinkedIn Easy Apply for job ${jobId}`,
+      target,
+      outbound: {
+        action: "easy_apply"
+      },
+      ready_to_confirm: inspection.readyToConfirm,
+      steps: inspection.steps.map((step) => ({
+        step_index: step.stepIndex,
+        step_title: step.stepTitle,
+        available_actions: step.availableActions
+      })),
+      fields: inspection.fields,
+      blocking_fields: inspection.blockingFields,
+      application_inputs_present: {
+        email: Boolean(application.email),
+        phone_country_code: Boolean(application.phoneCountryCode),
+        phone_number: Boolean(application.phoneNumber),
+        resume_path: Boolean(application.resumePath),
+        cover_letter_path: Boolean(application.coverLetterPath),
+        answer_count: Object.keys(application.answers ?? {}).length
+      },
+      rate_limit: formatRateLimitState(rateLimitState)
+    } satisfies Record<string, unknown>;
+
+    return this.runtime.twoPhaseCommit.prepare({
+      actionType: EASY_APPLY_ACTION_TYPE,
+      target,
+      payload: {
+        application
+      },
+      preview,
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+    });
   }
 }

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -53,6 +53,7 @@ import {
 } from "./linkedinProfile.js";
 import { LinkedInImageAssetsService } from "./linkedinImageAssets.js";
 import {
+  createJobActionExecutors,
   LinkedInJobsService,
   type LinkedInJobsRuntime
 } from "./linkedinJobs.js";
@@ -290,6 +291,10 @@ export function createCoreRuntime(
     string,
     import("./twoPhaseCommit.js").ActionExecutor<LinkedInMessagingRuntime>
   >;
+  const jobExecutors = createJobActionExecutors() as unknown as Record<
+    string,
+    import("./twoPhaseCommit.js").ActionExecutor<LinkedInMessagingRuntime>
+  >;
   const privacySettingExecutors =
     createPrivacySettingActionExecutors() as unknown as Record<
       string,
@@ -307,6 +312,7 @@ export function createCoreRuntime(
       ...followupExecutors,
       ...feedExecutors,
       ...postExecutors,
+      ...jobExecutors,
       ...privacySettingExecutors,
       [TEST_ECHO_ACTION_TYPE]: testEchoExecutor
     },

--- a/packages/core/src/selectorLocale.ts
+++ b/packages/core/src/selectorLocale.ts
@@ -163,6 +163,7 @@ export type LinkedInSelectorPhraseKey =
   | "resources"
   | "respond"
   | "save"
+  | "saved"
   | "share"
   | "send"
   | "send_without_note"
@@ -232,6 +233,7 @@ const ENGLISH_SELECTOR_PHRASES: SelectorPhraseDictionary = {
   resources: ["Resources"],
   respond: ["Respond"],
   save: ["Save"],
+  saved: ["Saved"],
   share: ["Share"],
   send: ["Send"],
   send_without_note: ["Send without a note"],
@@ -294,6 +296,7 @@ const DANISH_SELECTOR_PHRASE_OVERRIDES: SelectorPhraseOverrides = {
   resources: ["Ressourcer"],
   respond: ["Svar"],
   save: ["Gem"],
+  saved: ["Gemt"],
   send_without_note: ["Send uden note", "Send uden en note"],
   start_post: ["Start et opslag", "Start et indlæg"],
   support: ["Støt", "Støtter"],

--- a/packages/mcp/src/__tests__/linkedinMcp.test.ts
+++ b/packages/mcp/src/__tests__/linkedinMcp.test.ts
@@ -2,6 +2,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   LINKEDIN_COMPANY_PREPARE_FOLLOW_TOOL,
   LINKEDIN_COMPANY_VIEW_TOOL,
+  LINKEDIN_JOBS_ALERTS_CREATE_TOOL,
+  LINKEDIN_JOBS_ALERTS_LIST_TOOL,
+  LINKEDIN_JOBS_ALERTS_REMOVE_TOOL,
+  LINKEDIN_JOBS_PREPARE_EASY_APPLY_TOOL,
+  LINKEDIN_JOBS_SAVE_TOOL,
+  LINKEDIN_JOBS_UNSAVE_TOOL,
   LINKEDIN_MEMBERS_PREPARE_REPORT_TOOL,
   LINKEDIN_PRIVACY_GET_SETTINGS_TOOL
 } from "../index.js";
@@ -26,6 +32,14 @@ interface FakeRuntime {
     prepareFollowCompanyPage: ReturnType<typeof vi.fn>;
     viewCompanyPage: ReturnType<typeof vi.fn>;
   };
+  jobs: {
+    listJobAlerts: ReturnType<typeof vi.fn>;
+    prepareCreateJobAlert: ReturnType<typeof vi.fn>;
+    prepareEasyApply: ReturnType<typeof vi.fn>;
+    prepareRemoveJobAlert: ReturnType<typeof vi.fn>;
+    prepareSaveJob: ReturnType<typeof vi.fn>;
+    prepareUnsaveJob: ReturnType<typeof vi.fn>;
+  };
   logger: {
     log: ReturnType<typeof vi.fn>;
   };
@@ -38,6 +52,17 @@ interface FakeRuntime {
   runId: string;
 }
 
+function createPreparedResult(summary: string) {
+  return {
+    preparedActionId: "pa_test",
+    confirmToken: "ct_test",
+    expiresAtMs: 123,
+    preview: {
+      summary
+    }
+  };
+}
+
 function createFakeRuntime(): FakeRuntime {
   return {
     runId: "run_test",
@@ -45,6 +70,14 @@ function createFakeRuntime(): FakeRuntime {
     companyPages: {
       prepareFollowCompanyPage: vi.fn(),
       viewCompanyPage: vi.fn()
+    },
+    jobs: {
+      listJobAlerts: vi.fn(),
+      prepareCreateJobAlert: vi.fn(),
+      prepareEasyApply: vi.fn(),
+      prepareRemoveJobAlert: vi.fn(),
+      prepareSaveJob: vi.fn(),
+      prepareUnsaveJob: vi.fn()
     },
     logger: {
       log: vi.fn()
@@ -115,14 +148,9 @@ describe("handleToolCall", () => {
   });
 
   it("prepares member report actions through the MCP contract", async () => {
-    fakeRuntime.members.prepareReportMember.mockReturnValue({
-      preparedActionId: "pa_test",
-      confirmToken: "ct_test",
-      expiresAtMs: 123,
-      preview: {
-        summary: "Report LinkedIn member target-user for spam"
-      }
-    });
+    fakeRuntime.members.prepareReportMember.mockReturnValue(
+      createPreparedResult("Report LinkedIn member target-user for spam")
+    );
 
     const result = await handleToolCall(LINKEDIN_MEMBERS_PREPARE_REPORT_TOOL, {
       profileName: "default",
@@ -188,14 +216,9 @@ describe("handleToolCall", () => {
   });
 
   it("prepares company follow actions through the MCP contract", async () => {
-    fakeRuntime.companyPages.prepareFollowCompanyPage.mockReturnValue({
-      preparedActionId: "pa_company",
-      confirmToken: "ct_company",
-      expiresAtMs: 456,
-      preview: {
-        summary: "Follow company openai"
-      }
-    });
+    fakeRuntime.companyPages.prepareFollowCompanyPage.mockReturnValue(
+      createPreparedResult("Follow company openai")
+    );
 
     const result = await handleToolCall(LINKEDIN_COMPANY_PREPARE_FOLLOW_TOOL, {
       profileName: "default",
@@ -206,13 +229,180 @@ describe("handleToolCall", () => {
     expect(parseToolPayload(result)).toMatchObject({
       run_id: "run_test",
       profile_name: "default",
-      preparedActionId: "pa_company",
-      confirmToken: "ct_company"
+      preparedActionId: "pa_test",
+      confirmToken: "ct_test"
     });
     expect(fakeRuntime.companyPages.prepareFollowCompanyPage).toHaveBeenCalledWith({
       profileName: "default",
       targetCompany: "openai"
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("prepares job save and unsave actions through the MCP contract", async () => {
+    fakeRuntime.jobs.prepareSaveJob.mockReturnValue(
+      createPreparedResult("Save LinkedIn job 1234567890 for later")
+    );
+    fakeRuntime.jobs.prepareUnsaveJob.mockReturnValue(
+      createPreparedResult("Unsave LinkedIn job 1234567890")
+    );
+
+    const saveResult = await handleToolCall(LINKEDIN_JOBS_SAVE_TOOL, {
+      profileName: "default",
+      jobId: "1234567890"
+    });
+    const unsaveResult = await handleToolCall(LINKEDIN_JOBS_UNSAVE_TOOL, {
+      profileName: "jobs-profile",
+      jobId: "1234567890",
+      operatorNote: "cleanup"
+    });
+
+    expect(parseToolPayload(saveResult)).toMatchObject({
+      run_id: "run_test",
+      profile_name: "default",
+      preparedActionId: "pa_test",
+      confirmToken: "ct_test"
+    });
+    expect(parseToolPayload(unsaveResult)).toMatchObject({
+      run_id: "run_test",
+      profile_name: "jobs-profile",
+      preparedActionId: "pa_test",
+      confirmToken: "ct_test"
+    });
+    expect(fakeRuntime.jobs.prepareSaveJob).toHaveBeenCalledWith({
+      profileName: "default",
+      jobId: "1234567890"
+    });
+    expect(fakeRuntime.jobs.prepareUnsaveJob).toHaveBeenCalledWith({
+      profileName: "jobs-profile",
+      jobId: "1234567890",
+      operatorNote: "cleanup"
+    });
+  });
+
+  it("lists job alerts through the MCP contract", async () => {
+    fakeRuntime.jobs.listJobAlerts.mockResolvedValue({
+      count: 1,
+      alerts: [
+        {
+          alert_id: "ja_123",
+          query: "software engineer",
+          location: "Copenhagen",
+          search_url:
+            "https://www.linkedin.com/jobs/search/?keywords=software%20engineer&location=Copenhagen",
+          filters_text: "Filters: Easy Apply",
+          frequency: "daily",
+          notification_type: "email",
+          frequency_text: "Frequency: Daily via email",
+          include_similar_jobs: false
+        }
+      ]
+    });
+
+    const result = await handleToolCall(LINKEDIN_JOBS_ALERTS_LIST_TOOL, {
+      profileName: "default"
+    });
+
+    expect(parseToolPayload(result)).toMatchObject({
+      run_id: "run_test",
+      profile_name: "default",
+      count: 1,
+      alerts: [
+        expect.objectContaining({
+          alert_id: "ja_123",
+          query: "software engineer"
+        })
+      ]
+    });
+    expect(fakeRuntime.jobs.listJobAlerts).toHaveBeenCalledWith({
+      profileName: "default"
+    });
+  });
+
+  it("prepares job alert create and remove actions through the MCP contract", async () => {
+    fakeRuntime.jobs.prepareCreateJobAlert.mockReturnValue(
+      createPreparedResult("Create a LinkedIn job alert for software engineer")
+    );
+    fakeRuntime.jobs.prepareRemoveJobAlert.mockReturnValue(
+      createPreparedResult("Remove LinkedIn job alert ja_123")
+    );
+
+    const createResult = await handleToolCall(LINKEDIN_JOBS_ALERTS_CREATE_TOOL, {
+      profileName: "default",
+      query: "software engineer",
+      location: "Copenhagen",
+      frequency: "weekly",
+      notificationType: "email_and_notification",
+      includeSimilarJobs: true
+    });
+    const removeResult = await handleToolCall(LINKEDIN_JOBS_ALERTS_REMOVE_TOOL, {
+      profileName: "default",
+      alertId: "ja_123"
+    });
+
+    expect(parseToolPayload(createResult)).toMatchObject({
+      run_id: "run_test",
+      profile_name: "default",
+      preparedActionId: "pa_test",
+      confirmToken: "ct_test"
+    });
+    expect(parseToolPayload(removeResult)).toMatchObject({
+      run_id: "run_test",
+      profile_name: "default",
+      preparedActionId: "pa_test",
+      confirmToken: "ct_test"
+    });
+    expect(fakeRuntime.jobs.prepareCreateJobAlert).toHaveBeenCalledWith({
+      profileName: "default",
+      query: "software engineer",
+      location: "Copenhagen",
+      frequency: "weekly",
+      notificationType: "email_and_notification",
+      includeSimilarJobs: true
+    });
+    expect(fakeRuntime.jobs.prepareRemoveJobAlert).toHaveBeenCalledWith({
+      profileName: "default",
+      alertId: "ja_123"
+    });
+  });
+
+  it("prepares Easy Apply payloads through the MCP contract", async () => {
+    fakeRuntime.jobs.prepareEasyApply.mockResolvedValue(
+      createPreparedResult("Prepare LinkedIn Easy Apply for job 1234567890")
+    );
+
+    const result = await handleToolCall(LINKEDIN_JOBS_PREPARE_EASY_APPLY_TOOL, {
+      profileName: "default",
+      jobId: "1234567890",
+      application: {
+        email: "person@example.com",
+        phoneCountryCode: "+45",
+        phoneNumber: "12345678",
+        answers: {
+          sponsorship_required: false,
+          years_of_experience: "5"
+        }
+      }
+    });
+
+    expect(parseToolPayload(result)).toMatchObject({
+      run_id: "run_test",
+      profile_name: "default",
+      preparedActionId: "pa_test",
+      confirmToken: "ct_test"
+    });
+    expect(fakeRuntime.jobs.prepareEasyApply).toHaveBeenCalledWith({
+      profileName: "default",
+      jobId: "1234567890",
+      application: {
+        email: "person@example.com",
+        phoneCountryCode: "+45",
+        phoneNumber: "12345678",
+        answers: {
+          sponsorship_required: false,
+          years_of_experience: "5"
+        }
+      }
+    });
   });
 });

--- a/packages/mcp/src/bin/linkedin-mcp.ts
+++ b/packages/mcp/src/bin/linkedin-mcp.ts
@@ -11,6 +11,8 @@ import {
   DEFAULT_FOLLOWUP_SINCE,
   LINKEDIN_FEED_REACTION_TYPES,
   LINKEDIN_INBOX_REACTION_TYPES,
+  LINKEDIN_JOB_ALERT_FREQUENCIES,
+  LINKEDIN_JOB_ALERT_NOTIFICATION_TYPES,
   LINKEDIN_MEMBER_REPORT_REASONS,
   LINKEDIN_POST_VISIBILITY_TYPES,
   LINKEDIN_PRIVACY_SETTING_KEYS,
@@ -35,6 +37,7 @@ import {
   type ActivityEventType,
   type ActivityWatchKind,
   type ActivityWatchStatus,
+  type LinkedInEasyApplyApplicationDraft,
   type SearchCategory,
   type WebhookDeliveryAttemptStatus,
   type WebhookSubscriptionStatus
@@ -116,7 +119,13 @@ import {
   LINKEDIN_PRIVACY_GET_SETTINGS_TOOL,
   LINKEDIN_PRIVACY_PREPARE_UPDATE_SETTING_TOOL,
   LINKEDIN_JOBS_SEARCH_TOOL,
+  LINKEDIN_JOBS_SAVE_TOOL,
+  LINKEDIN_JOBS_UNSAVE_TOOL,
   LINKEDIN_JOBS_VIEW_TOOL,
+  LINKEDIN_JOBS_ALERTS_CREATE_TOOL,
+  LINKEDIN_JOBS_ALERTS_LIST_TOOL,
+  LINKEDIN_JOBS_ALERTS_REMOVE_TOOL,
+  LINKEDIN_JOBS_PREPARE_EASY_APPLY_TOOL,
   LINKEDIN_NOTIFICATIONS_LIST_TOOL,
   LINKEDIN_POST_PREPARE_CREATE_TOOL,
   LINKEDIN_POST_PREPARE_CREATE_MEDIA_TOOL,
@@ -438,6 +447,113 @@ function readSearchCategory(
     "ACTION_PRECONDITION_FAILED",
     `${key} must be one of: ${SEARCH_CATEGORIES.join(", ")}.`
   );
+}
+
+function readOptionalJobAlertFrequency(
+  args: ToolArgs,
+  key: string
+) {
+  const value = args[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return undefined;
+  }
+
+  return coerceEnumValue(
+    value.trim(),
+    LINKEDIN_JOB_ALERT_FREQUENCIES,
+    key
+  );
+}
+
+function readOptionalJobAlertNotificationType(
+  args: ToolArgs,
+  key: string
+) {
+  const value = args[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return undefined;
+  }
+
+  return coerceEnumValue(
+    value.trim(),
+    LINKEDIN_JOB_ALERT_NOTIFICATION_TYPES,
+    key
+  );
+}
+
+function readEasyApplyApplicationDraft(
+  args: ToolArgs,
+  key: string
+): LinkedInEasyApplyApplicationDraft | undefined {
+  const value = readObject(args, key);
+  if (!value) {
+    return undefined;
+  }
+
+  const readOptionalDraftString = (draftKey: string): string | undefined => {
+    const draftValue = value[draftKey];
+    return typeof draftValue === "string" && draftValue.trim().length > 0
+      ? draftValue.trim()
+      : undefined;
+  };
+
+  const answersValue = value.answers;
+  let answers: Record<string, string | boolean> | undefined;
+  const email = readOptionalDraftString("email");
+  const phoneCountryCode = readOptionalDraftString("phoneCountryCode");
+  const phoneNumber = readOptionalDraftString("phoneNumber");
+  const resumePath = readOptionalDraftString("resumePath");
+  const coverLetterPath = readOptionalDraftString("coverLetterPath");
+
+  if (answersValue !== undefined) {
+    if (
+      typeof answersValue !== "object" ||
+      answersValue === null ||
+      Array.isArray(answersValue)
+    ) {
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        "application.answers must be an object."
+      );
+    }
+
+    const parsedAnswers = Object.entries(answersValue).reduce<
+      Record<string, string | boolean>
+    >((result, [answerKey, answerValue]) => {
+      if (typeof answerValue === "boolean") {
+        result[answerKey] = answerValue;
+        return result;
+      }
+
+      if (typeof answerValue === "string" && answerValue.trim().length > 0) {
+        result[answerKey] = answerValue.trim();
+        return result;
+      }
+
+      throw new LinkedInAssistantError(
+        "ACTION_PRECONDITION_FAILED",
+        "application.answers values must be strings or booleans.",
+        {
+          answer_key: answerKey
+        }
+      );
+    }, {});
+
+    if (Object.keys(parsedAnswers).length > 0) {
+      answers = parsedAnswers;
+    }
+  }
+
+  const draft: LinkedInEasyApplyApplicationDraft = {
+    ...(email ? { email } : {}),
+    ...(phoneCountryCode ? { phoneCountryCode } : {}),
+    ...(phoneNumber ? { phoneNumber } : {}),
+    ...(resumePath ? { resumePath } : {}),
+    ...(coverLetterPath ? { coverLetterPath } : {}),
+    ...(answers ? { answers } : {})
+  };
+
+  return Object.keys(draft).length > 0 ? draft : undefined;
 }
 
 function readMemberReportReason(
@@ -1837,6 +1953,229 @@ async function handleJobsView(args: ToolArgs): Promise<ToolResult> {
       run_id: runtime.runId,
       profile_name: profileName,
       job
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function handleJobsSave(args: ToolArgs): Promise<ToolResult> {
+  const runtime = createRuntime(args);
+
+  try {
+    const profileName = readString(args, "profileName", "default");
+    const jobId = readRequiredString(args, "jobId");
+    const operatorNote = readString(args, "operatorNote", "");
+
+    runtime.logger.log("info", "mcp.jobs.save.start", {
+      profileName,
+      jobId
+    });
+
+    const prepared = runtime.jobs.prepareSaveJob({
+      profileName,
+      jobId,
+      ...(operatorNote ? { operatorNote } : {})
+    });
+
+    runtime.logger.log("info", "mcp.jobs.save.done", {
+      profileName,
+      preparedActionId: prepared.preparedActionId,
+      jobId
+    });
+
+    return toToolResult({
+      run_id: runtime.runId,
+      profile_name: profileName,
+      ...prepared
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function handleJobsUnsave(args: ToolArgs): Promise<ToolResult> {
+  const runtime = createRuntime(args);
+
+  try {
+    const profileName = readString(args, "profileName", "default");
+    const jobId = readRequiredString(args, "jobId");
+    const operatorNote = readString(args, "operatorNote", "");
+
+    runtime.logger.log("info", "mcp.jobs.unsave.start", {
+      profileName,
+      jobId
+    });
+
+    const prepared = runtime.jobs.prepareUnsaveJob({
+      profileName,
+      jobId,
+      ...(operatorNote ? { operatorNote } : {})
+    });
+
+    runtime.logger.log("info", "mcp.jobs.unsave.done", {
+      profileName,
+      preparedActionId: prepared.preparedActionId,
+      jobId
+    });
+
+    return toToolResult({
+      run_id: runtime.runId,
+      profile_name: profileName,
+      ...prepared
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function handleJobsAlertsCreate(args: ToolArgs): Promise<ToolResult> {
+  const runtime = createRuntime(args);
+
+  try {
+    const profileName = readString(args, "profileName", "default");
+    const query = readRequiredString(args, "query");
+    const location = readString(args, "location", "");
+    const frequency = readOptionalJobAlertFrequency(args, "frequency");
+    const notificationType = readOptionalJobAlertNotificationType(
+      args,
+      "notificationType"
+    );
+    const includeSimilarJobs = readBoolean(args, "includeSimilarJobs", false);
+    const operatorNote = readString(args, "operatorNote", "");
+
+    runtime.logger.log("info", "mcp.jobs.alerts.create.start", {
+      profileName,
+      query,
+      location,
+      ...(frequency ? { frequency } : {}),
+      ...(notificationType ? { notificationType } : {}),
+      includeSimilarJobs
+    });
+
+    const prepared = runtime.jobs.prepareCreateJobAlert({
+      profileName,
+      query,
+      ...(location ? { location } : {}),
+      ...(frequency ? { frequency } : {}),
+      ...(notificationType ? { notificationType } : {}),
+      includeSimilarJobs,
+      ...(operatorNote ? { operatorNote } : {})
+    });
+
+    runtime.logger.log("info", "mcp.jobs.alerts.create.done", {
+      profileName,
+      preparedActionId: prepared.preparedActionId,
+      query,
+      location
+    });
+
+    return toToolResult({
+      run_id: runtime.runId,
+      profile_name: profileName,
+      ...prepared
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function handleJobsAlertsList(args: ToolArgs): Promise<ToolResult> {
+  const runtime = createRuntime(args);
+
+  try {
+    const profileName = readString(args, "profileName", "default");
+
+    runtime.logger.log("info", "mcp.jobs.alerts.list.start", {
+      profileName
+    });
+
+    const result = await runtime.jobs.listJobAlerts({
+      profileName
+    });
+
+    runtime.logger.log("info", "mcp.jobs.alerts.list.done", {
+      profileName,
+      count: result.count
+    });
+
+    return toToolResult({
+      run_id: runtime.runId,
+      profile_name: profileName,
+      ...result
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function handleJobsAlertsRemove(args: ToolArgs): Promise<ToolResult> {
+  const runtime = createRuntime(args);
+
+  try {
+    const profileName = readString(args, "profileName", "default");
+    const alertId = readRequiredString(args, "alertId");
+    const operatorNote = readString(args, "operatorNote", "");
+
+    runtime.logger.log("info", "mcp.jobs.alerts.remove.start", {
+      profileName,
+      alertId
+    });
+
+    const prepared = runtime.jobs.prepareRemoveJobAlert({
+      profileName,
+      alertId,
+      ...(operatorNote ? { operatorNote } : {})
+    });
+
+    runtime.logger.log("info", "mcp.jobs.alerts.remove.done", {
+      profileName,
+      preparedActionId: prepared.preparedActionId,
+      alertId
+    });
+
+    return toToolResult({
+      run_id: runtime.runId,
+      profile_name: profileName,
+      ...prepared
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function handleJobsPrepareEasyApply(args: ToolArgs): Promise<ToolResult> {
+  const runtime = createRuntime(args);
+
+  try {
+    const profileName = readString(args, "profileName", "default");
+    const jobId = readRequiredString(args, "jobId");
+    const application = readEasyApplyApplicationDraft(args, "application");
+    const operatorNote = readString(args, "operatorNote", "");
+
+    runtime.logger.log("info", "mcp.jobs.prepare_easy_apply.start", {
+      profileName,
+      jobId,
+      hasApplication: Boolean(application)
+    });
+
+    const prepared = await runtime.jobs.prepareEasyApply({
+      profileName,
+      jobId,
+      ...(application ? { application } : {}),
+      ...(operatorNote ? { operatorNote } : {})
+    });
+
+    runtime.logger.log("info", "mcp.jobs.prepare_easy_apply.done", {
+      profileName,
+      preparedActionId: prepared.preparedActionId,
+      jobId
+    });
+
+    return toToolResult({
+      run_id: runtime.runId,
+      profile_name: profileName,
+      ...prepared
     });
   } finally {
     runtime.close();
@@ -5231,6 +5570,204 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         }
       },
       {
+        name: LINKEDIN_JOBS_SAVE_TOOL,
+        description:
+          "Prepare to save a LinkedIn job for later (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+          required: ["jobId"],
+          properties: withCdpSchemaProperties({
+            profileName: {
+              type: "string",
+              description:
+                "Persistent Playwright profile name. Defaults to default."
+            },
+            jobId: {
+              type: "string",
+              description: "LinkedIn job ID or job URL."
+            },
+            operatorNote: {
+              type: "string",
+              description: "Internal note for audit."
+            }
+          })
+        }
+      },
+      {
+        name: LINKEDIN_JOBS_UNSAVE_TOOL,
+        description:
+          "Prepare to remove a LinkedIn job from saved jobs (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+          required: ["jobId"],
+          properties: withCdpSchemaProperties({
+            profileName: {
+              type: "string",
+              description:
+                "Persistent Playwright profile name. Defaults to default."
+            },
+            jobId: {
+              type: "string",
+              description: "LinkedIn job ID or job URL."
+            },
+            operatorNote: {
+              type: "string",
+              description: "Internal note for audit."
+            }
+          })
+        }
+      },
+      {
+        name: LINKEDIN_JOBS_ALERTS_CREATE_TOOL,
+        description:
+          "Prepare to create or update a LinkedIn job alert for a search (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+          required: ["query"],
+          properties: withCdpSchemaProperties({
+            profileName: {
+              type: "string",
+              description:
+                "Persistent Playwright profile name. Defaults to default."
+            },
+            query: {
+              type: "string",
+              description: "Job search keywords for the alert."
+            },
+            location: {
+              type: "string",
+              description: "Optional location filter for the alert."
+            },
+            frequency: {
+              type: "string",
+              enum: [...LINKEDIN_JOB_ALERT_FREQUENCIES],
+              description: "Alert frequency. Defaults to daily."
+            },
+            notificationType: {
+              type: "string",
+              enum: [...LINKEDIN_JOB_ALERT_NOTIFICATION_TYPES],
+              description:
+                "Notification delivery preference. Defaults to email_and_notification."
+            },
+            includeSimilarJobs: {
+              type: "boolean",
+              description: "Whether the alert should include similar jobs."
+            },
+            operatorNote: {
+              type: "string",
+              description: "Internal note for audit."
+            }
+          })
+        }
+      },
+      {
+        name: LINKEDIN_JOBS_ALERTS_LIST_TOOL,
+        description:
+          withSelectorAuditHint(
+            "List active LinkedIn job alerts, including delivery settings and search URLs."
+          ),
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+          properties: withCdpSchemaProperties({
+            profileName: {
+              type: "string",
+              description:
+                "Persistent Playwright profile name. Defaults to default."
+            }
+          })
+        }
+      },
+      {
+        name: LINKEDIN_JOBS_ALERTS_REMOVE_TOOL,
+        description:
+          "Prepare to remove a LinkedIn job alert by alert ID (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+          required: ["alertId"],
+          properties: withCdpSchemaProperties({
+            profileName: {
+              type: "string",
+              description:
+                "Persistent Playwright profile name. Defaults to default."
+            },
+            alertId: {
+              type: "string",
+              description: "Alert ID returned by linkedin.jobs.alerts.list."
+            },
+            operatorNote: {
+              type: "string",
+              description: "Internal note for audit."
+            }
+          })
+        }
+      },
+      {
+        name: LINKEDIN_JOBS_PREPARE_EASY_APPLY_TOOL,
+        description:
+          "Inspect an Easy Apply flow and prepare a strict two-phase application submission. Returns blocking fields when more input is required. Use linkedin.actions.confirm to execute only after review.",
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+          required: ["jobId"],
+          properties: withCdpSchemaProperties({
+            profileName: {
+              type: "string",
+              description:
+                "Persistent Playwright profile name. Defaults to default."
+            },
+            jobId: {
+              type: "string",
+              description: "LinkedIn job ID or job URL."
+            },
+            application: {
+              type: "object",
+              additionalProperties: false,
+              description:
+                "Optional Easy Apply inputs collected during preparation.",
+              properties: {
+                email: {
+                  type: "string",
+                  description: "Email address to use in the application."
+                },
+                phoneCountryCode: {
+                  type: "string",
+                  description: "Phone country code label or value."
+                },
+                phoneNumber: {
+                  type: "string",
+                  description: "Phone number to use in the application."
+                },
+                resumePath: {
+                  type: "string",
+                  description: "Local filesystem path to a resume file."
+                },
+                coverLetterPath: {
+                  type: "string",
+                  description: "Local filesystem path to a cover letter file."
+                },
+                answers: {
+                  type: "object",
+                  description:
+                    "Optional mapping from field labels/keys to string or boolean answers.",
+                  additionalProperties: {
+                    anyOf: [{ type: "string" }, { type: "boolean" }]
+                  }
+                }
+              }
+            },
+            operatorNote: {
+              type: "string",
+              description: "Internal note for audit."
+            }
+          })
+        }
+      },
+      {
         name: LINKEDIN_ACTIVITY_WATCH_CREATE_TOOL,
         description:
           "Create a durable poll-based LinkedIn activity watch for one profile and activity source.",
@@ -5604,6 +6141,12 @@ const TOOL_HANDLERS: Record<string, ToolHandler> = {
   [LINKEDIN_NOTIFICATIONS_LIST_TOOL]: handleNotificationsList,
   [LINKEDIN_JOBS_SEARCH_TOOL]: handleJobsSearch,
   [LINKEDIN_JOBS_VIEW_TOOL]: handleJobsView,
+  [LINKEDIN_JOBS_SAVE_TOOL]: handleJobsSave,
+  [LINKEDIN_JOBS_UNSAVE_TOOL]: handleJobsUnsave,
+  [LINKEDIN_JOBS_ALERTS_CREATE_TOOL]: handleJobsAlertsCreate,
+  [LINKEDIN_JOBS_ALERTS_LIST_TOOL]: handleJobsAlertsList,
+  [LINKEDIN_JOBS_ALERTS_REMOVE_TOOL]: handleJobsAlertsRemove,
+  [LINKEDIN_JOBS_PREPARE_EASY_APPLY_TOOL]: handleJobsPrepareEasyApply,
   [LINKEDIN_ACTIVITY_WATCH_CREATE_TOOL]: handleActivityWatchCreate,
   [LINKEDIN_ACTIVITY_WATCH_LIST_TOOL]: handleActivityWatchList,
   [LINKEDIN_ACTIVITY_WATCH_PAUSE_TOOL]: handleActivityWatchPause,

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -98,6 +98,13 @@ export const LINKEDIN_POST_PREPARE_DELETE_TOOL = "linkedin.post.prepare_delete";
 export const LINKEDIN_NOTIFICATIONS_LIST_TOOL = "linkedin.notifications.list";
 export const LINKEDIN_JOBS_SEARCH_TOOL = "linkedin.jobs.search";
 export const LINKEDIN_JOBS_VIEW_TOOL = "linkedin.jobs.view";
+export const LINKEDIN_JOBS_SAVE_TOOL = "linkedin.jobs.save";
+export const LINKEDIN_JOBS_UNSAVE_TOOL = "linkedin.jobs.unsave";
+export const LINKEDIN_JOBS_ALERTS_CREATE_TOOL = "linkedin.jobs.alerts.create";
+export const LINKEDIN_JOBS_ALERTS_LIST_TOOL = "linkedin.jobs.alerts.list";
+export const LINKEDIN_JOBS_ALERTS_REMOVE_TOOL = "linkedin.jobs.alerts.remove";
+export const LINKEDIN_JOBS_PREPARE_EASY_APPLY_TOOL =
+  "linkedin.jobs.prepare_easy_apply";
 export const LINKEDIN_ACTIVITY_WATCH_CREATE_TOOL = "linkedin.activity_watch.create";
 export const LINKEDIN_ACTIVITY_WATCH_LIST_TOOL = "linkedin.activity_watch.list";
 export const LINKEDIN_ACTIVITY_WATCH_PAUSE_TOOL = "linkedin.activity_watch.pause";


### PR DESCRIPTION
## Summary
- add LinkedIn Jobs prepare/confirm support for save, unsave, alert create/remove, and Easy Apply submission
- add MCP tool constants, schemas, and handlers for job saves, alerts, and prepare_easy_apply
- expand core and MCP tests around the new job action previews and alert metadata

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

## Live validation
- attempted isolated test-account login with `LINKEDIN_ASSISTANT_HOME=/tmp/linkedin-issue-238-live` using `LINKEDIN_TEST_EMAIL` / `LINKEDIN_TEST_PASSWORD`
- LinkedIn redirected the dedicated test account to a checkpoint / security verification flow, so I did not run write actions live and did not fall back to the personal authenticated profile

Closes #238