### PR TITLE
feat: add LinkedIn analytics MCP surfaces

### DIFF
--- a/packages/core/src/__tests__/linkedinAnalytics.test.ts
+++ b/packages/core/src/__tests__/linkedinAnalytics.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  LINKEDIN_ANALYTICS_SURFACES,
+  LinkedInAnalyticsService,
+  parseLinkedInAnalyticsNumber,
+  toLinkedInAnalyticsMetricKey,
+  type LinkedInAnalyticsRuntime,
+  type ReadContentMetricsInput,
+  type ReadPostMetricsInput
+} from "../linkedinAnalytics.js";
+
+describe("LinkedInAnalyticsService", () => {
+  it("exports the service class", () => {
+    expect(LinkedInAnalyticsService).toBeDefined();
+    expect(typeof LinkedInAnalyticsService).toBe("function");
+  });
+
+  it("lists the supported analytics surfaces", () => {
+    expect(LINKEDIN_ANALYTICS_SURFACES).toEqual([
+      "profile_views",
+      "search_appearances",
+      "content_metrics",
+      "post_metrics"
+    ]);
+  });
+
+  it("normalizes analytics metric keys", () => {
+    expect(toLinkedInAnalyticsMetricKey("Profile views")).toBe("profile_views");
+    expect(toLinkedInAnalyticsMetricKey("Engagement total")).toBe(
+      "engagement_total"
+    );
+    expect(toLinkedInAnalyticsMetricKey(" CTR % ")).toBe("ctr");
+  });
+
+  it("parses abbreviated count metrics", () => {
+    expect(parseLinkedInAnalyticsNumber("1.2K")).toBe(1200);
+    expect(parseLinkedInAnalyticsNumber("2,450")).toBe(2450);
+    expect(parseLinkedInAnalyticsNumber("3,4M")).toBe(3_400_000);
+  });
+
+  it("parses percentage metrics", () => {
+    expect(parseLinkedInAnalyticsNumber("4.5%")).toBe(4.5);
+    expect(parseLinkedInAnalyticsNumber("+12% past 7 days")).toBe(12);
+  });
+
+  it("returns null for non-numeric analytics text", () => {
+    expect(parseLinkedInAnalyticsNumber("No data yet")).toBeNull();
+    expect(parseLinkedInAnalyticsNumber("")).toBeNull();
+  });
+
+  it("keeps the runtime contract minimal for read-only analytics", () => {
+    const runtimeKeys: (keyof LinkedInAnalyticsRuntime)[] = [
+      "auth",
+      "cdpUrl",
+      "profileManager",
+      "logger",
+      "feed"
+    ];
+    expect(runtimeKeys).toHaveLength(5);
+  });
+
+  it("accepts optional limits for aggregated content metrics", () => {
+    const input: ReadContentMetricsInput = {
+      profileName: "default",
+      limit: 3
+    };
+
+    expect(input.profileName).toBe("default");
+    expect(input.limit).toBe(3);
+  });
+
+  it("requires a post URL for post metrics inputs", () => {
+    const input: ReadPostMetricsInput = {
+      profileName: "default",
+      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123456789/"
+    };
+
+    expect(input.postUrl).toContain("linkedin.com/feed/update/");
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,7 @@ export * from "./linkedinFollowups.js";
 export * from "./linkedinGroups.js";
 export * from "./linkedinImageAssets.js";
 export * from "./linkedinInbox.js";
+export * from "./linkedinAnalytics.js";
 export * from "./linkedinMembers.js";
 export * from "./linkedinProfile.js";
 export * from "./linkedinPrivacySettings.js";

--- a/packages/core/src/linkedinAnalytics.ts
+++ b/packages/core/src/linkedinAnalytics.ts
@@ -1,0 +1,823 @@
+import { type BrowserContext, type Page } from "playwright-core";
+import type { LinkedInAuthService } from "./auth/session.js";
+import { LinkedInAssistantError, asLinkedInAssistantError } from "./errors.js";
+import type { LinkedInFeedService } from "./linkedinFeed.js";
+import type { JsonEventLogger } from "./logging.js";
+import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
+import type { ProfileManager } from "./profileManager.js";
+
+export const LINKEDIN_ANALYTICS_SURFACES = [
+  "profile_views",
+  "search_appearances",
+  "content_metrics",
+  "post_metrics"
+] as const;
+
+export type LinkedInAnalyticsSurface =
+  (typeof LINKEDIN_ANALYTICS_SURFACES)[number];
+
+export type LinkedInAnalyticsMetricUnit = "count" | "percent" | "unknown";
+export type LinkedInAnalyticsMetricTrend = "up" | "down" | "flat" | "unknown";
+
+export interface LinkedInAnalyticsMetric {
+  metric_key: string;
+  label: string;
+  value: number | null;
+  value_text: string;
+  delta_value: number | null;
+  delta_text: string | null;
+  unit: LinkedInAnalyticsMetricUnit;
+  trend: LinkedInAnalyticsMetricTrend;
+  observed_at: string;
+}
+
+export interface LinkedInAnalyticsCard {
+  card_key: string;
+  title: string;
+  description: string;
+  href: string | null;
+  metrics: LinkedInAnalyticsMetric[];
+}
+
+export interface LinkedInAnalyticsSummary {
+  surface: Exclude<LinkedInAnalyticsSurface, "post_metrics">;
+  source_url: string;
+  observed_at: string;
+  metrics: LinkedInAnalyticsMetric[];
+  cards: LinkedInAnalyticsCard[];
+}
+
+export interface LinkedInPostMetricsSummary {
+  surface: "post_metrics";
+  source_url: string;
+  observed_at: string;
+  metrics: LinkedInAnalyticsMetric[];
+  cards: LinkedInAnalyticsCard[];
+  post: {
+    post_id: string;
+    post_url: string;
+    author_name: string;
+    author_headline: string;
+    posted_at: string;
+    text: string;
+  };
+}
+
+export interface ReadAnalyticsInput {
+  profileName?: string;
+}
+
+export interface ReadContentMetricsInput extends ReadAnalyticsInput {
+  limit?: number;
+}
+
+export interface ReadPostMetricsInput extends ReadAnalyticsInput {
+  postUrl: string;
+}
+
+export interface LinkedInAnalyticsRuntime {
+  auth: LinkedInAuthService;
+  cdpUrl?: string | undefined;
+  profileManager: ProfileManager;
+  logger: JsonEventLogger;
+  feed: Pick<LinkedInFeedService, "viewPost">;
+}
+
+interface AnalyticsMetricDraft {
+  label: string;
+  valueText: string;
+  deltaText: string | null;
+}
+
+interface AnalyticsCardSnapshot {
+  title: string;
+  description: string;
+  href: string | null;
+  lines: string[];
+}
+
+const LINKEDIN_SELF_PROFILE_URL = "https://www.linkedin.com/in/me/";
+const PROFILE_VIEW_KEYWORDS = [
+  "profile view",
+  "who viewed",
+  "viewed your profile"
+] as const;
+const SEARCH_APPEARANCES_KEYWORDS = ["search appearance"] as const;
+const CONTENT_METRICS_KEYWORDS = [
+  "impression",
+  "content",
+  "engagement",
+  "creator analytics"
+] as const;
+const CONTENT_METRICS_NEGATIVE_KEYWORDS = [
+  ...PROFILE_VIEW_KEYWORDS,
+  ...SEARCH_APPEARANCES_KEYWORDS
+] as const;
+const IGNORED_ANALYTICS_LINES = new Set([
+  "private to you",
+  "only visible to you"
+]);
+
+function normalizeText(value: string | null | undefined): string {
+  return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function readAnalyticsLimit(
+  value: number | undefined,
+  fallback: number
+): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.max(1, Math.floor(value));
+}
+
+function isAbsoluteUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value);
+}
+
+function toAbsoluteLinkedInUrl(value: string | null | undefined): string | null {
+  const href = normalizeText(value);
+  if (!href) {
+    return null;
+  }
+
+  if (isAbsoluteUrl(href)) {
+    return href;
+  }
+
+  return href.startsWith("/")
+    ? `https://www.linkedin.com${href}`
+    : `https://www.linkedin.com/${href}`;
+}
+
+export function toLinkedInAnalyticsMetricKey(label: string): string {
+  const normalized = normalizeText(label).toLowerCase();
+  if (!normalized) {
+    return "metric";
+  }
+
+  return normalized
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .replace(/_{2,}/g, "_");
+}
+
+export function parseLinkedInAnalyticsNumber(value: string): number | null {
+  const normalized = normalizeText(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const tokenMatch = /[+-]?\d[\d.,\s]*(?:[KMBT])?\s*%?/i.exec(normalized);
+  const token = normalizeText(tokenMatch?.[0]);
+  if (!token) {
+    return null;
+  }
+
+  const isPercent = token.includes("%");
+  const suffixMatch = /([KMBT])\s*%?$/i.exec(token);
+  const suffix = suffixMatch?.[1]?.toUpperCase() ?? "";
+  const magnitude =
+    suffix === "K"
+      ? 1_000
+      : suffix === "M"
+        ? 1_000_000
+        : suffix === "B"
+          ? 1_000_000_000
+          : suffix === "T"
+            ? 1_000_000_000_000
+            : 1;
+
+  let numeric = token.replace(/[KMBT%]/gi, "").replace(/\s+/g, "");
+  if (!numeric) {
+    return null;
+  }
+
+  const lastComma = numeric.lastIndexOf(",");
+  const lastDot = numeric.lastIndexOf(".");
+
+  if (lastComma >= 0 && lastDot >= 0) {
+    if (lastComma > lastDot) {
+      numeric = numeric.replace(/\./g, "").replace(",", ".");
+    } else {
+      numeric = numeric.replace(/,/g, "");
+    }
+  } else if (lastComma >= 0) {
+    const decimalDigits = numeric.length - lastComma - 1;
+    numeric =
+      decimalDigits > 0 && decimalDigits <= 2
+        ? numeric.replace(",", ".")
+        : numeric.replace(/,/g, "");
+  } else if (lastDot >= 0) {
+    const decimalDigits = numeric.length - lastDot - 1;
+    numeric =
+      decimalDigits === 3 && !suffix && !isPercent
+        ? numeric.replace(/\./g, "")
+        : numeric;
+  }
+
+  const parsed = Number(numeric);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  return parsed * magnitude;
+}
+
+function inferAnalyticsMetricUnit(
+  label: string,
+  valueText: string
+): LinkedInAnalyticsMetricUnit {
+  if (valueText.includes("%") || /\brate\b|\bpercent\b/i.test(label)) {
+    return "percent";
+  }
+
+  return parseLinkedInAnalyticsNumber(valueText) === null ? "unknown" : "count";
+}
+
+function inferAnalyticsMetricTrend(
+  value: string | null | undefined
+): LinkedInAnalyticsMetricTrend {
+  const normalized = normalizeText(value).toLowerCase();
+  if (!normalized) {
+    return "unknown";
+  }
+
+  if (
+    normalized.startsWith("+") ||
+    /\b(up|increase|increased|higher|grew|growth)\b/.test(normalized)
+  ) {
+    return "up";
+  }
+
+  if (
+    normalized.startsWith("-") ||
+    /\b(down|decrease|decreased|lower|declined|drop)\b/.test(normalized)
+  ) {
+    return "down";
+  }
+
+  if (/\b(flat|same|unchanged|steady)\b/.test(normalized)) {
+    return "flat";
+  }
+
+  return "unknown";
+}
+
+function extractMetricValueToken(value: string): string | null {
+  const normalized = normalizeText(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const match = /[+-]?\d[\d.,\s]*(?:[KMBT])?\s*%?/i.exec(normalized);
+  return normalizeText(match?.[0]);
+}
+
+function isDeltaLikeLine(value: string): boolean {
+  const normalized = normalizeText(value);
+  if (!normalized) {
+    return false;
+  }
+
+  if (normalized.startsWith("+") || normalized.startsWith("-")) {
+    return true;
+  }
+
+  return /\b(up|down|increase|decrease|past|last|vs\.?)\b/i.test(normalized);
+}
+
+function createMetricDraft(
+  line: string,
+  fallbackLabel: string
+): AnalyticsMetricDraft | null {
+  const normalized = normalizeText(line);
+  const valueText = extractMetricValueToken(normalized);
+  if (!valueText) {
+    return null;
+  }
+
+  const label = normalizeText(normalized.replace(valueText, "")) || fallbackLabel;
+  return {
+    label,
+    valueText,
+    deltaText: null
+  };
+}
+
+function buildAnalyticsMetric(
+  draft: AnalyticsMetricDraft,
+  observedAt: string
+): LinkedInAnalyticsMetric {
+  const label = normalizeText(draft.label) || "Metric";
+  const metricKey = toLinkedInAnalyticsMetricKey(label);
+  const unit = inferAnalyticsMetricUnit(label, draft.valueText);
+
+  return {
+    metric_key: metricKey,
+    label,
+    value: parseLinkedInAnalyticsNumber(draft.valueText),
+    value_text: normalizeText(draft.valueText),
+    delta_value:
+      draft.deltaText === null
+        ? null
+        : parseLinkedInAnalyticsNumber(draft.deltaText),
+    delta_text: draft.deltaText,
+    unit,
+    trend: inferAnalyticsMetricTrend(draft.deltaText),
+    observed_at: observedAt
+  };
+}
+
+function buildCardMetricsFromLines(
+  title: string,
+  lines: string[],
+  observedAt: string
+): LinkedInAnalyticsMetric[] {
+  const cleanedLines = lines
+    .map((line) => normalizeText(line))
+    .filter((line) => line.length > 0)
+    .filter((line) => line.toLowerCase() !== normalizeText(title).toLowerCase())
+    .filter((line) => !IGNORED_ANALYTICS_LINES.has(line.toLowerCase()));
+
+  const drafts: AnalyticsMetricDraft[] = [];
+
+  for (const line of cleanedLines) {
+    if (isDeltaLikeLine(line) && drafts.length > 0) {
+      const previous = drafts[drafts.length - 1];
+      if (previous && previous.deltaText === null) {
+        previous.deltaText = line;
+        continue;
+      }
+    }
+
+    const draft = createMetricDraft(line, title);
+    if (draft) {
+      drafts.push(draft);
+    }
+  }
+
+  return drafts.map((draft) => buildAnalyticsMetric(draft, observedAt));
+}
+
+function flattenCardMetrics(cards: LinkedInAnalyticsCard[]): LinkedInAnalyticsMetric[] {
+  return cards.flatMap((card) => card.metrics);
+}
+
+function cardTextHaystack(card: LinkedInAnalyticsCard): string {
+  return [
+    card.card_key,
+    card.title,
+    card.description,
+    card.href ?? "",
+    ...card.metrics.map((metric) => metric.label)
+  ]
+    .join(" ")
+    .toLowerCase();
+}
+
+function matchesAnalyticsCard(
+  card: LinkedInAnalyticsCard,
+  keywords: readonly string[],
+  negativeKeywords: readonly string[] = []
+): boolean {
+  const haystack = cardTextHaystack(card);
+  if (negativeKeywords.some((keyword) => haystack.includes(keyword.toLowerCase()))) {
+    return false;
+  }
+
+  return keywords.some((keyword) => haystack.includes(keyword.toLowerCase()));
+}
+
+async function getOrCreatePage(context: BrowserContext): Promise<Page> {
+  const existing = context.pages()[0];
+  if (existing) {
+    return existing;
+  }
+  return context.newPage();
+}
+
+async function waitForAnalyticsSurface(page: Page): Promise<void> {
+  await page
+    .locator("main")
+    .first()
+    .waitFor({ state: "visible", timeout: 10_000 })
+    .catch(() => undefined);
+  await waitForNetworkIdleBestEffort(page);
+}
+
+/* eslint-disable no-undef -- DOM types are valid inside page.evaluate() */
+async function extractProfileAnalyticsCardSnapshots(
+  page: Page
+): Promise<AnalyticsCardSnapshot[]> {
+  return page.evaluate(() => {
+    const normalize = (value: string | null | undefined): string =>
+      (value ?? "").replace(/\s+/g, " ").trim();
+
+    const splitLines = (value: string): string[] =>
+      value
+        .split(/\n+/)
+        .map((line) => normalize(line))
+        .filter((line) => line.length > 0);
+
+    const toAbsoluteHref = (value: string | null | undefined): string | null => {
+      const href = normalize(value);
+      if (!href) {
+        return null;
+      }
+
+      try {
+        return new URL(href, globalThis.window.location.origin).toString();
+      } catch {
+        return href;
+      }
+    };
+
+    const readInnerText = (element: Element): string => {
+      return element instanceof HTMLElement
+        ? normalize(element.innerText)
+        : normalize(element.textContent);
+    };
+
+    const readTitle = (element: Element, lines: string[]): string => {
+      const heading = normalize(
+        element.querySelector("h1, h2, h3, h4, strong, dt")?.textContent
+      );
+      if (heading) {
+        return heading;
+      }
+
+      return lines[0] ?? "";
+    };
+
+    const relevantPattern =
+      /(profile views?|who viewed|viewed your profile|search appearances?|impressions?|content|engagement|analytics)/i;
+    const relevantHrefPattern = /(analytics|profile-view|search-appear)/i;
+    const candidates = Array.from(
+      document.querySelectorAll("a[href], button, article, li")
+    ).filter((element) => {
+      const text = readInnerText(element);
+      if (!text || text.length > 400) {
+        return false;
+      }
+
+      const href = normalize(
+        element instanceof HTMLAnchorElement ? element.href : element.getAttribute("href")
+      );
+
+      return relevantPattern.test(text) || relevantHrefPattern.test(href);
+    });
+
+    const deduped = new Map<string, AnalyticsCardSnapshot>();
+    for (const candidate of candidates) {
+      const text = readInnerText(candidate);
+      const lines = splitLines(text);
+      if (lines.length === 0) {
+        continue;
+      }
+
+      const title = readTitle(candidate, lines);
+      const href = toAbsoluteHref(
+        candidate instanceof HTMLAnchorElement
+          ? candidate.href
+          : candidate.getAttribute("href")
+      );
+      const description = lines
+        .filter((line) => line !== title)
+        .filter((line) => !/\d/.test(line))
+        .join(" ");
+
+      const snapshot: AnalyticsCardSnapshot = {
+        title,
+        description,
+        href,
+        lines
+      };
+      const dedupeKey = `${title.toLowerCase()}|${href ?? ""}`;
+      const existing = deduped.get(dedupeKey);
+      if (!existing || existing.lines.join(" ").length < lines.join(" ").length) {
+        deduped.set(dedupeKey, snapshot);
+      }
+    }
+
+    return Array.from(deduped.values());
+  });
+}
+/* eslint-enable no-undef -- DOM types are valid inside page.evaluate() */
+
+function toAnalyticsCards(
+  snapshots: AnalyticsCardSnapshot[],
+  observedAt: string
+): LinkedInAnalyticsCard[] {
+  return snapshots
+    .map((snapshot) => {
+      const title = normalizeText(snapshot.title);
+      const description = normalizeText(snapshot.description);
+      const metrics = buildCardMetricsFromLines(title, snapshot.lines, observedAt);
+      return {
+        card_key: toLinkedInAnalyticsMetricKey(title),
+        title,
+        description,
+        href: toAbsoluteLinkedInUrl(snapshot.href),
+        metrics
+      } satisfies LinkedInAnalyticsCard;
+    })
+    .filter((card) => card.title.length > 0)
+    .filter((card) => card.metrics.length > 0);
+}
+
+async function loadProfileAnalyticsCards(
+  runtime: LinkedInAnalyticsRuntime,
+  profileName: string
+): Promise<{
+  sourceUrl: string;
+  observedAt: string;
+  cards: LinkedInAnalyticsCard[];
+}> {
+  await runtime.auth.ensureAuthenticated({
+    profileName,
+    cdpUrl: runtime.cdpUrl
+  });
+
+  return runtime.profileManager.runWithContext(
+    {
+      cdpUrl: runtime.cdpUrl,
+      profileName,
+      headless: true
+    },
+    async (context) => {
+      const page = await getOrCreatePage(context);
+      await page.goto(LINKEDIN_SELF_PROFILE_URL, {
+        waitUntil: "domcontentloaded"
+      });
+      await waitForAnalyticsSurface(page);
+      const observedAt = new Date().toISOString();
+      const cards = toAnalyticsCards(
+        await extractProfileAnalyticsCardSnapshots(page),
+        observedAt
+      );
+      return {
+        sourceUrl: page.url(),
+        observedAt,
+        cards
+      };
+    }
+  );
+}
+
+function ensureMatchingCards(
+  surface: LinkedInAnalyticsSurface,
+  cards: LinkedInAnalyticsCard[],
+  availableCards: LinkedInAnalyticsCard[]
+): LinkedInAnalyticsCard[] {
+  if (cards.length > 0) {
+    return cards;
+  }
+
+  throw new LinkedInAssistantError(
+    "UI_CHANGED_SELECTOR_FAILED",
+    `Could not locate LinkedIn analytics cards for ${surface}.`,
+    {
+      surface,
+      available_card_titles: availableCards.map((card) => card.title)
+    }
+  );
+}
+
+function buildSummary(
+  surface: Exclude<LinkedInAnalyticsSurface, "post_metrics">,
+  sourceUrl: string,
+  observedAt: string,
+  cards: LinkedInAnalyticsCard[]
+): LinkedInAnalyticsSummary {
+  return {
+    surface,
+    source_url: sourceUrl,
+    observed_at: observedAt,
+    metrics: flattenCardMetrics(cards),
+    cards
+  };
+}
+
+export class LinkedInAnalyticsService {
+  constructor(private readonly runtime: LinkedInAnalyticsRuntime) {}
+
+  async getProfileViews(
+    input: ReadAnalyticsInput = {}
+  ): Promise<LinkedInAnalyticsSummary> {
+    const profileName = input.profileName ?? "default";
+
+    try {
+      const { sourceUrl, observedAt, cards } = await loadProfileAnalyticsCards(
+        this.runtime,
+        profileName
+      );
+      const matchedCards = ensureMatchingCards(
+        "profile_views",
+        cards.filter((card) =>
+          matchesAnalyticsCard(card, PROFILE_VIEW_KEYWORDS)
+        ),
+        cards
+      );
+
+      return buildSummary("profile_views", sourceUrl, observedAt, matchedCards);
+    } catch (error) {
+      if (error instanceof LinkedInAssistantError) {
+        throw error;
+      }
+
+      throw asLinkedInAssistantError(
+        error,
+        "UNKNOWN",
+        "Failed to read LinkedIn profile view analytics."
+      );
+    }
+  }
+
+  async getSearchAppearances(
+    input: ReadAnalyticsInput = {}
+  ): Promise<LinkedInAnalyticsSummary> {
+    const profileName = input.profileName ?? "default";
+
+    try {
+      const { sourceUrl, observedAt, cards } = await loadProfileAnalyticsCards(
+        this.runtime,
+        profileName
+      );
+      const matchedCards = ensureMatchingCards(
+        "search_appearances",
+        cards.filter((card) =>
+          matchesAnalyticsCard(card, SEARCH_APPEARANCES_KEYWORDS)
+        ),
+        cards
+      );
+
+      return buildSummary(
+        "search_appearances",
+        sourceUrl,
+        observedAt,
+        matchedCards
+      );
+    } catch (error) {
+      if (error instanceof LinkedInAssistantError) {
+        throw error;
+      }
+
+      throw asLinkedInAssistantError(
+        error,
+        "UNKNOWN",
+        "Failed to read LinkedIn search appearance analytics."
+      );
+    }
+  }
+
+  async getContentMetrics(
+    input: ReadContentMetricsInput = {}
+  ): Promise<LinkedInAnalyticsSummary> {
+    const profileName = input.profileName ?? "default";
+    const limit = readAnalyticsLimit(input.limit, 4);
+
+    try {
+      const { sourceUrl, observedAt, cards } = await loadProfileAnalyticsCards(
+        this.runtime,
+        profileName
+      );
+      const directMatches = cards.filter((card) =>
+        matchesAnalyticsCard(
+          card,
+          CONTENT_METRICS_KEYWORDS,
+          CONTENT_METRICS_NEGATIVE_KEYWORDS
+        )
+      );
+      const fallbackMatches = cards.filter(
+        (card) =>
+          !matchesAnalyticsCard(card, PROFILE_VIEW_KEYWORDS) &&
+          !matchesAnalyticsCard(card, SEARCH_APPEARANCES_KEYWORDS)
+      );
+      const matchedCards =
+        directMatches.length > 0
+          ? directMatches.slice(0, limit)
+          : fallbackMatches.slice(0, limit);
+      if (cards.length === 0) {
+        throw new LinkedInAssistantError(
+          "UI_CHANGED_SELECTOR_FAILED",
+          "Could not locate LinkedIn analytics cards for content_metrics.",
+          {
+            surface: "content_metrics",
+            available_card_titles: []
+          }
+        );
+      }
+
+      return buildSummary("content_metrics", sourceUrl, observedAt, matchedCards);
+    } catch (error) {
+      if (error instanceof LinkedInAssistantError) {
+        throw error;
+      }
+
+      throw asLinkedInAssistantError(
+        error,
+        "UNKNOWN",
+        "Failed to read LinkedIn content analytics."
+      );
+    }
+  }
+
+  async getPostMetrics(
+    input: ReadPostMetricsInput
+  ): Promise<LinkedInPostMetricsSummary> {
+    const profileName = input.profileName ?? "default";
+
+    try {
+      const post = await this.runtime.feed.viewPost({
+        profileName,
+        postUrl: input.postUrl
+      });
+      const observedAt = new Date().toISOString();
+      const metrics = [
+        {
+          label: "Reactions",
+          valueText: post.reactions_count
+        },
+        {
+          label: "Comments",
+          valueText: post.comments_count
+        },
+        {
+          label: "Reposts",
+          valueText: post.reposts_count
+        }
+      ]
+        .map((entry) => ({
+          metric_key: toLinkedInAnalyticsMetricKey(entry.label),
+          label: entry.label,
+          value: parseLinkedInAnalyticsNumber(entry.valueText),
+          value_text: normalizeText(entry.valueText),
+          delta_value: null,
+          delta_text: null,
+          unit: inferAnalyticsMetricUnit(entry.label, entry.valueText),
+          trend: "unknown" as const,
+          observed_at: observedAt
+        }))
+        .filter(
+          (metric) => metric.value_text.length > 0 || metric.value !== null
+        );
+
+      const engagementTotal = metrics.reduce((total, metric) => {
+        return metric.value === null ? total : total + metric.value;
+      }, 0);
+
+      const cards: LinkedInAnalyticsCard[] = [
+        {
+          card_key: "post_engagement",
+          title: "Post engagement",
+          description:
+            "Read from the live LinkedIn post surface and normalized for downstream automation.",
+          href: post.post_url,
+          metrics: [
+            ...metrics,
+            {
+              metric_key: "engagement_total",
+              label: "Engagement total",
+              value: engagementTotal,
+              value_text: String(engagementTotal),
+              delta_value: null,
+              delta_text: null,
+              unit: "count",
+              trend: "unknown",
+              observed_at: observedAt
+            }
+          ]
+        }
+      ];
+
+      return {
+        surface: "post_metrics",
+        source_url: post.post_url,
+        observed_at: observedAt,
+        metrics: flattenCardMetrics(cards),
+        cards,
+        post: {
+          post_id: normalizeText(post.post_id),
+          post_url: normalizeText(post.post_url),
+          author_name: normalizeText(post.author_name),
+          author_headline: normalizeText(post.author_headline),
+          posted_at: normalizeText(post.posted_at),
+          text: normalizeText(post.text)
+        }
+      };
+    } catch (error) {
+      if (error instanceof LinkedInAssistantError) {
+        throw error;
+      }
+
+      throw asLinkedInAssistantError(
+        error,
+        "UNKNOWN",
+        "Failed to read LinkedIn post metrics."
+      );
+    }
+  }
+}

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -63,6 +63,10 @@ import {
 } from "./linkedinProfile.js";
 import { LinkedInImageAssetsService } from "./linkedinImageAssets.js";
 import {
+  LinkedInAnalyticsService,
+  type LinkedInAnalyticsRuntime
+} from "./linkedinAnalytics.js";
+import {
   LinkedInJobsService,
   type LinkedInJobsRuntime
 } from "./linkedinJobs.js";
@@ -178,6 +182,7 @@ export interface CoreRuntime {
   profile: LinkedInProfileService;
   companyPages: LinkedInCompanyPagesService;
   imageAssets: LinkedInImageAssetsService;
+  analytics: LinkedInAnalyticsService;
   search: LinkedInSearchService;
   groups: LinkedInGroupsService;
   events: LinkedInEventsService;
@@ -361,6 +366,7 @@ export function createCoreRuntime(
     profile: undefined as unknown as LinkedInProfileService,
     companyPages: undefined as unknown as LinkedInCompanyPagesService,
     imageAssets: undefined as unknown as LinkedInImageAssetsService,
+    analytics: undefined as unknown as LinkedInAnalyticsService,
     search: undefined as unknown as LinkedInSearchService,
     groups: undefined as unknown as LinkedInGroupsService,
     events: undefined as unknown as LinkedInEventsService,
@@ -447,6 +453,8 @@ export function createCoreRuntime(
   runtime.followups = new LinkedInFollowupsService(followupsRuntime);
   const feedRuntime: LinkedInFeedRuntime = runtime;
   runtime.feed = new LinkedInFeedService(feedRuntime);
+  const analyticsRuntime: LinkedInAnalyticsRuntime = runtime;
+  runtime.analytics = new LinkedInAnalyticsService(analyticsRuntime);
   const postsRuntime: LinkedInPostsRuntime = runtime;
   runtime.posts = new LinkedInPostsService(postsRuntime);
   runtime.inbox = new LinkedInInboxService(runtime);

--- a/packages/mcp/src/__tests__/linkedinMcp.test.ts
+++ b/packages/mcp/src/__tests__/linkedinMcp.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  LINKEDIN_ANALYTICS_POST_METRICS_TOOL,
+  LINKEDIN_ANALYTICS_PROFILE_VIEWS_TOOL,
   LINKEDIN_EVENTS_SEARCH_TOOL,
   LINKEDIN_EVENTS_VIEW_TOOL,
   LINKEDIN_EVENTS_PREPARE_RSVP_TOOL,
@@ -27,6 +29,10 @@ vi.mock("@linkedin-assistant/core", async () => {
 });
 
 interface FakeRuntime {
+  analytics: {
+    getPostMetrics: ReturnType<typeof vi.fn>;
+    getProfileViews: ReturnType<typeof vi.fn>;
+  };
   close: ReturnType<typeof vi.fn>;
   companyPages: {
     prepareFollowCompanyPage: ReturnType<typeof vi.fn>;
@@ -59,6 +65,10 @@ interface FakeRuntime {
 function createFakeRuntime(): FakeRuntime {
   return {
     runId: "run_test",
+    analytics: {
+      getPostMetrics: vi.fn(),
+      getProfileViews: vi.fn()
+    },
     close: vi.fn(),
     companyPages: {
       prepareFollowCompanyPage: vi.fn(),
@@ -139,6 +149,69 @@ describe("handleToolCall", () => {
       ]
     });
     expect(fakeRuntime.privacySettings.getSettings).toHaveBeenCalledWith({
+      profileName: "default"
+    });
+    expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns profile-view analytics payloads through the MCP contract", async () => {
+    fakeRuntime.analytics.getProfileViews.mockResolvedValue({
+      surface: "profile_views",
+      source_url: "https://www.linkedin.com/in/me/",
+      observed_at: "2026-03-11T12:00:00.000Z",
+      metrics: [
+        {
+          metric_key: "profile_views",
+          label: "Profile views",
+          value: 42,
+          value_text: "42",
+          delta_value: null,
+          delta_text: null,
+          unit: "count",
+          trend: "unknown",
+          observed_at: "2026-03-11T12:00:00.000Z"
+        }
+      ],
+      cards: [
+        {
+          card_key: "profile_views",
+          title: "Profile views",
+          description: "See who's viewed your profile.",
+          href: "https://www.linkedin.com/in/me/",
+          metrics: [
+            {
+              metric_key: "profile_views",
+              label: "Profile views",
+              value: 42,
+              value_text: "42",
+              delta_value: null,
+              delta_text: null,
+              unit: "count",
+              trend: "unknown",
+              observed_at: "2026-03-11T12:00:00.000Z"
+            }
+          ]
+        }
+      ]
+    });
+
+    const result = await handleToolCall(LINKEDIN_ANALYTICS_PROFILE_VIEWS_TOOL, {
+      profileName: "default"
+    });
+
+    expect("isError" in result && result.isError).toBe(false);
+    expect(parseToolPayload(result)).toMatchObject({
+      run_id: "run_test",
+      profile_name: "default",
+      surface: "profile_views",
+      metrics: [
+        expect.objectContaining({
+          metric_key: "profile_views",
+          value: 42
+        })
+      ]
+    });
+    expect(fakeRuntime.analytics.getProfileViews).toHaveBeenCalledWith({
       profileName: "default"
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
@@ -448,6 +521,77 @@ describe("handleToolCall", () => {
     expect(fakeRuntime.events.prepareRsvp).toHaveBeenCalledWith({
       profileName: "default",
       event: "7433954919704973312"
+    });
+    expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns post-metrics payloads through the MCP contract", async () => {
+    fakeRuntime.analytics.getPostMetrics.mockResolvedValue({
+      surface: "post_metrics",
+      source_url: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      observed_at: "2026-03-11T12:00:00.000Z",
+      metrics: [
+        {
+          metric_key: "reactions",
+          label: "Reactions",
+          value: 12,
+          value_text: "12",
+          delta_value: null,
+          delta_text: null,
+          unit: "count",
+          trend: "unknown",
+          observed_at: "2026-03-11T12:00:00.000Z"
+        }
+      ],
+      cards: [
+        {
+          card_key: "post_engagement",
+          title: "Post engagement",
+          description: "Read from the live LinkedIn post surface.",
+          href: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+          metrics: [
+            {
+              metric_key: "reactions",
+              label: "Reactions",
+              value: 12,
+              value_text: "12",
+              delta_value: null,
+              delta_text: null,
+              unit: "count",
+              trend: "unknown",
+              observed_at: "2026-03-11T12:00:00.000Z"
+            }
+          ]
+        }
+      ],
+      post: {
+        post_id: "123",
+        post_url: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+        author_name: "Joi Ascend",
+        author_headline: "Automation operator",
+        posted_at: "1d",
+        text: "Testing metrics."
+      }
+    });
+
+    const result = await handleToolCall(LINKEDIN_ANALYTICS_POST_METRICS_TOOL, {
+      profileName: "default",
+      postUrl: "urn:li:activity:123"
+    });
+
+    expect("isError" in result && result.isError).toBe(false);
+    expect(parseToolPayload(result)).toMatchObject({
+      run_id: "run_test",
+      profile_name: "default",
+      surface: "post_metrics",
+      post: {
+        post_id: "123",
+        author_name: "Joi Ascend"
+      }
+    });
+    expect(fakeRuntime.analytics.getPostMetrics).toHaveBeenCalledWith({
+      profileName: "default",
+      postUrl: "urn:li:activity:123"
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });

--- a/packages/mcp/src/bin/linkedin-mcp.ts
+++ b/packages/mcp/src/bin/linkedin-mcp.ts
@@ -49,6 +49,10 @@ import {
 import {
   LINKEDIN_ACTIONS_CONFIRM_TOOL,
   LINKEDIN_ASSETS_GENERATE_PROFILE_IMAGES_TOOL,
+  LINKEDIN_ANALYTICS_CONTENT_METRICS_TOOL,
+  LINKEDIN_ANALYTICS_POST_METRICS_TOOL,
+  LINKEDIN_ANALYTICS_PROFILE_VIEWS_TOOL,
+  LINKEDIN_ANALYTICS_SEARCH_APPEARANCES_TOOL,
   LINKEDIN_ACTIVITY_DELIVERIES_LIST_TOOL,
   LINKEDIN_ACTIVITY_EVENTS_LIST_TOOL,
   LINKEDIN_ACTIVITY_POLLER_RUN_ONCE_TOOL,
@@ -1742,6 +1746,140 @@ async function handleAssetsGenerateProfileImages(
       profile_name: profileName,
       spec_path: resolvedSpecPath,
       ...report
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function handleAnalyticsProfileViews(
+  args: ToolArgs
+): Promise<ToolResult> {
+  const runtime = createRuntime(args);
+
+  try {
+    const profileName = readString(args, "profileName", "default");
+
+    runtime.logger.log("info", "mcp.analytics.profile_views.start", {
+      profileName
+    });
+
+    const summary = await runtime.analytics.getProfileViews({
+      profileName
+    });
+
+    runtime.logger.log("info", "mcp.analytics.profile_views.done", {
+      profileName,
+      card_count: summary.cards.length,
+      metric_count: summary.metrics.length
+    });
+
+    return toToolResult({
+      run_id: runtime.runId,
+      profile_name: profileName,
+      ...summary
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function handleAnalyticsSearchAppearances(
+  args: ToolArgs
+): Promise<ToolResult> {
+  const runtime = createRuntime(args);
+
+  try {
+    const profileName = readString(args, "profileName", "default");
+
+    runtime.logger.log("info", "mcp.analytics.search_appearances.start", {
+      profileName
+    });
+
+    const summary = await runtime.analytics.getSearchAppearances({
+      profileName
+    });
+
+    runtime.logger.log("info", "mcp.analytics.search_appearances.done", {
+      profileName,
+      card_count: summary.cards.length,
+      metric_count: summary.metrics.length
+    });
+
+    return toToolResult({
+      run_id: runtime.runId,
+      profile_name: profileName,
+      ...summary
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function handleAnalyticsContentMetrics(
+  args: ToolArgs
+): Promise<ToolResult> {
+  const runtime = createRuntime(args);
+
+  try {
+    const profileName = readString(args, "profileName", "default");
+    const limit = readPositiveNumber(args, "limit", 4);
+
+    runtime.logger.log("info", "mcp.analytics.content_metrics.start", {
+      profileName,
+      limit
+    });
+
+    const summary = await runtime.analytics.getContentMetrics({
+      profileName,
+      limit
+    });
+
+    runtime.logger.log("info", "mcp.analytics.content_metrics.done", {
+      profileName,
+      card_count: summary.cards.length,
+      metric_count: summary.metrics.length
+    });
+
+    return toToolResult({
+      run_id: runtime.runId,
+      profile_name: profileName,
+      ...summary
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function handleAnalyticsPostMetrics(
+  args: ToolArgs
+): Promise<ToolResult> {
+  const runtime = createRuntime(args);
+
+  try {
+    const profileName = readString(args, "profileName", "default");
+    const postUrl = readRequiredString(args, "postUrl");
+
+    runtime.logger.log("info", "mcp.analytics.post_metrics.start", {
+      profileName,
+      postUrl
+    });
+
+    const summary = await runtime.analytics.getPostMetrics({
+      profileName,
+      postUrl
+    });
+
+    runtime.logger.log("info", "mcp.analytics.post_metrics.done", {
+      profileName,
+      post_url: summary.post.post_url,
+      metric_count: summary.metrics.length
+    });
+
+    return toToolResult({
+      run_id: runtime.runId,
+      profile_name: profileName,
+      ...summary
     });
   } finally {
     runtime.close();
@@ -4564,6 +4702,88 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         }
       },
       {
+        name: LINKEDIN_ANALYTICS_PROFILE_VIEWS_TOOL,
+        description:
+          withSelectorAuditHint(
+            "Read the logged-in member's LinkedIn profile-view analytics cards with normalized numeric metrics."
+          ),
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+          properties: withCdpSchemaProperties({
+            profileName: {
+              type: "string",
+              description:
+                "Persistent Playwright profile name. Defaults to default."
+            }
+          })
+        }
+      },
+      {
+        name: LINKEDIN_ANALYTICS_SEARCH_APPEARANCES_TOOL,
+        description:
+          withSelectorAuditHint(
+            "Read the logged-in member's LinkedIn search-appearance analytics cards with normalized numeric metrics."
+          ),
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+          properties: withCdpSchemaProperties({
+            profileName: {
+              type: "string",
+              description:
+                "Persistent Playwright profile name. Defaults to default."
+            }
+          })
+        }
+      },
+      {
+        name: LINKEDIN_ANALYTICS_CONTENT_METRICS_TOOL,
+        description:
+          withSelectorAuditHint(
+            "Read LinkedIn content and impression analytics cards from the logged-in member's profile analytics surface."
+          ),
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+          properties: withCdpSchemaProperties({
+            profileName: {
+              type: "string",
+              description:
+                "Persistent Playwright profile name. Defaults to default."
+            },
+            limit: {
+              type: "number",
+              description:
+                "Maximum number of content analytics cards to return. Defaults to 4."
+            }
+          })
+        }
+      },
+      {
+        name: LINKEDIN_ANALYTICS_POST_METRICS_TOOL,
+        description:
+          withSelectorAuditHint(
+            "Read normalized engagement metrics for one LinkedIn post URL, URN, or activity/share identifier."
+          ),
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+          required: ["postUrl"],
+          properties: withCdpSchemaProperties({
+            profileName: {
+              type: "string",
+              description:
+                "Persistent Playwright profile name. Defaults to default."
+            },
+            postUrl: {
+              type: "string",
+              description: "LinkedIn post URL, URN, or activity/share identifier."
+            }
+          })
+        }
+      },
+      {
         name: LINKEDIN_SEARCH_TOOL,
         description: withSelectorAuditHint(
           `Search LinkedIn for ${SEARCH_CATEGORIES.join(", ")}.`
@@ -6052,6 +6272,11 @@ const TOOL_HANDLERS: Record<string, ToolHandler> = {
     handleProfilePrepareWriteRecommendation,
   [LINKEDIN_ASSETS_GENERATE_PROFILE_IMAGES_TOOL]:
     handleAssetsGenerateProfileImages,
+  [LINKEDIN_ANALYTICS_PROFILE_VIEWS_TOOL]: handleAnalyticsProfileViews,
+  [LINKEDIN_ANALYTICS_SEARCH_APPEARANCES_TOOL]:
+    handleAnalyticsSearchAppearances,
+  [LINKEDIN_ANALYTICS_CONTENT_METRICS_TOOL]: handleAnalyticsContentMetrics,
+  [LINKEDIN_ANALYTICS_POST_METRICS_TOOL]: handleAnalyticsPostMetrics,
   [LINKEDIN_SEARCH_TOOL]: handleSearch,
   [LINKEDIN_CONNECTIONS_LIST_TOOL]: handleConnectionsList,
   [LINKEDIN_CONNECTIONS_PENDING_TOOL]: handleConnectionsPending,

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -52,6 +52,14 @@ export const LINKEDIN_PROFILE_PREPARE_WRITE_RECOMMENDATION_TOOL =
   "linkedin.profile.prepare_write_recommendation";
 export const LINKEDIN_ASSETS_GENERATE_PROFILE_IMAGES_TOOL =
   "linkedin.assets.generate_profile_images";
+export const LINKEDIN_ANALYTICS_PROFILE_VIEWS_TOOL =
+  "linkedin.analytics.profile_views";
+export const LINKEDIN_ANALYTICS_SEARCH_APPEARANCES_TOOL =
+  "linkedin.analytics.search_appearances";
+export const LINKEDIN_ANALYTICS_POST_METRICS_TOOL =
+  "linkedin.analytics.post_metrics";
+export const LINKEDIN_ANALYTICS_CONTENT_METRICS_TOOL =
+  "linkedin.analytics.content_metrics";
 export const LINKEDIN_SEARCH_TOOL = "linkedin.search";
 export const LINKEDIN_CONNECTIONS_LIST_TOOL = "linkedin.connections.list";
 export const LINKEDIN_CONNECTIONS_PENDING_TOOL = "linkedin.connections.pending";


### PR DESCRIPTION
## Summary
- add a read-only core analytics service that normalizes LinkedIn profile-view, search-appearance, content, and post engagement metrics
- expose the new analytics surfaces through MCP with dedicated tool schemas and handlers
- cover the new service and MCP contract wiring with unit tests

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #239