### PR TITLE
fix: detect current self-profile add section control

### DIFF
--- a/packages/core/src/__tests__/linkedinProfile.test.ts
+++ b/packages/core/src/__tests__/linkedinProfile.test.ts
@@ -10,6 +10,7 @@ import {
   ENDORSE_PROFILE_SKILL_ACTION_TYPE,
   LINKEDIN_PROFILE_SECTION_TYPES,
   LINKEDIN_PROFILE_FEATURED_ITEM_KINDS,
+  PROFILE_GLOBAL_ADD_SECTION_CONTROL,
   PROFILE_MEDIA_STRUCTURAL_SELECTORS,
   REMOVE_PROFILE_SECTION_ITEM_ACTION_TYPE,
   REMOVE_PROFILE_FEATURED_ACTION_TYPE,
@@ -328,6 +329,15 @@ describe("createProfileActionExecutors", () => {
     expect(PROFILE_MEDIA_STRUCTURAL_SELECTORS.banner).toContain(
       "[id^='cover-photo-dropdown-button-trigger-']"
     );
+  });
+
+  it("keeps selector fallbacks for the current self-profile add section control", () => {
+    expect(PROFILE_GLOBAL_ADD_SECTION_CONTROL.labels.en).toContain(
+      "Add profile section"
+    );
+    expect(PROFILE_GLOBAL_ADD_SECTION_CONTROL.labels.en).toContain("Add section");
+    expect(PROFILE_GLOBAL_ADD_SECTION_CONTROL.roles).toContain("button");
+    expect(PROFILE_GLOBAL_ADD_SECTION_CONTROL.roles).toContain("link");
   });
 });
 

--- a/packages/core/src/linkedinProfile.ts
+++ b/packages/core/src/linkedinProfile.ts
@@ -493,15 +493,20 @@ const PROFILE_UPLOAD_MIME_TYPES: Record<string, string> = {
   ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
 };
 
+export const PROFILE_GLOBAL_ADD_SECTION_CONTROL = {
+  labels: {
+    en: ["Add profile section", "Add section"],
+    da: ["Tilføj profilsektion", "Tilføj sektion"]
+  },
+  roles: ["button", "link"]
+} as const;
+
 const PROFILE_ACTION_LABELS = {
   add: {
     en: ["Add"],
     da: ["Tilføj"]
   },
-  addProfileSection: {
-    en: ["Add profile section"],
-    da: ["Tilføj profilsektion"]
-  },
+  addProfileSection: PROFILE_GLOBAL_ADD_SECTION_CONTROL.labels,
   edit: {
     en: ["Edit"],
     da: ["Rediger"]
@@ -3448,11 +3453,23 @@ async function openGlobalAddSectionDialog(
   selectorLocale: LinkedInSelectorLocale
 ): Promise<Locator> {
   const topCardRoot = await getTopCardRoot(page);
-  const addCandidates = createActionCandidates(
-    topCardRoot,
-    getUiActionLabels("addProfileSection", selectorLocale),
-    "profile-section-add"
-  );
+  const addSectionLabels = getUiActionLabels("addProfileSection", selectorLocale);
+  const addCandidates: LocatorCandidate[] = [
+    ...PROFILE_GLOBAL_ADD_SECTION_CONTROL.roles.flatMap((role) =>
+      createActionCandidates(
+        topCardRoot,
+        addSectionLabels,
+        `profile-section-add-${role}`,
+        role
+      )
+    ),
+    {
+      key: "profile-section-add-generic",
+      locator: topCardRoot
+        .locator("button, a, [role='button'], [role='link']")
+        .filter({ hasText: buildTextRegex(addSectionLabels) })
+    }
+  ];
   const resolved = await findFirstVisibleLocator(addCandidates);
 
   if (!resolved) {


### PR DESCRIPTION
## Summary
- detect the current self-profile global add-section control when LinkedIn renders it as an `Add section` link
- keep matching the older `Add profile section` button by sharing the supported labels and roles
- add regression coverage for the current control fallback

## Testing
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #329