### PR TITLE
fix: support current LinkedIn home feed composer trigger

### DIFF
--- a/packages/cli/test/selectorAuditOutput.test.ts
+++ b/packages/cli/test/selectorAuditOutput.test.ts
@@ -126,15 +126,16 @@ function createSelectorAuditReportFixture(): SelectorAuditReport {
           secondary: {
             strategy: "secondary",
             status: "fail",
-            selector_key: "css-start-post",
-            selector_hint: ".share-box-feed-entry__trigger",
+            selector_key: "sharebox-entry-link-or-share-box-trigger",
+            selector_hint:
+              "a[href$='/preload/sharebox/'], a[href$='/preload/sharebox'], .share-box-feed-entry__trigger, .share-box__open",
             error: "Selector not visible"
           },
           tertiary: {
             strategy: "tertiary",
             status: "fail",
             selector_key: "text-start-post",
-            selector_hint: "text=Start a post",
+            selector_hint: "button, [role='button'], a hasText /start a post/i",
             error: "Selector not visible"
           }
         },

--- a/packages/core/src/__tests__/selectorAudit.test.ts
+++ b/packages/core/src/__tests__/selectorAudit.test.ts
@@ -96,9 +96,14 @@ describe("createLinkedInSelectorAuditRegistry", () => {
     const registry = createLinkedInSelectorAuditRegistry("da");
     const feedDefinition = registry.find((pageDefinition) => pageDefinition.page === "feed");
     const primaryCandidate = feedDefinition?.selectors[0]?.candidates[0];
+    const secondaryCandidate = feedDefinition?.selectors[0]?.candidates[1];
+    const tertiaryCandidate = feedDefinition?.selectors[0]?.candidates[2];
 
     expect(primaryCandidate?.selectorHint).toContain("Start et opslag");
     expect(primaryCandidate?.selectorHint).toContain("Start a post");
+    expect(secondaryCandidate?.selectorHint).toContain("a[href$='/preload/sharebox/']");
+    expect(secondaryCandidate?.selectorHint).toContain(".share-box-feed-entry__trigger");
+    expect(tertiaryCandidate?.selectorHint).toContain("button, [role='button'], a");
   });
 
   it("preserves selector keys and candidate ordering across locales", () => {

--- a/packages/core/src/feedPostComposerTriggerSelectors.ts
+++ b/packages/core/src/feedPostComposerTriggerSelectors.ts
@@ -1,0 +1,61 @@
+import type { Locator, Page } from "playwright-core";
+import type { LinkedInSelectorLocale } from "./selectorLocale.js";
+import {
+  buildLinkedInSelectorPhraseRegex,
+  formatLinkedInSelectorRegexHint
+} from "./selectorLocale.js";
+
+export interface FeedPostComposerTriggerCandidate {
+  key: string;
+  selectorHint: string;
+  locatorFactory: (page: Page) => Locator;
+}
+
+export const LINKEDIN_FEED_POST_COMPOSER_LINK_SELECTOR =
+  "a[href$='/preload/sharebox/'], a[href$='/preload/sharebox']";
+
+export function createFeedPostComposerTriggerCandidates(
+  selectorLocale: LinkedInSelectorLocale
+): FeedPostComposerTriggerCandidate[] {
+  const startPostExactRegex = buildLinkedInSelectorPhraseRegex(
+    "start_post",
+    selectorLocale,
+    { exact: true }
+  );
+  const startPostExactRegexHint = formatLinkedInSelectorRegexHint(
+    "start_post",
+    selectorLocale,
+    { exact: true }
+  );
+  const startPostTextRegex = buildLinkedInSelectorPhraseRegex(
+    "start_post",
+    selectorLocale
+  );
+  const startPostTextRegexHint = formatLinkedInSelectorRegexHint(
+    "start_post",
+    selectorLocale
+  );
+  const shareBoxTriggerSelector = `${LINKEDIN_FEED_POST_COMPOSER_LINK_SELECTOR}, .share-box-feed-entry__trigger, .share-box__open`;
+
+  return [
+    {
+      key: "role-button-start-post",
+      selectorHint: `getByRole(button, ${startPostExactRegexHint})`,
+      locatorFactory: (page) =>
+        page.getByRole("button", { name: startPostExactRegex })
+    },
+    {
+      key: "sharebox-entry-link-or-share-box-trigger",
+      selectorHint: shareBoxTriggerSelector,
+      locatorFactory: (page) => page.locator(shareBoxTriggerSelector)
+    },
+    {
+      key: "text-start-post",
+      selectorHint: `button, [role='button'], a hasText ${startPostTextRegexHint}`,
+      locatorFactory: (page) =>
+        page
+          .locator("button, [role='button'], a")
+          .filter({ hasText: startPostTextRegex })
+    }
+  ];
+}

--- a/packages/core/src/linkedinPosts.ts
+++ b/packages/core/src/linkedinPosts.ts
@@ -26,6 +26,7 @@ import {
   buildLinkedInSelectorPhraseRegex,
   formatLinkedInSelectorRegexHint
 } from "./selectorLocale.js";
+import { createFeedPostComposerTriggerCandidates } from "./feedPostComposerTriggerSelectors.js";
 import type {
   ActionExecutor,
   ActionExecutorInput,
@@ -1767,62 +1768,6 @@ function formatPollDurationLabels(
   return Array.from(new Set([...(localized ?? []), ...englishLabels[durationDays]]));
 }
 
-function createComposeTriggerCandidates(
-  selectorLocale: LinkedInSelectorLocale
-): SelectorCandidate[] {
-  const startPostExactRegex = buildLinkedInSelectorPhraseRegex(
-    "start_post",
-    selectorLocale,
-    { exact: true }
-  );
-  const startPostExactRegexHint = formatLinkedInSelectorRegexHint(
-    "start_post",
-    selectorLocale,
-    { exact: true }
-  );
-  const startPostTextRegex = buildLinkedInSelectorPhraseRegex(
-    "start_post",
-    selectorLocale
-  );
-  const startPostTextRegexHint = formatLinkedInSelectorRegexHint(
-    "start_post",
-    selectorLocale
-  );
-  const startPostAriaSelector = buildLinkedInAriaLabelContainsSelector(
-    ["button", "[role='button']"],
-    "start_post",
-    selectorLocale
-  );
-
-  return [
-    {
-      key: "role-button-start-post",
-      selectorHint: `getByRole(button, ${startPostExactRegexHint})`,
-      locatorFactory: (page) =>
-        page.getByRole("button", { name: startPostExactRegex })
-    },
-    {
-      key: "aria-start-post",
-      selectorHint: startPostAriaSelector,
-      locatorFactory: (page) => page.locator(startPostAriaSelector)
-    },
-    {
-      key: "share-box-trigger",
-      selectorHint: ".share-box-feed-entry__trigger, .share-box__open",
-      locatorFactory: (page) =>
-        page.locator(".share-box-feed-entry__trigger, .share-box__open")
-    },
-    {
-      key: "text-start-post",
-      selectorHint: `button, [role='button'] hasText ${startPostTextRegexHint}`,
-      locatorFactory: (page) =>
-        page
-          .locator("button, [role='button']")
-          .filter({ hasText: startPostTextRegex })
-    }
-  ];
-}
-
 function createComposerRootCandidates(
   selectorLocale: LinkedInSelectorLocale
 ): SelectorCandidate[] {
@@ -2530,7 +2475,7 @@ async function openPostComposer(
 ): Promise<{ composerRoot: Locator; triggerKey: string; rootKey: string }> {
   await page.goto(LINKEDIN_FEED_URL, { waitUntil: "domcontentloaded" });
   await waitForNetworkIdleBestEffort(page);
-  const triggerCandidates = createComposeTriggerCandidates(selectorLocale);
+  const triggerCandidates = createFeedPostComposerTriggerCandidates(selectorLocale);
   const visibleTrigger = await findOptionalVisibleLocator(page, triggerCandidates);
   if (!visibleTrigger) {
     await waitForFeedSurface(page);

--- a/packages/core/src/selectorAudit.ts
+++ b/packages/core/src/selectorAudit.ts
@@ -14,11 +14,11 @@ import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
 import {
   DEFAULT_LINKEDIN_SELECTOR_LOCALE,
-  buildLinkedInAriaLabelContainsSelector,
   buildLinkedInSelectorPhraseRegex,
   formatLinkedInSelectorRegexHint,
   type LinkedInSelectorLocale
 } from "./selectorLocale.js";
+import { createFeedPostComposerTriggerCandidates } from "./feedPostComposerTriggerSelectors.js";
 
 /**
  * Canonical LinkedIn page identifiers covered by the built-in selector audit.
@@ -290,29 +290,10 @@ function createSelectorAuditSelectorDefinition(
 function createDefaultSelectorAuditRegistry(
   selectorLocale: LinkedInSelectorLocale = DEFAULT_LINKEDIN_SELECTOR_LOCALE
 ): SelectorAuditPageDefinition[] {
-  const startPostExactRegex = buildLinkedInSelectorPhraseRegex(
-    "start_post",
-    selectorLocale,
-    { exact: true }
-  );
-  const startPostRegexHint = formatLinkedInSelectorRegexHint(
-    "start_post",
-    selectorLocale,
-    { exact: true }
-  );
-  const startPostTextRegex = buildLinkedInSelectorPhraseRegex(
-    "start_post",
-    selectorLocale
-  );
-  const startPostTextRegexHint = formatLinkedInSelectorRegexHint(
-    "start_post",
-    selectorLocale
-  );
-  const startPostAriaSelector = buildLinkedInAriaLabelContainsSelector(
-    ["button", "[role='button']"],
-    "start_post",
-    selectorLocale
-  );
+  const postComposerTriggerCandidates = createFeedPostComposerTriggerCandidates(selectorLocale);
+  const postComposerTriggerPrimary = postComposerTriggerCandidates[0]!;
+  const postComposerTriggerSecondary = postComposerTriggerCandidates[1]!;
+  const postComposerTriggerTertiary = postComposerTriggerCandidates[2]!;
   const inboxSurfaceRegex = buildLinkedInSelectorPhraseRegex(
     ["messaging", "write_message"],
     selectorLocale
@@ -371,28 +352,9 @@ function createDefaultSelectorAuditRegistry(
           "post_composer_trigger",
           "Feed post composer trigger",
           {
-            primary: {
-              key: "role-button-start-post",
-              selectorHint: `getByRole(button, ${startPostRegexHint})`,
-              locatorFactory: (page) =>
-                page.getByRole("button", { name: startPostExactRegex })
-            },
-            secondary: {
-              key: "aria-or-share-box-start-post",
-              selectorHint: `${startPostAriaSelector}, .share-box-feed-entry__trigger, .share-box__open`,
-              locatorFactory: (page) =>
-                page.locator(
-                  `${startPostAriaSelector}, .share-box-feed-entry__trigger, .share-box__open`
-                )
-            },
-            tertiary: {
-              key: "text-start-post",
-              selectorHint: `button, [role='button'] hasText ${startPostTextRegexHint}`,
-              locatorFactory: (page) =>
-                page
-                  .locator("button, [role='button']")
-                  .filter({ hasText: startPostTextRegex })
-            }
+            primary: postComposerTriggerPrimary,
+            secondary: postComposerTriggerSecondary,
+            tertiary: postComposerTriggerTertiary
           }
         )
       ]


### PR DESCRIPTION
## Summary
- share the feed post composer trigger selectors between post creation and the selector audit
- detect LinkedIn's current `/preload/sharebox/` anchor trigger alongside legacy feed selectors
- broaden the text fallback to include anchor-based triggers and update the selector audit fixtures

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build
- `node packages/cli/dist/bin/linkedin.js status` (verified the Joi Ascend profile URL)
- `node packages/cli/dist/bin/linkedin.js post prepare --text "Selector check only for issue 332" --visibility connections --profile default`

Closes #332