### PR TITLE
fix: support current nameless LinkedIn login inputs

### DIFF
--- a/packages/core/src/__tests__/sessionAuth.test.ts
+++ b/packages/core/src/__tests__/sessionAuth.test.ts
@@ -365,4 +365,63 @@ describe("LinkedInAuthService auth flow", () => {
     expect(rateLimitStateMocks.recordRateLimit).not.toHaveBeenCalled();
     expect(humanizeMocks.type).toHaveBeenCalledTimes(2);
   });
+
+  it("headlessLogin targets nameless login inputs when legacy names are absent", async () => {
+    let waitCount = 0;
+    let navVisible = false;
+
+    const { page, setUrl } = createMockPage({
+      initialUrl: "https://www.linkedin.com/login",
+      onWait: () => {
+        waitCount += 1;
+        if (waitCount === 1) {
+          navVisible = true;
+          setUrl("https://www.linkedin.com/feed/");
+        }
+      },
+      isVisible: (selector, currentUrl) => {
+        if (selector.includes("autocomplete~='username'")) {
+          return currentUrl.includes("/login");
+        }
+
+        if (selector.includes("type='password'")) {
+          return currentUrl.includes("/login");
+        }
+
+        if (selector === "nav.global-nav") {
+          return navVisible;
+        }
+
+        return false;
+      }
+    });
+
+    const context = createContextWithPage(page);
+    const profileManager = {
+      runWithContext: vi.fn(async (_options, callback) => callback(context))
+    } as const;
+    const auth = new LinkedInAuthService(profileManager as unknown as ProfileManager);
+
+    const result = await auth.headlessLogin({
+      email: "test@example.com",
+      password: "secret",
+      pollIntervalMs: 1,
+      timeoutMs: 100
+    });
+
+    expect(result.authenticated).toBe(true);
+    expect(result.checkpoint).toBe(false);
+    expect(humanizeMocks.type).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("autocomplete~='username'"),
+      "test@example.com",
+      { fieldLabel: "email" }
+    );
+    expect(humanizeMocks.type).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("type='password'"),
+      "secret",
+      { fieldLabel: "password" }
+    );
+  });
 });

--- a/packages/core/src/__tests__/sessionInspection.test.ts
+++ b/packages/core/src/__tests__/sessionInspection.test.ts
@@ -96,10 +96,12 @@ describe("inspectLinkedInSession", () => {
     expect(status.sessionCookiePresent).toBe(false);
   });
 
