### PR TITLE
fix: handle split intro location fields on edit page

### DIFF
--- a/packages/core/src/__tests__/linkedinProfile.test.ts
+++ b/packages/core/src/__tests__/linkedinProfile.test.ts
@@ -26,10 +26,12 @@ import {
   WRITE_PROFILE_RECOMMENDATION_ACTION_TYPE,
   LinkedInProfileService,
   createProfileActionExecutors,
+  findIntroLocationFieldLocator,
   isProfileIntroEditHref,
   navigateToOwnProfile,
   resolveFirstVisibleLocator,
   resolveProfileUrl,
+  splitProfileIntroLocationValue,
   type LinkedInProfileRuntime
 } from "../linkedinProfile.js";
 import { TwoPhaseCommitService } from "../twoPhaseCommit.js";
@@ -118,6 +120,86 @@ class MockLocator {
   async isVisible(): Promise<boolean> {
     const index = this.resolvedIndex ?? 0;
     return this.visibility[index] ?? false;
+  }
+}
+
+class MockDialogFieldLocator {
+  constructor(
+    readonly label: string,
+    readonly visible: boolean = true
+  ) {}
+}
+
+class MockDialogQueryLocator {
+  constructor(
+    readonly fields: readonly MockDialogFieldLocator[],
+    readonly resolvedIndex: number | null = null
+  ) {}
+
+  get resolvedLabel(): string | null {
+    return this.fields[this.resolvedIndex ?? 0]?.label ?? null;
+  }
+
+  async count(): Promise<number> {
+    return this.resolvedIndex === null ? this.fields.length : 1;
+  }
+
+  first(): MockDialogQueryLocator {
+    if (this.resolvedIndex !== null) {
+      return this;
+    }
+
+    return new MockDialogQueryLocator(this.fields, 0);
+  }
+
+  nth(index: number): MockDialogQueryLocator {
+    if (this.resolvedIndex !== null) {
+      return this;
+    }
+
+    return new MockDialogQueryLocator(this.fields, index);
+  }
+
+  locator(): MockDialogQueryLocator {
+    return this;
+  }
+
+  async isVisible(): Promise<boolean> {
+    return this.fields[this.resolvedIndex ?? 0]?.visible ?? false;
+  }
+}
+
+class MockDialogLocator {
+  constructor(private readonly fields: readonly MockDialogFieldLocator[]) {}
+
+  getByLabel(labelMatcher: RegExp): MockDialogQueryLocator {
+    return new MockDialogQueryLocator(
+      this.fields.filter((field) => labelMatcher.test(field.label))
+    );
+  }
+
+  getByRole(_role: string, options: { name?: RegExp } = {}): MockDialogQueryLocator {
+    const labelMatcher = options.name ?? /.*/;
+
+    return new MockDialogQueryLocator(
+      this.fields.filter((field) => labelMatcher.test(field.label))
+    );
+  }
+
+  getByText(labelMatcher: RegExp): MockDialogQueryLocator {
+    return new MockDialogQueryLocator(
+      this.fields.filter((field) => labelMatcher.test(field.label))
+    );
+  }
+
+  locator(selector: string): MockDialogQueryLocator {
+    const matches = Array.from(selector.matchAll(/"([^"]+)"/g));
+    const rawAlias = matches.at(-1)?.[1] ?? "";
+    const normalizedAlias = rawAlias.toLowerCase();
+
+    return new MockDialogQueryLocator(
+      this.fields.filter((field) => field.label.toLowerCase().includes(normalizedAlias))
+    );
   }
 }
 
@@ -317,6 +399,56 @@ describe("resolveFirstVisibleLocator", () => {
     await expect(
       resolveFirstVisibleLocator(locator as unknown as Locator)
     ).resolves.toBeNull();
+  });
+});
+
+describe("findIntroLocationFieldLocator", () => {
+  it("prefers the live split city field over the country field", async () => {
+    const dialog = new MockDialogLocator([
+      new MockDialogFieldLocator("Country/Region*"),
+      new MockDialogFieldLocator("City")
+    ]);
+
+    const locator = await findIntroLocationFieldLocator(dialog as unknown as Locator);
+
+    expect(locator).not.toBeNull();
+    expect((locator as unknown as MockDialogQueryLocator).resolvedLabel).toBe("City");
+  });
+
+  it("falls back to the classic single location label", async () => {
+    const dialog = new MockDialogLocator([new MockDialogFieldLocator("Location")]);
+
+    const locator = await findIntroLocationFieldLocator(dialog as unknown as Locator);
+
+    expect(locator).not.toBeNull();
+    expect((locator as unknown as MockDialogQueryLocator).resolvedLabel).toBe("Location");
+  });
+});
+
+describe("splitProfileIntroLocationValue", () => {
+  it("splits country and city for the current intro editor layout", () => {
+    expect(splitProfileIntroLocationValue("Copenhagen, Denmark")).toEqual({
+      city: "Copenhagen",
+      countryOrRegion: "Denmark"
+    });
+  });
+
+  it("keeps detailed locality text while peeling off the country", () => {
+    expect(
+      splitProfileIntroLocationValue(
+        "2800, Copenhagen, Capital Region of Denmark, Denmark"
+      )
+    ).toEqual({
+      city: "2800, Copenhagen, Capital Region of Denmark",
+      countryOrRegion: "Denmark"
+    });
+  });
+
+  it("leaves single-part locations untouched", () => {
+    expect(splitProfileIntroLocationValue("Copenhagen")).toEqual({
+      city: "Copenhagen",
+      countryOrRegion: null
+    });
   });
 });
 

--- a/packages/core/src/linkedinProfile.ts
+++ b/packages/core/src/linkedinProfile.ts
@@ -787,6 +787,32 @@ const PROFILE_INTRO_FIELD_DEFINITIONS: readonly EditableFieldDefinition[] = [
   }
 ] as const;
 
+const PROFILE_INTRO_LOCATION_FIELD_DEFINITION =
+  PROFILE_INTRO_FIELD_DEFINITIONS.find(
+    (definition) => definition.key === "location"
+  )!;
+
+const PROFILE_INTRO_LOCATION_COUNTRY_FIELD_DEFINITION = {
+  key: "countryOrRegion",
+  aliases: [
+    "countryOrRegion",
+    "countryRegion",
+    "Country/Region",
+    "Country or Region",
+    "Country",
+    "Land/område",
+    "Land/region",
+    "Land"
+  ],
+  control: "text"
+} as const satisfies EditableFieldDefinition;
+
+const PROFILE_INTRO_LOCATION_CITY_FIELD_DEFINITION = {
+  key: "city",
+  aliases: ["city", "City", "City/District", "Town/City", "By"],
+  control: "text"
+} as const satisfies EditableFieldDefinition;
+
 const PROFILE_SETTINGS_FIELD_DEFINITIONS = [
   {
     key: "industry",
@@ -3142,12 +3168,44 @@ async function resolveVisibleProfileIntroEditPage(page: Page): Promise<Locator |
     return null;
   }
 
-  const form = await resolveFirstVisibleLocator(page.locator("main form"));
-  if (form) {
-    return form;
-  }
+  const fieldSelector = [
+    "input[aria-autocomplete='list']",
+    "input",
+    "textarea",
+    "select",
+    "[role='combobox']",
+    "[role='textbox']",
+    "[contenteditable='true']"
+  ].join(", ");
+  const readyCandidates: LocatorCandidate[] = [
+    {
+      key: "intro-edit-page-lazy-column",
+      locator: page.locator("[data-testid='lazy-column']").filter({
+        has: page.locator(fieldSelector)
+      })
+    },
+    {
+      key: "intro-edit-page-form",
+      locator: page.locator("form").filter({
+        has: page.locator(fieldSelector)
+      })
+    },
+    {
+      key: "intro-edit-page-main",
+      locator: page.locator("main").filter({
+        has: page.locator(fieldSelector)
+      })
+    },
+    {
+      key: "intro-edit-page-body",
+      locator: page.locator("body").filter({
+        has: page.locator(fieldSelector)
+      })
+    }
+  ];
+  const ready = await findFirstVisibleLocator(readyCandidates);
 
-  return resolveFirstVisibleLocator(page.locator("main"));
+  return ready?.locator ?? null;
 }
 
 async function hasVisibleEditableField(
@@ -3818,7 +3876,7 @@ async function openExistingSectionItemDialog(
   return clickLocatorAndWaitForDialog(page, resolvedMenuEdit.locator);
 }
 
-async function findDialogFieldLocator(
+async function findDialogFieldLocatorByDefinition(
   dialog: Locator,
   definition: EditableFieldDefinition
 ): Promise<Locator | null> {
@@ -3866,6 +3924,15 @@ async function findDialogFieldLocator(
 
   for (const alias of definition.aliases) {
     const normalizedAlias = normalizeText(alias).toLowerCase();
+    const typeaheadInput = dialog
+      .locator(
+        `xpath=.//*[self::label or self::p or self::div or self::span][contains(translate(normalize-space(string(.)), 'ABCDEFGHIJKLMNOPQRSTUVWXYZÆØÅ', 'abcdefghijklmnopqrstuvwxyzæøå'), "${normalizedAlias}")]/following::input[@aria-autocomplete='list' or @role='combobox' or @data-testid='typeahead-input'][1]`
+      )
+      .first();
+    if (await isLocatorVisible(typeaheadInput)) {
+      return typeaheadInput;
+    }
+
     const xpath = dialog
       .locator(
         `xpath=.//*[self::label or self::p or self::div or self::span][contains(translate(normalize-space(string(.)), 'ABCDEFGHIJKLMNOPQRSTUVWXYZÆØÅ', 'abcdefghijklmnopqrstuvwxyzæøå'), "${normalizedAlias}")]/following::*[(${EDITABLE_FIELD_CONTROL_XPATH})][1]`
@@ -3878,6 +3945,31 @@ async function findDialogFieldLocator(
   }
 
   return null;
+}
+
+export async function findIntroLocationFieldLocator(
+  dialog: Locator
+): Promise<Locator | null> {
+  const cityField = await findDialogFieldLocatorByDefinition(
+    dialog,
+    PROFILE_INTRO_LOCATION_CITY_FIELD_DEFINITION
+  );
+  if (cityField) {
+    return cityField;
+  }
+
+  return findDialogFieldLocatorByDefinition(dialog, PROFILE_INTRO_LOCATION_FIELD_DEFINITION);
+}
+
+async function findDialogFieldLocator(
+  dialog: Locator,
+  definition: EditableFieldDefinition
+): Promise<Locator | null> {
+  if (definition.key === "location") {
+    return findIntroLocationFieldLocator(dialog);
+  }
+
+  return findDialogFieldLocatorByDefinition(dialog, definition);
 }
 
 async function waitForDialogFieldLocator(
@@ -3899,6 +3991,112 @@ async function waitForDialogFieldLocator(
   }
 
   return findDialogFieldLocator(dialog, definition);
+}
+
+export function splitProfileIntroLocationValue(value: string): {
+  city: string;
+  countryOrRegion: string | null;
+} {
+  const normalizedValue = normalizeText(value);
+  const segments = normalizedValue
+    .split(",")
+    .map((segment) => normalizeText(segment))
+    .filter((segment) => segment.length > 0);
+
+  if (segments.length < 2) {
+    return {
+      city: normalizedValue,
+      countryOrRegion: null
+    };
+  }
+
+  return {
+    city: segments.slice(0, -1).join(", "),
+    countryOrRegion: segments.at(-1) ?? null
+  };
+}
+
+async function isAutocompleteField(locator: Locator): Promise<boolean> {
+  return locator.evaluate((element) => {
+    const role = (element.getAttribute("role") ?? "").toLowerCase();
+    const autocomplete = (element.getAttribute("aria-autocomplete") ?? "").toLowerCase();
+    const testId = (element.getAttribute("data-testid") ?? "").toLowerCase();
+
+    return (
+      role === "combobox" ||
+      autocomplete === "list" ||
+      testId === "typeahead-input"
+    );
+  });
+}
+
+async function replaceDialogFieldValue(
+  locator: Locator,
+  value: string
+): Promise<void> {
+  await locator.click();
+  await locator.fill(value).catch(async () => {
+    await locator.press(`${process.platform === "darwin" ? "Meta" : "Control"}+A`).catch(
+      () => undefined
+    );
+    await locator.press("Backspace").catch(() => undefined);
+    await locator.type(value);
+  });
+}
+
+async function commitAutocompleteFieldIfNeeded(
+  page: Page,
+  locator: Locator,
+  value: string
+): Promise<void> {
+  if (!(await isAutocompleteField(locator))) {
+    return;
+  }
+
+  await page.waitForTimeout(500);
+  await selectAutocompleteOption(page, value);
+}
+
+async function fillSplitProfileIntroLocationField(
+  page: Page,
+  dialog: Locator,
+  value: string
+): Promise<boolean> {
+  const { city, countryOrRegion } = splitProfileIntroLocationValue(value);
+  let updatedField = false;
+
+  const countryField =
+    countryOrRegion !== null
+      ? await findDialogFieldLocatorByDefinition(
+          dialog,
+          PROFILE_INTRO_LOCATION_COUNTRY_FIELD_DEFINITION
+        )
+      : null;
+  if (countryField && countryOrRegion) {
+    await replaceDialogFieldValue(countryField, countryOrRegion);
+    await commitAutocompleteFieldIfNeeded(page, countryField, countryOrRegion);
+    updatedField = true;
+  }
+
+  let cityField = await findDialogFieldLocatorByDefinition(
+    dialog,
+    PROFILE_INTRO_LOCATION_CITY_FIELD_DEFINITION
+  );
+  if (!cityField && updatedField) {
+    await page.waitForTimeout(250);
+    cityField = await findDialogFieldLocatorByDefinition(
+      dialog,
+      PROFILE_INTRO_LOCATION_CITY_FIELD_DEFINITION
+    );
+  }
+
+  if (cityField && city.length > 0) {
+    await replaceDialogFieldValue(cityField, city);
+    await commitAutocompleteFieldIfNeeded(page, cityField, city);
+    updatedField = true;
+  }
+
+  return updatedField;
 }
 
 async function fillDialogField(
@@ -3930,6 +4128,18 @@ async function fillDialogField(
   }
 
   const stringValue = String(value);
+
+  if (definition.key === "location") {
+    const filledSplitLocation = await fillSplitProfileIntroLocationField(
+      page,
+      dialog,
+      stringValue
+    );
+    if (filledSplitLocation) {
+      return;
+    }
+  }
+
   const tagName = await locator.evaluate((element) => element.tagName.toLowerCase());
   const ariaAutocomplete = await locator.getAttribute("aria-autocomplete").catch(() => null);
   const dataTestId = await locator.getAttribute("data-testid").catch(() => null);
@@ -3944,20 +4154,16 @@ async function fillDialogField(
     return;
   }
 
-  await locator.click();
-  await locator.fill(stringValue).catch(async () => {
-    await locator.press(`${process.platform === "darwin" ? "Meta" : "Control"}+A`).catch(
-      () => undefined
-    );
-    await locator.press("Backspace").catch(() => undefined);
-    await locator.type(stringValue);
-  });
+  await replaceDialogFieldValue(locator, stringValue);
 
   if (definition.control === "select" || isTypeaheadField) {
     await page.waitForTimeout(250);
     await page.keyboard.press("ArrowDown").catch(() => undefined);
     await page.keyboard.press("Enter").catch(() => undefined);
+    return;
   }
+
+  await commitAutocompleteFieldIfNeeded(page, locator, stringValue);
 }
 
 async function clickSaveInProfileEditorSurface(


### PR DESCRIPTION
## Summary\n- detect the current LinkedIn intro editor root on lazy-column edit pages\n- prefer the split City field when resolving intro location inputs\n- split combined location values across Country/Region and City and add regression coverage\n\n## Testing\n- npm run typecheck\n- npm run lint\n- npm test\n- npm run build\n\nCloses #331