### PR TITLE
fix: read visible self-profile intro on current LinkedIn layout

### DIFF
--- a/packages/core/src/__tests__/linkedinProfile.test.ts
+++ b/packages/core/src/__tests__/linkedinProfile.test.ts
@@ -25,8 +25,10 @@ import {
   WRITE_PROFILE_RECOMMENDATION_ACTION_TYPE,
   LinkedInProfileService,
   createProfileActionExecutors,
+  extractVisibleTopCardSummaryFromRoot,
   isProfileIntroEditHref,
   navigateToOwnProfile,
+  readEditableFieldValue,
   resolveFirstVisibleLocator,
   resolveProfileUrl,
   type LinkedInProfileRuntime
@@ -120,6 +122,97 @@ class MockLocator {
   }
 }
 
+interface MockTextLocatorItem {
+  text: string;
+  visible: boolean;
+}
+
+class MockTextLocator {
+  constructor(
+    private readonly selectorMap: Record<string, readonly MockTextLocatorItem[]> = {},
+    private readonly items: readonly MockTextLocatorItem[] = []
+  ) {}
+
+  locator(selector: string): MockTextLocator {
+    return new MockTextLocator({}, this.selectorMap[selector] ?? []);
+  }
+
+  async count(): Promise<number> {
+    return this.items.length;
+  }
+
+  nth(index: number): MockTextLocator {
+    return new MockTextLocator({}, this.items[index] ? [this.items[index]!] : []);
+  }
+
+  async isVisible(): Promise<boolean> {
+    return this.items[0]?.visible ?? false;
+  }
+
+  async textContent(): Promise<string> {
+    return this.items[0]?.text ?? "";
+  }
+}
+
+interface MockFieldOption {
+  label?: unknown;
+  textContent?: string | null;
+}
+
+class MockFieldElement {
+  readonly tagName: string;
+  readonly textContent: string | null;
+  readonly value?: string;
+  readonly selectedOptions?: {
+    length?: number;
+    [index: number]: MockFieldOption;
+  };
+  private readonly attributes: Record<string, string>;
+  private readonly nestedControl: MockFieldElement | null;
+
+  constructor(input: {
+    tagName: string;
+    textContent?: string | null;
+    value?: string;
+    attributes?: Record<string, string>;
+    nestedControl?: MockFieldElement | null;
+    selectedOptions?: readonly MockFieldOption[];
+  }) {
+    this.tagName = input.tagName;
+    this.textContent = input.textContent ?? null;
+    this.value = input.value;
+    this.attributes = input.attributes ?? {};
+    this.nestedControl = input.nestedControl ?? null;
+    if (input.selectedOptions) {
+      this.selectedOptions = Object.assign([...input.selectedOptions], {
+        length: input.selectedOptions.length
+      }) as {
+        length?: number;
+        [index: number]: MockFieldOption;
+      };
+    }
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes[name] ?? null;
+  }
+
+  querySelector(selector: string): MockFieldElement | null {
+    void selector;
+    return this.nestedControl;
+  }
+}
+
+class MockEditableFieldLocator {
+  constructor(private readonly element: MockFieldElement) {}
+
+  async evaluate<TResult>(
+    pageFunction: (element: MockFieldElement) => TResult | Promise<TResult>
+  ): Promise<TResult> {
+    return await pageFunction(this.element);
+  }
+}
+
 function createNavigationMockPage(options: {
   canonicalUrl?: string | null;
   gotoError?: Error;
@@ -145,12 +238,14 @@ function createNavigationMockPage(options: {
     locator: vi.fn((selector: string) => {
       const isIntroEditSelector =
         selector.includes("/edit/intro/") || selector.includes("/edit/forms/intro/");
+      const isHeadingSelector = selector.includes("h1") || selector.includes("h2");
       const introEditCount =
         isIntroEditSelector && (options.introEditVisible || options.introEditPresent)
           ? 1
           : 0;
+      const headingCount = isHeadingSelector && (options.headingVisible ?? false) ? 1 : 0;
       const visible =
-        selector === "h1"
+        isHeadingSelector
           ? (options.headingVisible ?? false)
           : isIntroEditSelector
             ? (options.introEditVisible ?? false)
@@ -164,7 +259,7 @@ function createNavigationMockPage(options: {
               ? options.ogProfileUrl
               : null;
 
-      const count = vi.fn(async () => introEditCount);
+      const count = vi.fn(async () => (isHeadingSelector ? headingCount : introEditCount));
       const isVisible = vi.fn(async () => visible);
       const getAttribute = vi.fn(async () => attributeValue ?? null);
       const nth = vi.fn();
@@ -319,11 +414,76 @@ describe("resolveFirstVisibleLocator", () => {
   });
 });
 
+describe("extractVisibleTopCardSummaryFromRoot", () => {
+  it("falls back to visible paragraph text on the current self-profile layout", async () => {
+    const root = new MockTextLocator({
+      "h1.text-heading-xlarge, h1[class*='text-heading'], h2, h1": [
+        { text: "Joi Ascend", visible: true }
+      ],
+      ".text-body-medium[data-anonymize='headline'], .text-body-medium": [],
+      "span.text-body-small[data-anonymize='location'], .text-body-small.inline": [],
+      ".dist-value, .distance-badge, [class*='distance']": [],
+      p: [
+        { text: "Personal Assistant to Director at Signikant", visible: true },
+        { text: "Signikant", visible: false },
+        { text: "Copenhagen, Capital Region of Denmark, Denmark", visible: true },
+        { text: "Contact info", visible: true },
+        { text: "Get started", visible: true }
+      ]
+    });
+
+    await expect(
+      extractVisibleTopCardSummaryFromRoot(root as unknown as Locator)
+    ).resolves.toEqual({
+      full_name: "Joi Ascend",
+      headline: "Personal Assistant to Director at Signikant",
+      location: "Copenhagen, Capital Region of Denmark, Denmark",
+      connection_degree: ""
+    });
+  });
+});
+
+describe("readEditableFieldValue", () => {
+  it("prefers selected option text for select controls", async () => {
+    const locator = new MockEditableFieldLocator(
+      new MockFieldElement({
+        tagName: "SELECT",
+        value: "2863822437",
+        selectedOptions: [{ textContent: "Software Development" }]
+      })
+    );
+
+    await expect(readEditableFieldValue(locator as unknown as Locator)).resolves.toBe(
+      "Software Development"
+    );
+  });
+
+  it("falls back to nested combobox value metadata", async () => {
+    const locator = new MockEditableFieldLocator(
+      new MockFieldElement({
+        tagName: "DIV",
+        nestedControl: new MockFieldElement({
+          tagName: "DIV",
+          attributes: {
+            "aria-valuetext": "Software Development",
+            role: "combobox"
+          }
+        })
+      })
+    );
+
+    await expect(readEditableFieldValue(locator as unknown as Locator)).resolves.toBe(
+      "Software Development"
+    );
+  });
+});
+
 describe("navigateToOwnProfile", () => {
   it("recovers from /in/me/ navigation timeouts once self-only edit controls are present", async () => {
     const timeoutError = new playwrightErrors.TimeoutError("Navigation timeout");
     const page = createNavigationMockPage({
       gotoError: timeoutError,
+      headingVisible: true,
       introEditPresent: true,
       urlAfterGoto: "https://www.linkedin.com/in/me/"
     });
@@ -342,6 +502,7 @@ describe("navigateToOwnProfile", () => {
     const page = createNavigationMockPage({
       canonicalUrl: "https://www.linkedin.com/in/joi-ascend/",
       gotoError: timeoutError,
+      headingVisible: true,
       menuProfileUrl: "https://www.linkedin.com/in/joi-ascend/",
       urlAfterGoto: "https://www.linkedin.com/in/joi-ascend/"
     });

--- a/packages/core/src/linkedinProfile.ts
+++ b/packages/core/src/linkedinProfile.ts
@@ -1188,19 +1188,7 @@ async function extractEditableSettings(
 
     return {
       industry: industryField
-        ? normalizeText(
-            await industryField.evaluate((element) => {
-              if (
-                element instanceof globalThis.HTMLInputElement ||
-                element instanceof globalThis.HTMLTextAreaElement ||
-                element instanceof globalThis.HTMLSelectElement
-              ) {
-                return element.value;
-              }
-
-              return element.getAttribute("value") ?? element.textContent ?? "";
-            })
-          )
+        ? await readEditableFieldValue(industryField)
         : "",
       supported_fields: ["industry"]
     };
@@ -1218,6 +1206,79 @@ async function extractEditableSettings(
 
 function normalizeText(value: string | null | undefined): string {
   return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+export async function readEditableFieldValue(locator: Locator): Promise<string> {
+  try {
+    return normalizeText(
+      await locator.evaluate((element) => {
+        type EvaluatedFieldOption = {
+          label?: unknown;
+          textContent?: string | null;
+        };
+        type EvaluatedFieldElement = {
+          tagName: string;
+          textContent: string | null;
+          getAttribute(name: string): string | null;
+          querySelector(selector: string): EvaluatedFieldElement | null;
+          value?: unknown;
+          selectedOptions?: {
+            length?: number;
+            [index: number]: EvaluatedFieldOption;
+          };
+        };
+        const normalize = (value: string | null | undefined): string =>
+          (value ?? "").replace(/\s+/g, " ").trim();
+        const readString = (value: unknown): string =>
+          typeof value === "string" ? value : "";
+        const readSelectedOptionText = (
+          target: EvaluatedFieldElement
+        ): string => {
+          const firstOption = target.selectedOptions?.[0];
+          if (!firstOption) {
+            return "";
+          }
+
+          return normalize(
+            readString(firstOption.label) ||
+              readString(firstOption.textContent)
+          );
+        };
+        const readElementValue = (
+          target: EvaluatedFieldElement
+        ): string => {
+          const tagName = target.tagName.toLowerCase();
+          const directValue = normalize(readString(target.value));
+          const valueAttribute = normalize(target.getAttribute("value"));
+          const ariaValueText = normalize(target.getAttribute("aria-valuetext"));
+          const ariaLabel = normalize(target.getAttribute("aria-label"));
+          const textContent = normalize(target.textContent);
+
+          if (tagName === "select") {
+            return (
+              readSelectedOptionText(target) ||
+              directValue ||
+              valueAttribute ||
+              textContent ||
+              ariaLabel
+            );
+          }
+
+          return ariaValueText || directValue || valueAttribute || textContent || ariaLabel;
+        };
+
+        const nestedControl = element.querySelector(
+          "input, textarea, select, [role='combobox']"
+        );
+
+        return readElementValue(
+          (nestedControl ?? element) as EvaluatedFieldElement
+        );
+      })
+    );
+  } catch {
+    return "";
+  }
 }
 
 function getProfileRateLimitConfig(actionType: string): ConsumeRateLimitInput {
@@ -1883,6 +1944,7 @@ async function extractProfileData(
   page: Page,
   selectorLocale: LinkedInSelectorLocale
 ): Promise<LinkedInProfile> {
+  const visibleTopCardSummary = await extractVisibleTopCardSummary(page);
   const extracted = await page.evaluate((sectionLabels) => {
     const normalize = (value: string | null | undefined): string =>
       (value ?? "").replace(/\s+/g, " ").trim();
@@ -2263,11 +2325,19 @@ async function extractProfileData(
     vanity_name: extracted.vanity_name
       ? normalizeText(extracted.vanity_name)
       : null,
-    full_name: normalizeText(extracted.full_name),
-    headline: normalizeText(extracted.headline),
-    location: normalizeText(extracted.location),
+    full_name:
+      normalizeText(visibleTopCardSummary.full_name) ||
+      normalizeText(extracted.full_name),
+    headline:
+      normalizeText(visibleTopCardSummary.headline) ||
+      normalizeText(extracted.headline),
+    location:
+      normalizeText(visibleTopCardSummary.location) ||
+      normalizeText(extracted.location),
     about: normalizeText(extracted.about),
-    connection_degree: normalizeText(extracted.connection_degree),
+    connection_degree:
+      normalizeText(visibleTopCardSummary.connection_degree) ||
+      normalizeText(extracted.connection_degree),
     experience: extracted.experience.map((item) => ({
       title: normalizeText(item.title),
       company: normalizeText(item.company),
@@ -2285,12 +2355,136 @@ async function extractProfileData(
 }
 /* eslint-enable no-undef */
 
+interface LinkedInProfileTopCardSummary {
+  full_name: string;
+  headline: string;
+  location: string;
+  connection_degree: string;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function dedupeStrings(values: readonly string[]): string[] {
   return [...new Set(values.map((value) => normalizeText(value)).filter(Boolean))];
+}
+
+async function readFirstVisibleLocatorText(locator: Locator): Promise<string> {
+  const visibleLocator = await resolveFirstVisibleLocator(locator);
+  if (!visibleLocator) {
+    return "";
+  }
+
+  return normalizeText(await visibleLocator.textContent().catch(() => ""));
+}
+
+async function readVisibleLocatorTexts(locator: Locator): Promise<string[]> {
+  const count = await locator.count().catch(() => 0);
+  const texts: string[] = [];
+
+  for (let index = 0; index < count; index += 1) {
+    const candidate = locator.nth(index);
+    if (!(await candidate.isVisible().catch(() => false))) {
+      continue;
+    }
+
+    const text = normalizeText(await candidate.textContent().catch(() => ""));
+    if (text) {
+      texts.push(text);
+    }
+  }
+
+  return texts;
+}
+
+function looksLikeLocationText(value: string): boolean {
+  return /,/.test(value) || /\b(?:region|area|district|county|province)\b/i.test(value);
+}
+
+function looksLikeProfileActionText(value: string): boolean {
+  return /^(?:add|contact|edit|enhance|get started|learn more|open to|save|share|show|tell|try premium)\b/i.test(
+    value
+  );
+}
+
+export async function extractVisibleTopCardSummaryFromRoot(
+  root: Locator
+): Promise<LinkedInProfileTopCardSummary> {
+  const fullName = await readFirstVisibleLocatorText(
+    root.locator("h1.text-heading-xlarge, h1[class*='text-heading'], h2, h1")
+  );
+  let headline = await readFirstVisibleLocatorText(
+    root.locator(".text-body-medium[data-anonymize='headline'], .text-body-medium")
+  );
+  let location = await readFirstVisibleLocatorText(
+    root.locator("span.text-body-small[data-anonymize='location'], .text-body-small.inline")
+  );
+  const connectionDegree = await readFirstVisibleLocatorText(
+    root.locator(".dist-value, .distance-badge, [class*='distance']")
+  );
+
+  if (!headline) {
+    headline = await readFirstVisibleLocatorText(
+      root.locator(
+        "xpath=(.//*[self::h1 or self::h2]/ancestor::div[following-sibling::p][1]/following-sibling::p[normalize-space()][1])[1]"
+      )
+    );
+  }
+
+  if (!location) {
+    location = await readFirstVisibleLocatorText(
+      root.locator(
+        "xpath=(.//*[self::h1 or self::h2]/ancestor::div[following-sibling::p][1]/following-sibling::div[1]//*[self::p or self::span][normalize-space()][1])[1]"
+      )
+    );
+  }
+
+  if (!headline || !location) {
+    const paragraphTexts = dedupeStrings(await readVisibleLocatorTexts(root.locator("p")));
+
+    if (!headline) {
+      headline =
+        paragraphTexts.find(
+          (text) =>
+            !looksLikeLocationText(text) &&
+            !looksLikeProfileActionText(text)
+        ) ?? "";
+    }
+
+    if (!location) {
+      location =
+        paragraphTexts.find(
+          (text) =>
+            text !== headline &&
+            looksLikeLocationText(text) &&
+            !looksLikeProfileActionText(text)
+        ) ?? "";
+    }
+  }
+
+  return {
+    full_name: fullName,
+    headline,
+    location,
+    connection_degree: connectionDegree
+  };
+}
+
+async function extractVisibleTopCardSummary(
+  page: Page
+): Promise<LinkedInProfileTopCardSummary> {
+  try {
+    const topCardRoot = await getTopCardRoot(page);
+    return extractVisibleTopCardSummaryFromRoot(topCardRoot);
+  } catch {
+    return {
+      full_name: "",
+      headline: "",
+      location: "",
+      connection_degree: ""
+    };
+  }
 }
 
 function normalizeFieldKey(value: string): string {
@@ -2951,11 +3145,28 @@ function createCssLocatorCandidates(
 }
 
 async function waitForProfilePageReady(page: Page): Promise<void> {
-  await page
-    .locator("h1")
-    .first()
-    .waitFor({ state: "visible", timeout: 10_000 })
-    .catch(() => undefined);
+  const readyCandidates: LocatorCandidate[] = [
+    {
+      key: "profile-heading",
+      locator: page.locator(
+        "main h1.text-heading-xlarge, main h1[class*='text-heading'], main h2, main h1"
+      )
+    },
+    {
+      key: "profile-intro-edit",
+      locator: page.locator(buildProfileIntroEditHrefSelector())
+    },
+    ...createCssLocatorCandidates(
+      page,
+      [
+        ...PROFILE_MEDIA_STRUCTURAL_SELECTORS.photo,
+        ...PROFILE_MEDIA_STRUCTURAL_SELECTORS.banner
+      ],
+      "profile-ready-media"
+    )
+  ];
+
+  await waitForFirstVisibleLocator(readyCandidates, 10_000);
 }
 
 function tryNormalizeLinkedInProfileUrl(
@@ -3152,7 +3363,7 @@ export async function navigateToOwnProfile(page: Page): Promise<void> {
 
 async function getTopCardRoot(page: Page): Promise<Locator> {
   const headingLocator = page.locator(
-    "h1.text-heading-xlarge, h1[class*='text-heading'], h1"
+    "h1.text-heading-xlarge, h1[class*='text-heading'], h2, h1"
   );
   const candidateRoots: LocatorCandidate[] = [
     {
@@ -3722,19 +3933,19 @@ async function findDialogFieldLocator(
   definition: EditableFieldDefinition
 ): Promise<Locator | null> {
   const labelRegex = buildTextRegex(definition.aliases);
-  const byLabel = dialog.getByLabel(labelRegex).first();
-  if (await isLocatorVisible(byLabel)) {
+  const byLabel = await resolveFirstVisibleLocator(dialog.getByLabel(labelRegex));
+  if (byLabel) {
     return byLabel;
   }
 
   for (const alias of definition.aliases) {
     const normalizedAlias = normalizeText(alias).toLowerCase();
-    const xpath = dialog
-      .locator(
+    const xpath = await resolveFirstVisibleLocator(
+      dialog.locator(
         `xpath=.//label[contains(translate(normalize-space(.), 'ABCDEFGHIJKLMNOPQRSTUVWXYZÆØÅ', 'abcdefghijklmnopqrstuvwxyzæøå'), "${normalizedAlias}")]/following::*[(self::input or self::textarea or self::select or @role='combobox')][1]`
       )
-      .first();
-    if (await isLocatorVisible(xpath)) {
+    );
+    if (xpath) {
       return xpath;
     }
   }


### PR DESCRIPTION
## Summary
- read the visible self-profile top-card summary instead of relying on legacy heading/body selectors
- harden editable field lookup and value extraction for current intro/settings surfaces
- add regression coverage for the current self-profile layout and select/combobox field reads

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
- `node packages/cli/dist/bin/linkedin.js profile editable --profile issue-310-clone-1773235809`

Closes #333