-  it("marks the session unauthenticated when the login form is visible", async () => {
+  it("marks the session unauthenticated when nameless login inputs are visible", async () => {
     const page = createMockPage({
       url: "https://www.linkedin.com/feed/",
-      isVisible: (selector) => selector.includes("input[name='session_key']")
+      isVisible: (selector) =>
+        selector.includes("autocomplete~='username'") ||
+        selector.includes("type='password'")
     });
 
     const status = await inspectLinkedInSession(page);
@@ -151,7 +153,8 @@ describe("inspectLinkedInSession", () => {
     const page = createMockPage({
       url: "https://www.linkedin.com/uas/login?session_redirect=https%3A%2F%2Fwww.linkedin.com%2Ffeed%2F",
       isVisible: (selector) =>
-        selector.includes("input[name='session_key']") ||
+        selector.includes("autocomplete~='username'") ||
+        selector.includes("type='password'") ||
         selector.includes("form[action*='checkpoint']")
     });
 

--- a/packages/core/src/auth/loginSelectors.ts
+++ b/packages/core/src/auth/loginSelectors.ts
@@ -1,0 +1,27 @@
+// Modern LinkedIn login inputs can be rendered with React-generated ids and
+// no stable `name` attributes, so we match a small set of semantic fallbacks.
+const LINKEDIN_LOGIN_EMAIL_INPUT_SELECTORS = [
+  "input[name='session_key']",
+  "input#username",
+  "input[autocomplete~='username' i]",
+  "input[inputmode='email' i]",
+  "input[aria-label*='email' i]",
+  "input[aria-label*='phone' i]",
+  "input[placeholder*='email' i]",
+  "input[placeholder*='phone' i]"
+] as const;
+
+const LINKEDIN_LOGIN_PASSWORD_INPUT_SELECTORS = [
+  "input[name='session_password']",
+  "input#password",
+  "input[type='password']",
+  "input[autocomplete~='current-password' i]",
+  "input[aria-label*='password' i]",
+  "input[placeholder*='password' i]"
+] as const;
+
+export const LINKEDIN_LOGIN_EMAIL_INPUT_SELECTOR =
+  LINKEDIN_LOGIN_EMAIL_INPUT_SELECTORS.join(", ");
+
+export const LINKEDIN_LOGIN_PASSWORD_INPUT_SELECTOR =
+  LINKEDIN_LOGIN_PASSWORD_INPUT_SELECTORS.join(", ");

--- a/packages/core/src/auth/session.ts
+++ b/packages/core/src/auth/session.ts
@@ -12,6 +12,10 @@ import {
   type LinkedInSessionIdentity
 } from "./sessionInspection.js";
 import {
+  LINKEDIN_LOGIN_EMAIL_INPUT_SELECTOR,
+  LINKEDIN_LOGIN_PASSWORD_INPUT_SELECTOR
+} from "./loginSelectors.js";
+import {
   DEFAULT_LINKEDIN_SELECTOR_LOCALE,
   type LinkedInSelectorLocale
 } from "../selectorLocale.js";
@@ -345,10 +349,10 @@ export class LinkedInAuthService {
 
         try {
           const hp = humanize(page);
-          await hp.type("input[name='session_key'], input#username", options.email, {
+          await hp.type(LINKEDIN_LOGIN_EMAIL_INPUT_SELECTOR, options.email, {
             fieldLabel: "email"
           });
-          await hp.type("input[name='session_password'], input#password", options.password, {
+          await hp.type(LINKEDIN_LOGIN_PASSWORD_INPUT_SELECTOR, options.password, {
             fieldLabel: "password"
           });
         } finally {

--- a/packages/core/src/auth/sessionInspection.ts
+++ b/packages/core/src/auth/sessionInspection.ts
@@ -4,6 +4,10 @@ import {
   buildLinkedInAriaLabelContainsSelector,
   type LinkedInSelectorLocale
 } from "../selectorLocale.js";
+import {
+  LINKEDIN_LOGIN_EMAIL_INPUT_SELECTOR,
+  LINKEDIN_LOGIN_PASSWORD_INPUT_SELECTOR
+} from "./loginSelectors.js";
 
 /**
  * Snapshot of whether a Playwright page currently appears authenticated to
@@ -27,7 +31,6 @@ export interface LinkedInSessionIdentity {
   vanityName: string | null;
 }
 
-const LOGIN_FORM_SELECTOR = "input[name='session_key'], input#username";
 const CHECKPOINT_FORM_SELECTOR = "form[action*='checkpoint']";
 const AUTH_NAV_SELECTOR = "nav.global-nav";
 const AUTH_PROFILE_MENU_SELECTOR = "[data-control-name='nav.settings_view_profile']";
@@ -244,7 +247,15 @@ export async function inspectLinkedInSession(
     };
   }
 
-  const loginFormVisible = await isVisibleSafe(page, LOGIN_FORM_SELECTOR);
+  const loginEmailInputVisible = await isVisibleSafe(
+    page,
+    LINKEDIN_LOGIN_EMAIL_INPUT_SELECTOR
+  );
+  const loginPasswordInputVisible = await isVisibleSafe(
+    page,
+    LINKEDIN_LOGIN_PASSWORD_INPUT_SELECTOR
+  );
+  const loginFormVisible = loginEmailInputVisible && loginPasswordInputVisible;
   const loginWallVisible = await isVisibleSafe(page, LOGIN_WALL_SELECTOR);
   if (loginFormVisible || isLoginUrl(currentUrl) || loginWallVisible) {
     return {


### PR DESCRIPTION
## Summary
- add shared LinkedIn login selectors that cover the legacy fields plus the current autocomplete, placeholder, aria-label, and password fallbacks
- reuse those selectors in both session inspection and the headless login flow so auth no longer times out on the current React login form
- add regression coverage for nameless login inputs in session inspection and headless auth tests

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #314