### PR TITLE
chore: align @eslint/js with ESLint 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@eslint/js": "^9.21.0",
+        "@eslint/js": "^10.0.0",
         "@types/node": "^22.13.8",
         "@typescript-eslint/eslint-plugin": "^8.57.0",
         "@typescript-eslint/parser": "^8.24.1",
@@ -628,16 +628,24 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.3",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
-      "integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "release:prepare": "node ./scripts/prepare-release.mjs"
   },
   "devDependencies": {
-    "@eslint/js": "^9.21.0",
+    "@eslint/js": "^10.0.0",
     "@types/node": "^22.13.8",
     "@typescript-eslint/eslint-plugin": "^8.57.0",
     "@typescript-eslint/parser": "^8.24.1",

--- a/packages/core/src/__tests__/e2e/helpers.ts
+++ b/packages/core/src/__tests__/e2e/helpers.ts
@@ -377,7 +377,8 @@ function readCliCoverageFixturesFromFile(filePath: string): CliCoverageFixtures 
     const reason = error instanceof Error ? error.message : String(error);
     throw new Error(
       `Could not load discovery fixtures from ${filePath}. ${reason} ` +
-        "Delete the file or rerun with --refresh-fixtures (LINKEDIN_E2E_REFRESH_FIXTURES=1)."
+        "Delete the file or rerun with --refresh-fixtures (LINKEDIN_E2E_REFRESH_FIXTURES=1).",
+      { cause: error }
     );
   }
 }
@@ -559,7 +560,7 @@ async function captureCommandExecution(
   const originalConsoleLog = console.log;
   const originalConsoleError = console.error;
   const originalExitCode = process.exitCode;
-  let exitCode = 0;
+  let exitCode: number;
 
   process.stdout.write = createWriteInterceptor(stdoutChunks);
   process.stderr.write = createWriteInterceptor(stderrChunks);

--- a/packages/core/src/__tests__/e2e/setup.ts
+++ b/packages/core/src/__tests__/e2e/setup.ts
@@ -262,7 +262,9 @@ async function probeFixtureReplay(): Promise<{
         `(${replayServer.summary.locale}, ${replayServer.summary.viewport.width}x${replayServer.summary.viewport.height}).`
     };
   } catch (error) {
-    throw new Error(`Fixture replay could not start. ${summarizeUnknownError(error)}`);
+    throw new Error(`Fixture replay could not start. ${summarizeUnknownError(error)}`, {
+      cause: error
+    });
   }
 }
 

--- a/packages/core/src/fixtureReplay.ts
+++ b/packages/core/src/fixtureReplay.ts
@@ -800,7 +800,12 @@ async function readJsonFile(
   try {
     return JSON.parse(raw) as unknown;
   } catch (error) {
-    throw new Error(`${fileLabel} ${filePath} contains invalid JSON. ${summarizeUnknownError(error)}`);
+    throw new Error(
+      `${fileLabel} ${filePath} contains invalid JSON. ${summarizeUnknownError(error)}`,
+      {
+        cause: error
+      }
+    );
   }
 }
 

--- a/packages/core/src/linkedinNotifications.ts
+++ b/packages/core/src/linkedinNotifications.ts
@@ -1753,40 +1753,44 @@ export class LinkedInNotificationsService {
       );
     }
 
-    let currentEnabled: boolean | null = null;
-    let label = page.title;
-    if (page.view_type === "category") {
-      currentEnabled = page.master_toggle?.enabled ?? null;
-      label = page.master_toggle?.label ?? page.title;
-    } else {
-      if (!channel) {
-        throw new LinkedInBuddyError(
-          "ACTION_PRECONDITION_FAILED",
-          "channel is required when updating a notification preference subcategory."
-        );
-      }
-
-      const targetChannel = page.channels.find(
-        (candidate) => candidate.channel_key === channel
-      );
-      if (!targetChannel) {
-        throw new LinkedInBuddyError(
-          "TARGET_NOT_FOUND",
-          `Could not find the ${channel} notification preference switch on ${page.title}.`,
-          {
-            preference_url: preferenceUrl,
-            channel
+    const targetState =
+      page.view_type === "category"
+        ? {
+            currentEnabled: page.master_toggle?.enabled ?? null,
+            label: page.master_toggle?.label ?? page.title
           }
-        );
-      }
-      currentEnabled = targetChannel.enabled;
-      label = targetChannel.label || page.title;
-    }
+        : (() => {
+            if (!channel) {
+              throw new LinkedInBuddyError(
+                "ACTION_PRECONDITION_FAILED",
+                "channel is required when updating a notification preference subcategory."
+              );
+            }
 
-    if (currentEnabled === input.enabled) {
+            const targetChannel = page.channels.find(
+              (candidate) => candidate.channel_key === channel
+            );
+            if (!targetChannel) {
+              throw new LinkedInBuddyError(
+                "TARGET_NOT_FOUND",
+                `Could not find the ${channel} notification preference switch on ${page.title}.`,
+                {
+                  preference_url: preferenceUrl,
+                  channel
+                }
+              );
+            }
+
+            return {
+              currentEnabled: targetChannel.enabled,
+              label: targetChannel.label || page.title
+            };
+          })();
+
+    if (targetState.currentEnabled === input.enabled) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        `${label} is already ${input.enabled ? "enabled" : "disabled"}.`,
+        `${targetState.label} is already ${input.enabled ? "enabled" : "disabled"}.`,
         {
           preference_url: preferenceUrl,
           channel: channel ?? null
@@ -1807,7 +1811,7 @@ export class LinkedInNotificationsService {
           ? `Set LinkedIn notification preference "${page.title}" to ${input.enabled ? "on" : "off"}`
           : `Set LinkedIn notification preference "${page.title}" (${channel}) to ${input.enabled ? "on" : "off"}`,
       target,
-      current_enabled: currentEnabled,
+      current_enabled: targetState.currentEnabled,
       enabled: input.enabled
     } satisfies Record<string, unknown>;
 

--- a/packages/mcp/src/bin/linkedin-mcp.ts
+++ b/packages/mcp/src/bin/linkedin-mcp.ts
@@ -388,7 +388,7 @@ async function readJsonInputFile(
   label: string
 ): Promise<unknown> {
   const resolvedPath = path.resolve(filePath);
-  let rawValue = "";
+  let rawValue: string;
 
   try {
     rawValue = await readFile(resolvedPath, "utf8");


### PR DESCRIPTION
## Summary

- Upgrade `@eslint/js` from the v9 range to `^10.0.0` so it matches the repo's existing ESLint 10 dependency.
- Fix the new recommended-rule failures surfaced by the v10 preset (`preserve-caught-error` and `no-useless-assignment`) without weakening the lint config.
- Note that Dependabot PR #299 is already closed, so this issue now supersedes that change.

Closes #348

## Testing

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build`

## Checklist

- [x] Linked issue included (`Closes #...` when appropriate)
- [ ] Docs or README updated for user-facing changes
- [ ] Tests added or updated when behavior changed
- [x] No unrelated files or generated artifacts included
- [x] Live LinkedIn validation followed the documented safety rules

## Notes for Reviewers

- I checked the ESLint 10 migration notes before patching. The main relevant changes here were the higher Node.js floor and the updated recommended preset behavior; this repo already targets Node 22, so the only code work needed was fixing the newly enforced lint violations.
