### PR TITLE
fix: add confirm-time rate limiting for remaining write executors

### DIFF
--- a/packages/core/src/__tests__/confirmArtifacts.test.ts
+++ b/packages/core/src/__tests__/confirmArtifacts.test.ts
@@ -207,4 +207,54 @@ describe("executeConfirmActionWithArtifacts", () => {
     expect(result.artifacts[0]).toContain("trace-confirm-send-message");
     expect(statSync(runtime.artifacts.resolve(result.artifacts[0])).size).toBeGreaterThan(0);
   });
+
+  it("runs beforeExecute hooks and preserves RATE_LIMITED failures", async () => {
+    const runtime = createTestRuntime(2_048);
+    const context = createContext(createTraceArchive(), {
+      nodes: [{ role: { value: "RootWebArea" } }]
+    });
+    const page = createPage(
+      context,
+      "https://www.linkedin.com/in/realsimonmiller/"
+    );
+    const beforeExecute = vi.fn(() => {
+      throw new LinkedInBuddyError("RATE_LIMITED", "Local cooldown active.", {
+        rate_limit: {
+          counter_key: "linkedin.connections.send_invitation"
+        }
+      });
+    });
+    const execute = vi.fn(async () => ({
+      ok: true,
+      result: {},
+      artifacts: []
+    }));
+
+    await expect(
+      executeConfirmActionWithArtifacts({
+        runtime,
+        context,
+        page,
+        actionId: "act-3",
+        actionType: "connections.send_invitation",
+        profileName: "default",
+        beforeExecute,
+        mapError: (error) =>
+          asLinkedInBuddyError(error, "UNKNOWN", "Connection action failed."),
+        execute
+      })
+    ).rejects.toMatchObject({
+      code: "RATE_LIMITED",
+      details: {
+        action_id: "act-3",
+        artifact_paths: expect.any(Array),
+        rate_limit: {
+          counter_key: "linkedin.connections.send_invitation"
+        }
+      }
+    });
+
+    expect(beforeExecute).toHaveBeenCalledOnce();
+    expect(execute).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/__tests__/linkedinConnections.test.ts
+++ b/packages/core/src/__tests__/linkedinConnections.test.ts
@@ -10,6 +10,7 @@ import {
   WITHDRAW_INVITATION_ACTION_TYPE,
   createConnectionActionExecutors
 } from "../linkedinConnections.js";
+import { createAllowedRateLimiterStub } from "./rateLimiterTestUtils.js";
 
 describe("Connection action type constants", () => {
   it("has correct send invitation action type", () => {
@@ -65,7 +66,7 @@ describe("createConnectionActionExecutors", () => {
 });
 
 describe("LinkedInConnectionsService prepare relationship actions", () => {
-  it("prepares ignore, remove, follow, and unfollow actions with targeted previews", () => {
+  it("prepares connection actions with targeted previews and rate-limit metadata", () => {
     const prepare = vi.fn((input: {
       preview: Record<string, unknown>;
     }) => ({
@@ -74,10 +75,17 @@ describe("LinkedInConnectionsService prepare relationship actions", () => {
       expiresAtMs: 123,
       preview: input.preview
     }));
+    const rateLimiter = createAllowedRateLimiterStub();
 
     const service = new LinkedInConnectionsService({
+      rateLimiter,
       twoPhaseCommit: { prepare }
     } as unknown as ConstructorParameters<typeof LinkedInConnectionsService>[0]);
+
+    const sendPrepared = service.prepareSendInvitation({
+      targetProfile: "target-user",
+      note: "Let's connect."
+    });
 
     const ignorePrepared = service.prepareIgnoreInvitation({
       targetProfile: "target-user"
@@ -92,37 +100,59 @@ describe("LinkedInConnectionsService prepare relationship actions", () => {
       targetProfile: "target-user"
     });
 
+    expect(sendPrepared.preview).toMatchObject({
+      summary: "Send connection invitation to target-user",
+      rate_limit: {
+        counter_key: "linkedin.connections.send_invitation"
+      }
+    });
     expect(ignorePrepared.preview).toMatchObject({
       summary: "Ignore connection invitation from target-user",
       target: {
         target_profile: "target-user",
         profile_name: "default"
+      },
+      rate_limit: {
+        counter_key: "linkedin.connections.ignore_invitation"
       }
     });
     expect(removePrepared.preview).toMatchObject({
-      summary: "Remove existing connection with target-user"
+      summary: "Remove existing connection with target-user",
+      rate_limit: {
+        counter_key: "linkedin.connections.remove_connection"
+      }
     });
     expect(followPrepared.preview).toMatchObject({
-      summary: "Follow target-user"
+      summary: "Follow target-user",
+      rate_limit: {
+        counter_key: "linkedin.connections.follow_member"
+      }
     });
     expect(unfollowPrepared.preview).toMatchObject({
-      summary: "Unfollow target-user"
+      summary: "Unfollow target-user",
+      rate_limit: {
+        counter_key: "linkedin.connections.unfollow_member"
+      }
     });
 
     expect(prepare).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ actionType: IGNORE_INVITATION_ACTION_TYPE })
+      expect.objectContaining({ actionType: SEND_INVITATION_ACTION_TYPE })
     );
     expect(prepare).toHaveBeenNthCalledWith(
       2,
-      expect.objectContaining({ actionType: REMOVE_CONNECTION_ACTION_TYPE })
+      expect.objectContaining({ actionType: IGNORE_INVITATION_ACTION_TYPE })
     );
     expect(prepare).toHaveBeenNthCalledWith(
       3,
-      expect.objectContaining({ actionType: FOLLOW_MEMBER_ACTION_TYPE })
+      expect.objectContaining({ actionType: REMOVE_CONNECTION_ACTION_TYPE })
     );
     expect(prepare).toHaveBeenNthCalledWith(
       4,
+      expect.objectContaining({ actionType: FOLLOW_MEMBER_ACTION_TYPE })
+    );
+    expect(prepare).toHaveBeenNthCalledWith(
+      5,
       expect.objectContaining({ actionType: UNFOLLOW_MEMBER_ACTION_TYPE })
     );
   });

--- a/packages/core/src/__tests__/linkedinEvents.test.ts
+++ b/packages/core/src/__tests__/linkedinEvents.test.ts
@@ -6,6 +6,7 @@ import {
   buildEventViewUrl,
   createEventActionExecutors
 } from "../linkedinEvents.js";
+import { createAllowedRateLimiterStub } from "./rateLimiterTestUtils.js";
 
 describe("LinkedInEvents helpers", () => {
   it("builds event search URLs", () => {
@@ -41,7 +42,9 @@ describe("LinkedInEventsService prepare flows", () => {
       expiresAtMs: 123,
       preview: input.preview
     }));
+    const rateLimiter = createAllowedRateLimiterStub();
     const service = new LinkedInEventsService({
+      rateLimiter,
       twoPhaseCommit: { prepare }
     } as unknown as ConstructorParameters<typeof LinkedInEventsService>[0]);
 
@@ -58,6 +61,9 @@ describe("LinkedInEventsService prepare flows", () => {
       },
       payload: {
         response: "attend"
+      },
+      rate_limit: {
+        counter_key: "linkedin.events.rsvp"
       }
     });
     expect(prepare).toHaveBeenCalledWith(

--- a/packages/core/src/__tests__/linkedinGroups.test.ts
+++ b/packages/core/src/__tests__/linkedinGroups.test.ts
@@ -8,6 +8,7 @@ import {
   buildGroupViewUrl,
   createGroupActionExecutors
 } from "../linkedinGroups.js";
+import { createAllowedRateLimiterStub } from "./rateLimiterTestUtils.js";
 
 describe("LinkedInGroups helpers", () => {
   it("builds group search URLs", () => {
@@ -42,7 +43,9 @@ describe("LinkedInGroupsService prepare flows", () => {
       expiresAtMs: 123,
       preview: input.preview
     }));
+    const rateLimiter = createAllowedRateLimiterStub();
     const service = new LinkedInGroupsService({
+      rateLimiter,
       twoPhaseCommit: { prepare }
     } as unknown as ConstructorParameters<typeof LinkedInGroupsService>[0]);
 
@@ -59,10 +62,16 @@ describe("LinkedInGroupsService prepare flows", () => {
         group_id: "9806731",
         group_url: "https://www.linkedin.com/groups/9806731/",
         profile_name: "default"
+      },
+      rate_limit: {
+        counter_key: "linkedin.groups.join"
       }
     });
     expect(leavePrepared.preview).toMatchObject({
-      summary: "Leave LinkedIn group 9806731"
+      summary: "Leave LinkedIn group 9806731",
+      rate_limit: {
+        counter_key: "linkedin.groups.leave"
+      }
     });
 
     expect(prepare).toHaveBeenNthCalledWith(
@@ -85,7 +94,9 @@ describe("LinkedInGroupsService prepare flows", () => {
       expiresAtMs: 123,
       preview: input.preview
     }));
+    const rateLimiter = createAllowedRateLimiterStub();
     const service = new LinkedInGroupsService({
+      rateLimiter,
       twoPhaseCommit: { prepare }
     } as unknown as ConstructorParameters<typeof LinkedInGroupsService>[0]);
 
@@ -98,6 +109,9 @@ describe("LinkedInGroupsService prepare flows", () => {
       summary: "Post in LinkedIn group 9806731",
       payload: {
         text: "Ship it."
+      },
+      rate_limit: {
+        counter_key: "linkedin.groups.post"
       }
     });
     expect(prepare).toHaveBeenCalledWith(

--- a/packages/core/src/__tests__/linkedinMembers.test.ts
+++ b/packages/core/src/__tests__/linkedinMembers.test.ts
@@ -8,6 +8,7 @@ import {
   createMemberActionExecutors,
   normalizeLinkedInMemberReportReason
 } from "../linkedinMembers.js";
+import { createAllowedRateLimiterStub } from "./rateLimiterTestUtils.js";
 
 describe("LinkedIn member safety constants", () => {
   it("exposes the supported report reasons", () => {
@@ -61,7 +62,9 @@ describe("LinkedInMembersService prepare flows", () => {
       expiresAtMs: 123,
       preview: input.preview
     }));
+    const rateLimiter = createAllowedRateLimiterStub();
     const service = new LinkedInMembersService({
+      rateLimiter,
       twoPhaseCommit: { prepare }
     } as unknown as ConstructorParameters<typeof LinkedInMembersService>[0]);
 
@@ -77,10 +80,16 @@ describe("LinkedInMembersService prepare flows", () => {
       target: {
         target_profile: "target-user",
         profile_name: "default"
+      },
+      rate_limit: {
+        counter_key: "linkedin.members.block_member"
       }
     });
     expect(unblockPrepared.preview).toMatchObject({
-      summary: "Unblock LinkedIn member target-user"
+      summary: "Unblock LinkedIn member target-user",
+      rate_limit: {
+        counter_key: "linkedin.members.unblock_member"
+      }
     });
 
     expect(prepare).toHaveBeenNthCalledWith(
@@ -103,7 +112,9 @@ describe("LinkedInMembersService prepare flows", () => {
       expiresAtMs: 123,
       preview: input.preview
     }));
+    const rateLimiter = createAllowedRateLimiterStub();
     const service = new LinkedInMembersService({
+      rateLimiter,
       twoPhaseCommit: { prepare }
     } as unknown as ConstructorParameters<typeof LinkedInMembersService>[0]);
 
@@ -118,6 +129,9 @@ describe("LinkedInMembersService prepare flows", () => {
       payload: {
         reason: "spam",
         details: "Repeated unsolicited outreach."
+      },
+      rate_limit: {
+        counter_key: "linkedin.members.report_member"
       }
     });
     expect(prepare).toHaveBeenCalledWith(

--- a/packages/core/src/__tests__/linkedinPrivacySettings.test.ts
+++ b/packages/core/src/__tests__/linkedinPrivacySettings.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeLinkedInPrivacySettingKey,
   normalizeLinkedInPrivacySettingValue
 } from "../linkedinPrivacySettings.js";
+import { createAllowedRateLimiterStub } from "./rateLimiterTestUtils.js";
 
 describe("LinkedIn privacy setting constants", () => {
   it("exposes the supported setting keys", () => {
@@ -84,7 +85,9 @@ describe("LinkedInPrivacySettingsService prepare flow", () => {
       expiresAtMs: 123,
       preview: input.preview
     }));
+    const rateLimiter = createAllowedRateLimiterStub();
     const service = new LinkedInPrivacySettingsService({
+      rateLimiter,
       twoPhaseCommit: { prepare }
     } as unknown as ConstructorParameters<typeof LinkedInPrivacySettingsService>[0]);
 
@@ -103,6 +106,9 @@ describe("LinkedInPrivacySettingsService prepare flow", () => {
       target: {
         profile_name: "default",
         setting_key: "connections_visibility"
+      },
+      rate_limit: {
+        counter_key: "linkedin.privacy.update_setting"
       }
     });
     expect(prepare).toHaveBeenCalledWith(

--- a/packages/core/src/__tests__/linkedinProfile.test.ts
+++ b/packages/core/src/__tests__/linkedinProfile.test.ts
@@ -29,6 +29,7 @@ import {
   type LinkedInProfileRuntime
 } from "../linkedinProfile.js";
 import { TwoPhaseCommitService } from "../twoPhaseCommit.js";
+import { createAllowedRateLimiterStub } from "./rateLimiterTestUtils.js";
 
 const tempDirs: string[] = [];
 
@@ -65,6 +66,8 @@ function createTestRuntime(
   db: AssistantDatabase,
   artifactsRoot: string = createTempArtifactsDir()
 ): LinkedInProfileRuntime {
+  const rateLimiter = createAllowedRateLimiterStub();
+
   return {
     auth: {
       ensureAuthenticated: vi.fn(async () => undefined)
@@ -74,6 +77,7 @@ function createTestRuntime(
     profileManager: {
       runWithContext: vi.fn()
     },
+    rateLimiter: rateLimiter as unknown as LinkedInProfileRuntime["rateLimiter"],
     logger: {
       log: vi.fn()
     },
@@ -275,6 +279,9 @@ describe("LinkedInProfileService prepare helpers", () => {
           intro_updates: {
             headline: "Automation Engineer",
             location: "Copenhagen"
+          },
+          rate_limit: {
+            counter_key: "linkedin.profile.update_intro"
           }
         }
       });
@@ -706,6 +713,9 @@ describe("LinkedInProfileService prepare helpers", () => {
         fields: {
           relationship: "colleague",
           text: "A thoughtful collaborator who consistently follows through."
+        },
+        rate_limit: {
+          counter_key: "linkedin.profile.recommendation_write"
         }
       });
     } finally {

--- a/packages/core/src/__tests__/linkedinPublishing.test.ts
+++ b/packages/core/src/__tests__/linkedinPublishing.test.ts
@@ -9,6 +9,49 @@ import {
   PUBLISH_NEWSLETTER_ISSUE_ACTION_TYPE,
   createPublishingActionExecutors
 } from "../linkedinPublishing.js";
+import { createBlockedRateLimiterStub } from "./rateLimiterTestUtils.js";
+
+function createPublishingConfirmRuntime() {
+  const rateLimiter = createBlockedRateLimiterStub();
+  const page = {
+    screenshot: vi.fn(async () => undefined),
+    url: vi.fn(() => "https://www.linkedin.com/publishing/")
+  };
+  const context = {
+    pages: vi.fn(() => [page]),
+    newPage: vi.fn(async () => page),
+    tracing: {
+      start: vi.fn(async () => undefined),
+      stop: vi.fn(async () => undefined)
+    }
+  };
+  const runtime = {
+    auth: {
+      ensureAuthenticated: vi.fn(async () => undefined)
+    },
+    cdpUrl: undefined,
+    selectorLocale: "en",
+    profileManager: {
+      runWithContext: vi.fn(async (_options: unknown, callback: (ctx: typeof context) => unknown) =>
+        callback(context)
+      )
+    },
+    rateLimiter,
+    logger: {
+      log: vi.fn()
+    },
+    artifacts: {
+      resolve: vi.fn((relativePath: string) => `/tmp/${relativePath}`),
+      registerArtifact: vi.fn()
+    }
+  };
+
+  return {
+    page,
+    rateLimiter,
+    runtime
+  };
+}
 
 describe("publishing action type constants", () => {
   it("uses stable action identifiers for article and newsletter flows", () => {
@@ -33,6 +76,94 @@ describe("createPublishingActionExecutors", () => {
     expect(typeof executors[PUBLISH_NEWSLETTER_ISSUE_ACTION_TYPE]?.execute).toBe(
       "function"
     );
+  });
+
+  it("rejects confirm execution locally when publishing actions are rate limited", async () => {
+    const executors = createPublishingActionExecutors();
+    const cases = [
+      {
+        actionType: CREATE_ARTICLE_ACTION_TYPE,
+        counterKey: "linkedin.article.create",
+        action: {
+          id: "act-article-create",
+          target: {
+            profile_name: "default"
+          },
+          payload: {
+            title: "Title",
+            body: "Body"
+          }
+        }
+      },
+      {
+        actionType: PUBLISH_ARTICLE_ACTION_TYPE,
+        counterKey: "linkedin.article.publish",
+        action: {
+          id: "act-article-publish",
+          target: {
+            profile_name: "default"
+          },
+          payload: {
+            draft_url: "https://www.linkedin.com/pulse/edit/123/"
+          }
+        }
+      },
+      {
+        actionType: CREATE_NEWSLETTER_ACTION_TYPE,
+        counterKey: "linkedin.newsletter.create",
+        action: {
+          id: "act-newsletter-create",
+          target: {
+            profile_name: "default"
+          },
+          payload: {
+            title: "Builder Brief",
+            description: "Weekly notes.",
+            cadence: "weekly"
+          }
+        }
+      },
+      {
+        actionType: PUBLISH_NEWSLETTER_ISSUE_ACTION_TYPE,
+        counterKey: "linkedin.newsletter.publish_issue",
+        action: {
+          id: "act-newsletter-issue",
+          target: {
+            profile_name: "default"
+          },
+          payload: {
+            newsletter_title: "Builder Brief",
+            title: "March update",
+            body: "Long-form issue body."
+          }
+        }
+      }
+    ] as const;
+
+    for (const testCase of cases) {
+      const { page, rateLimiter, runtime } = createPublishingConfirmRuntime();
+
+      await expect(
+        executors[testCase.actionType]!.execute({
+          runtime,
+          action: testCase.action
+        } as never)
+      ).rejects.toMatchObject({
+        code: "RATE_LIMITED",
+        details: {
+          rate_limit: {
+            counter_key: testCase.counterKey
+          }
+        }
+      });
+
+      expect(rateLimiter.consume).toHaveBeenCalledWith(
+        expect.objectContaining({
+          counterKey: testCase.counterKey
+        })
+      );
+      expect(page.screenshot).toHaveBeenCalled();
+    }
   });
 });
 

--- a/packages/core/src/__tests__/rateLimiterTestUtils.ts
+++ b/packages/core/src/__tests__/rateLimiterTestUtils.ts
@@ -1,0 +1,53 @@
+import { vi } from "vitest";
+import type { ConsumeRateLimitInput, RateLimiterState } from "../rateLimiter.js";
+
+export function createRateLimitState(
+  input: ConsumeRateLimitInput,
+  overrides: Partial<RateLimiterState> = {}
+): RateLimiterState {
+  const count = overrides.count ?? 0;
+  const limit = overrides.limit ?? input.limit;
+  const remaining = overrides.remaining ?? Math.max(0, limit - count);
+
+  return {
+    counterKey: overrides.counterKey ?? input.counterKey,
+    windowStartMs: overrides.windowStartMs ?? 0,
+    windowSizeMs: overrides.windowSizeMs ?? input.windowSizeMs,
+    count,
+    limit,
+    remaining,
+    allowed: overrides.allowed ?? count < limit
+  };
+}
+
+export function createAllowedRateLimiterStub() {
+  return {
+    peek: vi.fn((input: ConsumeRateLimitInput) => createRateLimitState(input)),
+    consume: vi.fn((input: ConsumeRateLimitInput) =>
+      createRateLimitState(input, {
+        count: 1,
+        remaining: Math.max(0, input.limit - 1),
+        allowed: true
+      })
+    )
+  };
+}
+
+export function createBlockedRateLimiterStub() {
+  return {
+    peek: vi.fn((input: ConsumeRateLimitInput) =>
+      createRateLimitState(input, {
+        count: input.limit,
+        remaining: 0,
+        allowed: false
+      })
+    ),
+    consume: vi.fn((input: ConsumeRateLimitInput) =>
+      createRateLimitState(input, {
+        count: input.limit + 1,
+        remaining: 0,
+        allowed: false
+      })
+    )
+  };
+}

--- a/packages/core/src/confirmArtifacts.ts
+++ b/packages/core/src/confirmArtifacts.ts
@@ -36,6 +36,7 @@ export interface ExecuteConfirmActionWithArtifactsInput<
   persistTraceOnSuccess?: boolean;
   metadata?: Record<string, unknown> | undefined;
   errorDetails?: Record<string, unknown> | undefined;
+  beforeExecute?: (() => void) | undefined;
   mapError: (error: unknown) => LinkedInBuddyError;
   execute: () => Promise<ActionExecutorResult>;
 }
@@ -458,6 +459,7 @@ export async function executeConfirmActionWithArtifacts<
   }
 
   try {
+    input.beforeExecute?.();
     const result = await input.execute();
     const artifactPaths = [...result.artifacts];
 

--- a/packages/core/src/linkedinConnections.ts
+++ b/packages/core/src/linkedinConnections.ts
@@ -8,6 +8,13 @@ import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
 import {
+  consumeRateLimitOrThrow,
+  createConfirmRateLimitMessage,
+  peekRateLimitPreview,
+  type ConsumeRateLimitInput,
+  type RateLimiter
+} from "./rateLimiter.js";
+import {
   normalizeLinkedInProfileUrl,
   resolveProfileUrl
 } from "./linkedinProfile.js";
@@ -88,6 +95,7 @@ export interface LinkedInConnectionsExecutorRuntime {
   cdpUrl?: string | undefined;
   selectorLocale: LinkedInSelectorLocale;
   profileManager: ProfileManager;
+  rateLimiter: RateLimiter;
   logger: JsonEventLogger;
   artifacts: ArtifactHelpers;
   confirmFailureArtifacts: ConfirmFailureArtifactConfig;
@@ -112,6 +120,44 @@ export const REMOVE_CONNECTION_ACTION_TYPE = "connections.remove_connection";
 export const FOLLOW_MEMBER_ACTION_TYPE = "connections.follow_member";
 export const UNFOLLOW_MEMBER_ACTION_TYPE = "connections.unfollow_member";
 
+const CONNECTION_RATE_LIMIT_CONFIGS = {
+  [SEND_INVITATION_ACTION_TYPE]: {
+    counterKey: "linkedin.connections.send_invitation",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 20
+  },
+  [ACCEPT_INVITATION_ACTION_TYPE]: {
+    counterKey: "linkedin.connections.accept_invitation",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 30
+  },
+  [WITHDRAW_INVITATION_ACTION_TYPE]: {
+    counterKey: "linkedin.connections.withdraw_invitation",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 20
+  },
+  [IGNORE_INVITATION_ACTION_TYPE]: {
+    counterKey: "linkedin.connections.ignore_invitation",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 30
+  },
+  [REMOVE_CONNECTION_ACTION_TYPE]: {
+    counterKey: "linkedin.connections.remove_connection",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 20
+  },
+  [FOLLOW_MEMBER_ACTION_TYPE]: {
+    counterKey: "linkedin.connections.follow_member",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 30
+  },
+  [UNFOLLOW_MEMBER_ACTION_TYPE]: {
+    counterKey: "linkedin.connections.unfollow_member",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 30
+  }
+} as const satisfies Record<string, ConsumeRateLimitInput>;
+
 const CONNECTIONS_URL = "https://www.linkedin.com/mynetwork/invite-connect/connections/";
 const INVITATIONS_RECEIVED_URL = "https://www.linkedin.com/mynetwork/invitation-manager/";
 const INVITATIONS_SENT_URL = "https://www.linkedin.com/mynetwork/invitation-manager/sent/";
@@ -122,6 +168,22 @@ const INVITATIONS_SENT_URL = "https://www.linkedin.com/mynetwork/invitation-mana
 
 function normalizeText(value: string | null | undefined): string {
   return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function getConnectionRateLimitConfig(
+  actionType: string
+): ConsumeRateLimitInput {
+  const config = (
+    CONNECTION_RATE_LIMIT_CONFIGS as Record<string, ConsumeRateLimitInput>
+  )[actionType];
+
+  if (!config) {
+    throw new LinkedInBuddyError("UNKNOWN", "Missing rate limit policy.", {
+      action_type: actionType
+    });
+  }
+
+  return config;
 }
 
 type LocatorRoot = Page | Locator;
@@ -741,6 +803,18 @@ async function executeSendInvitation(
           profile_url: profileUrl,
           note_included: note.length > 0
         },
+        beforeExecute: () =>
+          consumeRateLimitOrThrow(runtime.rateLimiter, {
+            config: getConnectionRateLimitConfig(SEND_INVITATION_ACTION_TYPE),
+            message: createConfirmRateLimitMessage(SEND_INVITATION_ACTION_TYPE),
+            details: {
+              action_id: actionId,
+              profile_name: profileName,
+              target_profile: targetProfile,
+              profile_url: profileUrl,
+              note_included: note.length > 0
+            }
+          }),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -1182,6 +1256,16 @@ async function executeAcceptInvitation(
         errorDetails: {
           target_profile: targetProfile
         },
+        beforeExecute: () =>
+          consumeRateLimitOrThrow(runtime.rateLimiter, {
+            config: getConnectionRateLimitConfig(ACCEPT_INVITATION_ACTION_TYPE),
+            message: createConfirmRateLimitMessage(ACCEPT_INVITATION_ACTION_TYPE),
+            details: {
+              action_id: actionId,
+              profile_name: profileName,
+              target_profile: targetProfile
+            }
+          }),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -1281,6 +1365,16 @@ async function executeWithdrawInvitation(
         errorDetails: {
           target_profile: targetProfile
         },
+        beforeExecute: () =>
+          consumeRateLimitOrThrow(runtime.rateLimiter, {
+            config: getConnectionRateLimitConfig(WITHDRAW_INVITATION_ACTION_TYPE),
+            message: createConfirmRateLimitMessage(WITHDRAW_INVITATION_ACTION_TYPE),
+            details: {
+              action_id: actionId,
+              profile_name: profileName,
+              target_profile: targetProfile
+            }
+          }),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -1400,6 +1494,16 @@ async function executeIgnoreInvitation(
         errorDetails: {
           target_profile: targetProfile
         },
+        beforeExecute: () =>
+          consumeRateLimitOrThrow(runtime.rateLimiter, {
+            config: getConnectionRateLimitConfig(IGNORE_INVITATION_ACTION_TYPE),
+            message: createConfirmRateLimitMessage(IGNORE_INVITATION_ACTION_TYPE),
+            details: {
+              action_id: actionId,
+              profile_name: profileName,
+              target_profile: targetProfile
+            }
+          }),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -1503,6 +1607,17 @@ async function executeRemoveConnection(
           target_profile: targetProfile,
           profile_url: profileUrl
         },
+        beforeExecute: () =>
+          consumeRateLimitOrThrow(runtime.rateLimiter, {
+            config: getConnectionRateLimitConfig(REMOVE_CONNECTION_ACTION_TYPE),
+            message: createConfirmRateLimitMessage(REMOVE_CONNECTION_ACTION_TYPE),
+            details: {
+              action_id: actionId,
+              profile_name: profileName,
+              target_profile: targetProfile,
+              profile_url: profileUrl
+            }
+          }),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -1632,6 +1747,17 @@ async function executeFollowMember(
           target_profile: targetProfile,
           profile_url: profileUrl
         },
+        beforeExecute: () =>
+          consumeRateLimitOrThrow(runtime.rateLimiter, {
+            config: getConnectionRateLimitConfig(FOLLOW_MEMBER_ACTION_TYPE),
+            message: createConfirmRateLimitMessage(FOLLOW_MEMBER_ACTION_TYPE),
+            details: {
+              action_id: actionId,
+              profile_name: profileName,
+              target_profile: targetProfile,
+              profile_url: profileUrl
+            }
+          }),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -1745,6 +1871,17 @@ async function executeUnfollowMember(
           target_profile: targetProfile,
           profile_url: profileUrl
         },
+        beforeExecute: () =>
+          consumeRateLimitOrThrow(runtime.rateLimiter, {
+            config: getConnectionRateLimitConfig(UNFOLLOW_MEMBER_ACTION_TYPE),
+            message: createConfirmRateLimitMessage(UNFOLLOW_MEMBER_ACTION_TYPE),
+            details: {
+              action_id: actionId,
+              profile_name: profileName,
+              target_profile: targetProfile,
+              profile_url: profileUrl
+            }
+          }),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -2002,7 +2139,11 @@ export class LinkedInConnectionsService {
       payload: {},
       preview: {
         summary: input.summary,
-        target
+        target,
+        rate_limit: peekRateLimitPreview(
+          this.runtime.rateLimiter,
+          getConnectionRateLimitConfig(input.actionType)
+        )
       },
       ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
     });
@@ -2156,7 +2297,11 @@ export class LinkedInConnectionsService {
       target,
       outbound: {
         note: input.note ?? ""
-      }
+      },
+      rate_limit: peekRateLimitPreview(
+        this.runtime.rateLimiter,
+        getConnectionRateLimitConfig(SEND_INVITATION_ACTION_TYPE)
+      )
     };
 
     return this.runtime.twoPhaseCommit.prepare({

--- a/packages/core/src/linkedinEvents.ts
+++ b/packages/core/src/linkedinEvents.ts
@@ -10,6 +10,13 @@ import {
 import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
+import {
+  consumeRateLimitOrThrow,
+  createConfirmRateLimitMessage,
+  peekRateLimitPreview,
+  type ConsumeRateLimitInput,
+  type RateLimiter
+} from "./rateLimiter.js";
 import type { LinkedInSelectorLocale } from "./selectorLocale.js";
 import type {
   ActionExecutor,
@@ -20,6 +27,12 @@ import type {
 } from "./twoPhaseCommit.js";
 
 export const EVENT_RSVP_ACTION_TYPE = "events.rsvp";
+
+const EVENT_RSVP_RATE_LIMIT_CONFIG = {
+  counterKey: "linkedin.events.rsvp",
+  windowSizeMs: 24 * 60 * 60 * 1000,
+  limit: 20
+} as const satisfies ConsumeRateLimitInput;
 
 export type LinkedInEventRsvpState = "not_responded" | "attending" | "unknown";
 
@@ -76,6 +89,7 @@ export interface LinkedInEventsExecutorRuntime {
   cdpUrl?: string | undefined;
   selectorLocale: LinkedInSelectorLocale;
   profileManager: ProfileManager;
+  rateLimiter: RateLimiter;
   logger: JsonEventLogger;
   artifacts: ArtifactHelpers;
   confirmFailureArtifacts: ConfirmFailureArtifactConfig;
@@ -519,6 +533,18 @@ async function executeEventRsvp(
           event_url: eventUrl,
           response: "attend"
         },
+        beforeExecute: () =>
+          consumeRateLimitOrThrow(runtime.rateLimiter, {
+            config: EVENT_RSVP_RATE_LIMIT_CONFIG,
+            message: createConfirmRateLimitMessage(EVENT_RSVP_ACTION_TYPE),
+            details: {
+              action_id: actionId,
+              profile_name: profileName,
+              event_id: eventId,
+              event_url: eventUrl,
+              response: "attend"
+            }
+          }),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -742,7 +768,11 @@ export class LinkedInEventsService {
         target,
         payload: {
           response: "attend"
-        }
+        },
+        rate_limit: peekRateLimitPreview(
+          this.runtime.rateLimiter,
+          EVENT_RSVP_RATE_LIMIT_CONFIG
+        )
       },
       ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
     });

--- a/packages/core/src/linkedinGroups.ts
+++ b/packages/core/src/linkedinGroups.ts
@@ -11,6 +11,13 @@ import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
 import {
+  consumeRateLimitOrThrow,
+  createConfirmRateLimitMessage,
+  peekRateLimitPreview,
+  type ConsumeRateLimitInput,
+  type RateLimiter
+} from "./rateLimiter.js";
+import {
   buildLinkedInSelectorPhraseRegex,
   type LinkedInSelectorLocale
 } from "./selectorLocale.js";
@@ -25,6 +32,24 @@ import type {
 export const GROUP_JOIN_ACTION_TYPE = "groups.join";
 export const GROUP_LEAVE_ACTION_TYPE = "groups.leave";
 export const GROUP_POST_ACTION_TYPE = "groups.post";
+
+const GROUP_RATE_LIMIT_CONFIGS = {
+  [GROUP_JOIN_ACTION_TYPE]: {
+    counterKey: "linkedin.groups.join",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 10
+  },
+  [GROUP_LEAVE_ACTION_TYPE]: {
+    counterKey: "linkedin.groups.leave",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 10
+  },
+  [GROUP_POST_ACTION_TYPE]: {
+    counterKey: "linkedin.groups.post",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 1
+  }
+} as const satisfies Record<string, ConsumeRateLimitInput>;
 
 export type LinkedInGroupMembershipState =
   | "member"
@@ -95,6 +120,7 @@ export interface LinkedInGroupsExecutorRuntime {
   cdpUrl?: string | undefined;
   selectorLocale: LinkedInSelectorLocale;
   profileManager: ProfileManager;
+  rateLimiter: RateLimiter;
   logger: JsonEventLogger;
   artifacts: ArtifactHelpers;
   confirmFailureArtifacts: ConfirmFailureArtifactConfig;
@@ -128,6 +154,20 @@ interface GroupDetailSnapshot {
 
 function normalizeText(value: string | null | undefined): string {
   return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function getGroupRateLimitConfig(actionType: string): ConsumeRateLimitInput {
+  const config = (
+    GROUP_RATE_LIMIT_CONFIGS as Record<string, ConsumeRateLimitInput>
+  )[actionType];
+
+  if (!config) {
+    throw new LinkedInBuddyError("UNKNOWN", "Missing rate limit policy.", {
+      action_type: actionType
+    });
+  }
+
+  return config;
 }
 
 function escapeRegExp(value: string): string {
@@ -495,6 +535,17 @@ async function executeJoinGroup(
           group_id: groupId,
           group_url: groupUrl
         },
+        beforeExecute: () =>
+          consumeRateLimitOrThrow(runtime.rateLimiter, {
+            config: getGroupRateLimitConfig(GROUP_JOIN_ACTION_TYPE),
+            message: createConfirmRateLimitMessage(GROUP_JOIN_ACTION_TYPE),
+            details: {
+              action_id: actionId,
+              profile_name: profileName,
+              group_id: groupId,
+              group_url: groupUrl
+            }
+          }),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -599,6 +650,17 @@ async function executeLeaveGroup(
           group_id: groupId,
           group_url: groupUrl
         },
+        beforeExecute: () =>
+          consumeRateLimitOrThrow(runtime.rateLimiter, {
+            config: getGroupRateLimitConfig(GROUP_LEAVE_ACTION_TYPE),
+            message: createConfirmRateLimitMessage(GROUP_LEAVE_ACTION_TYPE),
+            details: {
+              action_id: actionId,
+              profile_name: profileName,
+              group_id: groupId,
+              group_url: groupUrl
+            }
+          }),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -710,6 +772,17 @@ async function executePostToGroup(
           group_id: groupId,
           group_url: groupUrl
         },
+        beforeExecute: () =>
+          consumeRateLimitOrThrow(runtime.rateLimiter, {
+            config: getGroupRateLimitConfig(GROUP_POST_ACTION_TYPE),
+            message: createConfirmRateLimitMessage(GROUP_POST_ACTION_TYPE),
+            details: {
+              action_id: actionId,
+              profile_name: profileName,
+              group_id: groupId,
+              group_url: groupUrl
+            }
+          }),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -972,7 +1045,11 @@ export class LinkedInGroupsService {
       preview: {
         summary: input.summary,
         target,
-        ...(input.payload ? { payload: input.payload } : {})
+        ...(input.payload ? { payload: input.payload } : {}),
+        rate_limit: peekRateLimitPreview(
+          this.runtime.rateLimiter,
+          getGroupRateLimitConfig(input.actionType)
+        )
       },
       ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
     });

--- a/packages/core/src/linkedinMembers.ts
+++ b/packages/core/src/linkedinMembers.ts
@@ -11,6 +11,13 @@ import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
 import {
+  consumeRateLimitOrThrow,
+  createConfirmRateLimitMessage,
+  peekRateLimitPreview,
+  type ConsumeRateLimitInput,
+  type RateLimiter
+} from "./rateLimiter.js";
+import {
   normalizeLinkedInProfileUrl,
   resolveProfileUrl
 } from "./linkedinProfile.js";
@@ -66,6 +73,7 @@ export interface LinkedInMembersExecutorRuntime {
   cdpUrl?: string | undefined;
   selectorLocale: LinkedInSelectorLocale;
   profileManager: ProfileManager;
+  rateLimiter: RateLimiter;
   logger: JsonEventLogger;
   artifacts: ArtifactHelpers;
   confirmFailureArtifacts: ConfirmFailureArtifactConfig;
@@ -78,6 +86,24 @@ export interface LinkedInMembersRuntime extends LinkedInMembersExecutorRuntime {
 export const BLOCK_MEMBER_ACTION_TYPE = "members.block_member";
 export const UNBLOCK_MEMBER_ACTION_TYPE = "members.unblock_member";
 export const REPORT_MEMBER_ACTION_TYPE = "members.report_member";
+
+const MEMBER_RATE_LIMIT_CONFIGS = {
+  [BLOCK_MEMBER_ACTION_TYPE]: {
+    counterKey: "linkedin.members.block_member",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 10
+  },
+  [UNBLOCK_MEMBER_ACTION_TYPE]: {
+    counterKey: "linkedin.members.unblock_member",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 10
+  },
+  [REPORT_MEMBER_ACTION_TYPE]: {
+    counterKey: "linkedin.members.report_member",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 10
+  }
+} as const satisfies Record<string, ConsumeRateLimitInput>;
 
 const BLOCKED_MEMBERS_URLS = [
   "https://www.linkedin.com/mypreferences/d/blocking",
@@ -92,6 +118,20 @@ interface VisibleLocatorCandidate {
 
 function normalizeText(value: string | null | undefined): string {
   return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function getMemberRateLimitConfig(actionType: string): ConsumeRateLimitInput {
+  const config = (
+    MEMBER_RATE_LIMIT_CONFIGS as Record<string, ConsumeRateLimitInput>
+  )[actionType];
+
+  if (!config) {
+    throw new LinkedInBuddyError("UNKNOWN", "Missing rate limit policy.", {
+      action_type: actionType
+    });
+  }
+
+  return config;
 }
 
 function escapeRegExp(value: string): string {
@@ -739,6 +779,17 @@ async function executeBlockMember(
           target_profile: targetProfile,
           profile_url: profileUrl
         },
+        beforeExecute: () =>
+          consumeRateLimitOrThrow(runtime.rateLimiter, {
+            config: getMemberRateLimitConfig(BLOCK_MEMBER_ACTION_TYPE),
+            message: createConfirmRateLimitMessage(BLOCK_MEMBER_ACTION_TYPE),
+            details: {
+              action_id: actionId,
+              profile_name: profileName,
+              target_profile: targetProfile,
+              profile_url: profileUrl
+            }
+          }),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -837,6 +888,16 @@ async function executeUnblockMember(
         errorDetails: {
           target_profile: targetProfile
         },
+        beforeExecute: () =>
+          consumeRateLimitOrThrow(runtime.rateLimiter, {
+            config: getMemberRateLimitConfig(UNBLOCK_MEMBER_ACTION_TYPE),
+            message: createConfirmRateLimitMessage(UNBLOCK_MEMBER_ACTION_TYPE),
+            details: {
+              action_id: actionId,
+              profile_name: profileName,
+              target_profile: targetProfile
+            }
+          }),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -995,6 +1056,18 @@ async function executeReportMember(
           report_reason: reason,
           profile_url: profileUrl
         },
+        beforeExecute: () =>
+          consumeRateLimitOrThrow(runtime.rateLimiter, {
+            config: getMemberRateLimitConfig(REPORT_MEMBER_ACTION_TYPE),
+            message: createConfirmRateLimitMessage(REPORT_MEMBER_ACTION_TYPE),
+            details: {
+              action_id: actionId,
+              profile_name: profileName,
+              target_profile: targetProfile,
+              report_reason: reason,
+              profile_url: profileUrl
+            }
+          }),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -1179,7 +1252,11 @@ export class LinkedInMembersService {
       preview: {
         summary: input.summary,
         target,
-        ...(input.payload ? { payload: input.payload } : {})
+        ...(input.payload ? { payload: input.payload } : {}),
+        rate_limit: peekRateLimitPreview(
+          this.runtime.rateLimiter,
+          getMemberRateLimitConfig(input.actionType)
+        )
       },
       ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
     });

--- a/packages/core/src/linkedinPrivacySettings.ts
+++ b/packages/core/src/linkedinPrivacySettings.ts
@@ -10,6 +10,13 @@ import {
 import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
+import {
+  consumeRateLimitOrThrow,
+  createConfirmRateLimitMessage,
+  peekRateLimitPreview,
+  type ConsumeRateLimitInput,
+  type RateLimiter
+} from "./rateLimiter.js";
 import type { LinkedInSelectorLocale } from "./selectorLocale.js";
 import type {
   ActionExecutor,
@@ -59,6 +66,7 @@ export interface LinkedInPrivacySettingsExecutorRuntime {
   cdpUrl?: string | undefined;
   selectorLocale: LinkedInSelectorLocale;
   profileManager: ProfileManager;
+  rateLimiter: RateLimiter;
   logger: JsonEventLogger;
   artifacts: ArtifactHelpers;
   confirmFailureArtifacts: ConfirmFailureArtifactConfig;
@@ -73,6 +81,12 @@ export interface LinkedInPrivacySettingsRuntime
 }
 
 export const UPDATE_PRIVACY_SETTING_ACTION_TYPE = "privacy.update_setting";
+
+const UPDATE_PRIVACY_SETTING_RATE_LIMIT_CONFIG = {
+  counterKey: "linkedin.privacy.update_setting",
+  windowSizeMs: 24 * 60 * 60 * 1000,
+  limit: 10
+} as const satisfies ConsumeRateLimitInput;
 
 interface VisibleLocatorCandidate {
   key: string;
@@ -812,6 +826,19 @@ async function executeUpdatePrivacySetting(
           setting_key: settingKey,
           requested_value: requestedValue
         },
+        beforeExecute: () =>
+          consumeRateLimitOrThrow(runtime.rateLimiter, {
+            config: UPDATE_PRIVACY_SETTING_RATE_LIMIT_CONFIG,
+            message: createConfirmRateLimitMessage(
+              UPDATE_PRIVACY_SETTING_ACTION_TYPE
+            ),
+            details: {
+              action_id: actionId,
+              profile_name: profileName,
+              setting_key: settingKey,
+              requested_value: requestedValue
+            }
+          }),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -996,7 +1023,11 @@ export class LinkedInPrivacySettingsService {
           label: descriptor.label,
           description: descriptor.description,
           value
-        }
+        },
+        rate_limit: peekRateLimitPreview(
+          this.runtime.rateLimiter,
+          UPDATE_PRIVACY_SETTING_RATE_LIMIT_CONFIG
+        )
       },
       ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
     });

--- a/packages/core/src/linkedinProfile.ts
+++ b/packages/core/src/linkedinProfile.ts
@@ -16,6 +16,13 @@ import { LinkedInBuddyError, asLinkedInBuddyError } from "./errors.js";
 import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
+import {
+  consumeRateLimitOrThrow,
+  createConfirmRateLimitMessage,
+  peekRateLimitPreview,
+  type ConsumeRateLimitInput,
+  type RateLimiter
+} from "./rateLimiter.js";
 import type { LinkedInSelectorLocale } from "./selectorLocale.js";
 import { getLinkedInSelectorPhrases } from "./selectorLocale.js";
 import type {
@@ -63,6 +70,7 @@ interface LinkedInProfileRuntimeBase {
   cdpUrl?: string | undefined;
   selectorLocale: LinkedInSelectorLocale;
   profileManager: ProfileManager;
+  rateLimiter: RateLimiter;
   logger: JsonEventLogger;
 }
 
@@ -86,6 +94,84 @@ export const REQUEST_PROFILE_RECOMMENDATION_ACTION_TYPE =
   "profile.recommendation_request";
 export const WRITE_PROFILE_RECOMMENDATION_ACTION_TYPE =
   "profile.recommendation_write";
+
+const PROFILE_RATE_LIMIT_CONFIGS = {
+  [UPDATE_PROFILE_INTRO_ACTION_TYPE]: {
+    counterKey: "linkedin.profile.update_intro",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 10
+  },
+  [UPDATE_PROFILE_SETTINGS_ACTION_TYPE]: {
+    counterKey: "linkedin.profile.update_settings",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 10
+  },
+  [UPDATE_PROFILE_PUBLIC_PROFILE_ACTION_TYPE]: {
+    counterKey: "linkedin.profile.update_public_profile",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 10
+  },
+  [UPSERT_PROFILE_SECTION_ITEM_ACTION_TYPE]: {
+    counterKey: "linkedin.profile.upsert_section_item",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 10
+  },
+  [REMOVE_PROFILE_SECTION_ITEM_ACTION_TYPE]: {
+    counterKey: "linkedin.profile.remove_section_item",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 10
+  },
+  [UPLOAD_PROFILE_PHOTO_ACTION_TYPE]: {
+    counterKey: "linkedin.profile.upload_photo",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 5
+  },
+  [UPLOAD_PROFILE_BANNER_ACTION_TYPE]: {
+    counterKey: "linkedin.profile.upload_banner",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 5
+  },
+  [ADD_PROFILE_FEATURED_ACTION_TYPE]: {
+    counterKey: "linkedin.profile.featured_add",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 10
+  },
+  [REMOVE_PROFILE_FEATURED_ACTION_TYPE]: {
+    counterKey: "linkedin.profile.featured_remove",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 10
+  },
+  [REORDER_PROFILE_FEATURED_ACTION_TYPE]: {
+    counterKey: "linkedin.profile.featured_reorder",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 10
+  },
+  [ADD_PROFILE_SKILL_ACTION_TYPE]: {
+    counterKey: "linkedin.profile.skill_add",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 10
+  },
+  [REORDER_PROFILE_SKILLS_ACTION_TYPE]: {
+    counterKey: "linkedin.profile.skills_reorder",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 10
+  },
+  [ENDORSE_PROFILE_SKILL_ACTION_TYPE]: {
+    counterKey: "linkedin.profile.skill_endorse",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 30
+  },
+  [REQUEST_PROFILE_RECOMMENDATION_ACTION_TYPE]: {
+    counterKey: "linkedin.profile.recommendation_request",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 5
+  },
+  [WRITE_PROFILE_RECOMMENDATION_ACTION_TYPE]: {
+    counterKey: "linkedin.profile.recommendation_write",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 5
+  }
+} as const satisfies Record<string, ConsumeRateLimitInput>;
 
 export const LINKEDIN_PROFILE_SECTION_TYPES = [
   "about",
@@ -1139,6 +1225,39 @@ async function extractEditableSettings(
 
 function normalizeText(value: string | null | undefined): string {
   return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function getProfileRateLimitConfig(actionType: string): ConsumeRateLimitInput {
+  const config = (
+    PROFILE_RATE_LIMIT_CONFIGS as Record<string, ConsumeRateLimitInput>
+  )[actionType];
+
+  if (!config) {
+    throw new LinkedInBuddyError("UNKNOWN", "Missing rate limit policy.", {
+      action_type: actionType
+    });
+  }
+
+  return config;
+}
+
+function createProfileRateLimitGuard(
+  runtime: LinkedInProfileExecutorRuntime,
+  actionType: string,
+  actionId: string,
+  profileName: string,
+  details: Record<string, unknown>
+): () => void {
+  return () =>
+    consumeRateLimitOrThrow(runtime.rateLimiter, {
+      config: getProfileRateLimitConfig(actionType),
+      message: createConfirmRateLimitMessage(actionType),
+      details: {
+        action_id: actionId,
+        profile_name: profileName,
+        ...details
+      }
+    });
 }
 
 function isAbsoluteUrl(value: string): boolean {
@@ -5258,6 +5377,15 @@ async function executeAddProfileSkill(
           profile_name: profileName,
           skill_name: skillName
         },
+        beforeExecute: createProfileRateLimitGuard(
+          runtime,
+          ADD_PROFILE_SKILL_ACTION_TYPE,
+          actionId,
+          profileName,
+          {
+            skill_name: skillName
+          }
+        ),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -5321,6 +5449,15 @@ async function executeReorderProfileSkills(
           profile_name: profileName,
           skill_count: skillNames.length
         },
+        beforeExecute: createProfileRateLimitGuard(
+          runtime,
+          REORDER_PROFILE_SKILLS_ACTION_TYPE,
+          actionId,
+          profileName,
+          {
+            skill_count: skillNames.length
+          }
+        ),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -5391,6 +5528,16 @@ async function executeEndorseProfileSkill(
           target_profile_url: targetProfileUrl,
           skill_name: skillName
         },
+        beforeExecute: createProfileRateLimitGuard(
+          runtime,
+          ENDORSE_PROFILE_SKILL_ACTION_TYPE,
+          actionId,
+          profileName,
+          {
+            target_profile_url: targetProfileUrl,
+            skill_name: skillName
+          }
+        ),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -5469,6 +5616,16 @@ async function executeRequestProfileRecommendation(
           target_profile_url: targetProfileUrl,
           provided_fields: Object.keys(fields)
         },
+        beforeExecute: createProfileRateLimitGuard(
+          runtime,
+          REQUEST_PROFILE_RECOMMENDATION_ACTION_TYPE,
+          actionId,
+          profileName,
+          {
+            target_profile_url: targetProfileUrl,
+            provided_fields: Object.keys(fields)
+          }
+        ),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -5556,6 +5713,16 @@ async function executeWriteProfileRecommendation(
           target_profile_url: targetProfileUrl,
           provided_fields: Object.keys(fields)
         },
+        beforeExecute: createProfileRateLimitGuard(
+          runtime,
+          WRITE_PROFILE_RECOMMENDATION_ACTION_TYPE,
+          actionId,
+          profileName,
+          {
+            target_profile_url: targetProfileUrl,
+            provided_fields: Object.keys(fields)
+          }
+        ),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -5633,6 +5800,18 @@ async function executeUploadProfileMedia(
           media_kind: kind,
           file_name: upload.file_name
         },
+        beforeExecute: createProfileRateLimitGuard(
+          runtime,
+          kind === "photo"
+            ? UPLOAD_PROFILE_PHOTO_ACTION_TYPE
+            : UPLOAD_PROFILE_BANNER_ACTION_TYPE,
+          actionId,
+          profileName,
+          {
+            media_kind: kind,
+            file_name: upload.file_name
+          }
+        ),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -5724,6 +5903,17 @@ async function executeAddFeaturedItem(
           ...(url ? { url } : {}),
           ...(upload ? { file_name: upload.file_name } : {})
         },
+        beforeExecute: createProfileRateLimitGuard(
+          runtime,
+          ADD_PROFILE_FEATURED_ACTION_TYPE,
+          actionId,
+          profileName,
+          {
+            featured_kind: kind,
+            ...(url ? { url } : {}),
+            ...(upload ? { file_name: upload.file_name } : {})
+          }
+        ),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -5816,6 +6006,16 @@ async function executeRemoveFeaturedItem(
           ...(match.url ? { url: match.url } : {}),
           ...(match.title ? { title: match.title } : {})
         },
+        beforeExecute: createProfileRateLimitGuard(
+          runtime,
+          REMOVE_PROFILE_FEATURED_ACTION_TYPE,
+          actionId,
+          profileName,
+          {
+            ...(match.url ? { url: match.url } : {}),
+            ...(match.title ? { title: match.title } : {})
+          }
+        ),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -5891,6 +6091,15 @@ async function executeReorderFeaturedItems(
           profile_name: profileName,
           item_count: itemIds.length
         },
+        beforeExecute: createProfileRateLimitGuard(
+          runtime,
+          REORDER_PROFILE_FEATURED_ACTION_TYPE,
+          actionId,
+          profileName,
+          {
+            item_count: itemIds.length
+          }
+        ),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -5953,6 +6162,15 @@ async function executeUpdateProfileIntro(
           profile_name: profileName,
           updated_fields: Object.keys(updates)
         },
+        beforeExecute: createProfileRateLimitGuard(
+          runtime,
+          UPDATE_PROFILE_INTRO_ACTION_TYPE,
+          actionId,
+          profileName,
+          {
+            updated_fields: Object.keys(updates)
+          }
+        ),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -6023,6 +6241,15 @@ async function executeUpdateProfileSettings(
           profile_name: profileName,
           updated_fields: Object.keys(updates)
         },
+        beforeExecute: createProfileRateLimitGuard(
+          runtime,
+          UPDATE_PROFILE_SETTINGS_ACTION_TYPE,
+          actionId,
+          profileName,
+          {
+            updated_fields: Object.keys(updates)
+          }
+        ),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -6101,6 +6328,16 @@ async function executeUpdateProfilePublicProfile(
           vanity_name: publicProfile.vanityName,
           public_profile_url: publicProfile.publicProfileUrl
         },
+        beforeExecute: createProfileRateLimitGuard(
+          runtime,
+          UPDATE_PROFILE_PUBLIC_PROFILE_ACTION_TYPE,
+          actionId,
+          profileName,
+          {
+            vanity_name: publicProfile.vanityName,
+            public_profile_url: publicProfile.publicProfileUrl
+          }
+        ),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -6193,6 +6430,17 @@ async function executeUpsertProfileSectionItem(
           mode,
           updated_fields: Object.keys(values)
         },
+        beforeExecute: createProfileRateLimitGuard(
+          runtime,
+          UPSERT_PROFILE_SECTION_ITEM_ACTION_TYPE,
+          actionId,
+          profileName,
+          {
+            section,
+            mode,
+            updated_fields: Object.keys(values)
+          }
+        ),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -6289,6 +6537,15 @@ async function executeRemoveProfileSectionItem(
           profile_name: profileName,
           section
         },
+        beforeExecute: createProfileRateLimitGuard(
+          runtime,
+          REMOVE_PROFILE_SECTION_ITEM_ACTION_TYPE,
+          actionId,
+          profileName,
+          {
+            section
+          }
+        ),
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -6620,6 +6877,28 @@ export function createProfileActionExecutors(): Record<
 export class LinkedInProfileService {
   constructor(private readonly runtime: LinkedInProfileRuntime) {}
 
+  private prepareRateLimitedAction(input: {
+    actionType: string;
+    target: Record<string, unknown>;
+    payload: Record<string, unknown>;
+    preview: Record<string, unknown>;
+    operatorNote?: string;
+  }): PreparedActionResult {
+    return this.runtime.twoPhaseCommit.prepare({
+      actionType: input.actionType,
+      target: input.target,
+      payload: input.payload,
+      preview: {
+        ...input.preview,
+        rate_limit: peekRateLimitPreview(
+          this.runtime.rateLimiter,
+          getProfileRateLimitConfig(input.actionType)
+        )
+      },
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+    });
+  }
+
   async viewProfile(input: ViewProfileInput): Promise<LinkedInProfile> {
     const profileName = input.profileName ?? "default";
     const profileUrl = resolveProfileUrl(input.target);
@@ -6741,7 +7020,7 @@ export class LinkedInProfileService {
       intro_updates: updates
     };
 
-    return this.runtime.twoPhaseCommit.prepare({
+    return this.prepareRateLimitedAction({
       actionType: UPDATE_PROFILE_INTRO_ACTION_TYPE,
       target,
       payload: {
@@ -6773,7 +7052,7 @@ export class LinkedInProfileService {
       settings_updates: updates
     };
 
-    return this.runtime.twoPhaseCommit.prepare({
+    return this.prepareRateLimitedAction({
       actionType: UPDATE_PROFILE_SETTINGS_ACTION_TYPE,
       target,
       payload: {
@@ -6800,7 +7079,7 @@ export class LinkedInProfileService {
       public_profile_url: publicProfile.publicProfileUrl
     };
 
-    return this.runtime.twoPhaseCommit.prepare({
+    return this.prepareRateLimitedAction({
       actionType: UPDATE_PROFILE_PUBLIC_PROFILE_ACTION_TYPE,
       target,
       payload: {
@@ -6842,7 +7121,7 @@ export class LinkedInProfileService {
       ...(match ? { match } : {})
     };
 
-    return this.runtime.twoPhaseCommit.prepare({
+    return this.prepareRateLimitedAction({
       actionType: UPSERT_PROFILE_SECTION_ITEM_ACTION_TYPE,
       target,
       payload: {
@@ -6885,7 +7164,7 @@ export class LinkedInProfileService {
       ...(match ? { match } : {})
     };
 
-    return this.runtime.twoPhaseCommit.prepare({
+    return this.prepareRateLimitedAction({
       actionType: REMOVE_PROFILE_SECTION_ITEM_ACTION_TYPE,
       target,
       payload: {
@@ -6919,7 +7198,7 @@ export class LinkedInProfileService {
       upload: buildPreparedUploadPreview(upload)
     };
 
-    return this.runtime.twoPhaseCommit.prepare({
+    return this.prepareRateLimitedAction({
       actionType: UPLOAD_PROFILE_PHOTO_ACTION_TYPE,
       target,
       payload: {
@@ -6952,7 +7231,7 @@ export class LinkedInProfileService {
       upload: buildPreparedUploadPreview(upload)
     };
 
-    return this.runtime.twoPhaseCommit.prepare({
+    return this.prepareRateLimitedAction({
       actionType: UPLOAD_PROFILE_BANNER_ACTION_TYPE,
       target,
       payload: {
@@ -7000,7 +7279,7 @@ export class LinkedInProfileService {
       ...(upload ? { upload: buildPreparedUploadPreview(upload) } : {})
     };
 
-    return this.runtime.twoPhaseCommit.prepare({
+    return this.prepareRateLimitedAction({
       actionType: ADD_PROFILE_FEATURED_ACTION_TYPE,
       target,
       payload: {
@@ -7038,7 +7317,7 @@ export class LinkedInProfileService {
       ...(match ? { match } : {})
     };
 
-    return this.runtime.twoPhaseCommit.prepare({
+    return this.prepareRateLimitedAction({
       actionType: REMOVE_PROFILE_FEATURED_ACTION_TYPE,
       target,
       payload: {
@@ -7093,7 +7372,7 @@ export class LinkedInProfileService {
       item_ids: itemIds
     };
 
-    return this.runtime.twoPhaseCommit.prepare({
+    return this.prepareRateLimitedAction({
       actionType: REORDER_PROFILE_FEATURED_ACTION_TYPE,
       target,
       payload: {
@@ -7117,7 +7396,7 @@ export class LinkedInProfileService {
       skill_name: skillName
     };
 
-    return this.runtime.twoPhaseCommit.prepare({
+    return this.prepareRateLimitedAction({
       actionType: ADD_PROFILE_SKILL_ACTION_TYPE,
       target,
       payload: {
@@ -7143,7 +7422,7 @@ export class LinkedInProfileService {
       skill_names: skillNames
     };
 
-    return this.runtime.twoPhaseCommit.prepare({
+    return this.prepareRateLimitedAction({
       actionType: REORDER_PROFILE_SKILLS_ACTION_TYPE,
       target,
       payload: {
@@ -7172,7 +7451,7 @@ export class LinkedInProfileService {
       skill_name: skillName
     };
 
-    return this.runtime.twoPhaseCommit.prepare({
+    return this.prepareRateLimitedAction({
       actionType: ENDORSE_PROFILE_SKILL_ACTION_TYPE,
       target,
       payload: {
@@ -7211,7 +7490,7 @@ export class LinkedInProfileService {
       ...(Object.keys(fields).length > 0 ? { fields } : {})
     };
 
-    return this.runtime.twoPhaseCommit.prepare({
+    return this.prepareRateLimitedAction({
       actionType: REQUEST_PROFILE_RECOMMENDATION_ACTION_TYPE,
       target,
       payload: {
@@ -7257,7 +7536,7 @@ export class LinkedInProfileService {
       fields
     };
 
-    return this.runtime.twoPhaseCommit.prepare({
+    return this.prepareRateLimitedAction({
       actionType: WRITE_PROFILE_RECOMMENDATION_ACTION_TYPE,
       target,
       payload: {

--- a/packages/core/src/linkedinPublishing.ts
+++ b/packages/core/src/linkedinPublishing.ts
@@ -13,6 +13,13 @@ import {
 import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
+import {
+  consumeRateLimitOrThrow,
+  createConfirmRateLimitMessage,
+  peekRateLimitPreview,
+  type ConsumeRateLimitInput,
+  type RateLimiter
+} from "./rateLimiter.js";
 import type { LinkedInSelectorLocale } from "./selectorLocale.js";
 import type {
   ActionExecutor,
@@ -29,6 +36,29 @@ export const CREATE_ARTICLE_ACTION_TYPE = "article.create";
 export const PUBLISH_ARTICLE_ACTION_TYPE = "article.publish";
 export const CREATE_NEWSLETTER_ACTION_TYPE = "newsletter.create";
 export const PUBLISH_NEWSLETTER_ISSUE_ACTION_TYPE = "newsletter.publish_issue";
+
+const PUBLISHING_RATE_LIMIT_CONFIGS = {
+  [CREATE_ARTICLE_ACTION_TYPE]: {
+    counterKey: "linkedin.article.create",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 1
+  },
+  [PUBLISH_ARTICLE_ACTION_TYPE]: {
+    counterKey: "linkedin.article.publish",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 1
+  },
+  [CREATE_NEWSLETTER_ACTION_TYPE]: {
+    counterKey: "linkedin.newsletter.create",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 1
+  },
+  [PUBLISH_NEWSLETTER_ISSUE_ACTION_TYPE]: {
+    counterKey: "linkedin.newsletter.publish_issue",
+    windowSizeMs: 24 * 60 * 60 * 1000,
+    limit: 1
+  }
+} as const satisfies Record<string, ConsumeRateLimitInput>;
 
 export const LINKEDIN_NEWSLETTER_CADENCE_TYPES = [
   "daily",
@@ -110,6 +140,7 @@ export interface LinkedInPublishingExecutorRuntime {
   cdpUrl?: string | undefined;
   selectorLocale: LinkedInSelectorLocale;
   profileManager: ProfileManager;
+  rateLimiter: RateLimiter;
   logger: JsonEventLogger;
   artifacts: ArtifactHelpers;
 }
@@ -143,6 +174,65 @@ interface EditorSurface {
 
 function normalizeText(value: string | null | undefined): string {
   return (value ?? "").replace(/\s+/gu, " ").trim();
+}
+
+function getPublishingRateLimitConfig(
+  actionType: string
+): ConsumeRateLimitInput {
+  const config = (
+    PUBLISHING_RATE_LIMIT_CONFIGS as Record<string, ConsumeRateLimitInput>
+  )[actionType];
+
+  if (!config) {
+    throw new LinkedInBuddyError("UNKNOWN", "Missing rate limit policy.", {
+      action_type: actionType
+    });
+  }
+
+  return config;
+}
+
+function enforcePublishingRateLimit(input: {
+  runtime: LinkedInPublishingExecutorRuntime;
+  actionType: string;
+  actionId: string;
+  profileName: string;
+  details?: Record<string, unknown>;
+}): void {
+  consumeRateLimitOrThrow(input.runtime.rateLimiter, {
+    config: getPublishingRateLimitConfig(input.actionType),
+    message: createConfirmRateLimitMessage(input.actionType),
+    details: {
+      action_id: input.actionId,
+      profile_name: input.profileName,
+      ...(input.details ?? {})
+    }
+  });
+}
+
+function preparePublishingAction(
+  runtime: LinkedInPublishingRuntime,
+  input: {
+    actionType: string;
+    target: Record<string, unknown>;
+    payload: Record<string, unknown>;
+    preview: Record<string, unknown>;
+    operatorNote?: string;
+  }
+): PreparedActionResult {
+  return runtime.twoPhaseCommit.prepare({
+    actionType: input.actionType,
+    target: input.target,
+    payload: input.payload,
+    preview: {
+      ...input.preview,
+      rate_limit: peekRateLimitPreview(
+        runtime.rateLimiter,
+        getPublishingRateLimitConfig(input.actionType)
+      )
+    },
+    ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+  });
 }
 
 function containsUnsupportedControlCharacters(value: string): boolean {
@@ -1392,7 +1482,7 @@ export class LinkedInArticlesService {
               }))
             } satisfies Record<string, unknown>;
 
-            return this.runtime.twoPhaseCommit.prepare({
+            return preparePublishingAction(this.runtime, {
               actionType: CREATE_ARTICLE_ACTION_TYPE,
               target,
               payload: {
@@ -1540,7 +1630,7 @@ export class LinkedInArticlesService {
               }))
             } satisfies Record<string, unknown>;
 
-            return this.runtime.twoPhaseCommit.prepare({
+            return preparePublishingAction(this.runtime, {
               actionType: PUBLISH_ARTICLE_ACTION_TYPE,
               target,
               payload: {
@@ -1693,7 +1783,7 @@ export class LinkedInNewslettersService {
               }))
             } satisfies Record<string, unknown>;
 
-            return this.runtime.twoPhaseCommit.prepare({
+            return preparePublishingAction(this.runtime, {
               actionType: CREATE_NEWSLETTER_ACTION_TYPE,
               target,
               payload: {
@@ -1860,7 +1950,7 @@ export class LinkedInNewslettersService {
               }))
             } satisfies Record<string, unknown>;
 
-            return this.runtime.twoPhaseCommit.prepare({
+            return preparePublishingAction(this.runtime, {
               actionType: PUBLISH_NEWSLETTER_ISSUE_ACTION_TYPE,
               target,
               payload: {
@@ -2019,6 +2109,16 @@ class CreateArticleActionExecutor
           });
           tracingStarted = true;
 
+          enforcePublishingRateLimit({
+            runtime,
+            actionType: CREATE_ARTICLE_ACTION_TYPE,
+            actionId: action.id,
+            profileName,
+            details: {
+              title
+            }
+          });
+
           const editor = await openPublishingEditor(
             context,
             currentPage,
@@ -2140,6 +2240,16 @@ class PublishArticleActionExecutor
           });
           tracingStarted = true;
 
+          enforcePublishingRateLimit({
+            runtime,
+            actionType: PUBLISH_ARTICLE_ACTION_TYPE,
+            actionId: action.id,
+            profileName,
+            details: {
+              draft_url: draftUrl
+            }
+          });
+
           await page.goto(draftUrl, { waitUntil: "domcontentloaded" });
           await waitForNetworkIdleBestEffort(page, 10_000);
 
@@ -2260,6 +2370,16 @@ class CreateNewsletterActionExecutor
             sources: true
           });
           tracingStarted = true;
+
+          enforcePublishingRateLimit({
+            runtime,
+            actionType: CREATE_NEWSLETTER_ACTION_TYPE,
+            actionId: action.id,
+            profileName,
+            details: {
+              title
+            }
+          });
 
           const editor = await openPublishingEditor(
             context,
@@ -2398,6 +2518,17 @@ class PublishNewsletterIssueActionExecutor
             sources: true
           });
           tracingStarted = true;
+
+          enforcePublishingRateLimit({
+            runtime,
+            actionType: PUBLISH_NEWSLETTER_ISSUE_ACTION_TYPE,
+            actionId: action.id,
+            profileName,
+            details: {
+              newsletter_title: newsletterTitle,
+              title
+            }
+          });
 
           const editor = await openPublishingEditor(
             context,

--- a/packages/core/src/rateLimiter.ts
+++ b/packages/core/src/rateLimiter.ts
@@ -1,3 +1,4 @@
+import { LinkedInBuddyError } from "./errors.js";
 import type { AssistantDatabase } from "./db/database.js";
 
 export interface ConsumeRateLimitInput {
@@ -15,6 +16,59 @@ export interface RateLimiterState {
   limit: number;
   remaining: number;
   allowed: boolean;
+}
+
+export interface ConsumeRateLimitOrThrowInput {
+  config: ConsumeRateLimitInput;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export function formatRateLimitState(
+  state: RateLimiterState
+): Record<string, number | boolean | string> {
+  return {
+    counter_key: state.counterKey,
+    window_start_ms: state.windowStartMs,
+    window_size_ms: state.windowSizeMs,
+    count: state.count,
+    limit: state.limit,
+    remaining: state.remaining,
+    allowed: state.allowed
+  };
+}
+
+export function peekRateLimitPreview(
+  rateLimiter: Pick<RateLimiter, "peek">,
+  config: ConsumeRateLimitInput
+): Record<string, number | boolean | string> {
+  return formatRateLimitState(rateLimiter.peek(config));
+}
+
+export function createConfirmRateLimitMessage(actionType: string): string {
+  const actionName =
+    actionType
+      .split(".")
+      .filter((segment) => segment.length > 0)
+      .at(-1) ?? actionType;
+
+  return `LinkedIn ${actionName} confirm is rate limited for the current window.`;
+}
+
+export function consumeRateLimitOrThrow(
+  rateLimiter: Pick<RateLimiter, "consume">,
+  input: ConsumeRateLimitOrThrowInput
+): RateLimiterState {
+  const rateLimitState = rateLimiter.consume(input.config);
+
+  if (!rateLimitState.allowed) {
+    throw new LinkedInBuddyError("RATE_LIMITED", input.message, {
+      ...(input.details ?? {}),
+      rate_limit: formatRateLimitState(rateLimitState)
+    });
+  }
+
+  return rateLimitState;
 }
 
 export class RateLimiter {


### PR DESCRIPTION
## Summary
- add local confirm-time rate-limit policies to the remaining write executors that were bypassing cooldown checks
- include rate-limit metadata in prepare previews for those actions so CLI and MCP previews stay consistent
- cover the shared confirm hook and publishing regressions with targeted unit tests

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #311