### PR TITLE
fix: handle current self-profile top card for intro edits

### DIFF
--- a/packages/core/src/__tests__/linkedinProfile.test.ts
+++ b/packages/core/src/__tests__/linkedinProfile.test.ts
@@ -12,6 +12,8 @@ import {
   LINKEDIN_PROFILE_FEATURED_ITEM_KINDS,
   PROFILE_GLOBAL_ADD_SECTION_CONTROL,
   PROFILE_MEDIA_STRUCTURAL_SELECTORS,
+  PROFILE_TOP_CARD_HEADING_SELECTORS,
+  PROFILE_TOP_CARD_STRUCTURAL_SELECTORS,
   REMOVE_PROFILE_SECTION_ITEM_ACTION_TYPE,
   REMOVE_PROFILE_FEATURED_ACTION_TYPE,
   REORDER_PROFILE_FEATURED_ACTION_TYPE,
@@ -146,12 +148,14 @@ function createNavigationMockPage(options: {
     locator: vi.fn((selector: string) => {
       const isIntroEditSelector =
         selector.includes("/edit/intro/") || selector.includes("/edit/forms/intro/");
+      const isHeadingSelector = selector.includes("h1") || selector.includes("h2");
       const introEditCount =
         isIntroEditSelector && (options.introEditVisible || options.introEditPresent)
           ? 1
           : 0;
+      const headingCount = isHeadingSelector && (options.headingVisible ?? false) ? 1 : 0;
       const visible =
-        selector === "h1"
+        isHeadingSelector
           ? (options.headingVisible ?? false)
           : isIntroEditSelector
             ? (options.introEditVisible ?? false)
@@ -165,7 +169,7 @@ function createNavigationMockPage(options: {
               ? options.ogProfileUrl
               : null;
 
-      const count = vi.fn(async () => introEditCount);
+      const count = vi.fn(async () => (isHeadingSelector ? headingCount : introEditCount));
       const isVisible = vi.fn(async () => visible);
       const getAttribute = vi.fn(async () => attributeValue ?? null);
       const nth = vi.fn();
@@ -325,6 +329,7 @@ describe("navigateToOwnProfile", () => {
     const timeoutError = new playwrightErrors.TimeoutError("Navigation timeout");
     const page = createNavigationMockPage({
       gotoError: timeoutError,
+      headingVisible: true,
       introEditPresent: true,
       urlAfterGoto: "https://www.linkedin.com/in/me/"
     });
@@ -343,6 +348,7 @@ describe("navigateToOwnProfile", () => {
     const page = createNavigationMockPage({
       canonicalUrl: "https://www.linkedin.com/in/joi-ascend/",
       gotoError: timeoutError,
+      headingVisible: true,
       menuProfileUrl: "https://www.linkedin.com/in/joi-ascend/",
       urlAfterGoto: "https://www.linkedin.com/in/joi-ascend/"
     });
@@ -489,6 +495,16 @@ describe("createProfileActionExecutors", () => {
     expect(PROFILE_MEDIA_STRUCTURAL_SELECTORS.photo).toContain(".profile-photo-edit button");
     expect(PROFILE_MEDIA_STRUCTURAL_SELECTORS.banner).toContain(
       "[id^='cover-photo-dropdown-button-trigger-']"
+    );
+  });
+
+  it("keeps selector fallbacks for the current self-profile top card", () => {
+    expect(PROFILE_TOP_CARD_HEADING_SELECTORS).toContain("h2");
+    expect(PROFILE_TOP_CARD_STRUCTURAL_SELECTORS).toContain(
+      "section[componentkey*='topcard' i]"
+    );
+    expect(PROFILE_TOP_CARD_STRUCTURAL_SELECTORS).toContain(
+      "div[componentkey*='topcard' i]"
     );
   });
 

--- a/packages/core/src/linkedinProfile.ts
+++ b/packages/core/src/linkedinProfile.ts
@@ -509,6 +509,18 @@ export const PROFILE_GLOBAL_ADD_SECTION_CONTROL = {
   roles: ["button", "link"]
 } as const;
 
+export const PROFILE_TOP_CARD_HEADING_SELECTORS = [
+  "h1.text-heading-xlarge",
+  "h1[class*='text-heading']",
+  "h2",
+  "h1"
+] as const;
+
+export const PROFILE_TOP_CARD_STRUCTURAL_SELECTORS = [
+  "section[componentkey*='topcard' i]",
+  "div[componentkey*='topcard' i]"
+] as const;
+
 const PROFILE_ACTION_LABELS = {
   add: {
     en: ["Add"],
@@ -3007,11 +3019,33 @@ function buildEditableFieldAttributeSelectors(labels: readonly string[]): string
 }
 
 async function waitForProfilePageReady(page: Page): Promise<void> {
-  await page
-    .locator("h1")
-    .first()
-    .waitFor({ state: "visible", timeout: 10_000 })
-    .catch(() => undefined);
+  const readyCandidates: LocatorCandidate[] = [
+    {
+      key: "profile-heading",
+      locator: page.locator(
+        PROFILE_TOP_CARD_HEADING_SELECTORS.map((selector) => `main ${selector}`).join(", ")
+      )
+    },
+    {
+      key: "profile-intro-edit",
+      locator: page.locator(buildProfileIntroEditHrefSelector())
+    },
+    {
+      key: "profile-top-card-current-self",
+      locator: page.locator(
+        PROFILE_TOP_CARD_STRUCTURAL_SELECTORS.map(
+          (selector) => `main ${selector}`
+        ).join(", ")
+      )
+    },
+    ...createCssLocatorCandidates(
+      page,
+      [...PROFILE_MEDIA_STRUCTURAL_SELECTORS.photo, ...PROFILE_MEDIA_STRUCTURAL_SELECTORS.banner],
+      "profile-ready-media"
+    )
+  ];
+
+  await waitForFirstVisibleLocator(readyCandidates, 10_000);
 }
 
 function tryNormalizeLinkedInProfileUrl(
@@ -3206,7 +3240,7 @@ export async function navigateToOwnProfile(page: Page): Promise<void> {
 
 async function getTopCardRoot(page: Page): Promise<Locator> {
   const headingLocator = page.locator(
-    "h1.text-heading-xlarge, h1[class*='text-heading'], h1"
+    PROFILE_TOP_CARD_HEADING_SELECTORS.join(", ")
   );
   const candidateRoots: LocatorCandidate[] = [
     {
@@ -3221,6 +3255,18 @@ async function getTopCardRoot(page: Page): Promise<Locator> {
       key: "top-card-legacy-with-heading",
       locator: page
         .locator("main .pv-top-card, main .top-card-layout")
+        .filter({
+          has: headingLocator
+        })
+    },
+    {
+      key: "top-card-current-self-with-heading",
+      locator: page
+        .locator(
+          PROFILE_TOP_CARD_STRUCTURAL_SELECTORS.map(
+            (selector) => `main ${selector}`
+          ).join(", ")
+        )
         .filter({
           has: headingLocator
         })


### PR DESCRIPTION
## Summary
- recognize the current self-profile top-card shell when LinkedIn renders the SDUI `componentkey` container instead of the legacy top-card classes
- treat `h2` top-card headings and the current self-profile root as page-ready signals so intro edit flows do not stall waiting for an `h1`
- add regression coverage for the current self-profile top-card selectors

## Why
The Joi Ascend live profile seeding workflow was failing on `profile.update_intro` because the self-profile page no longer exposed the legacy top-card container expected by the confirm flow.

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

Closes #337
