### PR TITLE
fix: recognize the current self-profile top card during intro edits

### DIFF
--- a/packages/core/src/__tests__/linkedinProfile.test.ts
+++ b/packages/core/src/__tests__/linkedinProfile.test.ts
@@ -206,6 +206,25 @@ describe("resolveFirstVisibleLocator", () => {
     expect((resolved as unknown as MockLocator).resolvedIndex).toBe(1);
   });
 
+  it("scans beyond an initial batch of hidden matches", async () => {
+    const locator = new MockLocator([
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true
+    ]);
+
+    const resolved = await resolveFirstVisibleLocator(locator as unknown as Locator);
+
+    expect(resolved).not.toBeNull();
+    expect((resolved as unknown as MockLocator).resolvedIndex).toBe(8);
+  });
+
   it("returns null when no locator match is visible", async () => {
     const locator = new MockLocator([false, false]);
 

--- a/packages/core/src/linkedinProfile.ts
+++ b/packages/core/src/linkedinProfile.ts
@@ -2733,13 +2733,10 @@ interface LocatorCandidate {
   locator: Locator;
 }
 
-const MAX_VISIBLE_LOCATOR_MATCHES = 8;
-
 export async function resolveFirstVisibleLocator(
-  locator: Locator,
-  maxMatches: number = MAX_VISIBLE_LOCATOR_MATCHES
+  locator: Locator
 ): Promise<Locator | null> {
-  const count = Math.min(Math.max(0, maxMatches), await locator.count().catch(() => 0));
+  const count = await locator.count().catch(() => 0);
 
   for (let index = 0; index < count; index += 1) {
     const candidate = locator.nth(index);


### PR DESCRIPTION
## Summary
- scan locator candidates for the first visible match instead of only the first DOM match
- include artdeco-card self-profile header containers when resolving the profile top card root
- add regression coverage for hidden-first locator matches in the profile locator helper

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #316