### PR TITLE
feat: quality pass for articles & newsletters (#235)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ See [`docs/repository-seo.md`](./docs/repository-seo.md) for the keyword targets
 | Brand and social preview assets | [`docs/brand-guidelines.md`](./docs/brand-guidelines.md) |
 | README media research | [`docs/readme-media-research.md`](./docs/readme-media-research.md) |
 | README media inventory | [`assets/media/README.md`](./assets/media/README.md) |
+| Articles and newsletters | [`docs/articles-newsletters.md`](./docs/articles-newsletters.md) |
 
 ## Contributing
 

--- a/docs/articles-newsletters.md
+++ b/docs/articles-newsletters.md
@@ -1,0 +1,231 @@
+# Articles & Newsletters
+
+LinkedIn Buddy supports creating and publishing long-form LinkedIn articles and newsletters through the CLI, MCP server, and TypeScript API.
+
+## Overview
+
+| Action                   | CLI                                | MCP Tool                                    | Two-Phase |
+| ------------------------ | ---------------------------------- | ------------------------------------------- | --------- |
+| Create article draft     | `article prepare-create`           | `linkedin.article.prepare_create`           | Yes       |
+| Publish article          | `article prepare-publish`          | `linkedin.article.prepare_publish`          | Yes       |
+| Create newsletter        | `newsletter prepare-create`        | `linkedin.newsletter.prepare_create`        | Yes       |
+| Publish newsletter issue | `newsletter prepare-publish-issue` | `linkedin.newsletter.prepare_publish_issue` | Yes       |
+| List newsletters         | `newsletter list`                  | `linkedin.newsletter.list`                  | No        |
+
+All write operations follow the two-phase commit pattern: **prepare** returns a confirm token, then **confirm** executes the action. This prevents accidental publishing and gives the operator full review capability.
+
+## CLI Usage
+
+### Articles
+
+#### Create a draft article
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin article prepare-create \
+  --title "Building Reliable Browser Automation" \
+  --body "Browser automation is tricky. Here is what I learned..."
+```
+
+Returns a prepared action with a `confirmToken`. Use `linkedin actions confirm --token ct_...` to create the draft in the LinkedIn publishing editor.
+
+#### Publish an existing article draft
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin article prepare-publish \
+  --draft-url "https://www.linkedin.com/pulse/edit/123456/"
+```
+
+### Newsletters
+
+#### List your newsletters
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin newsletter list
+```
+
+Returns a list of newsletter series available in your LinkedIn publishing editor, including which one is currently selected.
+
+#### Create a new newsletter series
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin newsletter prepare-create \
+  --title "Builder Brief" \
+  --description "Weekly notes on building developer tools" \
+  --cadence weekly
+```
+
+Supported cadence values: `daily`, `weekly`, `biweekly`, `monthly`.
+
+#### Publish a newsletter issue
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin newsletter prepare-publish-issue \
+  --newsletter "Builder Brief" \
+  --title "March Update: What We Shipped" \
+  --body "This month we focused on reliability improvements..."
+```
+
+### Common options
+
+All commands support:
+
+- `-p, --profile <profile>` — LinkedIn profile name (default: `default`)
+- `-o, --operator-note <note>` — Optional note attached to the prepared action
+- `--cdp-url <url>` — Connect to an existing Chrome DevTools Protocol session
+
+## MCP Usage
+
+### linkedin.article.prepare_create
+
+Prepare a new LinkedIn long-form article draft.
+
+**Parameters:**
+
+| Name           | Type   | Required | Description                                                            |
+| -------------- | ------ | -------- | ---------------------------------------------------------------------- |
+| `title`        | string | Yes      | Article headline (max 150 characters)                                  |
+| `body`         | string | Yes      | Plain-text article body with paragraph breaks (max 125,000 characters) |
+| `profileName`  | string | No       | Profile name (default: `default`)                                      |
+| `operatorNote` | string | No       | Optional operator note                                                 |
+
+### linkedin.article.prepare_publish
+
+Prepare to publish an existing LinkedIn article draft.
+
+**Parameters:**
+
+| Name           | Type   | Required | Description                                   |
+| -------------- | ------ | -------- | --------------------------------------------- |
+| `draftUrl`     | string | Yes      | Absolute LinkedIn article editor or draft URL |
+| `profileName`  | string | No       | Profile name                                  |
+| `operatorNote` | string | No       | Optional operator note                        |
+
+### linkedin.newsletter.prepare_create
+
+Prepare a new LinkedIn newsletter series.
+
+**Parameters:**
+
+| Name           | Type   | Required | Description                                                     |
+| -------------- | ------ | -------- | --------------------------------------------------------------- |
+| `title`        | string | Yes      | Newsletter title (max 64 characters)                            |
+| `description`  | string | Yes      | Short newsletter description (max 300 characters)               |
+| `cadence`      | string | Yes      | Publishing cadence: `daily`, `weekly`, `biweekly`, or `monthly` |
+| `profileName`  | string | No       | Profile name                                                    |
+| `operatorNote` | string | No       | Optional operator note                                          |
+
+### linkedin.newsletter.prepare_publish_issue
+
+Prepare a new LinkedIn newsletter issue.
+
+**Parameters:**
+
+| Name           | Type   | Required | Description                                                          |
+| -------------- | ------ | -------- | -------------------------------------------------------------------- |
+| `newsletter`   | string | Yes      | Newsletter title as returned by `linkedin.newsletter.list`           |
+| `title`        | string | Yes      | Issue title (max 150 characters)                                     |
+| `body`         | string | Yes      | Plain-text issue body with paragraph breaks (max 125,000 characters) |
+| `profileName`  | string | No       | Profile name                                                         |
+| `operatorNote` | string | No       | Optional operator note                                               |
+
+### linkedin.newsletter.list
+
+List newsletter series currently available in the LinkedIn publishing editor.
+
+**Parameters:**
+
+| Name          | Type   | Required | Description  |
+| ------------- | ------ | -------- | ------------ |
+| `profileName` | string | No       | Profile name |
+
+**Returns:** `{ count, newsletters: [{ title, selected }] }`
+
+## Rate Limits
+
+Each publishing action is rate limited to **1 per 24 hours**:
+
+| Action                   | Counter Key                         | Limit |
+| ------------------------ | ----------------------------------- | ----- |
+| Create article           | `linkedin.article.create`           | 1/day |
+| Publish article          | `linkedin.article.publish`          | 1/day |
+| Create newsletter        | `linkedin.newsletter.create`        | 1/day |
+| Publish newsletter issue | `linkedin.newsletter.publish_issue` | 1/day |
+
+Rate limits are enforced at confirm time (not prepare time). The prepare response includes a `rate_limit` preview showing current usage.
+
+## Input Validation
+
+All inputs are validated before authentication or browser automation:
+
+- **Titles**: Must be non-empty, single-line, no control characters, no raw URLs
+- **Bodies**: Must be non-empty, control characters rejected, line endings normalized
+- **Cadence**: Must be one of the supported values (case-insensitive, aliases accepted)
+- **Draft URLs**: Must be valid absolute URLs pointing to `linkedin.com`
+
+### Length Limits
+
+| Field                  | Max Length         |
+| ---------------------- | ------------------ |
+| Article title          | 150 characters     |
+| Article body           | 125,000 characters |
+| Newsletter title       | 64 characters      |
+| Newsletter description | 300 characters     |
+| Newsletter issue title | 150 characters     |
+| Newsletter issue body  | 125,000 characters |
+
+## TypeScript API
+
+```typescript
+import { createCoreRuntime } from "@linkedin-buddy/core";
+
+const runtime = createCoreRuntime();
+
+try {
+  // List newsletters
+  const newsletters = await runtime.newsletters.list({
+    profileName: "default",
+  });
+  console.log(newsletters);
+
+  // Prepare an article draft
+  const prepared = await runtime.articles.prepareCreate({
+    profileName: "default",
+    title: "My Article",
+    body: "Article content here...",
+  });
+  console.log(prepared.confirmToken);
+
+  // Confirm the action
+  const result = await runtime.twoPhaseCommit.confirmByToken({
+    confirmToken: prepared.confirmToken,
+  });
+  console.log(result);
+} finally {
+  runtime.close();
+}
+```
+
+## Error Codes
+
+| Code                         | When                                                                            |
+| ---------------------------- | ------------------------------------------------------------------------------- |
+| `ACTION_PRECONDITION_FAILED` | Invalid input (empty title, bad URL, unsupported cadence, exceeds length limit) |
+| `RATE_LIMITED`               | Daily rate limit exceeded for the action type                                   |
+| `AUTH_REQUIRED`              | LinkedIn session not authenticated                                              |
+| `UI_CHANGED_SELECTOR_FAILED` | LinkedIn UI changed and selectors no longer match                               |
+| `TIMEOUT`                    | Browser automation timed out                                                    |
+| `NETWORK_ERROR`              | Network connectivity issue during automation                                    |
+
+## Artifacts
+
+Every publishing operation captures:
+
+- **Screenshots**: Before and after screenshots of the LinkedIn editor
+- **Traces**: Playwright browser traces (`.zip`) for debugging
+- **Error screenshots**: Captured on failure for diagnostic purposes
+
+Artifacts are stored under `~/.linkedin-buddy/linkedin-buddy/runs/<run-id>/`.
+
+## E2E Verification
+
+Read-only operations (`newsletter list`) can be verified against any authenticated profile. Write operations (article create/publish, newsletter create/publish-issue) require manual E2E testing against an approved test account per the [E2E testing safety rules](./e2e-testing.md).

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -6033,6 +6033,159 @@ async function runPostPrepare(input: {
   }
 }
 
+async function runArticlePrepareCreate(input: {
+  profileName: string;
+  title: string;
+  body: string;
+  operatorNote?: string;
+}, cdpUrl?: string): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+  try {
+    runtime.logger.log("info", "cli.article.prepare_create.start", {
+      profileName: input.profileName
+    });
+    const prepared = await runtime.articles.prepareCreate({
+      profileName: input.profileName,
+      title: input.title,
+      body: input.body,
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+    });
+    runtime.logger.log("info", "cli.article.prepare_create.done", {
+      profileName: input.profileName,
+      preparedActionId: prepared.preparedActionId
+    });
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      ...prepared
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function runArticlePreparePublish(input: {
+  profileName: string;
+  draftUrl: string;
+  operatorNote?: string;
+}, cdpUrl?: string): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+  try {
+    runtime.logger.log("info", "cli.article.prepare_publish.start", {
+      profileName: input.profileName,
+      draftUrl: input.draftUrl
+    });
+    const prepared = await runtime.articles.preparePublish({
+      profileName: input.profileName,
+      draftUrl: input.draftUrl,
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+    });
+    runtime.logger.log("info", "cli.article.prepare_publish.done", {
+      profileName: input.profileName,
+      preparedActionId: prepared.preparedActionId
+    });
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      ...prepared
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function runNewsletterPrepareCreate(input: {
+  profileName: string;
+  title: string;
+  description: string;
+  cadence: string;
+  operatorNote?: string;
+}, cdpUrl?: string): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+  try {
+    runtime.logger.log("info", "cli.newsletter.prepare_create.start", {
+      profileName: input.profileName
+    });
+    const prepared = await runtime.newsletters.prepareCreate({
+      profileName: input.profileName,
+      title: input.title,
+      description: input.description,
+      cadence: input.cadence,
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+    });
+    runtime.logger.log("info", "cli.newsletter.prepare_create.done", {
+      profileName: input.profileName,
+      preparedActionId: prepared.preparedActionId
+    });
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      ...prepared
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function runNewsletterPreparePublishIssue(input: {
+  profileName: string;
+  newsletter: string;
+  title: string;
+  body: string;
+  operatorNote?: string;
+}, cdpUrl?: string): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+  try {
+    runtime.logger.log("info", "cli.newsletter.prepare_publish_issue.start", {
+      profileName: input.profileName,
+      newsletter: input.newsletter
+    });
+    const prepared = await runtime.newsletters.preparePublishIssue({
+      profileName: input.profileName,
+      newsletter: input.newsletter,
+      title: input.title,
+      body: input.body,
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+    });
+    runtime.logger.log("info", "cli.newsletter.prepare_publish_issue.done", {
+      profileName: input.profileName,
+      preparedActionId: prepared.preparedActionId
+    });
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      ...prepared
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function runNewsletterList(input: {
+  profileName: string;
+}, cdpUrl?: string): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+  try {
+    runtime.logger.log("info", "cli.newsletter.list.start", {
+      profileName: input.profileName
+    });
+    const result = await runtime.newsletters.list({
+      profileName: input.profileName
+    });
+    runtime.logger.log("info", "cli.newsletter.list.done", {
+      profileName: input.profileName,
+      count: result.count
+    });
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      ...result
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
 async function runProfileView(input: {
   profileName: string;
   target: string;
@@ -9805,6 +9958,161 @@ export function createCliProgram(): Command {
           yes: options.yes
         }, readCdpUrl());
       }
+    );
+
+  const articleCommand = program
+    .command("article")
+    .description("Prepare and confirm LinkedIn article creation and publishing");
+
+  articleCommand
+    .command("prepare-create")
+    .description("Prepare a new LinkedIn article draft (two-phase)")
+    .requiredOption("--title <title>", "Article headline")
+    .requiredOption(
+      "--body <body>",
+      "Plain-text article body (paragraph breaks preserved)",
+    )
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .option("-o, --operator-note <note>", "Optional operator note")
+    .action(
+      async (options: {
+        profile: string;
+        title: string;
+        body: string;
+        operatorNote?: string;
+      }) => {
+        await runArticlePrepareCreate(
+          {
+            profileName: options.profile,
+            title: options.title,
+            body: options.body,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
+    );
+
+  articleCommand
+    .command("prepare-publish")
+    .description("Prepare to publish an existing LinkedIn article draft (two-phase)")
+    .requiredOption("--draft-url <url>", "LinkedIn article draft URL")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .option("-o, --operator-note <note>", "Optional operator note")
+    .action(
+      async (options: {
+        profile: string;
+        draftUrl: string;
+        operatorNote?: string;
+      }) => {
+        await runArticlePreparePublish(
+          {
+            profileName: options.profile,
+            draftUrl: options.draftUrl,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
+    );
+
+  const newsletterCommand = program
+    .command("newsletter")
+    .description("Manage LinkedIn newsletters");
+
+  newsletterCommand
+    .command("prepare-create")
+    .description("Prepare a new LinkedIn newsletter series (two-phase)")
+    .requiredOption("--title <title>", "Newsletter title")
+    .requiredOption(
+      "--description <description>",
+      "Short newsletter description",
+    )
+    .requiredOption(
+      "--cadence <cadence>",
+      "Publishing cadence (daily, weekly, biweekly, monthly)",
+    )
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .option("-o, --operator-note <note>", "Optional operator note")
+    .action(
+      async (options: {
+        profile: string;
+        title: string;
+        description: string;
+        cadence: string;
+        operatorNote?: string;
+      }) => {
+        await runNewsletterPrepareCreate(
+          {
+            profileName: options.profile,
+            title: options.title,
+            description: options.description,
+            cadence: options.cadence,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
+    );
+
+  newsletterCommand
+    .command("prepare-publish-issue")
+    .description("Prepare a new LinkedIn newsletter issue (two-phase)")
+    .requiredOption(
+      "--newsletter <newsletter>",
+      "Newsletter title as returned by newsletter list",
+    )
+    .requiredOption("--title <title>", "Issue title")
+    .requiredOption(
+      "--body <body>",
+      "Plain-text issue body (paragraph breaks preserved)",
+    )
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .option("-o, --operator-note <note>", "Optional operator note")
+    .action(
+      async (options: {
+        profile: string;
+        newsletter: string;
+        title: string;
+        body: string;
+        operatorNote?: string;
+      }) => {
+        await runNewsletterPreparePublishIssue(
+          {
+            profileName: options.profile,
+            newsletter: options.newsletter,
+            title: options.title,
+            body: options.body,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
+    );
+
+  newsletterCommand
+    .command("list")
+    .description(
+      "List newsletter series available in the LinkedIn publishing editor",
+    )
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .action(
+      async (options: { profile: string }) => {
+        await runNewsletterList(
+          {
+            profileName: options.profile,
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   const notificationsCommand = program

--- a/packages/core/src/__tests__/linkedinPublishing.test.ts
+++ b/packages/core/src/__tests__/linkedinPublishing.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  ARTICLE_BODY_MAX_LENGTH,
+  ARTICLE_TITLE_MAX_LENGTH,
   CREATE_ARTICLE_ACTION_TYPE,
   CREATE_NEWSLETTER_ACTION_TYPE,
   LINKEDIN_NEWSLETTER_CADENCE_TYPES,
   LinkedInArticlesService,
   LinkedInNewslettersService,
+  NEWSLETTER_DESCRIPTION_MAX_LENGTH,
+  NEWSLETTER_ISSUE_BODY_MAX_LENGTH,
+  NEWSLETTER_ISSUE_TITLE_MAX_LENGTH,
+  NEWSLETTER_TITLE_MAX_LENGTH,
   PUBLISH_ARTICLE_ACTION_TYPE,
   PUBLISH_NEWSLETTER_ISSUE_ACTION_TYPE,
-  createPublishingActionExecutors
+  createPublishingActionExecutors,
 } from "../linkedinPublishing.js";
 import { createBlockedRateLimiterStub } from "./rateLimiterTestUtils.js";
 
@@ -15,41 +21,42 @@ function createPublishingConfirmRuntime() {
   const rateLimiter = createBlockedRateLimiterStub();
   const page = {
     screenshot: vi.fn(async () => undefined),
-    url: vi.fn(() => "https://www.linkedin.com/publishing/")
+    url: vi.fn(() => "https://www.linkedin.com/publishing/"),
   };
   const context = {
     pages: vi.fn(() => [page]),
     newPage: vi.fn(async () => page),
     tracing: {
       start: vi.fn(async () => undefined),
-      stop: vi.fn(async () => undefined)
-    }
+      stop: vi.fn(async () => undefined),
+    },
   };
   const runtime = {
     auth: {
-      ensureAuthenticated: vi.fn(async () => undefined)
+      ensureAuthenticated: vi.fn(async () => undefined),
     },
     cdpUrl: undefined,
     selectorLocale: "en",
     profileManager: {
-      runWithContext: vi.fn(async (_options: unknown, callback: (ctx: typeof context) => unknown) =>
-        callback(context)
-      )
+      runWithContext: vi.fn(
+        async (_options: unknown, callback: (ctx: typeof context) => unknown) =>
+          callback(context),
+      ),
     },
     rateLimiter,
     logger: {
-      log: vi.fn()
+      log: vi.fn(),
     },
     artifacts: {
       resolve: vi.fn((relativePath: string) => `/tmp/${relativePath}`),
-      registerArtifact: vi.fn()
-    }
+      registerArtifact: vi.fn(),
+    },
   };
 
   return {
     page,
     rateLimiter,
-    runtime
+    runtime,
   };
 }
 
@@ -58,7 +65,9 @@ describe("publishing action type constants", () => {
     expect(CREATE_ARTICLE_ACTION_TYPE).toBe("article.create");
     expect(PUBLISH_ARTICLE_ACTION_TYPE).toBe("article.publish");
     expect(CREATE_NEWSLETTER_ACTION_TYPE).toBe("newsletter.create");
-    expect(PUBLISH_NEWSLETTER_ISSUE_ACTION_TYPE).toBe("newsletter.publish_issue");
+    expect(PUBLISH_NEWSLETTER_ISSUE_ACTION_TYPE).toBe(
+      "newsletter.publish_issue",
+    );
   });
 });
 
@@ -70,12 +79,14 @@ describe("createPublishingActionExecutors", () => {
       CREATE_ARTICLE_ACTION_TYPE,
       PUBLISH_ARTICLE_ACTION_TYPE,
       CREATE_NEWSLETTER_ACTION_TYPE,
-      PUBLISH_NEWSLETTER_ISSUE_ACTION_TYPE
+      PUBLISH_NEWSLETTER_ISSUE_ACTION_TYPE,
     ]);
-    expect(typeof executors[CREATE_ARTICLE_ACTION_TYPE]?.execute).toBe("function");
-    expect(typeof executors[PUBLISH_NEWSLETTER_ISSUE_ACTION_TYPE]?.execute).toBe(
-      "function"
+    expect(typeof executors[CREATE_ARTICLE_ACTION_TYPE]?.execute).toBe(
+      "function",
     );
+    expect(
+      typeof executors[PUBLISH_NEWSLETTER_ISSUE_ACTION_TYPE]?.execute,
+    ).toBe("function");
   });
 
   it("rejects confirm execution locally when publishing actions are rate limited", async () => {
@@ -87,13 +98,13 @@ describe("createPublishingActionExecutors", () => {
         action: {
           id: "act-article-create",
           target: {
-            profile_name: "default"
+            profile_name: "default",
           },
           payload: {
             title: "Title",
-            body: "Body"
-          }
-        }
+            body: "Body",
+          },
+        },
       },
       {
         actionType: PUBLISH_ARTICLE_ACTION_TYPE,
@@ -101,12 +112,12 @@ describe("createPublishingActionExecutors", () => {
         action: {
           id: "act-article-publish",
           target: {
-            profile_name: "default"
+            profile_name: "default",
           },
           payload: {
-            draft_url: "https://www.linkedin.com/pulse/edit/123/"
-          }
-        }
+            draft_url: "https://www.linkedin.com/pulse/edit/123/",
+          },
+        },
       },
       {
         actionType: CREATE_NEWSLETTER_ACTION_TYPE,
@@ -114,14 +125,14 @@ describe("createPublishingActionExecutors", () => {
         action: {
           id: "act-newsletter-create",
           target: {
-            profile_name: "default"
+            profile_name: "default",
           },
           payload: {
             title: "Builder Brief",
             description: "Weekly notes.",
-            cadence: "weekly"
-          }
-        }
+            cadence: "weekly",
+          },
+        },
       },
       {
         actionType: PUBLISH_NEWSLETTER_ISSUE_ACTION_TYPE,
@@ -129,15 +140,15 @@ describe("createPublishingActionExecutors", () => {
         action: {
           id: "act-newsletter-issue",
           target: {
-            profile_name: "default"
+            profile_name: "default",
           },
           payload: {
             newsletter_title: "Builder Brief",
             title: "March update",
-            body: "Long-form issue body."
-          }
-        }
-      }
+            body: "Long-form issue body.",
+          },
+        },
+      },
     ] as const;
 
     for (const testCase of cases) {
@@ -146,21 +157,21 @@ describe("createPublishingActionExecutors", () => {
       await expect(
         executors[testCase.actionType]!.execute({
           runtime,
-          action: testCase.action
-        } as never)
+          action: testCase.action,
+        } as never),
       ).rejects.toMatchObject({
         code: "RATE_LIMITED",
         details: {
           rate_limit: {
-            counter_key: testCase.counterKey
-          }
-        }
+            counter_key: testCase.counterKey,
+          },
+        },
       });
 
       expect(rateLimiter.consume).toHaveBeenCalledWith(
         expect.objectContaining({
-          counterKey: testCase.counterKey
-        })
+          counterKey: testCase.counterKey,
+        }),
       );
       expect(page.screenshot).toHaveBeenCalled();
     }
@@ -173,7 +184,7 @@ describe("newsletter cadence surface", () => {
       "daily",
       "weekly",
       "biweekly",
-      "monthly"
+      "monthly",
     ]);
   });
 });
@@ -183,24 +194,24 @@ describe("LinkedInArticlesService validation", () => {
     const ensureAuthenticated = vi.fn();
     const service = new LinkedInArticlesService({
       auth: {
-        ensureAuthenticated
+        ensureAuthenticated,
       },
       cdpUrl: undefined,
       profileManager: {},
       logger: {
-        log: vi.fn()
+        log: vi.fn(),
       },
       artifacts: {},
       twoPhaseCommit: {
-        prepare: vi.fn()
-      }
+        prepare: vi.fn(),
+      },
     } as never);
 
     await expect(
       service.prepareCreate({
         title: "   ",
-        body: "Valid article body."
-      })
+        body: "Valid article body.",
+      }),
     ).rejects.toThrow("Article title must not be empty.");
 
     expect(ensureAuthenticated).not.toHaveBeenCalled();
@@ -210,24 +221,398 @@ describe("LinkedInArticlesService validation", () => {
     const ensureAuthenticated = vi.fn();
     const service = new LinkedInArticlesService({
       auth: {
-        ensureAuthenticated
+        ensureAuthenticated,
       },
       cdpUrl: undefined,
       profileManager: {},
       logger: {
-        log: vi.fn()
+        log: vi.fn(),
       },
       artifacts: {},
       twoPhaseCommit: {
-        prepare: vi.fn()
-      }
+        prepare: vi.fn(),
+      },
     } as never);
 
     await expect(
       service.preparePublish({
-        draftUrl: "https://example.com/article/123"
-      })
+        draftUrl: "https://example.com/article/123",
+      }),
     ).rejects.toThrow("draftUrl must point to linkedin.com.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects URL-only article titles before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInArticlesService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "https://example.com/title",
+        body: "Valid article body.",
+      }),
+    ).rejects.toThrow("Article title must be descriptive text, not a URL.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects article titles with control characters before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInArticlesService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "Invalid\u0007title",
+        body: "Valid article body.",
+      }),
+    ).rejects.toThrow("Article title contains unsupported control characters.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects article titles that exceed max length before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInArticlesService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "a".repeat(ARTICLE_TITLE_MAX_LENGTH + 1),
+        body: "Valid article body.",
+      }),
+    ).rejects.toThrow("exceeds maximum length of 150");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty article body before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInArticlesService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "Valid title",
+        body: "   ",
+      }),
+    ).rejects.toThrow("Article body must not be empty.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects article body with control characters before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInArticlesService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "Valid title",
+        body: "Invalid body\u0007",
+      }),
+    ).rejects.toThrow("Article body contains unsupported control characters.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects article body that exceeds max length before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInArticlesService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "Valid title",
+        body: "a".repeat(ARTICLE_BODY_MAX_LENGTH + 1),
+      }),
+    ).rejects.toThrow("exceeds maximum length of 125000");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid article create inputs and proceeds to authentication", async () => {
+    const ensureAuthenticated = vi.fn(async () => undefined);
+    const service = new LinkedInArticlesService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "Valid article title",
+        body: "Valid article body.",
+      }),
+    ).rejects.toThrow();
+
+    expect(ensureAuthenticated).toHaveBeenCalled();
+  });
+
+  it("rejects empty draft URLs before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInArticlesService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.preparePublish({
+        draftUrl: "   ",
+      }),
+    ).rejects.toThrow("draftUrl must not be empty.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-URL draft URL strings before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInArticlesService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.preparePublish({
+        draftUrl: "not-a-url",
+      }),
+    ).rejects.toThrow("Invalid URL");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid LinkedIn draft URLs and proceeds to authentication", async () => {
+    const ensureAuthenticated = vi.fn(async () => undefined);
+    const service = new LinkedInArticlesService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.preparePublish({
+        draftUrl: "https://www.linkedin.com/pulse/edit/123/",
+      }),
+    ).rejects.toThrow();
+
+    expect(ensureAuthenticated).toHaveBeenCalled();
+  });
+
+  it("treats newline-only article titles as empty before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInArticlesService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "\n\n",
+        body: "Valid article body.",
+      }),
+    ).rejects.toThrow("Article title must not be empty.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects article titles with bell control characters before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInArticlesService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "Bad\u0007title",
+        body: "Valid article body.",
+      }),
+    ).rejects.toThrow("Article title contains unsupported control characters.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects article bodies with vertical tab control characters before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInArticlesService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "Valid article title",
+        body: "Bad\u000bbody",
+      }),
+    ).rejects.toThrow("Article body contains unsupported control characters.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("treats draftUrl with only tabs as empty before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInArticlesService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.preparePublish({
+        draftUrl: "\t\t",
+      }),
+    ).rejects.toThrow("draftUrl must not be empty.");
 
     expect(ensureAuthenticated).not.toHaveBeenCalled();
   });
@@ -238,25 +623,25 @@ describe("LinkedInNewslettersService validation", () => {
     const ensureAuthenticated = vi.fn();
     const service = new LinkedInNewslettersService({
       auth: {
-        ensureAuthenticated
+        ensureAuthenticated,
       },
       cdpUrl: undefined,
       profileManager: {},
       logger: {
-        log: vi.fn()
+        log: vi.fn(),
       },
       artifacts: {},
       twoPhaseCommit: {
-        prepare: vi.fn()
-      }
+        prepare: vi.fn(),
+      },
     } as never);
 
     await expect(
       service.prepareCreate({
         title: "Builder Brief",
         description: "Weekly notes.",
-        cadence: "quarterly"
-      })
+        cadence: "quarterly",
+      }),
     ).rejects.toThrow("cadence must be one of");
 
     expect(ensureAuthenticated).not.toHaveBeenCalled();
@@ -266,26 +651,818 @@ describe("LinkedInNewslettersService validation", () => {
     const ensureAuthenticated = vi.fn();
     const service = new LinkedInNewslettersService({
       auth: {
-        ensureAuthenticated
+        ensureAuthenticated,
       },
       cdpUrl: undefined,
       profileManager: {},
       logger: {
-        log: vi.fn()
+        log: vi.fn(),
       },
       artifacts: {},
       twoPhaseCommit: {
-        prepare: vi.fn()
-      }
+        prepare: vi.fn(),
+      },
     } as never);
 
     await expect(
       service.preparePublishIssue({
         newsletter: "   ",
         title: "March update",
-        body: "Long-form issue body."
-      })
+        body: "Long-form issue body.",
+      }),
     ).rejects.toThrow("newsletter must not be empty.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty newsletter title on create before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "   ",
+        description: "Weekly notes.",
+        cadence: "weekly",
+      }),
+    ).rejects.toThrow("Newsletter title must not be empty.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects URL-only newsletter title before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "https://example.com/newsletter",
+        description: "Weekly notes.",
+        cadence: "weekly",
+      }),
+    ).rejects.toThrow("Newsletter title must be descriptive text, not a URL.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects newsletter title with control characters before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "Builder\u0007Brief",
+        description: "Weekly notes.",
+        cadence: "weekly",
+      }),
+    ).rejects.toThrow(
+      "Newsletter title contains unsupported control characters.",
+    );
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects newsletter title that exceeds max length before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "a".repeat(NEWSLETTER_TITLE_MAX_LENGTH + 1),
+        description: "Weekly notes.",
+        cadence: "weekly",
+      }),
+    ).rejects.toThrow("exceeds maximum length of 64");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty newsletter description before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "Builder Brief",
+        description: "   ",
+        cadence: "weekly",
+      }),
+    ).rejects.toThrow("Newsletter description must not be empty.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects newsletter description that exceeds max length before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "Builder Brief",
+        description: "a".repeat(NEWSLETTER_DESCRIPTION_MAX_LENGTH + 1),
+        cadence: "weekly",
+      }),
+    ).rejects.toThrow("exceeds maximum length of 300");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("accepts case-insensitive cadence values and proceeds to authentication", async () => {
+    const ensureAuthenticated = vi.fn(async () => undefined);
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "Builder Brief",
+        description: "Weekly notes.",
+        cadence: "Weekly",
+      }),
+    ).rejects.toThrow();
+
+    expect(ensureAuthenticated).toHaveBeenCalled();
+  });
+
+  it("accepts cadence aliases and proceeds to authentication", async () => {
+    const ensureAuthenticated = vi.fn(async () => undefined);
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "Builder Brief",
+        description: "Weekly notes.",
+        cadence: "every week",
+      }),
+    ).rejects.toThrow();
+
+    expect(ensureAuthenticated).toHaveBeenCalled();
+  });
+
+  it("accepts valid newsletter create inputs and proceeds to authentication", async () => {
+    const ensureAuthenticated = vi.fn(async () => undefined);
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "Builder Brief",
+        description: "Weekly notes.",
+        cadence: "weekly",
+      }),
+    ).rejects.toThrow();
+
+    expect(ensureAuthenticated).toHaveBeenCalled();
+  });
+
+  it("rejects empty issue title before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.preparePublishIssue({
+        newsletter: "Builder Brief",
+        title: "   ",
+        body: "Issue body",
+      }),
+    ).rejects.toThrow("Issue title must not be empty.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects URL-only issue titles before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.preparePublishIssue({
+        newsletter: "Builder Brief",
+        title: "https://example.com/issue",
+        body: "Issue body",
+      }),
+    ).rejects.toThrow("Issue title must be descriptive text, not a URL.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects issue titles with control characters before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.preparePublishIssue({
+        newsletter: "Builder Brief",
+        title: "Issue\u0007title",
+        body: "Issue body",
+      }),
+    ).rejects.toThrow("Issue title contains unsupported control characters.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects issue titles that exceed max length before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.preparePublishIssue({
+        newsletter: "Builder Brief",
+        title: "a".repeat(NEWSLETTER_ISSUE_TITLE_MAX_LENGTH + 1),
+        body: "Issue body",
+      }),
+    ).rejects.toThrow("exceeds maximum length of 150");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty issue body before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.preparePublishIssue({
+        newsletter: "Builder Brief",
+        title: "March update",
+        body: "   ",
+      }),
+    ).rejects.toThrow("Issue body must not be empty.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects issue body with control characters before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.preparePublishIssue({
+        newsletter: "Builder Brief",
+        title: "March update",
+        body: "Issue body\u0007",
+      }),
+    ).rejects.toThrow("Issue body contains unsupported control characters.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects issue body that exceeds max length before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.preparePublishIssue({
+        newsletter: "Builder Brief",
+        title: "March update",
+        body: "a".repeat(NEWSLETTER_ISSUE_BODY_MAX_LENGTH + 1),
+      }),
+    ).rejects.toThrow("exceeds maximum length of 125000");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid issue publish inputs and proceeds to authentication", async () => {
+    const ensureAuthenticated = vi.fn(async () => undefined);
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.preparePublishIssue({
+        newsletter: "Builder Brief",
+        title: "March update",
+        body: "Long-form issue body.",
+      }),
+    ).rejects.toThrow();
+
+    expect(ensureAuthenticated).toHaveBeenCalled();
+  });
+
+  it("treats whitespace-only newsletter descriptions as empty before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "Builder Brief",
+        description: "\n\t\n",
+        cadence: "weekly",
+      }),
+    ).rejects.toThrow("Newsletter description must not be empty.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects newsletter titles with bell control characters before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "Builder\u0007Brief",
+        description: "Weekly notes.",
+        cadence: "weekly",
+      }),
+    ).rejects.toThrow(
+      "Newsletter title contains unsupported control characters.",
+    );
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects issue titles with bell control characters before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.preparePublishIssue({
+        newsletter: "Builder Brief",
+        title: "Issue\u0007title",
+        body: "Issue body",
+      }),
+    ).rejects.toThrow("Issue title contains unsupported control characters.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("treats newline-only issue titles as empty before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.preparePublishIssue({
+        newsletter: "Builder Brief",
+        title: "\n\n",
+        body: "Issue body",
+      }),
+    ).rejects.toThrow("Issue title must not be empty.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("treats tab-only newsletter names as empty before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.preparePublishIssue({
+        newsletter: "\t\t",
+        title: "March update",
+        body: "Issue body",
+      }),
+    ).rejects.toThrow("newsletter must not be empty.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("accepts normalized cadence alias with mixed spacing before authentication", async () => {
+    const ensureAuthenticated = vi.fn(async () => undefined);
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "Builder Brief",
+        description: "Weekly notes.",
+        cadence: "Every_Week",
+      }),
+    ).rejects.toThrow();
+
+    expect(ensureAuthenticated).toHaveBeenCalled();
+  });
+
+  it("rejects newsletter descriptions with control characters before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "Builder Brief",
+        description: "Bad\u0007description",
+        cadence: "weekly",
+      }),
+    ).rejects.toThrow(
+      "Newsletter description contains unsupported control characters.",
+    );
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects URL-only newsletter descriptions before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: "Builder Brief",
+        description: "https://example.com/description",
+        cadence: "weekly",
+      }),
+    ).rejects.toThrow(
+      "Newsletter description must be descriptive text, not a URL.",
+    );
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects issue body with bell control characters before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.preparePublishIssue({
+        newsletter: "Builder Brief",
+        title: "March update",
+        body: "Issue body\u0007",
+      }),
+    ).rejects.toThrow("Issue body contains unsupported control characters.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("treats newsletter title with only tabs and spaces as empty before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.prepareCreate({
+        title: " \t ",
+        description: "Weekly notes.",
+        cadence: "weekly",
+      }),
+    ).rejects.toThrow("Newsletter title must not be empty.");
+
+    expect(ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("treats issue body with only newlines and tabs as empty before authentication", async () => {
+    const ensureAuthenticated = vi.fn();
+    const service = new LinkedInNewslettersService({
+      auth: {
+        ensureAuthenticated,
+      },
+      cdpUrl: undefined,
+      profileManager: {},
+      logger: {
+        log: vi.fn(),
+      },
+      artifacts: {},
+      twoPhaseCommit: {
+        prepare: vi.fn(),
+      },
+    } as never);
+
+    await expect(
+      service.preparePublishIssue({
+        newsletter: "Builder Brief",
+        title: "March update",
+        body: "\n\t\n",
+      }),
+    ).rejects.toThrow("Issue body must not be empty.");
 
     expect(ensureAuthenticated).not.toHaveBeenCalled();
   });

--- a/packages/core/src/linkedinPublishing.ts
+++ b/packages/core/src/linkedinPublishing.ts
@@ -92,6 +92,13 @@ const LINKEDIN_NEWSLETTER_CADENCE_LABELS: Record<
   }
 };
 
+export const ARTICLE_TITLE_MAX_LENGTH = 150;
+export const ARTICLE_BODY_MAX_LENGTH = 125_000;
+export const NEWSLETTER_TITLE_MAX_LENGTH = 64;
+export const NEWSLETTER_DESCRIPTION_MAX_LENGTH = 300;
+export const NEWSLETTER_ISSUE_TITLE_MAX_LENGTH = 150;
+export const NEWSLETTER_ISSUE_BODY_MAX_LENGTH = 125_000;
+
 export interface PrepareCreateArticleInput {
   profileName?: string;
   title: string;
@@ -278,6 +285,7 @@ function requireSingleLineText(
   label: string,
   options: {
     allowUrl?: boolean;
+    maxLength?: number;
   } = {}
 ): string {
   const normalizedValue = normalizeText(value);
@@ -302,10 +310,21 @@ function requireSingleLineText(
     );
   }
 
+
+  if (options.maxLength && normalizedValue.length > options.maxLength) {
+    throw new LinkedInBuddyError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} exceeds maximum length of ${options.maxLength} characters (got ${normalizedValue.length}).`,
+    );
+  }
   return normalizedValue;
 }
 
-function requireLongFormText(value: string, label: string): string {
+function requireLongFormText(
+  value: string,
+  label: string,
+  options: { maxLength?: number } = {},
+): string {
   const normalizedValue = normalizeLine(
     value.replace(/\r\n/gu, "\n").replace(/\r/gu, "\n")
   );
@@ -324,6 +343,13 @@ function requireLongFormText(value: string, label: string): string {
     );
   }
 
+
+  if (options.maxLength && normalizedValue.length > options.maxLength) {
+    throw new LinkedInBuddyError(
+      "ACTION_PRECONDITION_FAILED",
+      `${label} exceeds maximum length of ${options.maxLength} characters (got ${normalizedValue.length}).`,
+    );
+  }
   return normalizedValue;
 }
 
@@ -1412,8 +1438,8 @@ export class LinkedInArticlesService {
     input: PrepareCreateArticleInput
   ): Promise<PreparedActionResult> {
     const profileName = input.profileName ?? "default";
-    const title = requireSingleLineText(input.title, "Article title");
-    const body = requireLongFormText(input.body, "Article body");
+    const title = requireSingleLineText(input.title, "Article title", { maxLength: ARTICLE_TITLE_MAX_LENGTH });
+    const body = requireLongFormText(input.body, "Article body", { maxLength: ARTICLE_BODY_MAX_LENGTH });
     const tracePath = `linkedin/trace-article-prepare-${Date.now()}.zip`;
     const artifactPaths: string[] = [tracePath];
 
@@ -1702,10 +1728,11 @@ export class LinkedInNewslettersService {
     input: PrepareCreateNewsletterInput
   ): Promise<PreparedActionResult> {
     const profileName = input.profileName ?? "default";
-    const title = requireSingleLineText(input.title, "Newsletter title");
+    const title = requireSingleLineText(input.title, "Newsletter title", { maxLength: NEWSLETTER_TITLE_MAX_LENGTH });
     const description = requireSingleLineText(
       input.description,
-      "Newsletter description"
+      "Newsletter description",
+      { maxLength: NEWSLETTER_DESCRIPTION_MAX_LENGTH }
     );
     const cadence = normalizeNewsletterCadence(input.cadence);
     const tracePath = `linkedin/trace-newsletter-prepare-${Date.now()}.zip`;
@@ -1863,8 +1890,8 @@ export class LinkedInNewslettersService {
   ): Promise<PreparedActionResult> {
     const profileName = input.profileName ?? "default";
     const newsletter = requireSingleLineText(input.newsletter, "newsletter");
-    const title = requireSingleLineText(input.title, "Issue title");
-    const body = requireLongFormText(input.body, "Issue body");
+    const title = requireSingleLineText(input.title, "Issue title", { maxLength: NEWSLETTER_ISSUE_TITLE_MAX_LENGTH });
+    const body = requireLongFormText(input.body, "Issue body", { maxLength: NEWSLETTER_ISSUE_BODY_MAX_LENGTH });
     const tracePath = `linkedin/trace-newsletter-issue-prepare-${Date.now()}.zip`;
     const artifactPaths: string[] = [tracePath];
 

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -362,7 +362,6 @@ export function createCoreRuntime(
       ...postExecutors,
       ...publishingExecutors,
       ...notificationExecutors,
-      ...publishingExecutors,
       ...privacySettingExecutors,
       ...eventExecutors,
       [TEST_ECHO_ACTION_TYPE]: testEchoExecutor


### PR DESCRIPTION
## Summary

Quality pass on the Articles & Newsletters feature (#235, originally implemented in PR #305). Covers phases 3-8 from issue #352.

## Changes

### Phase 3 — Simplify + Refactor
- Removed duplicate `...publishingExecutors` spread in `packages/core/src/runtime.ts` (was registered twice in the executor map)

### Phase 5 — Harden
- Added 6 exported max-length constants to `linkedinPublishing.ts`:
  - `ARTICLE_TITLE_MAX_LENGTH` (150), `ARTICLE_BODY_MAX_LENGTH` (125,000)
  - `NEWSLETTER_TITLE_MAX_LENGTH` (64), `NEWSLETTER_DESCRIPTION_MAX_LENGTH` (300)
  - `NEWSLETTER_ISSUE_TITLE_MAX_LENGTH` (150), `NEWSLETTER_ISSUE_BODY_MAX_LENGTH` (125,000)
- Added `maxLength` option to `requireSingleLineText()` and `requireLongFormText()` helpers
- Wired limits into all `prepareCreate` / `preparePublishIssue` service methods

### Phase 4 — Test
- Expanded `linkedinPublishing.test.ts` from 7 to 50 test cases
- Covers: empty inputs, control characters, URL titles, cadence aliases, case-insensitive cadence, malformed URLs, max-length limits, valid-input pass-through

### Phase 6 — UX/QoL
- Added 5 `run*` functions to CLI: `runArticlePrepareCreate`, `runArticlePreparePublish`, `runNewsletterPrepareCreate`, `runNewsletterPreparePublishIssue`, `runNewsletterList`
- Added 5 CLI command registrations: `article prepare-create`, `article prepare-publish`, `newsletter prepare-create`, `newsletter prepare-publish-issue`, `newsletter list`

### Phase 8 — Docs
- Created `docs/articles-newsletters.md` covering CLI, MCP, TypeScript API usage, rate limits, input validation, length limits, error codes, and artifacts
- Added entry to README docs map

## Verification
- `npm run lint` — passes
- `npm test -- --run` — 983 tests pass (102 files)
- Pre-existing build errors confirmed identical on base branch

Closes #352