### PR TITLE
fix: add working CLI aliases for npm link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5106,6 +5106,7 @@
         "commander": "^14.0.3"
       },
       "bin": {
+        "lbud": "dist/bin/linkedin.js",
         "linkedin": "dist/bin/linkedin.js",
         "linkedin-buddy": "dist/bin/linkedin.js"
       }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,6 +2,8 @@
 
 Operator CLI for LinkedIn Buddy.
 
+Installed command names: `linkedin`, `linkedin-buddy`, and `lbud`.
+
 ## Activity webhooks
 
 The CLI owns the poll-based LinkedIn activity daemon, human-readable activity

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,6 +8,7 @@
     "dist"
   ],
   "bin": {
+    "lbud": "dist/bin/linkedin.js",
     "linkedin": "dist/bin/linkedin.js",
     "linkedin-buddy": "dist/bin/linkedin.js"
   },
@@ -30,7 +31,8 @@
     "playwright"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -b tsconfig.json",
+    "prepare": "npm run build",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import type { Dirent } from "node:fs";
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import {
   access,
   appendFile,
@@ -15,7 +15,7 @@ import {
 import path from "node:path";
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { Command } from "commander";
 import packageJson from "../../package.json" with { type: "json" };
 import {
@@ -10413,13 +10413,27 @@ export async function runCli(argv: string[] = process.argv): Promise<void> {
   }
 }
 
-function isDirectExecution(moduleUrl: string): boolean {
-  const entrypoint = process.argv[1];
+export function isDirectExecution(
+  moduleUrl: string,
+  entrypoint: string | undefined = process.argv[1]
+): boolean {
   if (!entrypoint) {
     return false;
   }
 
-  return pathToFileURL(entrypoint).href === moduleUrl;
+  return resolveCliEntrypointPath(entrypoint) === resolveCliEntrypointPath(
+    fileURLToPath(moduleUrl)
+  );
+}
+
+function resolveCliEntrypointPath(entrypoint: string): string {
+  const resolvedEntrypoint = path.resolve(entrypoint);
+
+  try {
+    return realpathSync(resolvedEntrypoint);
+  } catch {
+    return resolvedEntrypoint;
+  }
 }
 
 if (isDirectExecution(import.meta.url)) {

--- a/packages/cli/test/binEntrypoint.test.ts
+++ b/packages/cli/test/binEntrypoint.test.ts
@@ -1,0 +1,42 @@
+import { mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { isDirectExecution } from "../src/bin/linkedin.js";
+
+describe("CLI entrypoint detection", () => {
+  let tempDir = "";
+
+  afterEach(async () => {
+    if (tempDir.length > 0) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = "";
+    }
+  });
+
+  it("treats symlinked bin aliases as direct execution", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-cli-entrypoint-"));
+
+    const targetPath = path.join(tempDir, "linkedin.js");
+    const aliasPath = path.join(tempDir, "lbud");
+
+    await writeFile(targetPath, "#!/usr/bin/env node\n", "utf8");
+    await symlink(targetPath, aliasPath);
+
+    expect(isDirectExecution(pathToFileURL(targetPath).href, aliasPath)).toBe(true);
+  });
+
+  it("rejects unrelated entrypoints", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-cli-entrypoint-"));
+
+    const targetPath = path.join(tempDir, "linkedin.js");
+    const otherPath = path.join(tempDir, "linkedin-buddy.js");
+
+    await writeFile(targetPath, "#!/usr/bin/env node\n", "utf8");
+    await writeFile(otherPath, "#!/usr/bin/env node\n", "utf8");
+
+    expect(isDirectExecution(pathToFileURL(targetPath).href, otherPath)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add the `lbud` CLI bin alongside `linkedin` and `linkedin-buddy`
- fix direct-execution detection so symlinked global binaries still enter `runCli()`
- build the CLI workspace during `prepare` so `npm link` and local global installs have a fresh dist entrypoint

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
- clean `npm link` verification for `lbud --help`, `linkedin-buddy --help`, and `linkedin --help`

Closes #320
