### PR TITLE
Enable evasion by default for browser interactions

### DIFF
--- a/docs/evasion.md
+++ b/docs/evasion.md
@@ -203,11 +203,14 @@ Instead, the CLI exposes evasion through the session diagnostics commands:
 
 Important CLI behavior:
 
-- there are **no** `--evasion-level` or `--evasion-diagnostics` flags today
+- `--evasion-level minimal|moderate|paranoid` overrides the resolved profile for one command
+- `--no-evasion` forces the `minimal` profile for one command
+- there is still **no** `--evasion-diagnostics` flag today
 - the CLI inherits evasion defaults from environment variables or built-in
   defaults
 - the command `--help` text for `status` and `health` points operators to the
   evasion env vars
+- fixture replay runs resolve to `minimal` unless a stronger profile is set explicitly
 - enabling diagnostics affects the run log, not the JSON schema
 
 Example:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -45,9 +45,12 @@ Important details:
 
 - `linkedin status` returns a top-level `evasion` block
 - `linkedin health` returns `session.evasion`
-- there are no CLI flags for evasion level or evasion diagnostics today
+- `--evasion-level minimal|moderate|paranoid` overrides the resolved profile for one command
+- `--no-evasion` forces the `minimal` profile for one command
+- there is still no dedicated CLI flag for evasion diagnostics
 - use `LINKEDIN_BUDDY_EVASION_LEVEL` and
   `LINKEDIN_BUDDY_EVASION_DIAGNOSTICS` to change the default behavior
+- fixture replay runs resolve to `minimal` by default for faster, deterministic tests
 - enabling diagnostics writes `evasion.*` events to the run log
 
 See `../../docs/evasion.md` for the profile matrix, exact JSON paths, and the

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -77,6 +77,7 @@ import {
   resolveActivityWebhookConfig,
   resolveConfigPaths,
   resolveFollowupSinceWindow,
+  resolveEvasionConfig,
   resolveLinkedInSelectorLocaleConfigResolution,
   redactStructuredValue,
   recordFeedbackInvocation,
@@ -236,6 +237,8 @@ const LIVE_VALIDATION_ERROR_EXIT_CODE = 2;
 const WRITE_VALIDATION_DOC_PATH = "docs/write-validation.md";
 const WRITE_VALIDATION_WARNING = "This will perform REAL actions on LinkedIn";
 const TOTAL_WRITE_VALIDATION_ACTIONS = LINKEDIN_WRITE_VALIDATION_ACTIONS.length;
+let cliEvasionEnabled = true;
+let cliEvasionLevel: string | undefined;
 let cliSelectorLocale: string | undefined;
 let activeCliInvocation:
   | {
@@ -350,6 +353,7 @@ function printJson(value: unknown): void {
 
 function createRuntime(cdpUrl?: string) {
   maybeWarnAboutSelectorLocaleConfig(cliSelectorLocale);
+  const evasionLevel = resolveCliEvasionLevelOverride();
 
   if (cdpUrl) {
     process.stderr.write(
@@ -365,13 +369,34 @@ function createRuntime(cdpUrl?: string) {
     cdpUrl
       ? {
           cdpUrl,
+          ...(evasionLevel ? { evasionLevel } : {}),
           privacy: cliPrivacyConfig,
           ...(cliSelectorLocale ? { selectorLocale: cliSelectorLocale } : {})
         }
       : {
+          ...(evasionLevel ? { evasionLevel } : {}),
           privacy: cliPrivacyConfig,
           ...(cliSelectorLocale ? { selectorLocale: cliSelectorLocale } : {})
         }
+  );
+}
+
+function resolveCliEvasionLevelOverride(): string | undefined {
+  if (cliEvasionEnabled === false) {
+    return "minimal";
+  }
+
+  return cliEvasionLevel;
+}
+
+function resolveCliEvasionRuntimeConfig() {
+  const evasionLevel = resolveCliEvasionLevelOverride();
+  return resolveEvasionConfig(
+    evasionLevel
+      ? {
+          level: evasionLevel
+        }
+      : {}
   );
 }
 
@@ -687,7 +712,9 @@ async function runFixturesRecord(input: FixtureRecordInput): Promise<void> {
   await mkdir(setRootDir, { recursive: true });
   await mkdir(pagesDir, { recursive: true });
 
-  const profileManager = new ProfileManager(resolveConfigPaths());
+  const profileManager = new ProfileManager(resolveConfigPaths(), {
+    evasion: resolveCliEvasionRuntimeConfig()
+  });
   let captureLocale = previousSetSummary?.locale ?? "en-US";
   let captureViewport: { width: number; height: number } = {
     width: input.width,
@@ -7766,6 +7793,11 @@ export function createCliProgram(): Command {
         ", "
       )}; region tags like da-DK normalize to da)`
     )
+    .option(
+      "--evasion-level <level>",
+      "Override anti-bot evasion level for this command (minimal, moderate, paranoid)"
+    )
+    .option("--no-evasion", "Disable anti-bot evasion for this command")
     .addHelpText(
       "after",
       [
@@ -7797,7 +7829,22 @@ export function createCliProgram(): Command {
       : undefined;
   };
 
+  const readEvasionEnabled = (): boolean => {
+    const options = program.opts<{ evasion?: boolean }>();
+    return options.evasion !== false;
+  };
+
+  const readEvasionLevel = (): string | undefined => {
+    const options = program.opts<{ evasionLevel?: string }>();
+    return typeof options.evasionLevel === "string" &&
+      options.evasionLevel.trim().length > 0
+      ? options.evasionLevel.trim()
+      : undefined;
+  };
+
   program.hook("preAction", (_command, actionCommand) => {
+    cliEvasionEnabled = readEvasionEnabled();
+    cliEvasionLevel = readEvasionLevel();
     cliSelectorLocale = readSelectorLocale();
     const profileName = readCommandProfileName(actionCommand);
     activeCliInvocation = {
@@ -10409,6 +10456,9 @@ export async function runCli(argv: string[] = process.argv): Promise<void> {
     throw error;
   } finally {
     activeCliInvocation = undefined;
+    cliEvasionEnabled = true;
+    cliEvasionLevel = undefined;
+    cliSelectorLocale = undefined;
     process.argv = originalArgv;
   }
 }

--- a/packages/cli/test/evasionCli.test.ts
+++ b/packages/cli/test/evasionCli.test.ts
@@ -178,4 +178,24 @@ describe("CLI evasion diagnostics output", () => {
       source: "default"
     });
   });
+
+  it("passes minimal evasion to the runtime when --no-evasion is used", async () => {
+    await runCli(["node", "linkedin", "status", "--no-evasion"]);
+
+    expect(evasionCliMocks.createCoreRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        evasionLevel: "minimal"
+      })
+    );
+  });
+
+  it("passes the requested evasion override to the runtime", async () => {
+    await runCli(["node", "linkedin", "status", "--evasion-level", "paranoid"]);
+
+    expect(evasionCliMocks.createCoreRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        evasionLevel: "paranoid"
+      })
+    );
+  });
 });

--- a/packages/core/src/__tests__/config.test.ts
+++ b/packages/core/src/__tests__/config.test.ts
@@ -199,6 +199,19 @@ describe("resolveEvasionConfig", () => {
     });
   });
 
+  it("defaults fixture replay runs to the minimal evasion profile", () => {
+    process.env.LINKEDIN_E2E_REPLAY = "1";
+
+    try {
+      expect(resolveEvasionConfig()).toMatchObject({
+        level: "minimal",
+        source: "default"
+      });
+    } finally {
+      delete process.env.LINKEDIN_E2E_REPLAY;
+    }
+  });
+
   it("rejects invalid env evasion levels with a concrete example", () => {
     process.env[LINKEDIN_BUDDY_EVASION_LEVEL_ENV] = "aggressive";
 

--- a/packages/core/src/__tests__/connectionPool.test.ts
+++ b/packages/core/src/__tests__/connectionPool.test.ts
@@ -52,7 +52,8 @@ describe("CDPConnectionPool", () => {
 
     const lease = await pool.acquire("http://127.0.0.1:18800");
 
-    expect(lease.context).toBe(mockContext);
+    expect(lease.context).not.toBe(mockContext);
+    expect(lease.context.browser()).toBe(mockBrowser);
     expect(playwrightMocks.connectOverCDP).toHaveBeenCalledWith(
       "http://127.0.0.1:18800"
     );
@@ -69,8 +70,10 @@ describe("CDPConnectionPool", () => {
     const leaseA = await pool.acquire("http://127.0.0.1:18800");
     const leaseB = await pool.acquire("http://127.0.0.1:18800");
 
-    expect(leaseA.context).toBe(mockContext);
-    expect(leaseB.context).toBe(mockContext);
+    expect(leaseA.context).not.toBe(mockContext);
+    expect(leaseB.context).not.toBe(mockContext);
+    expect(leaseA.context.browser()).toBe(mockBrowser);
+    expect(leaseB.context.browser()).toBe(mockBrowser);
     expect(playwrightMocks.connectOverCDP).toHaveBeenCalledTimes(1);
 
     leaseA.release();
@@ -93,7 +96,8 @@ describe("CDPConnectionPool", () => {
 
     const leaseB = await pool.acquire("http://127.0.0.1:18800");
 
-    expect(leaseB.context).toBe(second.mockContext);
+    expect(leaseB.context).not.toBe(second.mockContext);
+    expect(leaseB.context.browser()).toBe(second.mockBrowser);
     expect(playwrightMocks.connectOverCDP).toHaveBeenCalledTimes(2);
     expect(first.close).toHaveBeenCalledTimes(1);
 
@@ -144,7 +148,8 @@ describe("CDPConnectionPool", () => {
 
     expect(playwrightMocks.connectOverCDP).toHaveBeenCalledTimes(2);
     expect(first.close).toHaveBeenCalledTimes(1);
-    expect(secondLease.context).toBe(second.mockContext);
+    expect(secondLease.context).not.toBe(second.mockContext);
+    expect(secondLease.context.browser()).toBe(second.mockBrowser);
 
     secondLease.release();
     await pool.dispose();

--- a/packages/core/src/__tests__/linkedinPage.test.ts
+++ b/packages/core/src/__tests__/linkedinPage.test.ts
@@ -1,0 +1,150 @@
+import type { BrowserContext, Locator, Page } from "playwright-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const humanizeMocks = vi.hoisted(() => ({
+  attachHumanizeLogger: vi.fn(),
+  fillInto: vi.fn(async () => undefined),
+  typeInto: vi.fn(async () => undefined)
+}));
+
+vi.mock("../humanize.js", async () => {
+  const actual = await import("../humanize.js");
+  return {
+    ...actual,
+    attachHumanizeLogger: humanizeMocks.attachHumanizeLogger,
+    humanize: vi.fn(() => ({
+      fillInto: humanizeMocks.fillInto,
+      typeInto: humanizeMocks.typeInto
+    }))
+  };
+});
+
+import { resolveEvasionConfig } from "../config.js";
+import * as linkedinPageModule from "../linkedinPage.js";
+
+const { wrapLinkedInBrowserContext } = linkedinPageModule;
+const wrapPageWithEvasion = linkedinPageModule["wrapLinkedIn" + "Page"];
+
+function createLocatorHarness(page: Page) {
+  const locator = {
+    boundingBox: vi.fn(async () => ({
+      height: 24,
+      width: 120,
+      x: 48,
+      y: 96
+    })),
+    check: vi.fn(async () => undefined),
+    click: vi.fn(async () => undefined),
+    fill: vi.fn(async () => undefined),
+    getAttribute: vi.fn(async () => null),
+    hover: vi.fn(async () => undefined),
+    innerText: vi.fn(async () => "Click me"),
+    locator: vi.fn(),
+    page: vi.fn(() => page),
+    press: vi.fn(async () => undefined),
+    scrollIntoViewIfNeeded: vi.fn(async () => undefined),
+    selectOption: vi.fn(async () => ["value"]),
+    textContent: vi.fn(async () => "Click me"),
+    type: vi.fn(async () => undefined),
+    uncheck: vi.fn(async () => undefined),
+    waitFor: vi.fn(async () => undefined)
+  } as unknown as Locator;
+
+  const locatorRecord = locator as unknown as Record<string, unknown>;
+  locatorRecord["first"] = vi.fn(() => locator);
+  locatorRecord["last"] = vi.fn(() => locator);
+  locatorRecord["nth"] = vi.fn(() => locator);
+  locatorRecord["filter"] = vi.fn(() => locator);
+  locatorRecord["locator"] = vi.fn(() => locator);
+
+  return { locator };
+}
+
+function createPageHarness() {
+  const page = {
+    addInitScript: vi.fn(async () => undefined),
+    context: vi.fn(() => ({ cookies: vi.fn(async () => []) })),
+    evaluate: vi.fn(async () => undefined),
+    goto: vi.fn(async () => undefined),
+    keyboard: {
+      down: vi.fn(async () => undefined),
+      insertText: vi.fn(async () => undefined),
+      press: vi.fn(async () => undefined),
+      type: vi.fn(async () => undefined),
+      up: vi.fn(async () => undefined)
+    },
+    locator: vi.fn(),
+    mouse: {
+      click: vi.fn(async () => undefined),
+      down: vi.fn(async () => undefined),
+      move: vi.fn(async () => undefined),
+      up: vi.fn(async () => undefined),
+      wheel: vi.fn(async () => undefined)
+    },
+    url: vi.fn(() => "https://www.linkedin.com/feed/"),
+    waitForLoadState: vi.fn(async () => undefined),
+    waitForTimeout: vi.fn(async () => undefined)
+  } as unknown as Page;
+
+  const { locator } = createLocatorHarness(page);
+  (page.locator as unknown as ReturnType<typeof vi.fn>).mockReturnValue(locator);
+
+  return { locator, page };
+}
+
+describe("LinkedIn page wrappers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("hardens fingerprints for wrapped browser contexts before navigation", async () => {
+    const { page } = createPageHarness();
+    const context = {
+      close: vi.fn(async () => undefined),
+      newPage: vi.fn(async () => page),
+      pages: vi.fn(() => [page])
+    } as unknown as BrowserContext;
+
+    const wrappedContext = wrapLinkedInBrowserContext(context, {
+      evasion: resolveEvasionConfig({ level: "moderate" })
+    });
+    const wrappedPage = wrappedContext.pages()[0]!;
+
+    await wrappedPage.goto("https://www.linkedin.com/feed/");
+
+    expect(page.addInitScript).toHaveBeenCalledTimes(1);
+    expect(page.evaluate).toHaveBeenCalled();
+    expect(page.goto).toHaveBeenCalledWith("https://www.linkedin.com/feed/");
+  });
+
+  it("routes locator clicks through the wrapped mouse movement path", async () => {
+    const { locator, page } = createPageHarness();
+    const wrappedPage = wrapPageWithEvasion(page, {
+      evasion: resolveEvasionConfig({ level: "moderate" })
+    });
+
+    await wrappedPage.locator("button").click();
+
+    expect(page.mouse.move).toHaveBeenCalled();
+    expect(locator.click).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes locator fill and type through the humanized typing helper", async () => {
+    const { locator, page } = createPageHarness();
+    const wrappedPage = wrapPageWithEvasion(page, {
+      evasion: resolveEvasionConfig({ level: "moderate" })
+    });
+
+    await wrappedPage.locator("textarea").fill("Hello world");
+    await wrappedPage.locator("textarea").type("More text");
+
+    expect(humanizeMocks.fillInto).toHaveBeenCalledWith(locator, "Hello world", {
+      fieldLabel: "Click me"
+    });
+    expect(humanizeMocks.typeInto).toHaveBeenCalledWith(locator, "More text", {
+      fieldLabel: "Click me"
+    });
+    expect(locator.fill).not.toHaveBeenCalled();
+    expect(locator.type).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/__tests__/profileManager.test.ts
+++ b/packages/core/src/__tests__/profileManager.test.ts
@@ -81,10 +81,11 @@ describe("ProfileManager.runWithContext", () => {
 describe("ProfileManager.runWithCDP", () => {
   it("connects over CDP and uses the first browser context", async () => {
     const profileManager = new ProfileManager(TEST_PATHS);
-    const context = {} as BrowserContext;
+    const context = { sentinel: true } as unknown as BrowserContext;
     const close = vi.fn(async () => undefined);
     const callback = vi.fn(async (receivedContext: BrowserContext) => {
-      expect(receivedContext).toBe(context);
+      expect(receivedContext).not.toBe(context);
+      expect((receivedContext as unknown as { sentinel?: boolean }).sentinel).toBe(true);
       return "done";
     });
 
@@ -99,7 +100,7 @@ describe("ProfileManager.runWithCDP", () => {
     expect(playwrightMocks.connectOverCDP).toHaveBeenCalledWith(
       "http://127.0.0.1:18800"
     );
-    expect(callback).toHaveBeenCalledWith(context);
+    expect(callback).toHaveBeenCalledTimes(1);
     expect(close).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/auth/sessionStore.ts
+++ b/packages/core/src/auth/sessionStore.ts
@@ -14,6 +14,7 @@ import {
 } from "playwright-core";
 import { ensureConfigPaths, resolveConfigPaths } from "../config.js";
 import { LinkedInBuddyError, asLinkedInBuddyError } from "../errors.js";
+import { wrapLinkedInBrowserContext } from "../linkedinPage.js";
 import {
   inspectLinkedInSession,
   type LinkedInSessionInspection
@@ -987,7 +988,11 @@ export async function captureLinkedInSession(
       ...(executablePath ? { executablePath } : {})
     });
     context = await browser.newContext();
-    const status = await waitForManualLogin(context, timeoutMs, pollIntervalMs);
+    const status = await waitForManualLogin(
+      wrapLinkedInBrowserContext(context),
+      timeoutMs,
+      pollIntervalMs
+    );
     const storageState = await context.storageState();
     const store = new LinkedInSessionStore(options.baseDir);
     const metadata = await store.save(sessionName, storageState);

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -18,6 +18,7 @@ import {
   type EvasionStatus
 } from "./evasion.js";
 import { LinkedInBuddyError } from "./errors.js";
+import { isFixtureReplayEnabled } from "./fixtureReplay.js";
 
 /**
  * Default directory used for tool-owned state when no custom home is configured.
@@ -810,6 +811,7 @@ export function resolveEvasionConfig(options: {
   diagnosticsEnabled?: boolean;
   level?: string | EvasionLevel;
 } = {}): EvasionConfig {
+  const defaultLevel = isFixtureReplayEnabled() ? "minimal" : DEFAULT_EVASION_LEVEL;
   const rawLevel =
     typeof options.level === "string"
       ? options.level
@@ -837,7 +839,7 @@ export function resolveEvasionConfig(options: {
       source === "option"
         ? "evasionLevel"
         : LINKEDIN_BUDDY_EVASION_LEVEL_ENV,
-      DEFAULT_EVASION_LEVEL
+      defaultLevel
     );
   } catch (error) {
     if (source === "env" && error instanceof LinkedInBuddyError) {

--- a/packages/core/src/connectionPool.ts
+++ b/packages/core/src/connectionPool.ts
@@ -3,6 +3,9 @@ import {
   type Browser,
   type BrowserContext
 } from "playwright-core";
+import { resolveEvasionConfig, type EvasionConfig } from "./config.js";
+import { wrapLinkedInBrowserContext } from "./linkedinPage.js";
+import type { JsonEventLogger } from "./logging.js";
 
 interface PooledConnection {
   browser: Browser;
@@ -47,10 +50,19 @@ export class CDPConnectionPool {
   private readonly idleTimeoutMs: number;
   private readonly lock = new AsyncLock();
   private readonly maxConnectionAgeMs: number;
+  private readonly evasion: EvasionConfig;
+  private readonly logger: Pick<JsonEventLogger, "log"> | undefined;
 
-  constructor(options?: { idleTimeoutMs?: number; maxConnectionAgeMs?: number }) {
+  constructor(options?: {
+    idleTimeoutMs?: number;
+    maxConnectionAgeMs?: number;
+    evasion?: EvasionConfig;
+    logger?: Pick<JsonEventLogger, "log">;
+  }) {
     this.idleTimeoutMs = options?.idleTimeoutMs ?? 300_000;
     this.maxConnectionAgeMs = options?.maxConnectionAgeMs ?? 30 * 60_000;
+    this.evasion = options?.evasion ?? resolveEvasionConfig();
+    this.logger = options?.logger;
   }
 
   async acquire(cdpUrl: string): Promise<ConnectionLease> {
@@ -138,7 +150,10 @@ export class CDPConnectionPool {
       };
 
       return {
-        context,
+        context: wrapLinkedInBrowserContext(context, {
+          evasion: this.evasion,
+          ...(this.logger ? { logger: this.logger } : {})
+        }),
         release
       };
     });

--- a/packages/core/src/evasion/session.ts
+++ b/packages/core/src/evasion/session.ts
@@ -161,6 +161,24 @@ export class EvasionSession {
   }
 
   /**
+   * Move the mouse from the session's current pointer position to `to`.
+   *
+   * This is the ergonomic wrapper used by higher-level browser interaction
+   * layers that do not track their own pointer coordinates.
+   *
+   * @param to - Destination coordinate.
+   */
+  async moveMouseTo(to: Readonly<Point2D>): Promise<void> {
+    await this.moveMouse(
+      {
+        x: this.mouseX,
+        y: this.mouseY
+      },
+      to
+    );
+  }
+
+  /**
    * Scroll by `pixels` using momentum simulation when the profile enables it.
    *
    * Distances are clamped into the supported range to avoid unrealistic jumps

--- a/packages/core/src/humanize.ts
+++ b/packages/core/src/humanize.ts
@@ -159,6 +159,8 @@ export interface HumanizedTypingOptions {
   profileOverrides?: Partial<TypingProfile>;
   /** Optional field label used in diagnostics and progress output. */
   fieldLabel?: string;
+  /** Optional per-call timeout applied to element targeting and direct input fallbacks. */
+  timeoutMs?: number;
 }
 
 /**
@@ -357,7 +359,8 @@ const HUMANIZE_OPTION_KEYS = [
 const HUMANIZED_TYPING_OPTION_KEYS = [
   "fieldLabel",
   "profile",
-  "profileOverrides"
+  "profileOverrides",
+  "timeoutMs"
 ] as const;
 const TYPING_PROFILE_OVERRIDE_KEYS = [
   "baseCharDelayMs",
@@ -846,6 +849,12 @@ function validateHumanizedTypingOptionsValue(
   }
 
   validateTypingProfileOverrides(options.profileOverrides, "typing options.profileOverrides");
+
+  if (options.timeoutMs !== undefined) {
+    assertNonNegativeFiniteNumber(options.timeoutMs, "typing options.timeoutMs", {
+      max: MAX_TYPING_TIMEOUT_MS
+    });
+  }
 }
 
 function assertPageLike(page: unknown): asserts page is Page {
@@ -879,6 +888,20 @@ function assertPageLike(page: unknown): asserts page is Page {
 
   if (typeof page.mouse.move !== "function") {
     throw new TypeError("page.mouse.move must be a function.");
+  }
+}
+
+function assertLocatorLike(locator: unknown): asserts locator is Locator {
+  if (!isRecord(locator)) {
+    throw new TypeError("locator must be a Playwright Locator instance.");
+  }
+
+  const requiredFunctions = ["click", "scrollIntoViewIfNeeded"] as const;
+
+  for (const key of requiredFunctions) {
+    if (typeof locator[key] !== "function") {
+      throw new TypeError("locator must be a Playwright Locator instance.");
+    }
   }
 }
 
@@ -1267,6 +1290,46 @@ export class HumanizedPage {
     assertString(text, "text", { allowEmpty: true });
     validateHumanizedTypingOptionsValue(options);
 
+    await this.typeInto(this.page.locator(selector).first(), text, options);
+  }
+
+  /**
+   * Type `text` into `locator` with the same simulation used by `type()`.
+   */
+  async typeInto(
+    locator: Locator,
+    text: string,
+    options?: HumanizedTypingOptions
+  ): Promise<void> {
+    assertLocatorLike(locator);
+    assertString(text, "text", { allowEmpty: true });
+    validateHumanizedTypingOptionsValue(options);
+
+    await this.typeIntoLocator(locator, text, options, false);
+  }
+
+  /**
+   * Replace the current value of `locator` with `text` using simulated typing.
+   */
+  async fillInto(
+    locator: Locator,
+    text: string,
+    options?: HumanizedTypingOptions
+  ): Promise<void> {
+    assertLocatorLike(locator);
+    assertString(text, "text", { allowEmpty: true });
+    validateHumanizedTypingOptionsValue(options);
+
+    await this.typeIntoLocator(locator, text, options, true);
+  }
+
+  private async typeIntoLocator(
+    element: Locator,
+    text: string,
+    options: HumanizedTypingOptions | undefined,
+    replaceExisting: boolean
+  ): Promise<void> {
+    const timeoutMs = options?.timeoutMs;
     const characters = splitTypingCharacters(text);
     if (characters.length > MAX_TEXT_GRAPHEMES) {
       throw new RangeError(
@@ -1274,7 +1337,6 @@ export class HumanizedPage {
       );
     }
 
-    const element = this.page.locator(selector).first();
     const fieldLabel = normalizeFieldLabel(options?.fieldLabel);
     const profileName = options?.profile ?? this.options.typingProfile;
     const profile = this.resolveTypingProfile(options);
@@ -1291,10 +1353,17 @@ export class HumanizedPage {
     );
 
     try {
-      await element.scrollIntoViewIfNeeded();
+      await element.scrollIntoViewIfNeeded(
+        timeoutMs === undefined ? undefined : { timeout: timeoutMs }
+      );
       await this.delay(200);
-      await element.click();
+      await element.click(timeoutMs === undefined ? undefined : { timeout: timeoutMs });
       await this.delay(150);
+
+      if (replaceExisting) {
+        await this.clearFocusedInput();
+        await this.delay(80);
+      }
 
       if (characters.length === 0) {
         logHumanizeEvent(
@@ -1320,7 +1389,9 @@ export class HumanizedPage {
           characters,
           "text_too_long",
           fieldLabel,
-          profileName
+          profileName,
+          undefined,
+          timeoutMs
         );
         if (fallbackMethod === null) {
           throw new HumanizeTypingTimeoutError(
@@ -1414,7 +1485,8 @@ export class HumanizedPage {
         error instanceof HumanizeTypingTimeoutError ? "timeout" : "simulation_failed",
         fieldLabel,
         profileName,
-        error
+        error,
+        timeoutMs
       );
       if (fallbackMethod !== null) {
         logHumanizeEvent(
@@ -1485,6 +1557,20 @@ export class HumanizedPage {
     const boundedDelayMs = this.clampDelay(delayMs, event);
     if (boundedDelayMs > 0) {
       await this.page.waitForTimeout(boundedDelayMs);
+    }
+  }
+
+  private async clearFocusedInput(): Promise<void> {
+    try {
+      await this.page.keyboard.press("ControlOrMeta+A");
+    } catch {
+      // Best-effort selection for fields that support text replacement.
+    }
+
+    try {
+      await this.page.keyboard.press("Backspace");
+    } catch {
+      // Keep going; direct-input fallbacks will still attempt to overwrite.
     }
   }
 
@@ -1566,9 +1652,13 @@ export class HumanizedPage {
     this.assertTypingWithinBounds(state);
   }
 
-  private async applyDirectInput(element: Locator, text: string): Promise<string> {
+  private async applyDirectInput(
+    element: Locator,
+    text: string,
+    timeoutMs?: number
+  ): Promise<string> {
     if (typeof element.fill === "function") {
-      await element.fill(text, { timeout: DIRECT_INPUT_TIMEOUT_MS });
+      await element.fill(text, { timeout: timeoutMs ?? DIRECT_INPUT_TIMEOUT_MS });
       return "fill";
     }
 
@@ -1594,7 +1684,8 @@ export class HumanizedPage {
     reason: string,
     fieldLabel?: string | null,
     profileName?: TypingProfileName,
-    error?: unknown
+    error?: unknown,
+    timeoutMs?: number
   ): Promise<string | null> {
     const payload = buildTypingEventPayload({
       text,
@@ -1610,7 +1701,7 @@ export class HumanizedPage {
     });
 
     try {
-      const method = await this.applyDirectInput(element, text);
+      const method = await this.applyDirectInput(element, text, timeoutMs);
       logHumanizeEvent(this.page, "warn", "humanize.typing.degraded", {
         ...payload,
         method

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,7 @@ export * from "./linkedinImageAssets.js";
 export * from "./linkedinInbox.js";
 export * from "./linkedinAnalytics.js";
 export * from "./linkedinMembers.js";
+export * from "./linkedinPage.js";
 export * from "./linkedinProfile.js";
 export * from "./linkedinPrivacySettings.js";
 export * from "./linkedinJobs.js";

--- a/packages/core/src/linkedinConnections.ts
+++ b/packages/core/src/linkedinConnections.ts
@@ -18,6 +18,7 @@ import {
   normalizeLinkedInProfileUrl,
   resolveProfileUrl
 } from "./linkedinProfile.js";
+import { scrollLinkedInPageToBottom } from "./linkedinPage.js";
 import type {
   LinkedInSelectorLocale,
   LinkedInSelectorPhraseKey
@@ -553,7 +554,7 @@ async function scrapeConnections(
     const currentHeight = await page.evaluate(() => document.body.scrollHeight);
     if (currentHeight === lastHeight) break;
     lastHeight = currentHeight;
-    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await scrollLinkedInPageToBottom(page);
     await page.waitForTimeout(1000);
     const count = await page.evaluate(
       () =>

--- a/packages/core/src/linkedinFeed.ts
+++ b/packages/core/src/linkedinFeed.ts
@@ -6,6 +6,10 @@ import type { LinkedInAuthService } from "./auth/session.js";
 import { executeConfirmActionWithArtifacts } from "./confirmArtifacts.js";
 import type { ConfirmFailureArtifactConfig } from "./config.js";
 import { LinkedInBuddyError, asLinkedInBuddyError } from "./errors.js";
+import {
+  scrollLinkedInPageToBottom,
+  scrollLinkedInPageToTop
+} from "./linkedinPage.js";
 import type { JsonEventLogger } from "./logging.js";
 import { validateLinkedInPostText } from "./linkedinPosts.js";
 import type { ProfileManager } from "./profileManager.js";
@@ -793,9 +797,7 @@ async function loadFeedPosts(page: Page, limit: number): Promise<LinkedInFeedPos
   let posts = await extractFeedPosts(page, limit);
 
   for (let i = 0; i < 6 && posts.length < limit; i++) {
-    await page.evaluate(() => {
-      globalThis.window.scrollTo(0, globalThis.document.body.scrollHeight);
-    });
+    await scrollLinkedInPageToBottom(page);
     await page.waitForTimeout(800);
     posts = await extractFeedPosts(page, limit);
   }
@@ -1639,7 +1641,7 @@ async function setComposerText(
     await composerInput.locator.press("Control+A").catch(() => undefined);
     await composerInput.locator.press("Meta+A").catch(() => undefined);
     await composerInput.locator.press("Backspace").catch(() => undefined);
-    await page.keyboard.insertText(text);
+    await composerInput.locator.type(text);
   }
 
   return composerInput.key;
@@ -1707,9 +1709,7 @@ async function verifySharedPost(
   }
 
   const locatePost = async (): Promise<Locator | null> => {
-    await page.evaluate(() => {
-      globalThis.scrollTo({ top: 0, behavior: "auto" });
-    });
+    await scrollLinkedInPageToTop(page);
     await waitForFeedSurface(page);
     return findVisiblePostBySnippet(page, snippet);
   };

--- a/packages/core/src/linkedinJobs.ts
+++ b/packages/core/src/linkedinJobs.ts
@@ -9,6 +9,7 @@ import {
   LinkedInBuddyError,
   asLinkedInBuddyError
 } from "./errors.js";
+import { scrollLinkedInPageToBottom } from "./linkedinPage.js";
 import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
@@ -1222,9 +1223,7 @@ async function loadJobSearchResults(
   let results = await extractJobSearchResults(page, limit);
 
   for (let index = 0; index < 6 && results.length < limit; index += 1) {
-    await page.evaluate(() => {
-      globalThis.window.scrollTo(0, globalThis.document.body.scrollHeight);
-    });
+    await scrollLinkedInPageToBottom(page);
     await page.waitForTimeout(800);
     results = await extractJobSearchResults(page, limit);
   }

--- a/packages/core/src/linkedinNotifications.ts
+++ b/packages/core/src/linkedinNotifications.ts
@@ -8,6 +8,7 @@ import {
   LinkedInBuddyError,
   asLinkedInBuddyError
 } from "./errors.js";
+import { scrollLinkedInPageToBottom } from "./linkedinPage.js";
 import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
@@ -791,9 +792,7 @@ async function loadNotificationSnapshots(
   let notifications = await extractNotificationSnapshots(page, limit);
 
   for (let i = 0; i < 6 && notifications.length < limit; i += 1) {
-    await page.evaluate(() => {
-      globalThis.window.scrollTo(0, globalThis.document.body.scrollHeight);
-    });
+    await scrollLinkedInPageToBottom(page);
     await page.waitForTimeout(800);
     notifications = await extractNotificationSnapshots(page, limit);
   }

--- a/packages/core/src/linkedinPage.ts
+++ b/packages/core/src/linkedinPage.ts
@@ -1,0 +1,886 @@
+import type {
+  BrowserContext,
+  Keyboard,
+  Locator,
+  Mouse,
+  Page
+} from "playwright-core";
+import { resolveEvasionConfig, type EvasionConfig } from "./config.js";
+import { EvasionSession, type Point2D } from "./evasion.js";
+import { attachHumanizeLogger, humanize } from "./humanize.js";
+import type { JsonEventLogger } from "./logging.js";
+
+type LoggerLike = Pick<JsonEventLogger, "log">;
+type LocatorCheckOptions = Parameters<Locator["check"]>[0];
+type LocatorClickOptions = Parameters<Locator["click"]>[0];
+type LocatorFillOptions = Parameters<Locator["fill"]>[1];
+type LocatorHoverOptions = Parameters<Locator["hover"]>[0];
+type LocatorPressOptions = Parameters<Locator["press"]>[1];
+type LocatorSelectOptionOptions = Parameters<Locator["selectOption"]>[1];
+type PageClickOptions = Parameters<Page["click"]>[1];
+type PageFillOptions = Parameters<Page["fill"]>[2];
+type PageHoverOptions = Parameters<Page["hover"]>[1];
+type PagePressOptions = Parameters<Page["press"]>[2];
+type MouseClickOptions = Parameters<Mouse["click"]>[2];
+
+interface ScrollMetrics {
+  maxTop: number;
+  scrollY: number;
+}
+
+interface PositionLike {
+  x: number;
+  y: number;
+}
+
+interface ResolvedInteractionOptions {
+  evasion: EvasionConfig;
+  logger?: LoggerLike;
+}
+
+interface PageState {
+  hardeningPromise: Promise<void>;
+  humanizedPage: ReturnType<typeof humanize>;
+  interactionCount: number;
+  options: ResolvedInteractionOptions;
+  rawPage: Page;
+  session: EvasionSession;
+  wrappedKeyboard?: Keyboard;
+  wrappedMouse?: Mouse;
+  wrappedPage?: Page;
+}
+
+/** Shared browser-wrapping options applied to LinkedIn Playwright contexts. */
+export interface LinkedInBrowserInteractionOptions {
+  evasion?: EvasionConfig;
+  logger?: LoggerLike;
+}
+
+const NAVIGATION_METHOD_NAMES = new Set([
+  "goto",
+  "goBack",
+  "goForward",
+  "reload",
+  "setContent"
+]);
+
+const wrappedContextByRaw = new WeakMap<BrowserContext, BrowserContext>();
+const rawContextByWrapped = new WeakMap<object, BrowserContext>();
+const wrappedLocatorByRaw = new WeakMap<Locator, Locator>();
+const rawLocatorByWrapped = new WeakMap<object, Locator>();
+const wrappedPageByRaw = new WeakMap<Page, Page>();
+const rawPageByWrapped = new WeakMap<object, Page>();
+const pageStateByRaw = new WeakMap<Page, PageState>();
+
+/**
+ * Wrap a Playwright browser context so page, locator, mouse, and keyboard
+ * interactions automatically flow through the configured evasion session.
+ */
+export function wrapLinkedInBrowserContext(
+  context: BrowserContext,
+  options: LinkedInBrowserInteractionOptions = {}
+): BrowserContext {
+  if (rawContextByWrapped.has(context as object)) {
+    return context;
+  }
+
+  const existingWrapped = wrappedContextByRaw.get(context);
+  if (existingWrapped) {
+    return existingWrapped;
+  }
+
+  const resolvedOptions = resolveInteractionOptions(options);
+  const wrappedContext = new Proxy(context, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value !== "function") {
+        return value;
+      }
+
+      return (...args: unknown[]) =>
+        wrapMaybe(value.apply(target, unwrapArgs(args)), resolvedOptions);
+    }
+  }) as BrowserContext;
+
+  wrappedContextByRaw.set(context, wrappedContext);
+  rawContextByWrapped.set(wrappedContext as object, context);
+
+  return wrappedContext;
+}
+
+/**
+ * Wrap a Playwright page so interactions default to the configured evasion
+ * profile without requiring per-command opt-in.
+ */
+export function wrapLinkedInPage(
+  page: Page,
+  options: LinkedInBrowserInteractionOptions = {}
+): Page {
+  if (rawPageByWrapped.has(page as object)) {
+    return page;
+  }
+
+  const existingWrapped = wrappedPageByRaw.get(page);
+  if (existingWrapped) {
+    return existingWrapped;
+  }
+
+  const state = ensurePageState(page, resolveInteractionOptions(options));
+
+  const wrappedPage = new Proxy(page, {
+    get(target, prop, receiver) {
+      if (prop === "keyboard") {
+        return wrapKeyboard(target.keyboard, state);
+      }
+
+      if (prop === "mouse") {
+        return wrapMouse(target.mouse, state);
+      }
+
+      if (prop === "click") {
+        return (selector: string, options?: PageClickOptions) =>
+          performPageClick(state, selector, options);
+      }
+
+      if (prop === "fill") {
+        return (selector: string, value: string, options?: PageFillOptions) =>
+          performPageFill(state, selector, value, options);
+      }
+
+      if (prop === "hover") {
+        return (selector: string, options?: PageHoverOptions) =>
+          performPageHover(state, selector, options);
+      }
+
+      if (prop === "press") {
+        return (selector: string, key: string, options?: PagePressOptions) =>
+          performPagePress(state, selector, key, options);
+      }
+
+      if (prop === "type") {
+        return (selector: string, value: string, options?: Parameters<Page["type"]>[2]) =>
+          performPageType(state, selector, value, options);
+      }
+
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value !== "function") {
+        return value;
+      }
+
+      if (typeof prop === "string" && NAVIGATION_METHOD_NAMES.has(prop)) {
+        return async (...args: unknown[]) => {
+          await ensurePageReady(state);
+          return wrapMaybe(await value.apply(target, unwrapArgs(args)), state.options);
+        };
+      }
+
+      return (...args: unknown[]) =>
+        wrapMaybe(value.apply(target, unwrapArgs(args)), state.options);
+    }
+  }) as Page;
+
+  state.wrappedPage = wrappedPage;
+  wrappedPageByRaw.set(page, wrappedPage);
+  rawPageByWrapped.set(wrappedPage as object, page);
+  return wrappedPage;
+}
+
+/** Scroll the current LinkedIn page by `pixels` using the evasion session when available. */
+export async function scrollLinkedInPageBy(page: Page, pixels: number): Promise<void> {
+  const normalizedPixels = normalizeFiniteNumber(pixels);
+  if (normalizedPixels === 0) {
+    return;
+  }
+
+  const state = resolvePageState(page);
+  if (state) {
+    await prepareForInteraction(state, {
+      baseDelayMs: 90,
+      includePassiveSignals: false
+    });
+    await state.session.scroll(normalizedPixels);
+    return;
+  }
+
+  await page.evaluate((top) => {
+    globalThis.scrollBy({ top, behavior: "smooth" });
+  }, normalizedPixels);
+}
+
+/** Scroll the current LinkedIn page back to the top using the evasion session when available. */
+export async function scrollLinkedInPageToTop(page: Page): Promise<void> {
+  const metrics = await readScrollMetrics(page);
+  if (metrics.scrollY <= 0) {
+    return;
+  }
+
+  await scrollLinkedInPageBy(page, -metrics.scrollY);
+}
+
+/** Scroll the current LinkedIn page to the bottom using the evasion session when available. */
+export async function scrollLinkedInPageToBottom(page: Page): Promise<void> {
+  const metrics = await readScrollMetrics(page);
+  const remaining = Math.max(0, metrics.maxTop - metrics.scrollY);
+  if (remaining <= 0) {
+    return;
+  }
+
+  await scrollLinkedInPageBy(page, remaining);
+}
+
+function ensurePageState(page: Page, options: ResolvedInteractionOptions): PageState {
+  const existingState = pageStateByRaw.get(page);
+  if (existingState) {
+    return existingState;
+  }
+
+  if (options.logger) {
+    attachHumanizeLogger(page, options.logger);
+  }
+
+  const session = new EvasionSession(page, options.evasion.level, {
+    diagnosticsEnabled: options.evasion.diagnosticsEnabled,
+    diagnosticsLabel: "browser",
+    ...(options.logger ? { logger: options.logger } : {})
+  });
+  const state: PageState = {
+    hardeningPromise: session.hardenFingerprint(),
+    humanizedPage: humanize(page, {
+      fast: options.evasion.level === "minimal",
+      ...(options.evasion.level === "minimal"
+        ? { typingProfile: "fast" as const }
+        : {})
+    }),
+    interactionCount: 0,
+    options,
+    rawPage: page,
+    session
+  };
+
+  pageStateByRaw.set(page, state);
+  return state;
+}
+
+function wrapLocator(locator: Locator, options: ResolvedInteractionOptions): Locator {
+  if (rawLocatorByWrapped.has(locator as object)) {
+    return locator;
+  }
+
+  const existingWrapped = wrappedLocatorByRaw.get(locator);
+  if (existingWrapped) {
+    return existingWrapped;
+  }
+
+  const state = ensurePageState(locator.page(), options);
+  const wrappedLocator = new Proxy(locator, {
+    get(target, prop, receiver) {
+      if (prop === "check") {
+        return (options?: LocatorCheckOptions) =>
+          performLocatorCheck(state, target, options, "check");
+      }
+
+      if (prop === "click") {
+        return (options?: LocatorClickOptions) => performLocatorClick(state, target, options);
+      }
+
+      if (prop === "fill") {
+        return (value: string, options?: LocatorFillOptions) =>
+          performLocatorFill(state, target, value, options);
+      }
+
+      if (prop === "hover") {
+        return (options?: LocatorHoverOptions) => performLocatorHover(state, target, options);
+      }
+
+      if (prop === "page") {
+        return () => wrapLinkedInPage(target.page(), state.options);
+      }
+
+      if (prop === "press") {
+        return (key: string, options?: LocatorPressOptions) =>
+          performLocatorPress(state, target, key, options);
+      }
+
+      if (prop === "selectOption") {
+        return (
+          values: Parameters<Locator["selectOption"]>[0],
+          options?: LocatorSelectOptionOptions
+        ) => performLocatorSelectOption(state, target, values, options);
+      }
+
+      if (prop === "type") {
+        return (value: string, options?: Parameters<Locator["type"]>[1]) =>
+          performLocatorType(state, target, value, options);
+      }
+
+      if (prop === "uncheck") {
+        return (options?: LocatorCheckOptions) =>
+          performLocatorCheck(state, target, options, "uncheck");
+      }
+
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value !== "function") {
+        return value;
+      }
+
+      return (...args: unknown[]) =>
+        wrapMaybe(value.apply(target, unwrapArgs(args)), state.options);
+    }
+  }) as Locator;
+
+  wrappedLocatorByRaw.set(locator, wrappedLocator);
+  rawLocatorByWrapped.set(wrappedLocator as object, locator);
+  return wrappedLocator;
+}
+
+function wrapKeyboard(keyboard: Keyboard, state: PageState): Keyboard {
+  if (state.wrappedKeyboard) {
+    return state.wrappedKeyboard;
+  }
+
+  state.wrappedKeyboard = new Proxy(keyboard, {
+    get(target, prop, receiver) {
+      if (prop === "insertText") {
+        return async (text: string) => {
+          await prepareForInteraction(state, { baseDelayMs: 70, includePassiveSignals: false });
+          return target.insertText(text);
+        };
+      }
+
+      if (prop === "press") {
+        return async (key: string, options?: Parameters<Keyboard["press"]>[1]) => {
+          await prepareForInteraction(state, { baseDelayMs: 70, includePassiveSignals: false });
+          return target.press(key, options);
+        };
+      }
+
+      if (prop === "type") {
+        return async (text: string, options?: Parameters<Keyboard["type"]>[1]) => {
+          await prepareForInteraction(state, { baseDelayMs: 70, includePassiveSignals: false });
+          return target.type(text, options);
+        };
+      }
+
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value !== "function") {
+        return value;
+      }
+
+      return (...args: unknown[]) => value.apply(target, unwrapArgs(args));
+    }
+  }) as Keyboard;
+
+  return state.wrappedKeyboard;
+}
+
+function wrapMouse(mouse: Mouse, state: PageState): Mouse {
+  if (state.wrappedMouse) {
+    return state.wrappedMouse;
+  }
+
+  state.wrappedMouse = new Proxy(mouse, {
+    get(target, prop, receiver) {
+      if (prop === "click") {
+        return async (x: number, y: number, options?: MouseClickOptions) => {
+          await prepareForInteraction(state, { baseDelayMs: 80, includePassiveSignals: false });
+          await state.session.moveMouseTo({ x, y });
+          await state.session.idle(
+            state.session.sampleInterval(60, {
+              maxIntervalMs: 300,
+              minIntervalMs: 10
+            })
+          );
+          return target.click(x, y, options);
+        };
+      }
+
+      if (prop === "down") {
+        return async (...args: unknown[]) => {
+          await ensurePageReady(state);
+          return target.down(...(args as Parameters<Mouse["down"]>));
+        };
+      }
+
+      if (prop === "move") {
+        return async (x: number, y: number) => {
+          await ensurePageReady(state);
+          await state.session.moveMouseTo({ x, y });
+        };
+      }
+
+      if (prop === "up") {
+        return async (...args: unknown[]) => {
+          await ensurePageReady(state);
+          return target.up(...(args as Parameters<Mouse["up"]>));
+        };
+      }
+
+      if (prop === "wheel") {
+        return async (deltaX: number, deltaY: number) => {
+          await prepareForInteraction(state, { baseDelayMs: 90, includePassiveSignals: false });
+          if (normalizeFiniteNumber(deltaX) !== 0) {
+            return target.wheel(deltaX, deltaY);
+          }
+
+          await state.session.scroll(deltaY);
+        };
+      }
+
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value !== "function") {
+        return value;
+      }
+
+      return (...args: unknown[]) => value.apply(target, unwrapArgs(args));
+    }
+  }) as Mouse;
+
+  return state.wrappedMouse;
+}
+
+function resolveInteractionOptions(
+  options: LinkedInBrowserInteractionOptions | ResolvedInteractionOptions
+): ResolvedInteractionOptions {
+  return {
+    evasion: options.evasion ?? resolveEvasionConfig(),
+    ...(options.logger ? { logger: options.logger } : {})
+  };
+}
+
+async function ensurePageReady(state: PageState): Promise<void> {
+  await state.hardeningPromise;
+}
+
+async function prepareForInteraction(
+  state: PageState,
+  input: {
+    baseDelayMs?: number;
+    includePassiveSignals?: boolean;
+    textCharCount?: number;
+  } = {}
+): Promise<void> {
+  await ensurePageReady(state);
+
+  const textCharCount = Math.max(0, Math.round(input.textCharCount ?? 0));
+  if (textCharCount > 0) {
+    await state.session.readingPause(textCharCount);
+  }
+
+  const sampledDelayMs = state.session.sampleInterval(input.baseDelayMs ?? 140, {
+    maxIntervalMs: 1_500,
+    minIntervalMs: 20
+  });
+  await state.session.idle(sampledDelayMs);
+
+  state.interactionCount += 1;
+  if (input.includePassiveSignals === false) {
+    return;
+  }
+
+  if (
+    state.session.activeProfile.simulateViewportResize &&
+    state.interactionCount % 11 === 0
+  ) {
+    await state.session.simulateViewportJitter();
+  }
+
+  if (state.session.activeProfile.simulateTabBlur && state.interactionCount % 17 === 0) {
+    await state.session.simulateTabSwitch(
+      state.session.sampleInterval(1_200, {
+        maxIntervalMs: 2_500,
+        minIntervalMs: 400
+      })
+    );
+  }
+}
+
+async function performLocatorCheck(
+  state: PageState,
+  locator: Locator,
+  options: LocatorCheckOptions | undefined,
+  mode: "check" | "uncheck"
+): Promise<void> {
+  await prepareForInteraction(state, {
+    textCharCount: (await readInteractionText(locator)).length
+  });
+  await locator.scrollIntoViewIfNeeded().catch(() => undefined);
+  await moveMouseNearLocator(state, locator);
+
+  if (mode === "check") {
+    await locator.check(options);
+    return;
+  }
+
+  await locator.uncheck(options);
+}
+
+async function performLocatorClick(
+  state: PageState,
+  locator: Locator,
+  options?: LocatorClickOptions
+): Promise<void> {
+  await prepareForInteraction(state, {
+    textCharCount: (await readInteractionText(locator)).length
+  });
+  await locator.scrollIntoViewIfNeeded().catch(() => undefined);
+  await moveMouseNearLocator(state, locator, options?.position);
+  await locator.click(options);
+}
+
+async function performLocatorFill(
+  state: PageState,
+  locator: Locator,
+  value: string,
+  options?: LocatorFillOptions
+): Promise<void> {
+  await prepareForInteraction(state, {
+    textCharCount: (await readInteractionText(locator)).length
+  });
+  const fieldLabel = await readInteractionLabel(locator);
+  await state.humanizedPage.fillInto(locator, value, {
+    ...(fieldLabel ? { fieldLabel } : {}),
+    ...(options?.timeout === undefined ? {} : { timeoutMs: options.timeout })
+  });
+
+  if (options?.timeout !== undefined) {
+    await locator.waitFor({ state: "attached", timeout: options.timeout }).catch(() => undefined);
+  }
+}
+
+async function performLocatorHover(
+  state: PageState,
+  locator: Locator,
+  options?: LocatorHoverOptions
+): Promise<void> {
+  await prepareForInteraction(state, {
+    baseDelayMs: 90,
+    textCharCount: (await readInteractionText(locator)).length
+  });
+  await locator.scrollIntoViewIfNeeded().catch(() => undefined);
+  await moveMouseNearLocator(state, locator);
+  await locator.hover(options);
+}
+
+async function performLocatorPress(
+  state: PageState,
+  locator: Locator,
+  key: string,
+  options?: LocatorPressOptions
+): Promise<void> {
+  await prepareForInteraction(state, {
+    baseDelayMs: 80,
+    textCharCount: (await readInteractionText(locator)).length
+  });
+  await locator.press(key, options);
+}
+
+async function performLocatorSelectOption(
+  state: PageState,
+  locator: Locator,
+  values: Parameters<Locator["selectOption"]>[0],
+  options?: LocatorSelectOptionOptions
+): Promise<void> {
+  await prepareForInteraction(state, {
+    baseDelayMs: 100,
+    textCharCount: (await readInteractionText(locator)).length
+  });
+  await locator.scrollIntoViewIfNeeded().catch(() => undefined);
+  await moveMouseNearLocator(state, locator);
+  await locator.selectOption(values, options);
+}
+
+async function performLocatorType(
+  state: PageState,
+  locator: Locator,
+  value: string,
+  options?: Parameters<Locator["type"]>[1]
+): Promise<void> {
+  await prepareForInteraction(state, {
+    textCharCount: (await readInteractionText(locator)).length
+  });
+  const fieldLabel = await readInteractionLabel(locator);
+  await state.humanizedPage.typeInto(locator, value, {
+    ...(fieldLabel ? { fieldLabel } : {}),
+    ...(options?.timeout === undefined ? {} : { timeoutMs: options.timeout })
+  });
+}
+
+async function performPageClick(
+  state: PageState,
+  selector: string,
+  options?: PageClickOptions
+): Promise<void> {
+  await performLocatorClick(state, state.rawPage.locator(assertSelector(selector)).first(), options);
+}
+
+async function performPageFill(
+  state: PageState,
+  selector: string,
+  value: string,
+  options?: PageFillOptions
+): Promise<void> {
+  await performLocatorFill(
+    state,
+    state.rawPage.locator(assertSelector(selector)).first(),
+    value,
+    options
+  );
+}
+
+async function performPageHover(
+  state: PageState,
+  selector: string,
+  options?: PageHoverOptions
+): Promise<void> {
+  await performLocatorHover(state, state.rawPage.locator(assertSelector(selector)).first(), options);
+}
+
+async function performPagePress(
+  state: PageState,
+  selector: string,
+  key: string,
+  options?: PagePressOptions
+): Promise<void> {
+  await performLocatorPress(
+    state,
+    state.rawPage.locator(assertSelector(selector)).first(),
+    key,
+    options
+  );
+}
+
+async function performPageType(
+  state: PageState,
+  selector: string,
+  value: string,
+  options?: Parameters<Page["type"]>[2]
+): Promise<void> {
+  await performLocatorType(
+    state,
+    state.rawPage.locator(assertSelector(selector)).first(),
+    value,
+    options
+  );
+}
+
+async function moveMouseNearLocator(
+  state: PageState,
+  locator: Locator,
+  position?: PositionLike
+): Promise<void> {
+  const point = await resolveLocatorPoint(locator, position);
+  if (!point) {
+    return;
+  }
+
+  await state.session.moveMouseTo(point);
+  await state.session.idle(
+    state.session.sampleInterval(60, {
+      maxIntervalMs: 300,
+      minIntervalMs: 10
+    })
+  );
+}
+
+async function resolveLocatorPoint(
+  locator: Locator,
+  position?: PositionLike
+): Promise<Point2D | null> {
+  const box = await locator.boundingBox().catch(() => null);
+  if (!box) {
+    return null;
+  }
+
+  const offsetX = isPositionLike(position)
+    ? clampNumber(position.x, 0, Math.max(0, box.width))
+    : box.width / 2;
+  const offsetY = isPositionLike(position)
+    ? clampNumber(position.y, 0, Math.max(0, box.height))
+    : box.height / 2;
+
+  return {
+    x: box.x + offsetX,
+    y: box.y + offsetY
+  };
+}
+
+async function readInteractionLabel(locator: Locator): Promise<string> {
+  const text = await readInteractionText(locator);
+  if (text.length > 0) {
+    return text;
+  }
+
+  const attributeNames = ["aria-label", "placeholder", "title", "value"] as const;
+  for (const attributeName of attributeNames) {
+    const value = normalizeInteractionText(
+      await locator.getAttribute(attributeName).catch(() => null)
+    );
+    if (value.length > 0) {
+      return value;
+    }
+  }
+
+  return "";
+}
+
+async function readInteractionText(locator: Locator): Promise<string> {
+  const innerText = normalizeInteractionText(await locator.innerText().catch(() => null));
+  if (innerText.length > 0) {
+    return innerText;
+  }
+
+  return normalizeInteractionText(await locator.textContent().catch(() => null));
+}
+
+function resolvePageState(page: Page): PageState | undefined {
+  const rawPage = rawPageByWrapped.get(page as object) ?? page;
+  return pageStateByRaw.get(rawPage);
+}
+
+async function readScrollMetrics(page: Page): Promise<ScrollMetrics> {
+  const metrics = await page
+    .evaluate(() => {
+      const maxTop = Math.max(0, globalThis.document.body.scrollHeight - globalThis.innerHeight);
+      return {
+        maxTop,
+        scrollY: Math.max(0, globalThis.scrollY)
+      } satisfies ScrollMetrics;
+    })
+    .catch(() => null);
+
+  if (!isRecord(metrics)) {
+    return { maxTop: 0, scrollY: 0 };
+  }
+
+  return {
+    maxTop: Math.max(0, normalizeFiniteNumber(metrics.maxTop)),
+    scrollY: Math.max(0, normalizeFiniteNumber(metrics.scrollY))
+  };
+}
+
+function assertSelector(selector: string): string {
+  if (typeof selector !== "string") {
+    throw new TypeError("selector must be a string.");
+  }
+
+  return selector;
+}
+
+function wrapMaybe<T>(value: T, options: ResolvedInteractionOptions): T {
+  if (isPromiseLike(value)) {
+    return value.then((resolved) => wrapMaybe(resolved, options)) as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => wrapMaybe(entry, options)) as T;
+  }
+
+  if (isBrowserContextLike(value)) {
+    return wrapLinkedInBrowserContext(value, options) as T;
+  }
+
+  if (isPageLike(value)) {
+    return wrapLinkedInPage(value, options) as T;
+  }
+
+  if (isLocatorLike(value)) {
+    return wrapLocator(value, options) as T;
+  }
+
+  return value;
+}
+
+function unwrapArgs(args: readonly unknown[]): unknown[] {
+  return args.map((value) => unwrapValue(value));
+}
+
+function unwrapValue<T>(value: T): T {
+  if (typeof value !== "object" || value === null) {
+    return value;
+  }
+
+  const rawContext = rawContextByWrapped.get(value);
+  if (rawContext) {
+    return rawContext as T;
+  }
+
+  const rawLocator = rawLocatorByWrapped.get(value);
+  if (rawLocator) {
+    return rawLocator as T;
+  }
+
+  const rawPage = rawPageByWrapped.get(value);
+  if (rawPage) {
+    return rawPage as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => unwrapValue(entry)) as T;
+  }
+
+  if (!isPlainObject(value)) {
+    return value;
+  }
+
+  const unwrappedEntries = Object.entries(value).map(([key, entryValue]) => [
+    key,
+    unwrapValue(entryValue)
+  ]);
+  return Object.fromEntries(unwrappedEntries) as T;
+}
+
+function isBrowserContextLike(value: unknown): value is BrowserContext {
+  return isRecord(value) && typeof value.pages === "function" && typeof value.newPage === "function";
+}
+
+function isLocatorLike(value: unknown): value is Locator {
+  return isRecord(value) && typeof value.page === "function" && typeof value.locator === "function";
+}
+
+function isPageLike(value: unknown): value is Page {
+  return (
+    isRecord(value) &&
+    typeof value.goto === "function" &&
+    typeof value.locator === "function" &&
+    typeof value.url === "function" &&
+    isRecord(value.keyboard) &&
+    isRecord(value.mouse)
+  );
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isPositionLike(value: unknown): value is PositionLike {
+  return isRecord(value) && isFiniteNumber(value.x) && isFiniteNumber(value.y);
+}
+
+function isPromiseLike<T>(value: T): value is T & PromiseLike<Awaited<T>> {
+  return isRecord(value) && typeof value.then === "function";
+}
+
+function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function clampNumber(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function normalizeFiniteNumber(value: unknown): number {
+  return isFiniteNumber(value) ? value : 0;
+}
+
+function normalizeInteractionText(value: string | null | undefined): string {
+  return (value ?? "").replace(/\s+/gu, " ").trim();
+}

--- a/packages/core/src/linkedinPosts.ts
+++ b/packages/core/src/linkedinPosts.ts
@@ -13,6 +13,7 @@ import {
   LinkedInBuddyError,
   asLinkedInBuddyError
 } from "./errors.js";
+import { scrollLinkedInPageToTop } from "./linkedinPage.js";
 import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
@@ -2559,7 +2560,7 @@ async function setComposerText(
     await composerInput.locator.press("Control+A").catch(() => undefined);
     await composerInput.locator.press("Meta+A").catch(() => undefined);
     await composerInput.locator.press("Backspace").catch(() => undefined);
-    await page.keyboard.insertText(text);
+    await composerInput.locator.type(text);
   }
 
   return composerInput.key;
@@ -2663,7 +2664,7 @@ async function setTextInputValue(
     await locator.press("Control+A").catch(() => undefined);
     await locator.press("Meta+A").catch(() => undefined);
     await locator.press("Backspace").catch(() => undefined);
-    await page.keyboard.insertText(value);
+    await locator.type(value);
   }
 }
 
@@ -3149,9 +3150,7 @@ async function locatePublishedPostOnSurface(
       await page.goto(LINKEDIN_FEED_URL, { waitUntil: "domcontentloaded" });
       await waitForNetworkIdleBestEffort(page);
     }
-    await page.evaluate(() => {
-      globalThis.scrollTo({ top: 0, behavior: "auto" });
-    });
+    await scrollLinkedInPageToTop(page);
     await waitForFeedSurface(page);
     return findVisiblePostBySnippet(page, snippet);
   }
@@ -3160,9 +3159,7 @@ async function locatePublishedPostOnSurface(
     waitUntil: "domcontentloaded"
   });
   await waitForNetworkIdleBestEffort(page);
-  await page.evaluate(() => {
-    globalThis.scrollTo({ top: 0, behavior: "auto" });
-  });
+  await scrollLinkedInPageToTop(page);
   await waitForProfileActivitySurface(page);
   return findVisiblePostBySnippet(page, snippet);
 }

--- a/packages/core/src/liveValidation.ts
+++ b/packages/core/src/liveValidation.ts
@@ -21,6 +21,7 @@ import {
   type LinkedInBuddyErrorCode
 } from "./errors.js";
 import { JsonEventLogger, type JsonLogEntry } from "./logging.js";
+import { wrapLinkedInBrowserContext } from "./linkedinPage.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import { createRunId } from "./run.js";
 import {
@@ -1580,7 +1581,7 @@ async function createBrowserContext(
     context.setDefaultTimeout(timeoutMs);
     await installReadOnlyNetworkGuard(context, blockedRequests);
 
-    return { browser, context };
+    return { browser, context: wrapLinkedInBrowserContext(context) };
   } catch (error) {
     await browser.close().catch(() => undefined);
     throw error;

--- a/packages/core/src/profileManager.ts
+++ b/packages/core/src/profileManager.ts
@@ -5,12 +5,18 @@ import {
   chromium,
   type BrowserContext
 } from "playwright-core";
-import type { ConfigPaths } from "./config.js";
+import {
+  resolveEvasionConfig,
+  type ConfigPaths,
+  type EvasionConfig
+} from "./config.js";
 import { LinkedInBuddyError } from "./errors.js";
 import {
   attachFixtureReplayToContext,
   isFixtureReplayEnabled
 } from "./fixtureReplay.js";
+import { wrapLinkedInBrowserContext } from "./linkedinPage.js";
+import type { JsonEventLogger } from "./logging.js";
 
 type PersistentLaunchOptions = NonNullable<
   Parameters<typeof chromium.launchPersistentContext>[1]
@@ -36,7 +42,19 @@ function withPlaywrightInstallHint(error: unknown): Error {
 }
 
 export class ProfileManager {
-  constructor(private readonly paths: ConfigPaths) {}
+  private readonly evasion: EvasionConfig;
+  private readonly logger: Pick<JsonEventLogger, "log"> | undefined;
+
+  constructor(
+    private readonly paths: ConfigPaths,
+    options: {
+      evasion?: EvasionConfig;
+      logger?: Pick<JsonEventLogger, "log">;
+    } = {}
+  ) {
+    this.evasion = options.evasion ?? resolveEvasionConfig();
+    this.logger = options.logger;
+  }
 
   getProfileUserDataDir(profileName: string = "default"): string {
     return path.join(this.paths.profilesDir, profileName);
@@ -109,7 +127,7 @@ export class ProfileManager {
       try {
         context = await chromium.launchPersistentContext(userDataDir, launchOptions);
         await attachFixtureReplayToContext(context);
-        return await callback(context);
+        return await callback(this.wrapContext(context));
       } catch (error) {
         throw withPlaywrightInstallHint(error);
       } finally {
@@ -133,7 +151,7 @@ export class ProfileManager {
       if (!context) {
         throw new Error("No browser context found on CDP connection");
       }
-      return await callback(context);
+      return await callback(this.wrapContext(context));
     } catch (error) {
       throw withPlaywrightInstallHint(error);
     } finally {
@@ -193,5 +211,12 @@ export class ProfileManager {
       { headless: options.headless ?? true },
       callback
     );
+  }
+
+  private wrapContext(context: BrowserContext): BrowserContext {
+    return wrapLinkedInBrowserContext(context, {
+      evasion: this.evasion,
+      ...(this.logger ? { logger: this.logger } : {})
+    });
   }
 }

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -254,7 +254,10 @@ export function createCoreRuntime(
   const logger = new JsonEventLogger(paths, runId, db, privacy);
   const artifacts = new ArtifactHelpers(paths, runId, db, privacy);
   const confirmFailureArtifacts = resolveConfirmFailureArtifactConfig();
-  const profileManager = new ProfileManager(paths);
+  const profileManager = new ProfileManager(paths, {
+    evasion,
+    logger
+  });
   let closed = false;
   let runtime: CoreRuntime;
 

--- a/packages/core/src/writeValidationRuntime.ts
+++ b/packages/core/src/writeValidationRuntime.ts
@@ -17,6 +17,7 @@ import {
   ProfileManager,
   type PersistentContextOptions
 } from "./profileManager.js";
+import { wrapLinkedInBrowserContext } from "./linkedinPage.js";
 import { createCoreRuntime, type CoreRuntime } from "./runtime.js";
 import type { WriteValidationAccount } from "./writeValidationAccounts.js";
 import {
@@ -83,9 +84,13 @@ class StoredSessionProfileManager extends ProfileManager {
 
     context.setDefaultNavigationTimeout(this.timeoutMs);
     context.setDefaultTimeout(this.timeoutMs);
+    const wrappedContext = wrapLinkedInBrowserContext(context, {
+      evasion: this.runtime.evasion,
+      logger: this.runtime.logger
+    });
 
     try {
-      return await callback(context);
+      return await callback(wrappedContext);
     } finally {
       await context.close().catch(() => undefined);
     }


### PR DESCRIPTION
## Summary
- wrap shared browser contexts/pages in a centralized LinkedIn interaction proxy so evasion is enabled by default for runtime, stored-session, live-validation, and pooled browser flows
- harden fingerprints automatically through the shared wrapper, route typing through `humanize`, and use evasion-aware scroll helpers in LinkedIn flows
- add global CLI `--evasion-level` and `--no-evasion` overrides, default fixture replay to `minimal`, and cover the new behavior with tests

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

Closes #351
