### PR TITLE
feat: quality pass for analytics & insights (#353)

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,111 @@
+# Analytics and insights
+
+LinkedIn Buddy exposes four read-only analytics surfaces through the MCP server and the TypeScript API. These surfaces normalize metric data from LinkedIn's profile analytics pages and individual post engagement counters.
+
+| Surface            | MCP tool                                | Description                                        |
+| ------------------ | --------------------------------------- | -------------------------------------------------- |
+| Profile views      | `linkedin.analytics.profile_views`      | Who viewed your profile — counts, trend, and delta |
+| Search appearances | `linkedin.analytics.search_appearances` | How often you appeared in LinkedIn search          |
+| Content metrics    | `linkedin.analytics.content_metrics`    | Impressions, engagement, and creator analytics     |
+| Post metrics       | `linkedin.analytics.post_metrics`       | Reactions, comments, reposts for a single post     |
+
+## MCP usage
+
+The analytics tools allow you to retrieve snapshots of your performance data. The `profile_views`, `search_appearances`, and `content_metrics` tools all accept an optional `profileName` parameter (defaults to "default"). The `post_metrics` tool requires a `postUrl`.
+
+Example MCP call for profile views:
+
+```json
+{
+  "name": "linkedin.analytics.profile_views",
+  "arguments": {
+    "profileName": "default"
+  }
+}
+```
+
+Example MCP call for post metrics:
+
+```json
+{
+  "name": "linkedin.analytics.post_metrics",
+  "arguments": {
+    "postUrl": "https://www.linkedin.com/feed/update/urn:li:activity:1234567890/"
+  }
+}
+```
+
+## TypeScript API
+
+You can access analytics services directly through the core runtime.
+
+```ts
+import { createCoreRuntime } from "@linkedin-buddy/core";
+
+const runtime = createCoreRuntime();
+
+try {
+  const views = await runtime.analytics.getProfileViews({
+    profileName: "default",
+  });
+  console.log(views.metrics);
+} finally {
+  runtime.close();
+}
+```
+
+## Return shape
+
+The analytics services return structured summaries containing normalized metrics and the original UI cards they were extracted from.
+
+### LinkedInAnalyticsSummary
+
+- `surface`: The analytics surface name
+- `source_url`: The LinkedIn URL where the data was found
+- `observed_at`: ISO timestamp of the observation
+- `metrics[]`: Array of normalized metrics
+- `cards[]`: Array of source UI cards
+
+### LinkedInPostMetricsSummary
+
+Includes all fields from `LinkedInAnalyticsSummary` plus a `post` object:
+
+- `post_id`: Unique identifier for the post
+- `post_url`: Canonical URL of the post
+- `author_name`: Name of the post author
+- `author_headline`: Headline of the post author
+- `posted_at`: When the post was published
+- `text`: The text content of the post
+
+### LinkedInAnalyticsMetric
+
+- `metric_key`: Stable identifier for the metric (e.g., `profile_views`)
+- `label`: The display label from the UI
+- `value`: Numeric value if parsable, otherwise null
+- `value_text`: Raw text value from the UI
+- `delta_value`: Numeric change value if available
+- `delta_text`: Raw change text (e.g., "+12% past 7 days")
+- `unit`: `count`, `percent`, or `unknown`
+- `trend`: `up`, `down`, `flat`, or `unknown`
+- `observed_at`: ISO timestamp
+
+### LinkedInAnalyticsCard
+
+- `card_key`: Stable identifier for the card
+- `title`: Card title
+- `description`: Card description or subtitle
+- `href`: Link to the detailed analytics page
+- `metrics[]`: Metrics contained within this specific card
+
+## Limits
+
+The `content_metrics` surface accepts an optional `limit` parameter (1–50, default 4) to cap the number of returned cards. This is useful for focusing on the most prominent creator analytics cards.
+
+## Error handling
+
+Analytics tools throw `LinkedInBuddyError` in specific failure scenarios:
+
+- `UI_CHANGED_SELECTOR_FAILED`: Thrown when LinkedIn's UI has changed and the expected analytics cards cannot be located.
+- `UNKNOWN`: Thrown for unexpected browser or network failures.
+
+Both error types include the `surface` and `profileName` in their error details to help with debugging.

--- a/packages/core/src/__tests__/linkedinAnalytics.test.ts
+++ b/packages/core/src/__tests__/linkedinAnalytics.test.ts
@@ -2,12 +2,20 @@ import { describe, expect, it } from "vitest";
 import {
   LINKEDIN_ANALYTICS_SURFACES,
   LinkedInAnalyticsService,
+  ensureMatchingCards,
+  inferAnalyticsMetricTrend,
+  inferAnalyticsMetricUnit,
+  matchesAnalyticsCard,
   parseLinkedInAnalyticsNumber,
+  readAnalyticsLimit,
+  toAbsoluteLinkedInUrl,
   toLinkedInAnalyticsMetricKey,
+  type LinkedInAnalyticsCard,
   type LinkedInAnalyticsRuntime,
   type ReadContentMetricsInput,
-  type ReadPostMetricsInput
+  type ReadPostMetricsInput,
 } from "../linkedinAnalytics.js";
+import { LinkedInBuddyError } from "../errors.js";
 
 describe("LinkedInAnalyticsService", () => {
   it("exports the service class", () => {
@@ -20,32 +28,137 @@ describe("LinkedInAnalyticsService", () => {
       "profile_views",
       "search_appearances",
       "content_metrics",
-      "post_metrics"
+      "post_metrics",
     ]);
   });
 
   it("normalizes analytics metric keys", () => {
     expect(toLinkedInAnalyticsMetricKey("Profile views")).toBe("profile_views");
     expect(toLinkedInAnalyticsMetricKey("Engagement total")).toBe(
-      "engagement_total"
+      "engagement_total",
     );
     expect(toLinkedInAnalyticsMetricKey(" CTR % ")).toBe("ctr");
+    expect(toLinkedInAnalyticsMetricKey("")).toBe("metric");
+    expect(toLinkedInAnalyticsMetricKey("Click-through Rate (%)")).toBe(
+      "click_through_rate",
+    );
+    expect(toLinkedInAnalyticsMetricKey("___  Mixed___Value  ")).toBe(
+      "mixed_value",
+    );
+    expect(toLinkedInAnalyticsMetricKey("Ünicode   label")).toBe(
+      "nicode_label",
+    );
   });
 
   it("parses abbreviated count metrics", () => {
     expect(parseLinkedInAnalyticsNumber("1.2K")).toBe(1200);
     expect(parseLinkedInAnalyticsNumber("2,450")).toBe(2450);
     expect(parseLinkedInAnalyticsNumber("3,4M")).toBe(3_400_000);
+    expect(parseLinkedInAnalyticsNumber("2.5B")).toBe(2_500_000_000);
+    expect(parseLinkedInAnalyticsNumber("1T")).toBe(1_000_000_000_000);
+    expect(parseLinkedInAnalyticsNumber("-5.2K")).toBe(-5200);
   });
 
   it("parses percentage metrics", () => {
     expect(parseLinkedInAnalyticsNumber("4.5%")).toBe(4.5);
     expect(parseLinkedInAnalyticsNumber("+12% past 7 days")).toBe(12);
+    expect(parseLinkedInAnalyticsNumber("+12%")).toBe(12);
+  });
+
+  it("parses locale formats and whitespace", () => {
+    expect(parseLinkedInAnalyticsNumber("1.234,56")).toBe(1234.56);
+    expect(parseLinkedInAnalyticsNumber(" 1,234 ")).toBe(1234);
+    expect(parseLinkedInAnalyticsNumber("0")).toBe(0);
   });
 
   it("returns null for non-numeric analytics text", () => {
     expect(parseLinkedInAnalyticsNumber("No data yet")).toBeNull();
     expect(parseLinkedInAnalyticsNumber("")).toBeNull();
+    expect(parseLinkedInAnalyticsNumber("N/A")).toBeNull();
+    expect(parseLinkedInAnalyticsNumber("--")).toBeNull();
+  });
+
+  it("infers analytics metric units", () => {
+    expect(inferAnalyticsMetricUnit("Engagement", "45%")).toBe("percent");
+    expect(inferAnalyticsMetricUnit("Engagement rate", "12")).toBe("percent");
+    expect(inferAnalyticsMetricUnit("Impressions", "1200")).toBe("count");
+    expect(inferAnalyticsMetricUnit("Impressions", "N/A")).toBe("unknown");
+  });
+
+  it("infers analytics metric trends", () => {
+    expect(inferAnalyticsMetricTrend("+5%")).toBe("up");
+    expect(inferAnalyticsMetricTrend("-3 down")).toBe("down");
+    expect(inferAnalyticsMetricTrend("flat")).toBe("flat");
+    expect(inferAnalyticsMetricTrend("unknown text")).toBe("unknown");
+    expect(inferAnalyticsMetricTrend(null)).toBe("unknown");
+    expect(inferAnalyticsMetricTrend(undefined)).toBe("unknown");
+    expect(inferAnalyticsMetricTrend("")).toBe("unknown");
+  });
+
+  it("converts LinkedIn urls to absolute urls", () => {
+    expect(toAbsoluteLinkedInUrl("https://www.linkedin.com/in/me/")).toBe(
+      "https://www.linkedin.com/in/me/",
+    );
+    expect(toAbsoluteLinkedInUrl("/in/me/")).toBe(
+      "https://www.linkedin.com/in/me/",
+    );
+    expect(toAbsoluteLinkedInUrl("in/me/")).toBe(
+      "https://www.linkedin.com/in/me/",
+    );
+    expect(toAbsoluteLinkedInUrl(null)).toBeNull();
+    expect(toAbsoluteLinkedInUrl("")).toBeNull();
+  });
+
+  it("applies analytics limit fallback and bounds", () => {
+    expect(readAnalyticsLimit(undefined, 4)).toBe(4);
+    expect(readAnalyticsLimit(Number.NaN, 4)).toBe(4);
+    expect(readAnalyticsLimit(Number.POSITIVE_INFINITY, 4)).toBe(4);
+    expect(readAnalyticsLimit(0.5, 4)).toBe(1);
+    expect(readAnalyticsLimit(10, 4)).toBe(10);
+    expect(readAnalyticsLimit(100, 4)).toBe(50);
+  });
+
+  it("throws UI_CHANGED_SELECTOR_FAILED when no matching cards exist", () => {
+    expect(() => ensureMatchingCards("profile_views", [], [])).toThrow(
+      LinkedInBuddyError,
+    );
+
+    try {
+      ensureMatchingCards("profile_views", [], []);
+    } catch (error) {
+      expect(error).toBeInstanceOf(LinkedInBuddyError);
+      expect((error as LinkedInBuddyError).code).toBe(
+        "UI_CHANGED_SELECTOR_FAILED",
+      );
+    }
+  });
+
+  it("matches analytics cards with negative keyword filtering", () => {
+    const card: LinkedInAnalyticsCard = {
+      card_key: "content_analytics",
+      title: "Creator analytics",
+      description: "Content impressions and engagement",
+      href: "https://www.linkedin.com/in/me/",
+      metrics: [
+        {
+          metric_key: "impressions",
+          label: "Impressions",
+          value: 200,
+          value_text: "200",
+          delta_value: null,
+          delta_text: null,
+          unit: "count",
+          trend: "unknown",
+          observed_at: "2026-03-12T00:00:00.000Z",
+        },
+      ],
+    };
+
+    expect(matchesAnalyticsCard(card, ["creator analytics"])).toBe(true);
+    expect(matchesAnalyticsCard(card, ["profile view"])).toBe(false);
+    expect(
+      matchesAnalyticsCard(card, ["creator analytics"], ["engagement"]),
+    ).toBe(false);
   });
 
   it("keeps the runtime contract minimal for read-only analytics", () => {
@@ -54,7 +167,7 @@ describe("LinkedInAnalyticsService", () => {
       "cdpUrl",
       "profileManager",
       "logger",
-      "feed"
+      "feed",
     ];
     expect(runtimeKeys).toHaveLength(5);
   });
@@ -62,7 +175,7 @@ describe("LinkedInAnalyticsService", () => {
   it("accepts optional limits for aggregated content metrics", () => {
     const input: ReadContentMetricsInput = {
       profileName: "default",
-      limit: 3
+      limit: 3,
     };
 
     expect(input.profileName).toBe("default");
@@ -72,7 +185,8 @@ describe("LinkedInAnalyticsService", () => {
   it("requires a post URL for post metrics inputs", () => {
     const input: ReadPostMetricsInput = {
       profileName: "default",
-      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123456789/"
+      postUrl:
+        "https://www.linkedin.com/feed/update/urn:li:activity:123456789/",
     };
 
     expect(input.postUrl).toContain("linkedin.com/feed/update/");

--- a/packages/core/src/linkedinAnalytics.ts
+++ b/packages/core/src/linkedinAnalytics.ts
@@ -10,7 +10,7 @@ export const LINKEDIN_ANALYTICS_SURFACES = [
   "profile_views",
   "search_appearances",
   "content_metrics",
-  "post_metrics"
+  "post_metrics",
 ] as const;
 
 export type LinkedInAnalyticsSurface =
@@ -100,44 +100,46 @@ const LINKEDIN_SELF_PROFILE_URL = "https://www.linkedin.com/in/me/";
 const PROFILE_VIEW_KEYWORDS = [
   "profile view",
   "who viewed",
-  "viewed your profile"
+  "viewed your profile",
 ] as const;
 const SEARCH_APPEARANCES_KEYWORDS = ["search appearance"] as const;
 const CONTENT_METRICS_KEYWORDS = [
   "impression",
   "content",
   "engagement",
-  "creator analytics"
+  "creator analytics",
 ] as const;
 const CONTENT_METRICS_NEGATIVE_KEYWORDS = [
   ...PROFILE_VIEW_KEYWORDS,
-  ...SEARCH_APPEARANCES_KEYWORDS
+  ...SEARCH_APPEARANCES_KEYWORDS,
 ] as const;
 const IGNORED_ANALYTICS_LINES = new Set([
   "private to you",
-  "only visible to you"
+  "only visible to you",
 ]);
 
 function normalizeText(value: string | null | undefined): string {
   return (value ?? "").replace(/\s+/g, " ").trim();
 }
 
-function readAnalyticsLimit(
+export function readAnalyticsLimit(
   value: number | undefined,
-  fallback: number
+  fallback: number,
 ): number {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return fallback;
   }
 
-  return Math.max(1, Math.floor(value));
+  return Math.max(1, Math.min(Math.floor(value), 50));
 }
 
 function isAbsoluteUrl(value: string): boolean {
   return /^https?:\/\//i.test(value);
 }
 
-function toAbsoluteLinkedInUrl(value: string | null | undefined): string | null {
+export function toAbsoluteLinkedInUrl(
+  value: string | null | undefined,
+): string | null {
   const href = normalizeText(value);
   if (!href) {
     return null;
@@ -226,9 +228,9 @@ export function parseLinkedInAnalyticsNumber(value: string): number | null {
   return parsed * magnitude;
 }
 
-function inferAnalyticsMetricUnit(
+export function inferAnalyticsMetricUnit(
   label: string,
-  valueText: string
+  valueText: string,
 ): LinkedInAnalyticsMetricUnit {
   if (valueText.includes("%") || /\brate\b|\bpercent\b/i.test(label)) {
     return "percent";
@@ -237,8 +239,8 @@ function inferAnalyticsMetricUnit(
   return parseLinkedInAnalyticsNumber(valueText) === null ? "unknown" : "count";
 }
 
-function inferAnalyticsMetricTrend(
-  value: string | null | undefined
+export function inferAnalyticsMetricTrend(
+  value: string | null | undefined,
 ): LinkedInAnalyticsMetricTrend {
   const normalized = normalizeText(value).toLowerCase();
   if (!normalized) {
@@ -291,7 +293,7 @@ function isDeltaLikeLine(value: string): boolean {
 
 function createMetricDraft(
   line: string,
-  fallbackLabel: string
+  fallbackLabel: string,
 ): AnalyticsMetricDraft | null {
   const normalized = normalizeText(line);
   const valueText = extractMetricValueToken(normalized);
@@ -299,17 +301,18 @@ function createMetricDraft(
     return null;
   }
 
-  const label = normalizeText(normalized.replace(valueText, "")) || fallbackLabel;
+  const label =
+    normalizeText(normalized.replace(valueText, "")) || fallbackLabel;
   return {
     label,
     valueText,
-    deltaText: null
+    deltaText: null,
   };
 }
 
 function buildAnalyticsMetric(
   draft: AnalyticsMetricDraft,
-  observedAt: string
+  observedAt: string,
 ): LinkedInAnalyticsMetric {
   const label = normalizeText(draft.label) || "Metric";
   const metricKey = toLinkedInAnalyticsMetricKey(label);
@@ -327,14 +330,14 @@ function buildAnalyticsMetric(
     delta_text: draft.deltaText,
     unit,
     trend: inferAnalyticsMetricTrend(draft.deltaText),
-    observed_at: observedAt
+    observed_at: observedAt,
   };
 }
 
 function buildCardMetricsFromLines(
   title: string,
   lines: string[],
-  observedAt: string
+  observedAt: string,
 ): LinkedInAnalyticsMetric[] {
   const cleanedLines = lines
     .map((line) => normalizeText(line))
@@ -362,29 +365,27 @@ function buildCardMetricsFromLines(
   return drafts.map((draft) => buildAnalyticsMetric(draft, observedAt));
 }
 
-function flattenCardMetrics(cards: LinkedInAnalyticsCard[]): LinkedInAnalyticsMetric[] {
-  return cards.flatMap((card) => card.metrics);
-}
-
 function cardTextHaystack(card: LinkedInAnalyticsCard): string {
   return [
     card.card_key,
     card.title,
     card.description,
     card.href ?? "",
-    ...card.metrics.map((metric) => metric.label)
+    ...card.metrics.map((metric) => metric.label),
   ]
     .join(" ")
     .toLowerCase();
 }
 
-function matchesAnalyticsCard(
+export function matchesAnalyticsCard(
   card: LinkedInAnalyticsCard,
   keywords: readonly string[],
-  negativeKeywords: readonly string[] = []
+  negativeKeywords: readonly string[] = [],
 ): boolean {
   const haystack = cardTextHaystack(card);
-  if (negativeKeywords.some((keyword) => haystack.includes(keyword.toLowerCase()))) {
+  if (
+    negativeKeywords.some((keyword) => haystack.includes(keyword.toLowerCase()))
+  ) {
     return false;
   }
 
@@ -410,7 +411,7 @@ async function waitForAnalyticsSurface(page: Page): Promise<void> {
 
 /* eslint-disable no-undef -- DOM types are valid inside page.evaluate() */
 async function extractProfileAnalyticsCardSnapshots(
-  page: Page
+  page: Page,
 ): Promise<AnalyticsCardSnapshot[]> {
   return page.evaluate(() => {
     const normalize = (value: string | null | undefined): string =>
@@ -422,7 +423,9 @@ async function extractProfileAnalyticsCardSnapshots(
         .map((line) => normalize(line))
         .filter((line) => line.length > 0);
 
-    const toAbsoluteHref = (value: string | null | undefined): string | null => {
+    const toAbsoluteHref = (
+      value: string | null | undefined,
+    ): string | null => {
       const href = normalize(value);
       if (!href) {
         return null;
@@ -443,7 +446,7 @@ async function extractProfileAnalyticsCardSnapshots(
 
     const readTitle = (element: Element, lines: string[]): string => {
       const heading = normalize(
-        element.querySelector("h1, h2, h3, h4, strong, dt")?.textContent
+        element.querySelector("h1, h2, h3, h4, strong, dt")?.textContent,
       );
       if (heading) {
         return heading;
@@ -456,7 +459,7 @@ async function extractProfileAnalyticsCardSnapshots(
       /(profile views?|who viewed|viewed your profile|search appearances?|impressions?|content|engagement|analytics)/i;
     const relevantHrefPattern = /(analytics|profile-view|search-appear)/i;
     const candidates = Array.from(
-      document.querySelectorAll("a[href], button, article, li")
+      document.querySelectorAll("a[href], button, article, li"),
     ).filter((element) => {
       const text = readInnerText(element);
       if (!text || text.length > 400) {
@@ -464,7 +467,9 @@ async function extractProfileAnalyticsCardSnapshots(
       }
 
       const href = normalize(
-        element instanceof HTMLAnchorElement ? element.href : element.getAttribute("href")
+        element instanceof HTMLAnchorElement
+          ? element.href
+          : element.getAttribute("href"),
       );
 
       return relevantPattern.test(text) || relevantHrefPattern.test(href);
@@ -482,7 +487,7 @@ async function extractProfileAnalyticsCardSnapshots(
       const href = toAbsoluteHref(
         candidate instanceof HTMLAnchorElement
           ? candidate.href
-          : candidate.getAttribute("href")
+          : candidate.getAttribute("href"),
       );
       const description = lines
         .filter((line) => line !== title)
@@ -493,11 +498,14 @@ async function extractProfileAnalyticsCardSnapshots(
         title,
         description,
         href,
-        lines
+        lines,
       };
       const dedupeKey = `${title.toLowerCase()}|${href ?? ""}`;
       const existing = deduped.get(dedupeKey);
-      if (!existing || existing.lines.join(" ").length < lines.join(" ").length) {
+      if (
+        !existing ||
+        existing.lines.join(" ").length < lines.join(" ").length
+      ) {
         deduped.set(dedupeKey, snapshot);
       }
     }
@@ -509,19 +517,23 @@ async function extractProfileAnalyticsCardSnapshots(
 
 function toAnalyticsCards(
   snapshots: AnalyticsCardSnapshot[],
-  observedAt: string
+  observedAt: string,
 ): LinkedInAnalyticsCard[] {
   return snapshots
     .map((snapshot) => {
       const title = normalizeText(snapshot.title);
       const description = normalizeText(snapshot.description);
-      const metrics = buildCardMetricsFromLines(title, snapshot.lines, observedAt);
+      const metrics = buildCardMetricsFromLines(
+        title,
+        snapshot.lines,
+        observedAt,
+      );
       return {
         card_key: toLinkedInAnalyticsMetricKey(title),
         title,
         description,
         href: toAbsoluteLinkedInUrl(snapshot.href),
-        metrics
+        metrics,
       } satisfies LinkedInAnalyticsCard;
     })
     .filter((card) => card.title.length > 0)
@@ -530,7 +542,7 @@ function toAnalyticsCards(
 
 async function loadProfileAnalyticsCards(
   runtime: LinkedInAnalyticsRuntime,
-  profileName: string
+  profileName: string,
 ): Promise<{
   sourceUrl: string;
   observedAt: string;
@@ -538,39 +550,40 @@ async function loadProfileAnalyticsCards(
 }> {
   await runtime.auth.ensureAuthenticated({
     profileName,
-    cdpUrl: runtime.cdpUrl
+    cdpUrl: runtime.cdpUrl,
   });
 
   return runtime.profileManager.runWithContext(
     {
       cdpUrl: runtime.cdpUrl,
       profileName,
-      headless: true
+      headless: true,
     },
     async (context) => {
       const page = await getOrCreatePage(context);
       await page.goto(LINKEDIN_SELF_PROFILE_URL, {
-        waitUntil: "domcontentloaded"
+        waitUntil: "domcontentloaded",
+        timeout: 30_000,
       });
       await waitForAnalyticsSurface(page);
       const observedAt = new Date().toISOString();
       const cards = toAnalyticsCards(
         await extractProfileAnalyticsCardSnapshots(page),
-        observedAt
+        observedAt,
       );
       return {
         sourceUrl: page.url(),
         observedAt,
-        cards
+        cards,
       };
-    }
+    },
   );
 }
 
-function ensureMatchingCards(
+export function ensureMatchingCards(
   surface: LinkedInAnalyticsSurface,
   cards: LinkedInAnalyticsCard[],
-  availableCards: LinkedInAnalyticsCard[]
+  availableCards: LinkedInAnalyticsCard[],
 ): LinkedInAnalyticsCard[] {
   if (cards.length > 0) {
     return cards;
@@ -581,8 +594,8 @@ function ensureMatchingCards(
     `Could not locate LinkedIn analytics cards for ${surface}.`,
     {
       surface,
-      available_card_titles: availableCards.map((card) => card.title)
-    }
+      available_card_titles: availableCards.map((card) => card.title),
+    },
   );
 }
 
@@ -590,39 +603,45 @@ function buildSummary(
   surface: Exclude<LinkedInAnalyticsSurface, "post_metrics">,
   sourceUrl: string,
   observedAt: string,
-  cards: LinkedInAnalyticsCard[]
+  cards: LinkedInAnalyticsCard[],
 ): LinkedInAnalyticsSummary {
   return {
     surface,
     source_url: sourceUrl,
     observed_at: observedAt,
-    metrics: flattenCardMetrics(cards),
-    cards
+    metrics: cards.flatMap((card) => card.metrics),
+    cards,
   };
 }
 
 export class LinkedInAnalyticsService {
   constructor(private readonly runtime: LinkedInAnalyticsRuntime) {}
 
-  async getProfileViews(
-    input: ReadAnalyticsInput = {}
-  ): Promise<LinkedInAnalyticsSummary> {
-    const profileName = input.profileName ?? "default";
+  private resolveProfileName(profileName: string | undefined): string {
+    const normalizedProfileName = normalizeText(profileName);
+    return normalizedProfileName || "default";
+  }
+
+  private async fetchProfileSurface(input: {
+    surface: Exclude<LinkedInAnalyticsSurface, "post_metrics">;
+    profileName: string | undefined;
+    selectCards: (cards: LinkedInAnalyticsCard[]) => LinkedInAnalyticsCard[];
+    errorMessage: string;
+  }): Promise<LinkedInAnalyticsSummary> {
+    const profileName = this.resolveProfileName(input.profileName);
 
     try {
       const { sourceUrl, observedAt, cards } = await loadProfileAnalyticsCards(
         this.runtime,
-        profileName
+        profileName,
       );
       const matchedCards = ensureMatchingCards(
-        "profile_views",
-        cards.filter((card) =>
-          matchesAnalyticsCard(card, PROFILE_VIEW_KEYWORDS)
-        ),
-        cards
+        input.surface,
+        input.selectCards(cards),
+        cards,
       );
 
-      return buildSummary("profile_views", sourceUrl, observedAt, matchedCards);
+      return buildSummary(input.surface, sourceUrl, observedAt, matchedCards);
     } catch (error) {
       if (error instanceof LinkedInBuddyError) {
         throw error;
@@ -631,124 +650,95 @@ export class LinkedInAnalyticsService {
       throw asLinkedInBuddyError(
         error,
         "UNKNOWN",
-        "Failed to read LinkedIn profile view analytics."
+        `${input.errorMessage} (profileName: ${profileName}).`,
       );
     }
+  }
+
+  async getProfileViews(
+    input: ReadAnalyticsInput = {},
+  ): Promise<LinkedInAnalyticsSummary> {
+    return this.fetchProfileSurface({
+      surface: "profile_views",
+      profileName: input.profileName,
+      selectCards: (cards) =>
+        cards.filter((card) =>
+          matchesAnalyticsCard(card, PROFILE_VIEW_KEYWORDS),
+        ),
+      errorMessage: "Failed to read LinkedIn profile view analytics.",
+    });
   }
 
   async getSearchAppearances(
-    input: ReadAnalyticsInput = {}
+    input: ReadAnalyticsInput = {},
   ): Promise<LinkedInAnalyticsSummary> {
-    const profileName = input.profileName ?? "default";
-
-    try {
-      const { sourceUrl, observedAt, cards } = await loadProfileAnalyticsCards(
-        this.runtime,
-        profileName
-      );
-      const matchedCards = ensureMatchingCards(
-        "search_appearances",
+    return this.fetchProfileSurface({
+      surface: "search_appearances",
+      profileName: input.profileName,
+      selectCards: (cards) =>
         cards.filter((card) =>
-          matchesAnalyticsCard(card, SEARCH_APPEARANCES_KEYWORDS)
+          matchesAnalyticsCard(card, SEARCH_APPEARANCES_KEYWORDS),
         ),
-        cards
-      );
-
-      return buildSummary(
-        "search_appearances",
-        sourceUrl,
-        observedAt,
-        matchedCards
-      );
-    } catch (error) {
-      if (error instanceof LinkedInBuddyError) {
-        throw error;
-      }
-
-      throw asLinkedInBuddyError(
-        error,
-        "UNKNOWN",
-        "Failed to read LinkedIn search appearance analytics."
-      );
-    }
+      errorMessage: "Failed to read LinkedIn search appearance analytics.",
+    });
   }
 
   async getContentMetrics(
-    input: ReadContentMetricsInput = {}
+    input: ReadContentMetricsInput = {},
   ): Promise<LinkedInAnalyticsSummary> {
-    const profileName = input.profileName ?? "default";
     const limit = readAnalyticsLimit(input.limit, 4);
 
-    try {
-      const { sourceUrl, observedAt, cards } = await loadProfileAnalyticsCards(
-        this.runtime,
-        profileName
-      );
-      const directMatches = cards.filter((card) =>
-        matchesAnalyticsCard(
-          card,
-          CONTENT_METRICS_KEYWORDS,
-          CONTENT_METRICS_NEGATIVE_KEYWORDS
-        )
-      );
-      const fallbackMatches = cards.filter(
-        (card) =>
-          !matchesAnalyticsCard(card, PROFILE_VIEW_KEYWORDS) &&
-          !matchesAnalyticsCard(card, SEARCH_APPEARANCES_KEYWORDS)
-      );
-      const matchedCards =
-        directMatches.length > 0
-          ? directMatches.slice(0, limit)
-          : fallbackMatches.slice(0, limit);
-      if (cards.length === 0) {
-        throw new LinkedInBuddyError(
-          "UI_CHANGED_SELECTOR_FAILED",
-          "Could not locate LinkedIn analytics cards for content_metrics.",
-          {
-            surface: "content_metrics",
-            available_card_titles: []
-          }
+    return this.fetchProfileSurface({
+      surface: "content_metrics",
+      profileName: input.profileName,
+      selectCards: (cards) => {
+        const directMatches = cards.filter((card) =>
+          matchesAnalyticsCard(
+            card,
+            CONTENT_METRICS_KEYWORDS,
+            CONTENT_METRICS_NEGATIVE_KEYWORDS,
+          ),
         );
-      }
+        const fallbackMatches = cards.filter(
+          (card) =>
+            !matchesAnalyticsCard(card, PROFILE_VIEW_KEYWORDS) &&
+            !matchesAnalyticsCard(card, SEARCH_APPEARANCES_KEYWORDS),
+        );
+        const matchedCards =
+          directMatches.length > 0
+            ? directMatches.slice(0, limit)
+            : fallbackMatches.slice(0, limit);
 
-      return buildSummary("content_metrics", sourceUrl, observedAt, matchedCards);
-    } catch (error) {
-      if (error instanceof LinkedInBuddyError) {
-        throw error;
-      }
-
-      throw asLinkedInBuddyError(
-        error,
-        "UNKNOWN",
-        "Failed to read LinkedIn content analytics."
-      );
-    }
+        return matchedCards;
+      },
+      errorMessage: "Failed to read LinkedIn content analytics.",
+    });
   }
 
   async getPostMetrics(
-    input: ReadPostMetricsInput
+    input: ReadPostMetricsInput,
   ): Promise<LinkedInPostMetricsSummary> {
-    const profileName = input.profileName ?? "default";
+    const profileName = this.resolveProfileName(input.profileName);
 
     try {
       const post = await this.runtime.feed.viewPost({
         profileName,
-        postUrl: input.postUrl
+        postUrl: input.postUrl,
       });
       const observedAt = new Date().toISOString();
       const metrics = [
         {
           label: "Reactions",
-          valueText: post.reactions_count
+          valueText: post.reactions_count,
         },
         {
           label: "Comments",
-          valueText: post.comments_count
+          valueText: post.comments_count,
         },
         {
           label: "Reposts",
-          valueText: post.reposts_count
-        }
+          valueText: post.reposts_count,
+        },
       ]
         .map((entry) => ({
           metric_key: toLinkedInAnalyticsMetricKey(entry.label),
@@ -759,10 +749,10 @@ export class LinkedInAnalyticsService {
           delta_text: null,
           unit: inferAnalyticsMetricUnit(entry.label, entry.valueText),
           trend: "unknown" as const,
-          observed_at: observedAt
+          observed_at: observedAt,
         }))
         .filter(
-          (metric) => metric.value_text.length > 0 || metric.value !== null
+          (metric) => metric.value_text.length > 0 || metric.value !== null,
         );
 
       const engagementTotal = metrics.reduce((total, metric) => {
@@ -787,17 +777,17 @@ export class LinkedInAnalyticsService {
               delta_text: null,
               unit: "count",
               trend: "unknown",
-              observed_at: observedAt
-            }
-          ]
-        }
+              observed_at: observedAt,
+            },
+          ],
+        },
       ];
 
       return {
         surface: "post_metrics",
         source_url: post.post_url,
         observed_at: observedAt,
-        metrics: flattenCardMetrics(cards),
+        metrics: cards.flatMap((card) => card.metrics),
         cards,
         post: {
           post_id: normalizeText(post.post_id),
@@ -805,8 +795,8 @@ export class LinkedInAnalyticsService {
           author_name: normalizeText(post.author_name),
           author_headline: normalizeText(post.author_headline),
           posted_at: normalizeText(post.posted_at),
-          text: normalizeText(post.text)
-        }
+          text: normalizeText(post.text),
+        },
       };
     } catch (error) {
       if (error instanceof LinkedInBuddyError) {
@@ -816,7 +806,7 @@ export class LinkedInAnalyticsService {
       throw asLinkedInBuddyError(
         error,
         "UNKNOWN",
-        "Failed to read LinkedIn post metrics."
+        `Failed to read LinkedIn post metrics. (profileName: ${profileName}).`,
       );
     }
   }

--- a/packages/mcp/src/__tests__/linkedinMcp.test.ts
+++ b/packages/mcp/src/__tests__/linkedinMcp.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  LINKEDIN_ANALYTICS_CONTENT_METRICS_TOOL,
   LINKEDIN_ANALYTICS_POST_METRICS_TOOL,
   LINKEDIN_ANALYTICS_PROFILE_VIEWS_TOOL,
+  LINKEDIN_ANALYTICS_SEARCH_APPEARANCES_TOOL,
   LINKEDIN_ARTICLE_PREPARE_CREATE_TOOL,
   LINKEDIN_ARTICLE_PREPARE_PUBLISH_TOOL,
   LINKEDIN_COMPANY_VIEW_TOOL,
@@ -28,27 +30,28 @@ import {
   LINKEDIN_NOTIFICATIONS_MARK_READ_TOOL,
   LINKEDIN_NOTIFICATIONS_PREFERENCES_GET_TOOL,
   LINKEDIN_NOTIFICATIONS_PREFERENCES_PREPARE_UPDATE_TOOL,
-  LINKEDIN_PRIVACY_GET_SETTINGS_TOOL
+  LINKEDIN_PRIVACY_GET_SETTINGS_TOOL,
 } from "../index.js";
 
 const runtimeFactory = vi.fn();
 
 vi.mock("@linkedin-buddy/core", async () => {
-  const actual =
-    await vi.importActual<typeof import("@linkedin-buddy/core")>(
-      "@linkedin-buddy/core"
-    );
+  const actual = await vi.importActual<typeof import("@linkedin-buddy/core")>(
+    "@linkedin-buddy/core",
+  );
 
   return {
     ...actual,
-    createCoreRuntime: runtimeFactory
+    createCoreRuntime: runtimeFactory,
   };
 });
 
 interface FakeRuntime {
   analytics: {
+    getContentMetrics: ReturnType<typeof vi.fn>;
     getPostMetrics: ReturnType<typeof vi.fn>;
     getProfileViews: ReturnType<typeof vi.fn>;
+    getSearchAppearances: ReturnType<typeof vi.fn>;
   };
   close: ReturnType<typeof vi.fn>;
   companyPages: {
@@ -106,49 +109,51 @@ function createFakeRuntime(): FakeRuntime {
   return {
     runId: "run_test",
     analytics: {
+      getContentMetrics: vi.fn(),
       getPostMetrics: vi.fn(),
-      getProfileViews: vi.fn()
+      getProfileViews: vi.fn(),
+      getSearchAppearances: vi.fn(),
     },
     close: vi.fn(),
     companyPages: {
       prepareFollowCompanyPage: vi.fn(),
-      viewCompanyPage: vi.fn()
+      viewCompanyPage: vi.fn(),
     },
     logger: {
-      log: vi.fn()
+      log: vi.fn(),
     },
     notifications: {
       getPreferences: vi.fn(),
       markRead: vi.fn(),
       prepareDismissNotification: vi.fn(),
-      prepareUpdatePreference: vi.fn()
+      prepareUpdatePreference: vi.fn(),
     },
     members: {
-      prepareReportMember: vi.fn()
+      prepareReportMember: vi.fn(),
     },
     groups: {
       searchGroups: vi.fn(),
       viewGroup: vi.fn(),
       prepareJoinGroup: vi.fn(),
       prepareLeaveGroup: vi.fn(),
-      preparePostToGroup: vi.fn()
+      preparePostToGroup: vi.fn(),
     },
     articles: {
       prepareCreate: vi.fn(),
-      preparePublish: vi.fn()
+      preparePublish: vi.fn(),
     },
     newsletters: {
       prepareCreate: vi.fn(),
       preparePublishIssue: vi.fn(),
-      list: vi.fn()
+      list: vi.fn(),
     },
     events: {
       searchEvents: vi.fn(),
       viewEvent: vi.fn(),
-      prepareRsvp: vi.fn()
+      prepareRsvp: vi.fn(),
     },
     privacySettings: {
-      getSettings: vi.fn()
+      getSettings: vi.fn(),
     },
     jobs: {
       listJobAlerts: vi.fn(),
@@ -156,8 +161,8 @@ function createFakeRuntime(): FakeRuntime {
       prepareEasyApply: vi.fn(),
       prepareRemoveJobAlert: vi.fn(),
       prepareSaveJob: vi.fn(),
-      prepareUnsaveJob: vi.fn()
-    }
+      prepareUnsaveJob: vi.fn(),
+    },
   };
 }
 
@@ -182,7 +187,7 @@ describe("handleToolCall", () => {
 
     const result = await handleToolCall(LINKEDIN_INBOX_SEARCH_RECIPIENTS_TOOL, {
       query: "Simon Miller",
-      limit: "5" as unknown as number
+      limit: "5" as unknown as number,
     });
 
     expect("isError" in result && result.isError).toBe(true);
@@ -191,8 +196,8 @@ describe("handleToolCall", () => {
       message: "limit must be a finite number.",
       details: {
         path: "limit",
-        actual_type: "string"
-      }
+        actual_type: "string",
+      },
     });
     expect(runtimeFactory).not.toHaveBeenCalled();
   });
@@ -206,18 +211,19 @@ describe("handleToolCall", () => {
         allowed_values: [
           "full_profile",
           "private_profile_characteristics",
-          "private_mode"
+          "private_mode",
         ],
         current_value: "private_mode",
         status: "available",
-        source_url: "https://www.linkedin.com/mypreferences/d/profile-viewing-options",
+        source_url:
+          "https://www.linkedin.com/mypreferences/d/profile-viewing-options",
         selector_key: "profile-viewing-mode-input-index-2",
-        message: null
-      }
+        message: null,
+      },
     ]);
 
     const result = await handleToolCall(LINKEDIN_PRIVACY_GET_SETTINGS_TOOL, {
-      profileName: "default"
+      profileName: "default",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -227,12 +233,12 @@ describe("handleToolCall", () => {
       settings: [
         expect.objectContaining({
           key: "profile_viewing_mode",
-          current_value: "private_mode"
-        })
-      ]
+          current_value: "private_mode",
+        }),
+      ],
     });
     expect(fakeRuntime.privacySettings.getSettings).toHaveBeenCalledWith({
-      profileName: "default"
+      profileName: "default",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -252,8 +258,8 @@ describe("handleToolCall", () => {
           delta_text: null,
           unit: "count",
           trend: "unknown",
-          observed_at: "2026-03-11T12:00:00.000Z"
-        }
+          observed_at: "2026-03-11T12:00:00.000Z",
+        },
       ],
       cards: [
         {
@@ -271,15 +277,15 @@ describe("handleToolCall", () => {
               delta_text: null,
               unit: "count",
               trend: "unknown",
-              observed_at: "2026-03-11T12:00:00.000Z"
-            }
-          ]
-        }
-      ]
+              observed_at: "2026-03-11T12:00:00.000Z",
+            },
+          ],
+        },
+      ],
     });
 
     const result = await handleToolCall(LINKEDIN_ANALYTICS_PROFILE_VIEWS_TOOL, {
-      profileName: "default"
+      profileName: "default",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -290,12 +296,146 @@ describe("handleToolCall", () => {
       metrics: [
         expect.objectContaining({
           metric_key: "profile_views",
-          value: 42
-        })
-      ]
+          value: 42,
+        }),
+      ],
     });
     expect(fakeRuntime.analytics.getProfileViews).toHaveBeenCalledWith({
-      profileName: "default"
+      profileName: "default",
+    });
+    expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns search-appearances analytics payloads through the MCP contract", async () => {
+    fakeRuntime.analytics.getSearchAppearances.mockResolvedValue({
+      surface: "search_appearances",
+      source_url: "https://www.linkedin.com/in/me/",
+      observed_at: "2026-03-11T12:00:00.000Z",
+      metrics: [
+        {
+          metric_key: "search_appearances",
+          label: "Search appearances",
+          value: 28,
+          value_text: "28",
+          delta_value: null,
+          delta_text: null,
+          unit: "count",
+          trend: "unknown",
+          observed_at: "2026-03-11T12:00:00.000Z",
+        },
+      ],
+      cards: [
+        {
+          card_key: "search_appearances",
+          title: "Search appearances",
+          description: "How often your profile appears in search.",
+          href: "https://www.linkedin.com/in/me/",
+          metrics: [
+            {
+              metric_key: "search_appearances",
+              label: "Search appearances",
+              value: 28,
+              value_text: "28",
+              delta_value: null,
+              delta_text: null,
+              unit: "count",
+              trend: "unknown",
+              observed_at: "2026-03-11T12:00:00.000Z",
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await handleToolCall(
+      LINKEDIN_ANALYTICS_SEARCH_APPEARANCES_TOOL,
+      {
+        profileName: "default",
+      },
+    );
+
+    expect("isError" in result && result.isError).toBe(false);
+    expect(parseToolPayload(result)).toMatchObject({
+      run_id: "run_test",
+      profile_name: "default",
+      surface: "search_appearances",
+      metrics: [
+        expect.objectContaining({
+          metric_key: "search_appearances",
+          value: 28,
+        }),
+      ],
+    });
+    expect(fakeRuntime.analytics.getSearchAppearances).toHaveBeenCalledWith({
+      profileName: "default",
+    });
+    expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns content-metrics analytics payloads through the MCP contract", async () => {
+    fakeRuntime.analytics.getContentMetrics.mockResolvedValue({
+      surface: "content_metrics",
+      source_url: "https://www.linkedin.com/in/me/",
+      observed_at: "2026-03-11T12:00:00.000Z",
+      metrics: [
+        {
+          metric_key: "impressions",
+          label: "Impressions",
+          value: 350,
+          value_text: "350",
+          delta_value: null,
+          delta_text: null,
+          unit: "count",
+          trend: "unknown",
+          observed_at: "2026-03-11T12:00:00.000Z",
+        },
+      ],
+      cards: [
+        {
+          card_key: "content_metrics",
+          title: "Creator analytics",
+          description: "Performance summary for your content.",
+          href: "https://www.linkedin.com/in/me/",
+          metrics: [
+            {
+              metric_key: "impressions",
+              label: "Impressions",
+              value: 350,
+              value_text: "350",
+              delta_value: null,
+              delta_text: null,
+              unit: "count",
+              trend: "unknown",
+              observed_at: "2026-03-11T12:00:00.000Z",
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await handleToolCall(
+      LINKEDIN_ANALYTICS_CONTENT_METRICS_TOOL,
+      {
+        profileName: "default",
+        limit: 3,
+      },
+    );
+
+    expect("isError" in result && result.isError).toBe(false);
+    expect(parseToolPayload(result)).toMatchObject({
+      run_id: "run_test",
+      profile_name: "default",
+      surface: "content_metrics",
+      metrics: [
+        expect.objectContaining({
+          metric_key: "impressions",
+          value: 350,
+        }),
+      ],
+    });
+    expect(fakeRuntime.analytics.getContentMetrics).toHaveBeenCalledWith({
+      profileName: "default",
+      limit: 3,
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -306,15 +446,15 @@ describe("handleToolCall", () => {
       confirmToken: "ct_test",
       expiresAtMs: 123,
       preview: {
-        summary: "Report LinkedIn member target-user for spam"
-      }
+        summary: "Report LinkedIn member target-user for spam",
+      },
     });
 
     const result = await handleToolCall(LINKEDIN_MEMBERS_PREPARE_REPORT_TOOL, {
       profileName: "default",
       targetProfile: "target-user",
       reason: "spam",
-      details: "Repeated unsolicited outreach."
+      details: "Repeated unsolicited outreach.",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -322,13 +462,13 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_test",
-      confirmToken: "ct_test"
+      confirmToken: "ct_test",
     });
     expect(fakeRuntime.members.prepareReportMember).toHaveBeenCalledWith({
       profileName: "default",
       targetProfile: "target-user",
       reason: "spam",
-      details: "Repeated unsolicited outreach."
+      details: "Repeated unsolicited outreach.",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -339,12 +479,12 @@ describe("handleToolCall", () => {
       was_already_read: false,
       notification_id: "notif_1",
       link: "https://www.linkedin.com/feed/update/urn:li:activity:1",
-      selector_key: "headline-link"
+      selector_key: "headline-link",
     });
 
     const result = await handleToolCall(LINKEDIN_NOTIFICATIONS_MARK_READ_TOOL, {
       profileName: "default",
-      notificationId: "notif_1"
+      notificationId: "notif_1",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -352,11 +492,11 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       marked_read: true,
-      notification_id: "notif_1"
+      notification_id: "notif_1",
     });
     expect(fakeRuntime.notifications.markRead).toHaveBeenCalledWith({
       profileName: "default",
-      notificationId: "notif_1"
+      notificationId: "notif_1",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -367,13 +507,13 @@ describe("handleToolCall", () => {
       confirmToken: "ct_notif",
       expiresAtMs: 789,
       preview: {
-        summary: "Dismiss notification"
-      }
+        summary: "Dismiss notification",
+      },
     });
 
     const result = await handleToolCall(LINKEDIN_NOTIFICATIONS_DISMISS_TOOL, {
       profileName: "default",
-      notificationId: "notif_1"
+      notificationId: "notif_1",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -381,11 +521,13 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_notif",
-      confirmToken: "ct_notif"
+      confirmToken: "ct_notif",
     });
-    expect(fakeRuntime.notifications.prepareDismissNotification).toHaveBeenCalledWith({
+    expect(
+      fakeRuntime.notifications.prepareDismissNotification,
+    ).toHaveBeenCalledWith({
       profileName: "default",
-      notificationId: "notif_1"
+      notificationId: "notif_1",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -394,22 +536,23 @@ describe("handleToolCall", () => {
     fakeRuntime.notifications.getPreferences.mockResolvedValue({
       view_type: "overview",
       title: "Notifications",
-      preference_url: "https://www.linkedin.com/mypreferences/d/categories/notifications",
+      preference_url:
+        "https://www.linkedin.com/mypreferences/d/categories/notifications",
       categories: [
         {
           title: "Posting and commenting",
           slug: "posting-and-commenting",
           preference_url:
-            "https://www.linkedin.com/mypreferences/d/notification-categories/posting-and-commenting"
-        }
-      ]
+            "https://www.linkedin.com/mypreferences/d/notification-categories/posting-and-commenting",
+        },
+      ],
     });
 
     const result = await handleToolCall(
       LINKEDIN_NOTIFICATIONS_PREFERENCES_GET_TOOL,
       {
-        profileName: "default"
-      }
+        profileName: "default",
+      },
     );
 
     expect("isError" in result && result.isError).toBe(false);
@@ -420,13 +563,13 @@ describe("handleToolCall", () => {
         view_type: "overview",
         categories: [
           expect.objectContaining({
-            slug: "posting-and-commenting"
-          })
-        ]
-      }
+            slug: "posting-and-commenting",
+          }),
+        ],
+      },
     });
     expect(fakeRuntime.notifications.getPreferences).toHaveBeenCalledWith({
-      profileName: "default"
+      profileName: "default",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -437,8 +580,8 @@ describe("handleToolCall", () => {
       confirmToken: "ct_pref",
       expiresAtMs: 999,
       preview: {
-        summary: "Update notification preference"
-      }
+        summary: "Update notification preference",
+      },
     });
 
     const result = await handleToolCall(
@@ -448,8 +591,8 @@ describe("handleToolCall", () => {
         preferenceUrl:
           "https://www.linkedin.com/mypreferences/d/notification-subcategories/comments-and-reactions",
         enabled: false,
-        channel: "push"
-      }
+        channel: "push",
+      },
     );
 
     expect("isError" in result && result.isError).toBe(false);
@@ -457,14 +600,16 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_pref",
-      confirmToken: "ct_pref"
+      confirmToken: "ct_pref",
     });
-    expect(fakeRuntime.notifications.prepareUpdatePreference).toHaveBeenCalledWith({
+    expect(
+      fakeRuntime.notifications.prepareUpdatePreference,
+    ).toHaveBeenCalledWith({
       profileName: "default",
       preferenceUrl:
         "https://www.linkedin.com/mypreferences/d/notification-subcategories/comments-and-reactions",
       enabled: false,
-      channel: "push"
+      channel: "push",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -481,15 +626,15 @@ describe("handleToolCall", () => {
           visibility: "Private Listed",
           member_count: "706,250 members",
           description: "Community for next-generation leaders.",
-          membership_state: "member"
-        }
-      ]
+          membership_state: "member",
+        },
+      ],
     });
 
     const result = await handleToolCall(LINKEDIN_GROUPS_SEARCH_TOOL, {
       profileName: "default",
       query: "technology",
-      limit: 5
+      limit: 5,
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -499,14 +644,14 @@ describe("handleToolCall", () => {
       query: "technology",
       results: [
         expect.objectContaining({
-          group_id: "9806731"
-        })
-      ]
+          group_id: "9806731",
+        }),
+      ],
     });
     expect(fakeRuntime.groups.searchGroups).toHaveBeenCalledWith({
       profileName: "default",
       query: "technology",
-      limit: 5
+      limit: 5,
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -527,12 +672,12 @@ describe("handleToolCall", () => {
       headquarters: "San Francisco, CA",
       specialties: "artificial intelligence and machine learning",
       overview: "OpenAI is an AI research and deployment company.",
-      follow_state: "following"
+      follow_state: "following",
     });
 
     const result = await handleToolCall(LINKEDIN_COMPANY_VIEW_TOOL, {
       profileName: "default",
-      target: "openai"
+      target: "openai",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -541,12 +686,12 @@ describe("handleToolCall", () => {
       profile_name: "default",
       company: {
         name: "OpenAI",
-        follow_state: "following"
-      }
+        follow_state: "following",
+      },
     });
     expect(fakeRuntime.companyPages.viewCompanyPage).toHaveBeenCalledWith({
       profileName: "default",
-      target: "openai"
+      target: "openai",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -561,12 +706,12 @@ describe("handleToolCall", () => {
       description: "Community for next-generation leaders.",
       about: "Community for next-generation leaders.",
       joined_at: "Apr 2024",
-      membership_state: "member"
+      membership_state: "member",
     });
 
     const result = await handleToolCall(LINKEDIN_GROUPS_VIEW_TOOL, {
       profileName: "default",
-      group: "9806731"
+      group: "9806731",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -575,12 +720,12 @@ describe("handleToolCall", () => {
       profile_name: "default",
       group: expect.objectContaining({
         group_id: "9806731",
-        membership_state: "member"
-      })
+        membership_state: "member",
+      }),
     });
     expect(fakeRuntime.groups.viewGroup).toHaveBeenCalledWith({
       profileName: "default",
-      group: "9806731"
+      group: "9806731",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -591,13 +736,13 @@ describe("handleToolCall", () => {
       confirmToken: "ct_group_join",
       expiresAtMs: 123,
       preview: {
-        summary: "Join LinkedIn group 63979"
-      }
+        summary: "Join LinkedIn group 63979",
+      },
     });
 
     const result = await handleToolCall(LINKEDIN_GROUPS_PREPARE_JOIN_TOOL, {
       profileName: "default",
-      group: "63979"
+      group: "63979",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -605,11 +750,11 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_group_join",
-      confirmToken: "ct_group_join"
+      confirmToken: "ct_group_join",
     });
     expect(fakeRuntime.groups.prepareJoinGroup).toHaveBeenCalledWith({
       profileName: "default",
-      group: "63979"
+      group: "63979",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -620,14 +765,14 @@ describe("handleToolCall", () => {
       confirmToken: "ct_group_leave",
       expiresAtMs: 123,
       preview: {
-        summary: "Leave LinkedIn group 9806731"
-      }
+        summary: "Leave LinkedIn group 9806731",
+      },
     });
 
     const result = await handleToolCall(LINKEDIN_GROUPS_PREPARE_LEAVE_TOOL, {
       profileName: "default",
       group: "9806731",
-      operatorNote: "Validation"
+      operatorNote: "Validation",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -635,12 +780,12 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_group_leave",
-      confirmToken: "ct_group_leave"
+      confirmToken: "ct_group_leave",
     });
     expect(fakeRuntime.groups.prepareLeaveGroup).toHaveBeenCalledWith({
       profileName: "default",
       group: "9806731",
-      operatorNote: "Validation"
+      operatorNote: "Validation",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -651,14 +796,14 @@ describe("handleToolCall", () => {
       confirmToken: "ct_group_post",
       expiresAtMs: 123,
       preview: {
-        summary: "Post to LinkedIn group 9806731"
-      }
+        summary: "Post to LinkedIn group 9806731",
+      },
     });
 
     const result = await handleToolCall(LINKEDIN_GROUPS_PREPARE_POST_TOOL, {
       profileName: "default",
       group: "9806731",
-      text: "Thanks for sharing this perspective."
+      text: "Thanks for sharing this perspective.",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -666,12 +811,12 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_group_post",
-      confirmToken: "ct_group_post"
+      confirmToken: "ct_group_post",
     });
     expect(fakeRuntime.groups.preparePostToGroup).toHaveBeenCalledWith({
       profileName: "default",
       group: "9806731",
-      text: "Thanks for sharing this perspective."
+      text: "Thanks for sharing this perspective.",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -682,14 +827,14 @@ describe("handleToolCall", () => {
       confirmToken: "ct_article_create",
       expiresAtMs: 123,
       preview: {
-        summary: 'Create LinkedIn article draft "Launch notes"'
-      }
+        summary: 'Create LinkedIn article draft "Launch notes"',
+      },
     });
 
     const result = await handleToolCall(LINKEDIN_ARTICLE_PREPARE_CREATE_TOOL, {
       profileName: "default",
       title: "Launch notes",
-      body: "A longer article body."
+      body: "A longer article body.",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -697,12 +842,12 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_article_create",
-      confirmToken: "ct_article_create"
+      confirmToken: "ct_article_create",
     });
     expect(fakeRuntime.articles.prepareCreate).toHaveBeenCalledWith({
       profileName: "default",
       title: "Launch notes",
-      body: "A longer article body."
+      body: "A longer article body.",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -713,13 +858,13 @@ describe("handleToolCall", () => {
       confirmToken: "ct_article_publish",
       expiresAtMs: 123,
       preview: {
-        summary: 'Publish LinkedIn article draft "Launch notes"'
-      }
+        summary: 'Publish LinkedIn article draft "Launch notes"',
+      },
     });
 
     const result = await handleToolCall(LINKEDIN_ARTICLE_PREPARE_PUBLISH_TOOL, {
       profileName: "default",
-      draftUrl: "https://www.linkedin.com/pulse/article/123/edit/"
+      draftUrl: "https://www.linkedin.com/pulse/article/123/edit/",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -727,11 +872,11 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_article_publish",
-      confirmToken: "ct_article_publish"
+      confirmToken: "ct_article_publish",
     });
     expect(fakeRuntime.articles.preparePublish).toHaveBeenCalledWith({
       profileName: "default",
-      draftUrl: "https://www.linkedin.com/pulse/article/123/edit/"
+      draftUrl: "https://www.linkedin.com/pulse/article/123/edit/",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -742,29 +887,32 @@ describe("handleToolCall", () => {
       confirmToken: "ct_newsletter_create",
       expiresAtMs: 123,
       preview: {
-        summary: 'Create LinkedIn newsletter "Builder Brief"'
-      }
+        summary: 'Create LinkedIn newsletter "Builder Brief"',
+      },
     });
 
-    const result = await handleToolCall(LINKEDIN_NEWSLETTER_PREPARE_CREATE_TOOL, {
-      profileName: "default",
-      title: "Builder Brief",
-      description: "Weekly notes from the product team.",
-      cadence: "weekly"
-    });
+    const result = await handleToolCall(
+      LINKEDIN_NEWSLETTER_PREPARE_CREATE_TOOL,
+      {
+        profileName: "default",
+        title: "Builder Brief",
+        description: "Weekly notes from the product team.",
+        cadence: "weekly",
+      },
+    );
 
     expect("isError" in result && result.isError).toBe(false);
     expect(parseToolPayload(result)).toMatchObject({
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_newsletter_create",
-      confirmToken: "ct_newsletter_create"
+      confirmToken: "ct_newsletter_create",
     });
     expect(fakeRuntime.newsletters.prepareCreate).toHaveBeenCalledWith({
       profileName: "default",
       title: "Builder Brief",
       description: "Weekly notes from the product team.",
-      cadence: "weekly"
+      cadence: "weekly",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -775,8 +923,9 @@ describe("handleToolCall", () => {
       confirmToken: "ct_newsletter_issue",
       expiresAtMs: 123,
       preview: {
-        summary: 'Publish LinkedIn newsletter issue "March update" in Builder Brief'
-      }
+        summary:
+          'Publish LinkedIn newsletter issue "March update" in Builder Brief',
+      },
     });
 
     const result = await handleToolCall(
@@ -785,8 +934,8 @@ describe("handleToolCall", () => {
         profileName: "default",
         newsletter: "Builder Brief",
         title: "March update",
-        body: "Long-form issue body."
-      }
+        body: "Long-form issue body.",
+      },
     );
 
     expect("isError" in result && result.isError).toBe(false);
@@ -794,13 +943,13 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_newsletter_issue",
-      confirmToken: "ct_newsletter_issue"
+      confirmToken: "ct_newsletter_issue",
     });
     expect(fakeRuntime.newsletters.preparePublishIssue).toHaveBeenCalledWith({
       profileName: "default",
       newsletter: "Builder Brief",
       title: "March update",
-      body: "Long-form issue body."
+      body: "Long-form issue body.",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -811,13 +960,13 @@ describe("handleToolCall", () => {
       newsletters: [
         {
           title: "Builder Brief",
-          selected: false
-        }
-      ]
+          selected: false,
+        },
+      ],
     });
 
     const result = await handleToolCall(LINKEDIN_NEWSLETTER_LIST_TOOL, {
-      profileName: "default"
+      profileName: "default",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -827,12 +976,12 @@ describe("handleToolCall", () => {
       count: 1,
       newsletters: [
         expect.objectContaining({
-          title: "Builder Brief"
-        })
-      ]
+          title: "Builder Brief",
+        }),
+      ],
     });
     expect(fakeRuntime.newsletters.list).toHaveBeenCalledWith({
-      profileName: "default"
+      profileName: "default",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -851,15 +1000,15 @@ describe("handleToolCall", () => {
           attendee_count: "1,234 attendees",
           description: "A live session on leadership under pressure.",
           event_url: "https://www.linkedin.com/events/7433954919704973312/",
-          is_online: true
-        }
-      ]
+          is_online: true,
+        },
+      ],
     });
 
     const result = await handleToolCall(LINKEDIN_EVENTS_SEARCH_TOOL, {
       profileName: "default",
       query: "leadership",
-      limit: 5
+      limit: 5,
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -869,14 +1018,14 @@ describe("handleToolCall", () => {
       query: "leadership",
       results: [
         expect.objectContaining({
-          event_id: "7433954919704973312"
-        })
-      ]
+          event_id: "7433954919704973312",
+        }),
+      ],
     });
     expect(fakeRuntime.events.searchEvents).toHaveBeenCalledWith({
       profileName: "default",
       query: "leadership",
-      limit: 5
+      limit: 5,
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -892,12 +1041,12 @@ describe("handleToolCall", () => {
       attendee_count: "1,234 attendees",
       description: "A live session on leadership under pressure.",
       is_online: true,
-      rsvp_state: "not_responded"
+      rsvp_state: "not_responded",
     });
 
     const result = await handleToolCall(LINKEDIN_EVENTS_VIEW_TOOL, {
       profileName: "default",
-      event: "7433954919704973312"
+      event: "7433954919704973312",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -906,12 +1055,12 @@ describe("handleToolCall", () => {
       profile_name: "default",
       event: expect.objectContaining({
         event_id: "7433954919704973312",
-        rsvp_state: "not_responded"
-      })
+        rsvp_state: "not_responded",
+      }),
     });
     expect(fakeRuntime.events.viewEvent).toHaveBeenCalledWith({
       profileName: "default",
-      event: "7433954919704973312"
+      event: "7433954919704973312",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -922,13 +1071,13 @@ describe("handleToolCall", () => {
       confirmToken: "ct_event",
       expiresAtMs: 123,
       preview: {
-        summary: "RSVP attend for LinkedIn event 7433954919704973312"
-      }
+        summary: "RSVP attend for LinkedIn event 7433954919704973312",
+      },
     });
 
     const result = await handleToolCall(LINKEDIN_EVENTS_PREPARE_RSVP_TOOL, {
       profileName: "default",
-      event: "7433954919704973312"
+      event: "7433954919704973312",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -936,11 +1085,11 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_event",
-      confirmToken: "ct_event"
+      confirmToken: "ct_event",
     });
     expect(fakeRuntime.events.prepareRsvp).toHaveBeenCalledWith({
       profileName: "default",
-      event: "7433954919704973312"
+      event: "7433954919704973312",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -960,8 +1109,8 @@ describe("handleToolCall", () => {
           delta_text: null,
           unit: "count",
           trend: "unknown",
-          observed_at: "2026-03-11T12:00:00.000Z"
-        }
+          observed_at: "2026-03-11T12:00:00.000Z",
+        },
       ],
       cards: [
         {
@@ -979,10 +1128,10 @@ describe("handleToolCall", () => {
               delta_text: null,
               unit: "count",
               trend: "unknown",
-              observed_at: "2026-03-11T12:00:00.000Z"
-            }
-          ]
-        }
+              observed_at: "2026-03-11T12:00:00.000Z",
+            },
+          ],
+        },
       ],
       post: {
         post_id: "123",
@@ -990,13 +1139,13 @@ describe("handleToolCall", () => {
         author_name: "Joi Ascend",
         author_headline: "Automation operator",
         posted_at: "1d",
-        text: "Testing metrics."
-      }
+        text: "Testing metrics.",
+      },
     });
 
     const result = await handleToolCall(LINKEDIN_ANALYTICS_POST_METRICS_TOOL, {
       profileName: "default",
-      postUrl: "urn:li:activity:123"
+      postUrl: "urn:li:activity:123",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -1006,12 +1155,12 @@ describe("handleToolCall", () => {
       surface: "post_metrics",
       post: {
         post_id: "123",
-        author_name: "Joi Ascend"
-      }
+        author_name: "Joi Ascend",
+      },
     });
     expect(fakeRuntime.analytics.getPostMetrics).toHaveBeenCalledWith({
       profileName: "default",
-      postUrl: "urn:li:activity:123"
+      postUrl: "urn:li:activity:123",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -1022,26 +1171,26 @@ describe("handleToolCall", () => {
       confirmToken: "ct_job_save",
       expiresAtMs: 123,
       preview: {
-        summary: "Save LinkedIn job https://www.linkedin.com/jobs/view/123/"
-      }
+        summary: "Save LinkedIn job https://www.linkedin.com/jobs/view/123/",
+      },
     });
     fakeRuntime.jobs.prepareUnsaveJob.mockReturnValue({
       preparedActionId: "pa_job_unsave",
       confirmToken: "ct_job_unsave",
       expiresAtMs: 123,
       preview: {
-        summary: "Unsave LinkedIn job https://www.linkedin.com/jobs/view/123/"
-      }
+        summary: "Unsave LinkedIn job https://www.linkedin.com/jobs/view/123/",
+      },
     });
 
     const saveResult = await handleToolCall(LINKEDIN_JOBS_SAVE_TOOL, {
       profileName: "default",
-      jobId: "123"
+      jobId: "123",
     });
     const unsaveResult = await handleToolCall(LINKEDIN_JOBS_UNSAVE_TOOL, {
       profileName: "default",
       jobId: "123",
-      operatorNote: "cleanup"
+      operatorNote: "cleanup",
     });
 
     expect("isError" in saveResult && saveResult.isError).toBe(false);
@@ -1049,11 +1198,11 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_job_save",
-      confirmToken: "ct_job_save"
+      confirmToken: "ct_job_save",
     });
     expect(fakeRuntime.jobs.prepareSaveJob).toHaveBeenCalledWith({
       profileName: "default",
-      jobId: "123"
+      jobId: "123",
     });
 
     expect("isError" in unsaveResult && unsaveResult.isError).toBe(false);
@@ -1061,12 +1210,12 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_job_unsave",
-      confirmToken: "ct_job_unsave"
+      confirmToken: "ct_job_unsave",
     });
     expect(fakeRuntime.jobs.prepareUnsaveJob).toHaveBeenCalledWith({
       profileName: "default",
       jobId: "123",
-      operatorNote: "cleanup"
+      operatorNote: "cleanup",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(2);
   });
@@ -1082,14 +1231,14 @@ describe("handleToolCall", () => {
           frequency: "Daily",
           search_url:
             "https://www.linkedin.com/jobs/search/?keywords=Staff%20Engineer&location=Remote",
-          enabled: true
-        }
-      ]
+          enabled: true,
+        },
+      ],
     });
 
     const result = await handleToolCall(LINKEDIN_JOBS_ALERTS_LIST_TOOL, {
       profileName: "default",
-      limit: 5
+      limit: 5,
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -1100,13 +1249,13 @@ describe("handleToolCall", () => {
       alerts: [
         expect.objectContaining({
           alert_id: "alert-1",
-          enabled: true
-        })
-      ]
+          enabled: true,
+        }),
+      ],
     });
     expect(fakeRuntime.jobs.listJobAlerts).toHaveBeenCalledWith({
       profileName: "default",
-      limit: 5
+      limit: 5,
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -1117,40 +1266,46 @@ describe("handleToolCall", () => {
       confirmToken: "ct_alert_create",
       expiresAtMs: 123,
       preview: {
-        summary: 'Create a LinkedIn job alert for "Staff Engineer" in Remote'
-      }
+        summary: 'Create a LinkedIn job alert for "Staff Engineer" in Remote',
+      },
     });
     fakeRuntime.jobs.prepareRemoveJobAlert.mockResolvedValue({
       preparedActionId: "pa_alert_remove",
       confirmToken: "ct_alert_remove",
       expiresAtMs: 123,
       preview: {
-        summary: 'Remove LinkedIn job alert for "Staff Engineer" in Remote'
-      }
+        summary: 'Remove LinkedIn job alert for "Staff Engineer" in Remote',
+      },
     });
 
-    const createResult = await handleToolCall(LINKEDIN_JOBS_ALERTS_CREATE_TOOL, {
-      profileName: "default",
-      query: "Staff Engineer",
-      location: "Remote"
-    });
-    const removeResult = await handleToolCall(LINKEDIN_JOBS_ALERTS_REMOVE_TOOL, {
-      profileName: "default",
-      alertId: "alert-1",
-      operatorNote: "cleanup"
-    });
+    const createResult = await handleToolCall(
+      LINKEDIN_JOBS_ALERTS_CREATE_TOOL,
+      {
+        profileName: "default",
+        query: "Staff Engineer",
+        location: "Remote",
+      },
+    );
+    const removeResult = await handleToolCall(
+      LINKEDIN_JOBS_ALERTS_REMOVE_TOOL,
+      {
+        profileName: "default",
+        alertId: "alert-1",
+        operatorNote: "cleanup",
+      },
+    );
 
     expect("isError" in createResult && createResult.isError).toBe(false);
     expect(parseToolPayload(createResult)).toMatchObject({
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_alert_create",
-      confirmToken: "ct_alert_create"
+      confirmToken: "ct_alert_create",
     });
     expect(fakeRuntime.jobs.prepareCreateJobAlert).toHaveBeenCalledWith({
       profileName: "default",
       query: "Staff Engineer",
-      location: "Remote"
+      location: "Remote",
     });
 
     expect("isError" in removeResult && removeResult.isError).toBe(false);
@@ -1158,12 +1313,12 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_alert_remove",
-      confirmToken: "ct_alert_remove"
+      confirmToken: "ct_alert_remove",
     });
     expect(fakeRuntime.jobs.prepareRemoveJobAlert).toHaveBeenCalledWith({
       profileName: "default",
       alertId: "alert-1",
-      operatorNote: "cleanup"
+      operatorNote: "cleanup",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(2);
   });
@@ -1174,8 +1329,9 @@ describe("handleToolCall", () => {
       confirmToken: "ct_easy_apply",
       expiresAtMs: 123,
       preview: {
-        summary: "Submit LinkedIn Easy Apply application for https://www.linkedin.com/jobs/view/123/"
-      }
+        summary:
+          "Submit LinkedIn Easy Apply application for https://www.linkedin.com/jobs/view/123/",
+      },
     });
 
     const result = await handleToolCall(LINKEDIN_JOBS_PREPARE_EASY_APPLY_TOOL, {
@@ -1184,8 +1340,8 @@ describe("handleToolCall", () => {
       email: "candidate@example.com",
       resumePath: "/tmp/resume.pdf",
       answers: {
-        "Years of experience": 8
-      }
+        "Years of experience": 8,
+      },
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -1193,7 +1349,7 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_easy_apply",
-      confirmToken: "ct_easy_apply"
+      confirmToken: "ct_easy_apply",
     });
     expect(fakeRuntime.jobs.prepareEasyApply).toHaveBeenCalledWith({
       profileName: "default",
@@ -1201,8 +1357,8 @@ describe("handleToolCall", () => {
       email: "candidate@example.com",
       resumePath: "/tmp/resume.pdf",
       answers: {
-        "Years of experience": 8
-      }
+        "Years of experience": 8,
+      },
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });

--- a/packages/mcp/src/bin/linkedin-mcp.ts
+++ b/packages/mcp/src/bin/linkedin-mcp.ts
@@ -45,14 +45,14 @@ import {
   type ActivityWatchStatus,
   type SearchCategory,
   type WebhookDeliveryAttemptStatus,
-  type WebhookSubscriptionStatus
+  type WebhookSubscriptionStatus,
 } from "@linkedin-buddy/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
-  type CallToolRequest
+  type CallToolRequest,
 } from "@modelcontextprotocol/sdk/types.js";
 import {
   SUBMIT_FEEDBACK_TOOL,
@@ -164,7 +164,7 @@ import {
   LINKEDIN_SEARCH_TOOL,
   LINKEDIN_SESSION_HEALTH_TOOL,
   LINKEDIN_SESSION_OPEN_LOGIN_TOOL,
-  LINKEDIN_SESSION_STATUS_TOOL
+  LINKEDIN_SESSION_STATUS_TOOL,
 } from "../index.js";
 
 type ToolArgs = Record<string, unknown>;
@@ -202,8 +202,7 @@ export interface LinkedInMcpToolDefinition {
 
 const mcpPrivacyConfig = resolvePrivacyConfig();
 const SELECTOR_AUDIT_DOC_PATH = "docs/selector-audit.md";
-const SELECTOR_AUDIT_MCP_HINT =
-  `For broader UI-drift diagnostics, run the CLI selector audit ("linkedin audit selectors") and see ${SELECTOR_AUDIT_DOC_PATH}.`;
+const SELECTOR_AUDIT_MCP_HINT = `For broader UI-drift diagnostics, run the CLI selector audit ("linkedin audit selectors") and see ${SELECTOR_AUDIT_DOC_PATH}.`;
 
 function withSelectorAuditHint(description: string): string {
   return `${description} ${SELECTOR_AUDIT_MCP_HINT}`;
@@ -232,14 +231,14 @@ function readRequiredString(args: ToolArgs, key: string): string {
   }
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    `${key} is required.`
+    `${key} is required.`,
   );
 }
 
 function readPositiveNumber(
   args: ToolArgs,
   key: string,
-  fallback: number
+  fallback: number,
 ): number {
   const value = args[key];
   if (typeof value !== "number") {
@@ -249,7 +248,7 @@ function readPositiveNumber(
   if (!Number.isFinite(value) || value <= 0) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      `${key} must be a positive number.`
+      `${key} must be a positive number.`,
     );
   }
 
@@ -259,7 +258,7 @@ function readPositiveNumber(
 function readNonNegativeNumber(
   args: ToolArgs,
   key: string,
-  fallback: number
+  fallback: number,
 ): number {
   const value = args[key];
   if (typeof value !== "number") {
@@ -269,7 +268,7 @@ function readNonNegativeNumber(
   if (!Number.isFinite(value) || value < 0) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      `${key} must be zero or a positive number.`
+      `${key} must be zero or a positive number.`,
     );
   }
 
@@ -289,13 +288,13 @@ function readRequiredBoolean(args: ToolArgs, key: string): boolean {
 
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    `${key} is required.`
+    `${key} is required.`,
   );
 }
 
 function readOptionalPositiveNumber(
   args: ToolArgs,
-  key: string
+  key: string,
 ): number | undefined {
   if (!(key in args) || args[key] === undefined) {
     return undefined;
@@ -306,7 +305,7 @@ function readOptionalPositiveNumber(
 
 function readOptionalNonNegativeNumber(
   args: ToolArgs,
-  key: string
+  key: string,
 ): number | undefined {
   if (!(key in args) || args[key] === undefined) {
     return undefined;
@@ -321,7 +320,7 @@ function readOptionalNonNegativeNumber(
   ) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      `${key} must be a non-negative integer.`
+      `${key} must be a non-negative integer.`,
     );
   }
 
@@ -348,7 +347,7 @@ function readStringArray(args: ToolArgs, key: string): string[] | undefined {
 
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    `${key} must be a string or array of strings.`
+    `${key} must be a string or array of strings.`,
   );
 }
 
@@ -360,13 +359,13 @@ function readRequiredStringArray(args: ToolArgs, key: string): string[] {
 
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    `${key} is required.`
+    `${key} is required.`,
   );
 }
 
 function readObject(
   args: ToolArgs,
-  key: string
+  key: string,
 ): Record<string, unknown> | undefined {
   const value = args[key];
   if (value === undefined) {
@@ -379,13 +378,13 @@ function readObject(
 
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    `${key} must be an object.`
+    `${key} must be an object.`,
   );
 }
 
 async function readJsonInputFile(
   filePath: string,
-  label: string
+  label: string,
 ): Promise<unknown> {
   const resolvedPath = path.resolve(filePath);
   let rawValue: string;
@@ -398,8 +397,8 @@ async function readJsonInputFile(
       `Could not read ${label}.`,
       {
         path: resolvedPath,
-        cause: error instanceof Error ? error.message : String(error)
-      }
+        cause: error instanceof Error ? error.message : String(error),
+      },
     );
   }
 
@@ -411,8 +410,8 @@ async function readJsonInputFile(
       `${label} must contain valid JSON.`,
       {
         path: resolvedPath,
-        cause: error instanceof Error ? error.message : String(error)
-      }
+        cause: error instanceof Error ? error.message : String(error),
+      },
     );
   }
 }
@@ -420,7 +419,7 @@ async function readJsonInputFile(
 function coerceEnumValue<T extends string>(
   value: string,
   allowed: readonly T[],
-  label: string
+  label: string,
 ): T {
   if ((allowed as readonly string[]).includes(value)) {
     return value as T;
@@ -428,7 +427,7 @@ function coerceEnumValue<T extends string>(
 
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    `${label} must be one of: ${allowed.join(", ")}.`
+    `${label} must be one of: ${allowed.join(", ")}.`,
   );
 }
 
@@ -436,61 +435,49 @@ function readActivityWatchKind(args: ToolArgs, key: string): ActivityWatchKind {
   return coerceEnumValue(
     readRequiredString(args, key),
     ACTIVITY_WATCH_KINDS,
-    key
+    key,
   );
 }
 
 function readOptionalActivityWatchStatus(
   args: ToolArgs,
-  key: string
+  key: string,
 ): ActivityWatchStatus | undefined {
   const value = args[key];
   if (typeof value !== "string" || value.trim().length === 0) {
     return undefined;
   }
 
-  return coerceEnumValue(
-    value.trim(),
-    ACTIVITY_WATCH_STATUSES,
-    key
-  );
+  return coerceEnumValue(value.trim(), ACTIVITY_WATCH_STATUSES, key);
 }
 
 function readOptionalWebhookSubscriptionStatus(
   args: ToolArgs,
-  key: string
+  key: string,
 ): WebhookSubscriptionStatus | undefined {
   const value = args[key];
   if (typeof value !== "string" || value.trim().length === 0) {
     return undefined;
   }
 
-  return coerceEnumValue(
-    value.trim(),
-    WEBHOOK_SUBSCRIPTION_STATUSES,
-    key
-  );
+  return coerceEnumValue(value.trim(), WEBHOOK_SUBSCRIPTION_STATUSES, key);
 }
 
 function readOptionalWebhookDeliveryStatus(
   args: ToolArgs,
-  key: string
+  key: string,
 ): WebhookDeliveryAttemptStatus | undefined {
   const value = args[key];
   if (typeof value !== "string" || value.trim().length === 0) {
     return undefined;
   }
 
-  return coerceEnumValue(
-    value.trim(),
-    WEBHOOK_DELIVERY_ATTEMPT_STATUSES,
-    key
-  );
+  return coerceEnumValue(value.trim(), WEBHOOK_DELIVERY_ATTEMPT_STATUSES, key);
 }
 
 function readActivityEventTypes(
   args: ToolArgs,
-  key: string
+  key: string,
 ): ActivityEventType[] | undefined {
   const values = readStringArray(args, key);
   if (!values) {
@@ -498,15 +485,14 @@ function readActivityEventTypes(
   }
 
   return values.map((value) =>
-    coerceEnumValue(value, ACTIVITY_EVENT_TYPES, key)
+    coerceEnumValue(value, ACTIVITY_EVENT_TYPES, key),
   );
 }
-
 
 function readSearchCategory(
   args: ToolArgs,
   key: string,
-  fallback: SearchCategory
+  fallback: SearchCategory,
 ): SearchCategory {
   const value = args[key];
   if (typeof value !== "string" || value.trim().length === 0) {
@@ -520,13 +506,13 @@ function readSearchCategory(
 
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    `${key} must be one of: ${SEARCH_CATEGORIES.join(", ")}.`
+    `${key} must be one of: ${SEARCH_CATEGORIES.join(", ")}.`,
   );
 }
 
 function readMemberReportReason(
   args: ToolArgs,
-  key: string
+  key: string,
 ): ReturnType<typeof normalizeLinkedInMemberReportReason> {
   return normalizeLinkedInMemberReportReason(readRequiredString(args, key));
 }
@@ -543,10 +529,10 @@ function toToolResult(payload: unknown): ToolResult {
         text: JSON.stringify(
           redactStructuredValue(payload, mcpPrivacyConfig, "cli"),
           null,
-          2
-        )
-      }
-    ]
+          2,
+        ),
+      },
+    ],
   };
 }
 
@@ -559,10 +545,10 @@ function toErrorResult(error: unknown): ToolErrorResult {
         text: JSON.stringify(
           toLinkedInBuddyErrorPayload(error, mcpPrivacyConfig),
           null,
-          2
-        )
-      }
-    ]
+          2,
+        ),
+      },
+    ],
   };
 }
 
@@ -571,7 +557,7 @@ function shouldTrackMcpFeedback(toolName: string): boolean {
 }
 
 function addFeedbackHintToResult<T extends ToolResult | ToolErrorResult>(
-  result: T
+  result: T,
 ): T {
   const firstContent = result.content[0];
   if (!firstContent || firstContent.type !== "text") {
@@ -587,16 +573,18 @@ function addFeedbackHintToResult<T extends ToolResult | ToolErrorResult>(
       content: [
         {
           type: "text",
-          text: JSON.stringify(parsed, null, 2)
-        }
-      ]
+          text: JSON.stringify(parsed, null, 2),
+        },
+      ],
     };
   } catch {
     return result;
   }
 }
 
-function readTargetProfileName(target: Record<string, unknown>): string | undefined {
+function readTargetProfileName(
+  target: Record<string, unknown>,
+): string | undefined {
   const value = target.profile_name;
   if (typeof value === "string" && value.trim().length > 0) {
     return value.trim();
@@ -607,23 +595,23 @@ function readTargetProfileName(target: Record<string, unknown>): string | undefi
 const cdpUrlInputSchemaProperty: LinkedInMcpInputSchema = {
   type: "string",
   description:
-    "Connect to an existing browser via CDP endpoint (for example http://127.0.0.1:18800)."
+    "Connect to an existing browser via CDP endpoint (for example http://127.0.0.1:18800).",
 };
 
 const selectorLocaleInputSchemaProperty: LinkedInMcpInputSchema = {
   type: "string",
   description: `Prefer localized LinkedIn UI text first (${LINKEDIN_SELECTOR_LOCALES.join(
-    ", "
-  )}; region tags like da-DK normalize to da). Unsupported values fall back to en.`
+    ", ",
+  )}; region tags like da-DK normalize to da). Unsupported values fall back to en.`,
 };
 
 function withCdpSchemaProperties(
-  properties: Record<string, LinkedInMcpInputSchema>
+  properties: Record<string, LinkedInMcpInputSchema>,
 ): Record<string, LinkedInMcpInputSchema> {
   return {
     ...properties,
     cdpUrl: cdpUrlInputSchemaProperty,
-    selectorLocale: selectorLocaleInputSchemaProperty
+    selectorLocale: selectorLocaleInputSchemaProperty,
   };
 }
 
@@ -665,7 +653,9 @@ function formatToolSchemaPath(path: string): string {
 
 function describeToolSchemaTypes(schema: LinkedInMcpInputSchema): string {
   if (schema.anyOf && schema.anyOf.length > 0) {
-    return schema.anyOf.map((entry) => describeToolSchemaTypes(entry)).join(", ");
+    return schema.anyOf
+      .map((entry) => describeToolSchemaTypes(entry))
+      .join(", ");
   }
 
   if (schema.enum && schema.enum.length > 0) {
@@ -682,31 +672,34 @@ function describeToolSchemaTypes(schema: LinkedInMcpInputSchema): string {
 function throwToolSchemaValidationError(
   path: string,
   message: string,
-  details: Record<string, unknown> = {}
+  details: Record<string, unknown> = {},
 ): never {
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
     `${formatToolSchemaPath(path)} ${message}`,
     {
       path: formatToolSchemaPath(path),
-      ...details
-    }
+      ...details,
+    },
   );
 }
 
 function validateToolArgEnum(
   schema: LinkedInMcpInputSchema,
   value: unknown,
-  path: string
+  path: string,
 ): void {
-  if (schema.enum && !schema.enum.includes(value as LinkedInMcpSchemaEnumValue)) {
+  if (
+    schema.enum &&
+    !schema.enum.includes(value as LinkedInMcpSchemaEnumValue)
+  ) {
     throwToolSchemaValidationError(
       path,
       `must be one of: ${schema.enum.map((entry) => JSON.stringify(entry)).join(", ")}.`,
       {
         actual_type: describeToolArgValue(value),
-        allowed_values: [...schema.enum]
-      }
+        allowed_values: [...schema.enum],
+      },
     );
   }
 }
@@ -714,7 +707,7 @@ function validateToolArgEnum(
 function validateToolArgValueAgainstSchema(
   schema: LinkedInMcpInputSchema,
   value: unknown,
-  path: string
+  path: string,
 ): void {
   if (schema.anyOf && schema.anyOf.length > 0) {
     for (const candidate of schema.anyOf) {
@@ -733,8 +726,8 @@ function validateToolArgValueAgainstSchema(
       `must match one of: ${describeToolSchemaTypes(schema)}.`,
       {
         actual_type: describeToolArgValue(value),
-        expected: describeToolSchemaTypes(schema)
-      }
+        expected: describeToolSchemaTypes(schema),
+      },
     );
   }
 
@@ -742,7 +735,7 @@ function validateToolArgValueAgainstSchema(
     case "string":
       if (typeof value !== "string") {
         throwToolSchemaValidationError(path, "must be a string.", {
-          actual_type: describeToolArgValue(value)
+          actual_type: describeToolArgValue(value),
         });
       }
       validateToolArgEnum(schema, value, path);
@@ -750,7 +743,7 @@ function validateToolArgValueAgainstSchema(
     case "number":
       if (typeof value !== "number" || !Number.isFinite(value)) {
         throwToolSchemaValidationError(path, "must be a finite number.", {
-          actual_type: describeToolArgValue(value)
+          actual_type: describeToolArgValue(value),
         });
       }
       validateToolArgEnum(schema, value, path);
@@ -762,7 +755,7 @@ function validateToolArgValueAgainstSchema(
         !Number.isInteger(value)
       ) {
         throwToolSchemaValidationError(path, "must be an integer.", {
-          actual_type: describeToolArgValue(value)
+          actual_type: describeToolArgValue(value),
         });
       }
       validateToolArgEnum(schema, value, path);
@@ -770,7 +763,7 @@ function validateToolArgValueAgainstSchema(
     case "boolean":
       if (typeof value !== "boolean") {
         throwToolSchemaValidationError(path, "must be a boolean.", {
-          actual_type: describeToolArgValue(value)
+          actual_type: describeToolArgValue(value),
         });
       }
       validateToolArgEnum(schema, value, path);
@@ -778,7 +771,7 @@ function validateToolArgValueAgainstSchema(
     case "array":
       if (!Array.isArray(value)) {
         throwToolSchemaValidationError(path, "must be an array.", {
-          actual_type: describeToolArgValue(value)
+          actual_type: describeToolArgValue(value),
         });
       }
 
@@ -787,7 +780,7 @@ function validateToolArgValueAgainstSchema(
           validateToolArgValueAgainstSchema(
             schema.items!,
             entry,
-            appendToolSchemaPath(path, `[${index}]`)
+            appendToolSchemaPath(path, `[${index}]`),
           );
         });
       }
@@ -795,7 +788,7 @@ function validateToolArgValueAgainstSchema(
     case "object": {
       if (!isPlainObject(value)) {
         throwToolSchemaValidationError(path, "must be an object.", {
-          actual_type: describeToolArgValue(value)
+          actual_type: describeToolArgValue(value),
         });
       }
 
@@ -805,7 +798,7 @@ function validateToolArgValueAgainstSchema(
         if (!(requiredKey in value) || value[requiredKey] === undefined) {
           throwToolSchemaValidationError(
             appendToolSchemaPath(path, requiredKey),
-            "is required."
+            "is required.",
           );
         }
       }
@@ -816,7 +809,11 @@ function validateToolArgValueAgainstSchema(
 
         if (propertySchema) {
           if (entryValue !== undefined) {
-            validateToolArgValueAgainstSchema(propertySchema, entryValue, propertyPath);
+            validateToolArgValueAgainstSchema(
+              propertySchema,
+              entryValue,
+              propertyPath,
+            );
           }
           continue;
         }
@@ -832,7 +829,7 @@ function validateToolArgValueAgainstSchema(
           validateToolArgValueAgainstSchema(
             schema.additionalProperties,
             entryValue,
-            propertyPath
+            propertyPath,
           );
         }
       }
@@ -852,12 +849,12 @@ function createRuntime(args: ToolArgs) {
       ? {
           cdpUrl,
           privacy: mcpPrivacyConfig,
-          ...(selectorLocale ? { selectorLocale } : {})
+          ...(selectorLocale ? { selectorLocale } : {}),
         }
       : {
           privacy: mcpPrivacyConfig,
-          ...(selectorLocale ? { selectorLocale } : {})
-        }
+          ...(selectorLocale ? { selectorLocale } : {}),
+        },
   );
 }
 
@@ -868,24 +865,24 @@ async function handleSessionStatus(args: ToolArgs): Promise<ToolResult> {
     const profileName = readString(args, "profileName", "default");
 
     runtime.logger.log("info", "mcp.session.status.start", {
-      profileName
+      profileName,
     });
 
     const status = await runtime.auth.status({
-      profileName
+      profileName,
     });
 
     runtime.logger.log("info", "mcp.session.status.done", {
       profileName,
       authenticated: status.authenticated,
       evasion_level: status.evasion?.level,
-      evasion_diagnostics_enabled: status.evasion?.diagnosticsEnabled ?? false
+      evasion_diagnostics_enabled: status.evasion?.diagnosticsEnabled ?? false,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      status
+      status,
     });
   } finally {
     runtime.close();
@@ -901,24 +898,24 @@ async function handleSessionOpenLogin(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.session.open_login.start", {
       profileName,
-      timeoutMs
+      timeoutMs,
     });
 
     const status = await runtime.auth.openLogin({
       profileName,
-      timeoutMs
+      timeoutMs,
     });
 
     runtime.logger.log("info", "mcp.session.open_login.done", {
       profileName,
       authenticated: status.authenticated,
-      timedOut: status.timedOut
+      timedOut: status.timedOut,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      status
+      status,
     });
   } finally {
     runtime.close();
@@ -932,11 +929,11 @@ async function handleSessionHealth(args: ToolArgs): Promise<ToolResult> {
     const profileName = readString(args, "profileName", "default");
 
     runtime.logger.log("info", "mcp.session.health.start", {
-      profileName
+      profileName,
     });
 
     const health = await runtime.healthCheck({
-      profileName
+      profileName,
     });
 
     runtime.logger.log("info", "mcp.session.health.done", {
@@ -944,13 +941,13 @@ async function handleSessionHealth(args: ToolArgs): Promise<ToolResult> {
       browserHealthy: health.browser.healthy,
       authenticated: health.session.authenticated,
       evasion_level: health.session.evasion.level,
-      evasion_diagnostics_enabled: health.session.evasion.diagnosticsEnabled
+      evasion_diagnostics_enabled: health.session.evasion.diagnosticsEnabled,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...health
+      ...health,
     });
   } finally {
     runtime.close();
@@ -959,7 +956,9 @@ async function handleSessionHealth(args: ToolArgs): Promise<ToolResult> {
 
 async function handleSubmitFeedback(args: ToolArgs): Promise<ToolResult> {
   const snapshot = await readFeedbackStateSnapshot();
-  const feedbackType = normalizeFeedbackInputType(readRequiredString(args, "type"));
+  const feedbackType = normalizeFeedbackInputType(
+    readRequiredString(args, "type"),
+  );
   const title = readRequiredString(args, "title");
   const description = readRequiredString(args, "description");
 
@@ -971,8 +970,8 @@ async function handleSubmitFeedback(args: ToolArgs): Promise<ToolResult> {
       cliVersion: packageJson.version,
       mcpToolName: SUBMIT_FEEDBACK_TOOL,
       snapshot,
-      source: "mcp"
-    })
+      source: "mcp",
+    }),
   });
 
   return toToolResult({
@@ -988,10 +987,10 @@ async function handleSubmitFeedback(args: ToolArgs): Promise<ToolResult> {
           pending_file_path: path.join(
             ".linkedin-buddy",
             "pending-feedback",
-            path.basename(result.pendingFilePath)
-          )
+            path.basename(result.pendingFilePath),
+          ),
         }
-      : {})
+      : {}),
   });
 }
 
@@ -1006,25 +1005,25 @@ async function handleListThreads(args: ToolArgs): Promise<ToolResult> {
     runtime.logger.log("info", "mcp.inbox.list_threads.start", {
       profileName,
       limit,
-      unreadOnly
+      unreadOnly,
     });
 
     const threads = await runtime.inbox.listThreads({
       profileName,
       limit,
-      unreadOnly
+      unreadOnly,
     });
 
     runtime.logger.log("info", "mcp.inbox.list_threads.done", {
       profileName,
-      count: threads.length
+      count: threads.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
       count: threads.length,
-      threads
+      threads,
     });
   } finally {
     runtime.close();
@@ -1042,24 +1041,24 @@ async function handleGetThread(args: ToolArgs): Promise<ToolResult> {
     runtime.logger.log("info", "mcp.inbox.get_thread.start", {
       profileName,
       thread,
-      limit
+      limit,
     });
 
     const detail = await runtime.inbox.getThread({
       profileName,
       thread,
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.inbox.get_thread.done", {
       profileName,
-      threadId: detail.thread_id
+      threadId: detail.thread_id,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      thread: detail
+      thread: detail,
     });
   } finally {
     runtime.close();
@@ -1077,25 +1076,25 @@ async function handleSearchRecipients(args: ToolArgs): Promise<ToolResult> {
     runtime.logger.log("info", "mcp.inbox.search_recipients.start", {
       profileName,
       query,
-      limit
+      limit,
     });
 
     const result = await runtime.inbox.searchRecipients({
       profileName,
       query,
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.inbox.search_recipients.done", {
       profileName,
       query,
-      count: result.count
+      count: result.count,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
@@ -1113,7 +1112,7 @@ async function handlePrepareReply(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.inbox.prepare_reply.start", {
       profileName,
-      thread
+      thread,
     });
 
     const prepared = await runtime.inbox.prepareReply({
@@ -1122,20 +1121,20 @@ async function handlePrepareReply(args: ToolArgs): Promise<ToolResult> {
       text,
       ...(operatorNote
         ? {
-            operatorNote
+            operatorNote,
           }
-        : {})
+        : {}),
     });
 
     runtime.logger.log("info", "mcp.inbox.prepare_reply.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1153,7 +1152,7 @@ async function handlePrepareNewThread(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.inbox.prepare_new_thread.start", {
       profileName,
-      recipientCount: recipients.length
+      recipientCount: recipients.length,
     });
 
     const prepared = await runtime.inbox.prepareNewThread({
@@ -1162,21 +1161,21 @@ async function handlePrepareNewThread(args: ToolArgs): Promise<ToolResult> {
       text,
       ...(operatorNote
         ? {
-            operatorNote
+            operatorNote,
           }
-        : {})
+        : {}),
     });
 
     runtime.logger.log("info", "mcp.inbox.prepare_new_thread.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
-      recipientCount: recipients.length
+      recipientCount: recipients.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1195,7 +1194,7 @@ async function handlePrepareAddRecipients(args: ToolArgs): Promise<ToolResult> {
     runtime.logger.log("info", "mcp.inbox.prepare_add_recipients.start", {
       profileName,
       recipientCount: recipients.length,
-      thread
+      thread,
     });
 
     const prepared = await runtime.inbox.prepareAddRecipients({
@@ -1204,22 +1203,22 @@ async function handlePrepareAddRecipients(args: ToolArgs): Promise<ToolResult> {
       recipients,
       ...(operatorNote
         ? {
-            operatorNote
+            operatorNote,
           }
-        : {})
+        : {}),
     });
 
     runtime.logger.log("info", "mcp.inbox.prepare_add_recipients.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
       recipientCount: recipients.length,
-      thread
+      thread,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1232,7 +1231,9 @@ async function handlePrepareReact(args: ToolArgs): Promise<ToolResult> {
   try {
     const profileName = readString(args, "profileName", "default");
     const thread = readRequiredString(args, "thread");
-    const reaction = normalizeLinkedInInboxReaction(readString(args, "reaction", "like"));
+    const reaction = normalizeLinkedInInboxReaction(
+      readString(args, "reaction", "like"),
+    );
     const messageIndex = readOptionalNonNegativeNumber(args, "messageIndex");
     const operatorNote = readString(args, "operatorNote", "");
 
@@ -1240,7 +1241,7 @@ async function handlePrepareReact(args: ToolArgs): Promise<ToolResult> {
       profileName,
       thread,
       reaction,
-      messageIndex
+      messageIndex,
     });
 
     const prepared = await runtime.inbox.prepareReact({
@@ -1250,22 +1251,22 @@ async function handlePrepareReact(args: ToolArgs): Promise<ToolResult> {
       ...(messageIndex !== undefined ? { messageIndex } : {}),
       ...(operatorNote
         ? {
-            operatorNote
+            operatorNote,
           }
-        : {})
+        : {}),
     });
 
     runtime.logger.log("info", "mcp.inbox.prepare_react.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
       reaction,
-      messageIndex
+      messageIndex,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1281,23 +1282,23 @@ async function handleArchiveThread(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.inbox.archive_thread.start", {
       profileName,
-      thread
+      thread,
     });
 
     const result = await runtime.inbox.archiveThread({
       profileName,
-      thread
+      thread,
     });
 
     runtime.logger.log("info", "mcp.inbox.archive_thread.done", {
       profileName,
-      threadId: result.thread_id
+      threadId: result.thread_id,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
@@ -1313,23 +1314,23 @@ async function handleUnarchiveThread(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.inbox.unarchive_thread.start", {
       profileName,
-      thread
+      thread,
     });
 
     const result = await runtime.inbox.unarchiveThread({
       profileName,
-      thread
+      thread,
     });
 
     runtime.logger.log("info", "mcp.inbox.unarchive_thread.done", {
       profileName,
-      threadId: result.thread_id
+      threadId: result.thread_id,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
@@ -1345,23 +1346,23 @@ async function handleMarkUnread(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.inbox.mark_unread.start", {
       profileName,
-      thread
+      thread,
     });
 
     const result = await runtime.inbox.markUnread({
       profileName,
-      thread
+      thread,
     });
 
     runtime.logger.log("info", "mcp.inbox.mark_unread.done", {
       profileName,
-      threadId: result.thread_id
+      threadId: result.thread_id,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
@@ -1377,23 +1378,23 @@ async function handleMuteThread(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.inbox.mute_thread.start", {
       profileName,
-      thread
+      thread,
     });
 
     const result = await runtime.inbox.muteThread({
       profileName,
-      thread
+      thread,
     });
 
     runtime.logger.log("info", "mcp.inbox.mute_thread.done", {
       profileName,
-      threadId: result.thread_id
+      threadId: result.thread_id,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
@@ -1409,23 +1410,23 @@ async function handleProfileView(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.profile.view.start", {
       profileName,
-      target
+      target,
     });
 
     const profile = await runtime.profile.viewProfile({
       profileName,
-      target
+      target,
     });
 
     runtime.logger.log("info", "mcp.profile.view.done", {
       profileName,
-      fullName: profile.full_name
+      fullName: profile.full_name,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      profile
+      profile,
     });
   } finally {
     runtime.close();
@@ -1441,23 +1442,23 @@ async function handleCompanyView(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.company.view.start", {
       profileName,
-      target
+      target,
     });
 
     const company = await runtime.companyPages.viewCompanyPage({
       profileName,
-      target
+      target,
     });
 
     runtime.logger.log("info", "mcp.company.view.done", {
       profileName,
-      companyName: company.name
+      companyName: company.name,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      company
+      company,
     });
   } finally {
     runtime.close();
@@ -1471,22 +1472,22 @@ async function handleProfileViewEditable(args: ToolArgs): Promise<ToolResult> {
     const profileName = readString(args, "profileName", "default");
 
     runtime.logger.log("info", "mcp.profile.view_editable.start", {
-      profileName
+      profileName,
     });
 
     const profile = await runtime.profile.viewEditableProfile({
-      profileName
+      profileName,
     });
 
     runtime.logger.log("info", "mcp.profile.view_editable.done", {
       profileName,
-      sectionCount: profile.sections.length
+      sectionCount: profile.sections.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      profile
+      profile,
     });
   } finally {
     runtime.close();
@@ -1494,7 +1495,7 @@ async function handleProfileViewEditable(args: ToolArgs): Promise<ToolResult> {
 }
 
 async function handleProfilePrepareUpdateIntro(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1503,7 +1504,7 @@ async function handleProfilePrepareUpdateIntro(
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.profile.prepare_update_intro.start", {
-      profileName
+      profileName,
     });
 
     const prepared = runtime.profile.prepareUpdateIntro({
@@ -1520,18 +1521,18 @@ async function handleProfilePrepareUpdateIntro(
       ...(typeof args.location === "string"
         ? { location: readString(args, "location", "") }
         : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_update_intro.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1539,7 +1540,7 @@ async function handleProfilePrepareUpdateIntro(
 }
 
 async function handleProfilePrepareUpdateSettings(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1549,24 +1550,24 @@ async function handleProfilePrepareUpdateSettings(
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.profile.prepare_update_settings.start", {
-      profileName
+      profileName,
     });
 
     const prepared = runtime.profile.prepareUpdateSettings({
       profileName,
       industry,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_update_settings.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1574,7 +1575,7 @@ async function handleProfilePrepareUpdateSettings(
 }
 
 async function handleProfilePrepareUpdatePublicProfile(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1582,7 +1583,9 @@ async function handleProfilePrepareUpdatePublicProfile(
     const profileName = readString(args, "profileName", "default");
     const operatorNote = readString(args, "operatorNote", "");
     const vanityName =
-      typeof args.vanityName === "string" ? readString(args, "vanityName", "") : "";
+      typeof args.vanityName === "string"
+        ? readString(args, "vanityName", "")
+        : "";
     const customProfileUrl =
       typeof args.customProfileUrl === "string"
         ? readString(args, "customProfileUrl", "")
@@ -1595,7 +1598,7 @@ async function handleProfilePrepareUpdatePublicProfile(
     if (!vanityName && !customProfileUrl && !publicProfileUrl) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "vanityName, customProfileUrl, or publicProfileUrl is required."
+        "vanityName, customProfileUrl, or publicProfileUrl is required.",
       );
     }
 
@@ -1603,8 +1606,8 @@ async function handleProfilePrepareUpdatePublicProfile(
       "info",
       "mcp.profile.prepare_update_public_profile.start",
       {
-        profileName
-      }
+        profileName,
+      },
     );
 
     const prepared = runtime.profile.prepareUpdatePublicProfile({
@@ -1612,18 +1615,22 @@ async function handleProfilePrepareUpdatePublicProfile(
       ...(vanityName ? { vanityName } : {}),
       ...(customProfileUrl ? { customProfileUrl } : {}),
       ...(publicProfileUrl ? { publicProfileUrl } : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
-    runtime.logger.log("info", "mcp.profile.prepare_update_public_profile.done", {
-      profileName,
-      preparedActionId: prepared.preparedActionId
-    });
+    runtime.logger.log(
+      "info",
+      "mcp.profile.prepare_update_public_profile.done",
+      {
+        profileName,
+        preparedActionId: prepared.preparedActionId,
+      },
+    );
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1631,7 +1638,7 @@ async function handleProfilePrepareUpdatePublicProfile(
 }
 
 async function handleProfilePrepareUpsertSectionItem(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1646,15 +1653,19 @@ async function handleProfilePrepareUpsertSectionItem(
     if (!values) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "values is required."
+        "values is required.",
       );
     }
 
-    runtime.logger.log("info", "mcp.profile.prepare_upsert_section_item.start", {
-      profileName,
-      section,
-      hasItemId: itemId.length > 0
-    });
+    runtime.logger.log(
+      "info",
+      "mcp.profile.prepare_upsert_section_item.start",
+      {
+        profileName,
+        section,
+        hasItemId: itemId.length > 0,
+      },
+    );
 
     const prepared = runtime.profile.prepareUpsertSectionItem({
       profileName,
@@ -1662,19 +1673,19 @@ async function handleProfilePrepareUpsertSectionItem(
       values,
       ...(itemId ? { itemId } : {}),
       ...(match ? { match } : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_upsert_section_item.done", {
       profileName,
       section,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1682,7 +1693,7 @@ async function handleProfilePrepareUpsertSectionItem(
 }
 
 async function handleProfilePrepareRemoveSectionItem(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1693,30 +1704,34 @@ async function handleProfilePrepareRemoveSectionItem(
     const itemId = readString(args, "itemId", "");
     const operatorNote = readString(args, "operatorNote", "");
 
-    runtime.logger.log("info", "mcp.profile.prepare_remove_section_item.start", {
-      profileName,
-      section,
-      hasItemId: itemId.length > 0
-    });
+    runtime.logger.log(
+      "info",
+      "mcp.profile.prepare_remove_section_item.start",
+      {
+        profileName,
+        section,
+        hasItemId: itemId.length > 0,
+      },
+    );
 
     const prepared = runtime.profile.prepareRemoveSectionItem({
       profileName,
       section,
       ...(itemId ? { itemId } : {}),
       ...(match ? { match } : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_remove_section_item.done", {
       profileName,
       section,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1724,7 +1739,7 @@ async function handleProfilePrepareRemoveSectionItem(
 }
 
 async function handleProfilePrepareUploadPhoto(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1734,24 +1749,24 @@ async function handleProfilePrepareUploadPhoto(
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.profile.prepare_upload_photo.start", {
-      profileName
+      profileName,
     });
 
     const prepared = await runtime.profile.prepareUploadPhoto({
       profileName,
       filePath,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_upload_photo.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1759,7 +1774,7 @@ async function handleProfilePrepareUploadPhoto(
 }
 
 async function handleProfilePrepareUploadBanner(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1769,24 +1784,24 @@ async function handleProfilePrepareUploadBanner(
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.profile.prepare_upload_banner.start", {
-      profileName
+      profileName,
     });
 
     const prepared = await runtime.profile.prepareUploadBanner({
       profileName,
       filePath,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_upload_banner.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1794,7 +1809,7 @@ async function handleProfilePrepareUploadBanner(
 }
 
 async function handleProfilePrepareFeaturedAdd(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1805,33 +1820,37 @@ async function handleProfilePrepareFeaturedAdd(
 
     runtime.logger.log("info", "mcp.profile.prepare_featured_add.start", {
       profileName,
-      kind
+      kind,
     });
 
     const prepared = await runtime.profile.prepareFeaturedAdd({
       profileName,
       kind,
-      ...(typeof args.url === "string" ? { url: readString(args, "url", "") } : {}),
+      ...(typeof args.url === "string"
+        ? { url: readString(args, "url", "") }
+        : {}),
       ...(typeof args.filePath === "string"
         ? { filePath: readString(args, "filePath", "") }
         : {}),
-      ...(typeof args.title === "string" ? { title: readString(args, "title", "") } : {}),
+      ...(typeof args.title === "string"
+        ? { title: readString(args, "title", "") }
+        : {}),
       ...(typeof args.description === "string"
         ? { description: readString(args, "description", "") }
         : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_featured_add.done", {
       profileName,
       kind,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1839,7 +1858,7 @@ async function handleProfilePrepareFeaturedAdd(
 }
 
 async function handleProfilePrepareFeaturedRemove(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1851,25 +1870,25 @@ async function handleProfilePrepareFeaturedRemove(
 
     runtime.logger.log("info", "mcp.profile.prepare_featured_remove.start", {
       profileName,
-      hasItemId: itemId.length > 0
+      hasItemId: itemId.length > 0,
     });
 
     const prepared = runtime.profile.prepareFeaturedRemove({
       profileName,
       ...(itemId ? { itemId } : {}),
       ...(match ? { match } : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_featured_remove.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1877,7 +1896,7 @@ async function handleProfilePrepareFeaturedRemove(
 }
 
 async function handleProfilePrepareFeaturedReorder(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1889,31 +1908,31 @@ async function handleProfilePrepareFeaturedReorder(
     if (!itemIds || itemIds.length === 0) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "itemIds is required."
+        "itemIds is required.",
       );
     }
 
     runtime.logger.log("info", "mcp.profile.prepare_featured_reorder.start", {
       profileName,
-      itemCount: itemIds.length
+      itemCount: itemIds.length,
     });
 
     const prepared = runtime.profile.prepareFeaturedReorder({
       profileName,
       itemIds,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_featured_reorder.done", {
       profileName,
       itemCount: itemIds.length,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1921,7 +1940,7 @@ async function handleProfilePrepareFeaturedReorder(
 }
 
 async function handleProfilePrepareAddSkill(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1932,24 +1951,24 @@ async function handleProfilePrepareAddSkill(
 
     runtime.logger.log("info", "mcp.profile.prepare_add_skill.start", {
       profileName,
-      skillName
+      skillName,
     });
 
     const prepared = runtime.profile.prepareAddSkill({
       profileName,
       skillName,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_add_skill.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1957,7 +1976,7 @@ async function handleProfilePrepareAddSkill(
 }
 
 async function handleProfilePrepareReorderSkills(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1968,25 +1987,25 @@ async function handleProfilePrepareReorderSkills(
 
     runtime.logger.log("info", "mcp.profile.prepare_reorder_skills.start", {
       profileName,
-      skillCount: skillNames.length
+      skillCount: skillNames.length,
     });
 
     const prepared = runtime.profile.prepareReorderSkills({
       profileName,
       skillNames,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_reorder_skills.done", {
       profileName,
       skillCount: skillNames.length,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1994,7 +2013,7 @@ async function handleProfilePrepareReorderSkills(
 }
 
 async function handleProfilePrepareEndorseSkill(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -2006,25 +2025,25 @@ async function handleProfilePrepareEndorseSkill(
 
     runtime.logger.log("info", "mcp.profile.prepare_endorse_skill.start", {
       profileName,
-      target
+      target,
     });
 
     const prepared = runtime.profile.prepareEndorseSkill({
       profileName,
       target,
       skillName,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_endorse_skill.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2032,7 +2051,7 @@ async function handleProfilePrepareEndorseSkill(
 }
 
 async function handleProfilePrepareRequestRecommendation(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -2046,8 +2065,8 @@ async function handleProfilePrepareRequestRecommendation(
       "mcp.profile.prepare_request_recommendation.start",
       {
         profileName,
-        target
-      }
+        target,
+      },
     );
 
     const prepared = runtime.profile.prepareRequestRecommendation({
@@ -2065,7 +2084,7 @@ async function handleProfilePrepareRequestRecommendation(
       ...(typeof args.message === "string"
         ? { message: readString(args, "message", "") }
         : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log(
@@ -2073,14 +2092,14 @@ async function handleProfilePrepareRequestRecommendation(
       "mcp.profile.prepare_request_recommendation.done",
       {
         profileName,
-        preparedActionId: prepared.preparedActionId
-      }
+        preparedActionId: prepared.preparedActionId,
+      },
     );
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2088,7 +2107,7 @@ async function handleProfilePrepareRequestRecommendation(
 }
 
 async function handleProfilePrepareWriteRecommendation(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -2103,8 +2122,8 @@ async function handleProfilePrepareWriteRecommendation(
       "mcp.profile.prepare_write_recommendation.start",
       {
         profileName,
-        target
-      }
+        target,
+      },
     );
 
     const prepared = runtime.profile.prepareWriteRecommendation({
@@ -2120,7 +2139,7 @@ async function handleProfilePrepareWriteRecommendation(
       ...(typeof args.company === "string"
         ? { company: readString(args, "company", "") }
         : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log(
@@ -2128,14 +2147,14 @@ async function handleProfilePrepareWriteRecommendation(
       "mcp.profile.prepare_write_recommendation.done",
       {
         profileName,
-        preparedActionId: prepared.preparedActionId
-      }
+        preparedActionId: prepared.preparedActionId,
+      },
     );
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2143,7 +2162,7 @@ async function handleProfilePrepareWriteRecommendation(
 }
 
 async function handleAssetsGenerateProfileImages(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -2153,7 +2172,7 @@ async function handleAssetsGenerateProfileImages(
     const postImageCount = readPositiveNumber(
       args,
       "postImageCount",
-      DEFAULT_LINKEDIN_PERSONA_POST_IMAGE_COUNT
+      DEFAULT_LINKEDIN_PERSONA_POST_IMAGE_COUNT,
     );
     const uploadProfileMedia = readBoolean(args, "uploadProfileMedia", false);
     const uploadDelayMs = readNonNegativeNumber(args, "uploadDelayMs", 4_500);
@@ -2161,7 +2180,7 @@ async function handleAssetsGenerateProfileImages(
     const operatorNote = readString(args, "operatorNote", "");
     const resolvedSpecPath = path.resolve(specPath);
     const persona = buildLinkedInImagePersonaFromProfileSeed(
-      await readJsonInputFile(resolvedSpecPath, "image persona spec")
+      await readJsonInputFile(resolvedSpecPath, "image persona spec"),
     );
 
     runtime.logger.log("info", "mcp.assets.generate_profile_images.start", {
@@ -2169,7 +2188,7 @@ async function handleAssetsGenerateProfileImages(
       specPath: resolvedSpecPath,
       postImageCount,
       uploadProfileMedia,
-      model: model || null
+      model: model || null,
     });
 
     const report = await runtime.imageAssets.generatePersonaImageSet({
@@ -2179,22 +2198,23 @@ async function handleAssetsGenerateProfileImages(
       profileName,
       uploadDelayMs,
       operatorNote:
-        operatorNote || `issue-211 persona images: ${path.basename(resolvedSpecPath)}`,
-      ...(model ? { model } : {})
+        operatorNote ||
+        `issue-211 persona images: ${path.basename(resolvedSpecPath)}`,
+      ...(model ? { model } : {}),
     });
 
     runtime.logger.log("info", "mcp.assets.generate_profile_images.done", {
       profileName,
       specPath: resolvedSpecPath,
       postImageCount,
-      uploadProfileMedia
+      uploadProfileMedia,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
       spec_path: resolvedSpecPath,
-      ...report
+      ...report,
     });
   } finally {
     runtime.close();
@@ -2202,7 +2222,7 @@ async function handleAssetsGenerateProfileImages(
 }
 
 async function handleAnalyticsProfileViews(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -2210,23 +2230,23 @@ async function handleAnalyticsProfileViews(
     const profileName = readString(args, "profileName", "default");
 
     runtime.logger.log("info", "mcp.analytics.profile_views.start", {
-      profileName
+      profileName,
     });
 
     const summary = await runtime.analytics.getProfileViews({
-      profileName
+      profileName,
     });
 
     runtime.logger.log("info", "mcp.analytics.profile_views.done", {
       profileName,
       card_count: summary.cards.length,
-      metric_count: summary.metrics.length
+      metric_count: summary.metrics.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...summary
+      ...summary,
     });
   } finally {
     runtime.close();
@@ -2234,7 +2254,7 @@ async function handleAnalyticsProfileViews(
 }
 
 async function handleAnalyticsSearchAppearances(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -2242,23 +2262,23 @@ async function handleAnalyticsSearchAppearances(
     const profileName = readString(args, "profileName", "default");
 
     runtime.logger.log("info", "mcp.analytics.search_appearances.start", {
-      profileName
+      profileName,
     });
 
     const summary = await runtime.analytics.getSearchAppearances({
-      profileName
+      profileName,
     });
 
     runtime.logger.log("info", "mcp.analytics.search_appearances.done", {
       profileName,
       card_count: summary.cards.length,
-      metric_count: summary.metrics.length
+      metric_count: summary.metrics.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...summary
+      ...summary,
     });
   } finally {
     runtime.close();
@@ -2266,7 +2286,7 @@ async function handleAnalyticsSearchAppearances(
 }
 
 async function handleAnalyticsContentMetrics(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -2276,33 +2296,31 @@ async function handleAnalyticsContentMetrics(
 
     runtime.logger.log("info", "mcp.analytics.content_metrics.start", {
       profileName,
-      limit
+      limit,
     });
 
     const summary = await runtime.analytics.getContentMetrics({
       profileName,
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.analytics.content_metrics.done", {
       profileName,
       card_count: summary.cards.length,
-      metric_count: summary.metrics.length
+      metric_count: summary.metrics.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...summary
+      ...summary,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handleAnalyticsPostMetrics(
-  args: ToolArgs
-): Promise<ToolResult> {
+async function handleAnalyticsPostMetrics(args: ToolArgs): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
@@ -2311,24 +2329,24 @@ async function handleAnalyticsPostMetrics(
 
     runtime.logger.log("info", "mcp.analytics.post_metrics.start", {
       profileName,
-      postUrl
+      postUrl,
     });
 
     const summary = await runtime.analytics.getPostMetrics({
       profileName,
-      postUrl
+      postUrl,
     });
 
     runtime.logger.log("info", "mcp.analytics.post_metrics.done", {
       profileName,
       post_url: summary.post.post_url,
-      metric_count: summary.metrics.length
+      metric_count: summary.metrics.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...summary
+      ...summary,
     });
   } finally {
     runtime.close();
@@ -2344,31 +2362,33 @@ async function handleNotificationsList(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.notifications.list.start", {
       profileName,
-      limit
+      limit,
     });
 
     const notifications = await runtime.notifications.listNotifications({
       profileName,
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.notifications.list.done", {
       profileName,
-      count: notifications.length
+      count: notifications.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
       count: notifications.length,
-      notifications
+      notifications,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handleNotificationsMarkRead(args: ToolArgs): Promise<ToolResult> {
+async function handleNotificationsMarkRead(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
@@ -2377,24 +2397,24 @@ async function handleNotificationsMarkRead(args: ToolArgs): Promise<ToolResult> 
 
     runtime.logger.log("info", "mcp.notifications.mark_read.start", {
       profileName,
-      notificationId
+      notificationId,
     });
 
     const result = await runtime.notifications.markRead({
       profileName,
-      notificationId
+      notificationId,
     });
 
     runtime.logger.log("info", "mcp.notifications.mark_read.done", {
       profileName,
       notificationId,
-      wasAlreadyRead: result.was_already_read
+      wasAlreadyRead: result.was_already_read,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
@@ -2411,25 +2431,25 @@ async function handleNotificationsDismiss(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.notifications.dismiss.start", {
       profileName,
-      notificationId
+      notificationId,
     });
 
     const prepared = await runtime.notifications.prepareDismissNotification({
       profileName,
       notificationId,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.notifications.dismiss.done", {
       profileName,
       notificationId,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2437,7 +2457,7 @@ async function handleNotificationsDismiss(args: ToolArgs): Promise<ToolResult> {
 }
 
 async function handleNotificationPreferencesGet(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -2447,24 +2467,24 @@ async function handleNotificationPreferencesGet(
 
     runtime.logger.log("info", "mcp.notifications.preferences.get.start", {
       profileName,
-      preferenceUrl: preferenceUrl || null
+      preferenceUrl: preferenceUrl || null,
     });
 
     const preferences = await runtime.notifications.getPreferences({
       profileName,
-      ...(preferenceUrl ? { preferenceUrl } : {})
+      ...(preferenceUrl ? { preferenceUrl } : {}),
     });
 
     runtime.logger.log("info", "mcp.notifications.preferences.get.done", {
       profileName,
       viewType: preferences.view_type,
-      preferenceUrl: preferences.preference_url
+      preferenceUrl: preferences.preference_url,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      preferences
+      preferences,
     });
   } finally {
     runtime.close();
@@ -2472,7 +2492,7 @@ async function handleNotificationPreferencesGet(
 }
 
 async function handleNotificationPreferencesPrepareUpdate(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -2480,36 +2500,47 @@ async function handleNotificationPreferencesPrepareUpdate(
     const profileName = readString(args, "profileName", "default");
     const preferenceUrl = readRequiredString(args, "preferenceUrl");
     const enabled = readRequiredBoolean(args, "enabled");
-    const channel = typeof args.channel === "string"
-      ? normalizeLinkedInNotificationPreferenceChannel(readRequiredString(args, "channel"))
-      : undefined;
+    const channel =
+      typeof args.channel === "string"
+        ? normalizeLinkedInNotificationPreferenceChannel(
+            readRequiredString(args, "channel"),
+          )
+        : undefined;
     const operatorNote = readString(args, "operatorNote", "");
 
-    runtime.logger.log("info", "mcp.notifications.preferences.prepare_update.start", {
-      profileName,
-      preferenceUrl,
-      enabled,
-      channel: channel ?? null
-    });
+    runtime.logger.log(
+      "info",
+      "mcp.notifications.preferences.prepare_update.start",
+      {
+        profileName,
+        preferenceUrl,
+        enabled,
+        channel: channel ?? null,
+      },
+    );
 
     const prepared = await runtime.notifications.prepareUpdatePreference({
       profileName,
       preferenceUrl,
       enabled,
       ...(channel ? { channel } : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
-    runtime.logger.log("info", "mcp.notifications.preferences.prepare_update.done", {
-      profileName,
-      preferenceUrl,
-      preparedActionId: prepared.preparedActionId
-    });
+    runtime.logger.log(
+      "info",
+      "mcp.notifications.preferences.prepare_update.done",
+      {
+        profileName,
+        preferenceUrl,
+        preparedActionId: prepared.preparedActionId,
+      },
+    );
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2529,25 +2560,25 @@ async function handleJobsSearch(args: ToolArgs): Promise<ToolResult> {
       profileName,
       query,
       location,
-      limit
+      limit,
     });
 
     const result = await runtime.jobs.searchJobs({
       profileName,
       query,
       ...(location ? { location } : {}),
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.jobs.search.done", {
       profileName,
-      count: result.count
+      count: result.count,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
@@ -2563,23 +2594,23 @@ async function handleJobsView(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.jobs.view.start", {
       profileName,
-      jobId
+      jobId,
     });
 
     const job = await runtime.jobs.viewJob({
       profileName,
-      jobId
+      jobId,
     });
 
     runtime.logger.log("info", "mcp.jobs.view.done", {
       profileName,
-      jobId: job.job_id
+      jobId: job.job_id,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      job
+      job,
     });
   } finally {
     runtime.close();
@@ -2596,24 +2627,24 @@ async function handleJobsSave(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.jobs.save.start", {
       profileName,
-      jobId
+      jobId,
     });
 
     const prepared = runtime.jobs.prepareSaveJob({
       profileName,
       jobId,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.jobs.save.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2630,24 +2661,24 @@ async function handleJobsUnsave(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.jobs.unsave.start", {
       profileName,
-      jobId
+      jobId,
     });
 
     const prepared = runtime.jobs.prepareUnsaveJob({
       profileName,
       jobId,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.jobs.unsave.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2663,23 +2694,23 @@ async function handleJobsAlertsList(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.jobs.alerts.list.start", {
       profileName,
-      limit
+      limit,
     });
 
     const result = await runtime.jobs.listJobAlerts({
       profileName,
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.jobs.alerts.list.done", {
       profileName,
-      count: result.count
+      count: result.count,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
@@ -2698,25 +2729,25 @@ async function handleJobsAlertsCreate(args: ToolArgs): Promise<ToolResult> {
     runtime.logger.log("info", "mcp.jobs.alerts.create.start", {
       profileName,
       query,
-      location
+      location,
     });
 
     const prepared = runtime.jobs.prepareCreateJobAlert({
       profileName,
       query,
       ...(location ? { location } : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.jobs.alerts.create.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2738,7 +2769,7 @@ async function handleJobsAlertsRemove(args: ToolArgs): Promise<ToolResult> {
       profileName,
       hasAlertId: alertId.length > 0,
       hasSearchUrl: searchUrl.length > 0,
-      hasQuery: query.length > 0
+      hasQuery: query.length > 0,
     });
 
     const prepared = await runtime.jobs.prepareRemoveJobAlert({
@@ -2747,18 +2778,18 @@ async function handleJobsAlertsRemove(args: ToolArgs): Promise<ToolResult> {
       ...(searchUrl ? { searchUrl } : {}),
       ...(query ? { query } : {}),
       ...(location ? { location } : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.jobs.alerts.remove.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2783,7 +2814,7 @@ async function handleJobsPrepareEasyApply(args: ToolArgs): Promise<ToolResult> {
       profileName,
       jobId,
       hasResumePath: resumePath.length > 0,
-      hasAnswers: Boolean(answers)
+      hasAnswers: Boolean(answers),
     });
 
     const prepared = runtime.jobs.prepareEasyApply({
@@ -2795,18 +2826,18 @@ async function handleJobsPrepareEasyApply(args: ToolArgs): Promise<ToolResult> {
       ...(resumePath ? { resumePath } : {}),
       ...(coverLetter ? { coverLetter } : {}),
       ...(answers ? { answers } : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.jobs.easy_apply.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2824,24 +2855,24 @@ async function handleGroupsSearch(args: ToolArgs): Promise<ToolResult> {
     runtime.logger.log("info", "mcp.groups.search.start", {
       profileName,
       query,
-      limit
+      limit,
     });
 
     const result = await runtime.groups.searchGroups({
       profileName,
       query,
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.groups.search.done", {
       profileName,
-      count: result.count
+      count: result.count,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
@@ -2857,23 +2888,23 @@ async function handleGroupsView(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.groups.view.start", {
       profileName,
-      group
+      group,
     });
 
     const groupDetails = await runtime.groups.viewGroup({
       profileName,
-      group
+      group,
     });
 
     runtime.logger.log("info", "mcp.groups.view.done", {
       profileName,
-      groupId: groupDetails.group_id
+      groupId: groupDetails.group_id,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      group: groupDetails
+      group: groupDetails,
     });
   } finally {
     runtime.close();
@@ -2890,24 +2921,24 @@ async function handleGroupsPrepareJoin(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.groups.prepare_join.start", {
       profileName,
-      group
+      group,
     });
 
     const prepared = runtime.groups.prepareJoinGroup({
       profileName,
       group,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.groups.prepare_join.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2924,24 +2955,24 @@ async function handleGroupsPrepareLeave(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.groups.prepare_leave.start", {
       profileName,
-      group
+      group,
     });
 
     const prepared = runtime.groups.prepareLeaveGroup({
       profileName,
       group,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.groups.prepare_leave.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2959,25 +2990,25 @@ async function handleGroupsPreparePost(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.groups.prepare_post.start", {
       profileName,
-      group
+      group,
     });
 
     const prepared = runtime.groups.preparePostToGroup({
       profileName,
       group,
       text,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.groups.prepare_post.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2995,24 +3026,24 @@ async function handleEventsSearch(args: ToolArgs): Promise<ToolResult> {
     runtime.logger.log("info", "mcp.events.search.start", {
       profileName,
       query,
-      limit
+      limit,
     });
 
     const result = await runtime.events.searchEvents({
       profileName,
       query,
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.events.search.done", {
       profileName,
-      count: result.count
+      count: result.count,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
@@ -3028,23 +3059,23 @@ async function handleEventsView(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.events.view.start", {
       profileName,
-      event
+      event,
     });
 
     const eventDetails = await runtime.events.viewEvent({
       profileName,
-      event
+      event,
     });
 
     runtime.logger.log("info", "mcp.events.view.done", {
       profileName,
-      eventId: eventDetails.event_id
+      eventId: eventDetails.event_id,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      event: eventDetails
+      event: eventDetails,
     });
   } finally {
     runtime.close();
@@ -3061,24 +3092,24 @@ async function handleEventsPrepareRsvp(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.events.prepare_rsvp.start", {
       profileName,
-      event
+      event,
     });
 
     const prepared = runtime.events.prepareRsvp({
       profileName,
       event,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.events.prepare_rsvp.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3098,26 +3129,26 @@ async function handleSearch(args: ToolArgs): Promise<ToolResult> {
       profileName,
       query,
       category,
-      limit
+      limit,
     });
 
     const search = await runtime.search.search({
       profileName,
       query,
       category,
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.search.done", {
       profileName,
       category: search.category,
-      count: search.count
+      count: search.count,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...search
+      ...search,
     });
   } finally {
     runtime.close();
@@ -3133,24 +3164,24 @@ async function handleConnectionsList(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.connections.list.start", {
       profileName,
-      limit
+      limit,
     });
 
     const connections = await runtime.connections.listConnections({
       profileName,
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.connections.list.done", {
       profileName,
-      count: connections.length
+      count: connections.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
       count: connections.length,
-      connections
+      connections,
     });
   } finally {
     runtime.close();
@@ -3163,23 +3194,23 @@ async function handleConnectionsPending(args: ToolArgs): Promise<ToolResult> {
   try {
     const profileName = readString(args, "profileName", "default");
     const filterRaw = readString(args, "filter", "all");
-    const filter = (["sent", "received", "all"].includes(filterRaw)
-      ? filterRaw
-      : "all") as "sent" | "received" | "all";
+    const filter = (
+      ["sent", "received", "all"].includes(filterRaw) ? filterRaw : "all"
+    ) as "sent" | "received" | "all";
 
     runtime.logger.log("info", "mcp.connections.pending.start", {
       profileName,
-      filter
+      filter,
     });
 
     const invitations = await runtime.connections.listPendingInvitations({
       profileName,
-      filter
+      filter,
     });
 
     runtime.logger.log("info", "mcp.connections.pending.done", {
       profileName,
-      count: invitations.length
+      count: invitations.length,
     });
 
     return toToolResult({
@@ -3187,7 +3218,7 @@ async function handleConnectionsPending(args: ToolArgs): Promise<ToolResult> {
       profile_name: profileName,
       filter,
       count: invitations.length,
-      invitations
+      invitations,
     });
   } finally {
     runtime.close();
@@ -3205,25 +3236,25 @@ async function handleConnectionsInvite(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.connections.invite.start", {
       profileName,
-      targetProfile
+      targetProfile,
     });
 
     const prepared = runtime.connections.prepareSendInvitation({
       profileName,
       targetProfile,
       ...(note ? { note } : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.connections.invite.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3240,24 +3271,24 @@ async function handleConnectionsAccept(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.connections.accept.start", {
       profileName,
-      targetProfile
+      targetProfile,
     });
 
     const prepared = runtime.connections.prepareAcceptInvitation({
       profileName,
       targetProfile,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.connections.accept.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3274,24 +3305,24 @@ async function handleConnectionsWithdraw(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.connections.withdraw.start", {
       profileName,
-      targetProfile
+      targetProfile,
     });
 
     const prepared = runtime.connections.prepareWithdrawInvitation({
       profileName,
       targetProfile,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.connections.withdraw.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3299,7 +3330,7 @@ async function handleConnectionsWithdraw(args: ToolArgs): Promise<ToolResult> {
 }
 
 async function handleConnectionsPrepareIgnore(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -3310,24 +3341,24 @@ async function handleConnectionsPrepareIgnore(
 
     runtime.logger.log("info", "mcp.connections.prepare_ignore.start", {
       profileName,
-      targetProfile
+      targetProfile,
     });
 
     const prepared = runtime.connections.prepareIgnoreInvitation({
       profileName,
       targetProfile,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.connections.prepare_ignore.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3335,7 +3366,7 @@ async function handleConnectionsPrepareIgnore(
 }
 
 async function handleConnectionsPrepareRemove(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -3346,24 +3377,24 @@ async function handleConnectionsPrepareRemove(
 
     runtime.logger.log("info", "mcp.connections.prepare_remove.start", {
       profileName,
-      targetProfile
+      targetProfile,
     });
 
     const prepared = runtime.connections.prepareRemoveConnection({
       profileName,
       targetProfile,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.connections.prepare_remove.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3371,7 +3402,7 @@ async function handleConnectionsPrepareRemove(
 }
 
 async function handleConnectionsPrepareFollow(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -3382,24 +3413,24 @@ async function handleConnectionsPrepareFollow(
 
     runtime.logger.log("info", "mcp.connections.prepare_follow.start", {
       profileName,
-      targetProfile
+      targetProfile,
     });
 
     const prepared = runtime.connections.prepareFollowMember({
       profileName,
       targetProfile,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.connections.prepare_follow.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3407,7 +3438,7 @@ async function handleConnectionsPrepareFollow(
 }
 
 async function handleConnectionsPrepareUnfollow(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -3418,24 +3449,24 @@ async function handleConnectionsPrepareUnfollow(
 
     runtime.logger.log("info", "mcp.connections.prepare_unfollow.start", {
       profileName,
-      targetProfile
+      targetProfile,
     });
 
     const prepared = runtime.connections.prepareUnfollowMember({
       profileName,
       targetProfile,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.connections.prepare_unfollow.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3452,24 +3483,24 @@ async function handleCompanyPrepareFollow(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.company.prepare_follow.start", {
       profileName,
-      targetCompany
+      targetCompany,
     });
 
     const prepared = runtime.companyPages.prepareFollowCompanyPage({
       profileName,
       targetCompany,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.company.prepare_follow.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3477,7 +3508,7 @@ async function handleCompanyPrepareFollow(args: ToolArgs): Promise<ToolResult> {
 }
 
 async function handleCompanyPrepareUnfollow(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -3488,24 +3519,24 @@ async function handleCompanyPrepareUnfollow(
 
     runtime.logger.log("info", "mcp.company.prepare_unfollow.start", {
       profileName,
-      targetCompany
+      targetCompany,
     });
 
     const prepared = runtime.companyPages.prepareUnfollowCompanyPage({
       profileName,
       targetCompany,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.company.prepare_unfollow.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3522,31 +3553,33 @@ async function handleMembersPrepareBlock(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.members.prepare_block.start", {
       profileName,
-      targetProfile
+      targetProfile,
     });
 
     const prepared = runtime.members.prepareBlockMember({
       profileName,
       targetProfile,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.members.prepare_block.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handleMembersPrepareUnblock(args: ToolArgs): Promise<ToolResult> {
+async function handleMembersPrepareUnblock(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
@@ -3556,24 +3589,24 @@ async function handleMembersPrepareUnblock(args: ToolArgs): Promise<ToolResult> 
 
     runtime.logger.log("info", "mcp.members.prepare_unblock.start", {
       profileName,
-      targetProfile
+      targetProfile,
     });
 
     const prepared = runtime.members.prepareUnblockMember({
       profileName,
       targetProfile,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.members.prepare_unblock.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3593,7 +3626,7 @@ async function handleMembersPrepareReport(args: ToolArgs): Promise<ToolResult> {
     runtime.logger.log("info", "mcp.members.prepare_report.start", {
       profileName,
       targetProfile,
-      reason
+      reason,
     });
 
     const prepared = runtime.members.prepareReportMember({
@@ -3601,18 +3634,18 @@ async function handleMembersPrepareReport(args: ToolArgs): Promise<ToolResult> {
       targetProfile,
       reason,
       ...(details ? { details } : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.members.prepare_report.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3626,22 +3659,22 @@ async function handlePrivacyGetSettings(args: ToolArgs): Promise<ToolResult> {
     const profileName = readString(args, "profileName", "default");
 
     runtime.logger.log("info", "mcp.privacy.get_settings.start", {
-      profileName
+      profileName,
     });
 
     const settings = await runtime.privacySettings.getSettings({
-      profileName
+      profileName,
     });
 
     runtime.logger.log("info", "mcp.privacy.get_settings.done", {
       profileName,
-      count: settings.length
+      count: settings.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      settings
+      settings,
     });
   } finally {
     runtime.close();
@@ -3649,7 +3682,7 @@ async function handlePrivacyGetSettings(args: ToolArgs): Promise<ToolResult> {
 }
 
 async function handlePrivacyPrepareUpdateSetting(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -3658,32 +3691,32 @@ async function handlePrivacyPrepareUpdateSetting(
     const settingKey = readPrivacySettingKey(args, "settingKey");
     const value = normalizeLinkedInPrivacySettingValue(
       settingKey,
-      readRequiredString(args, "value")
+      readRequiredString(args, "value"),
     );
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.privacy.prepare_update_setting.start", {
       profileName,
       settingKey,
-      value
+      value,
     });
 
     const prepared = runtime.privacySettings.prepareUpdateSetting({
       profileName,
       settingKey,
       value,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.privacy.prepare_update_setting.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3691,7 +3724,7 @@ async function handlePrivacyPrepareUpdateSetting(
 }
 
 async function handlePrepareFollowupAfterAccept(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -3703,19 +3736,19 @@ async function handlePrepareFollowupAfterAccept(
 
     runtime.logger.log("info", "mcp.followups.prepare.start", {
       profileName,
-      since
+      since,
     });
 
     const result = await runtime.followups.prepareFollowupsAfterAccept({
       profileName,
       since,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.followups.prepare.done", {
       profileName,
       acceptedConnectionCount: result.acceptedConnections.length,
-      preparedCount: result.preparedFollowups.length
+      preparedCount: result.preparedFollowups.length,
     });
 
     return toToolResult({
@@ -3727,7 +3760,7 @@ async function handlePrepareFollowupAfterAccept(
       accepted_connection_count: result.acceptedConnections.length,
       prepared_count: result.preparedFollowups.length,
       accepted_connections: result.acceptedConnections,
-      prepared_followups: result.preparedFollowups
+      prepared_followups: result.preparedFollowups,
     });
   } finally {
     runtime.close();
@@ -3743,24 +3776,24 @@ async function handleFeedList(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.feed.list.start", {
       profileName,
-      limit
+      limit,
     });
 
     const posts = await runtime.feed.viewFeed({
       profileName,
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.feed.list.done", {
       profileName,
-      count: posts.length
+      count: posts.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
       count: posts.length,
-      posts
+      posts,
     });
   } finally {
     runtime.close();
@@ -3776,23 +3809,23 @@ async function handleFeedViewPost(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.feed.view_post.start", {
       profileName,
-      postUrl
+      postUrl,
     });
 
     const post = await runtime.feed.viewPost({
       profileName,
-      postUrl
+      postUrl,
     });
 
     runtime.logger.log("info", "mcp.feed.view_post.done", {
       profileName,
-      postId: post.post_id
+      postId: post.post_id,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      post
+      post,
     });
   } finally {
     runtime.close();
@@ -3805,32 +3838,34 @@ async function handleFeedLike(args: ToolArgs): Promise<ToolResult> {
   try {
     const profileName = readString(args, "profileName", "default");
     const postUrl = readRequiredString(args, "postUrl");
-    const reaction = normalizeLinkedInFeedReaction(readString(args, "reaction", "like"));
+    const reaction = normalizeLinkedInFeedReaction(
+      readString(args, "reaction", "like"),
+    );
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.feed.like.start", {
       profileName,
       postUrl,
-      reaction
+      reaction,
     });
 
     const prepared = runtime.feed.prepareLikePost({
       profileName,
       postUrl,
       reaction,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.feed.like.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
-      reaction
+      reaction,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3848,25 +3883,25 @@ async function handleFeedComment(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.feed.comment.start", {
       profileName,
-      postUrl
+      postUrl,
     });
 
     const prepared = runtime.feed.prepareCommentOnPost({
       profileName,
       postUrl,
       text,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.feed.comment.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3883,24 +3918,24 @@ async function handleFeedPrepareRepost(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.feed.prepare_repost.start", {
       profileName,
-      postUrl
+      postUrl,
     });
 
     const prepared = runtime.feed.prepareRepostPost({
       profileName,
       postUrl,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.feed.prepare_repost.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3918,25 +3953,25 @@ async function handleFeedPrepareShare(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.feed.prepare_share.start", {
       profileName,
-      postUrl
+      postUrl,
     });
 
     const prepared = runtime.feed.prepareSharePost({
       profileName,
       postUrl,
       text,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.feed.prepare_share.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3953,24 +3988,24 @@ async function handleFeedSavePost(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.feed.save_post.start", {
       profileName,
-      postUrl
+      postUrl,
     });
 
     const prepared = runtime.feed.prepareSavePost({
       profileName,
       postUrl,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.feed.save_post.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3987,24 +4022,24 @@ async function handleFeedUnsavePost(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.feed.unsave_post.start", {
       profileName,
-      postUrl
+      postUrl,
     });
 
     const prepared = runtime.feed.prepareUnsavePost({
       profileName,
       postUrl,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.feed.unsave_post.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -4012,7 +4047,7 @@ async function handleFeedUnsavePost(args: ToolArgs): Promise<ToolResult> {
 }
 
 async function handleFeedPrepareRemoveReaction(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -4023,24 +4058,24 @@ async function handleFeedPrepareRemoveReaction(
 
     runtime.logger.log("info", "mcp.feed.prepare_remove_reaction.start", {
       profileName,
-      postUrl
+      postUrl,
     });
 
     const prepared = runtime.feed.prepareRemoveReaction({
       profileName,
       postUrl,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.feed.prepare_remove_reaction.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -4055,39 +4090,41 @@ async function handlePostPrepareCreate(args: ToolArgs): Promise<ToolResult> {
     const text = readRequiredString(args, "text");
     const visibility = normalizeLinkedInPostVisibility(
       readString(args, "visibility", "public"),
-      "public"
+      "public",
     );
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.post.prepare_create.start", {
       profileName,
-      visibility
+      visibility,
     });
 
     const prepared = await runtime.posts.prepareCreate({
       profileName,
       text,
       visibility,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.post.prepare_create.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
-      visibility
+      visibility,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handlePostPrepareCreateMedia(args: ToolArgs): Promise<ToolResult> {
+async function handlePostPrepareCreateMedia(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
@@ -4097,19 +4134,19 @@ async function handlePostPrepareCreateMedia(args: ToolArgs): Promise<ToolResult>
     if (!mediaPaths) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "mediaPaths is required."
+        "mediaPaths is required.",
       );
     }
     const visibility = normalizeLinkedInPostVisibility(
       readString(args, "visibility", "public"),
-      "public"
+      "public",
     );
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.post.prepare_create_media.start", {
       profileName,
       visibility,
-      mediaCount: mediaPaths.length
+      mediaCount: mediaPaths.length,
     });
 
     const prepared = await runtime.posts.prepareCreateMedia({
@@ -4117,27 +4154,29 @@ async function handlePostPrepareCreateMedia(args: ToolArgs): Promise<ToolResult>
       text,
       mediaPaths,
       visibility,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.post.prepare_create_media.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
       visibility,
-      mediaCount: mediaPaths.length
+      mediaCount: mediaPaths.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handlePostPrepareCreatePoll(args: ToolArgs): Promise<ToolResult> {
+async function handlePostPrepareCreatePoll(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
@@ -4147,14 +4186,14 @@ async function handlePostPrepareCreatePoll(args: ToolArgs): Promise<ToolResult> 
     if (!options) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "options is required."
+        "options is required.",
       );
     }
     const text = readString(args, "text", "");
     const durationDays = readOptionalPositiveNumber(args, "durationDays");
     const visibility = normalizeLinkedInPostVisibility(
       readString(args, "visibility", "public"),
-      "public"
+      "public",
     );
     const operatorNote = readString(args, "operatorNote", "");
 
@@ -4162,7 +4201,7 @@ async function handlePostPrepareCreatePoll(args: ToolArgs): Promise<ToolResult> 
       profileName,
       visibility,
       optionCount: options.length,
-      ...(typeof durationDays === "number" ? { durationDays } : {})
+      ...(typeof durationDays === "number" ? { durationDays } : {}),
     });
 
     const prepared = await runtime.posts.prepareCreatePoll({
@@ -4172,7 +4211,7 @@ async function handlePostPrepareCreatePoll(args: ToolArgs): Promise<ToolResult> 
       ...(text ? { text } : {}),
       ...(typeof durationDays === "number" ? { durationDays } : {}),
       visibility,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.post.prepare_create_poll.done", {
@@ -4180,13 +4219,13 @@ async function handlePostPrepareCreatePoll(args: ToolArgs): Promise<ToolResult> 
       preparedActionId: prepared.preparedActionId,
       visibility,
       optionCount: options.length,
-      ...(typeof durationDays === "number" ? { durationDays } : {})
+      ...(typeof durationDays === "number" ? { durationDays } : {}),
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -4204,26 +4243,26 @@ async function handlePostPrepareEdit(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.post.prepare_edit.start", {
       profileName,
-      postUrl
+      postUrl,
     });
 
     const prepared = await runtime.posts.prepareEdit({
       profileName,
       postUrl,
       text,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.post.prepare_edit.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
-      postUrl
+      postUrl,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -4240,25 +4279,25 @@ async function handlePostPrepareDelete(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.post.prepare_delete.start", {
       profileName,
-      postUrl
+      postUrl,
     });
 
     const prepared = await runtime.posts.prepareDelete({
       profileName,
       postUrl,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.post.prepare_delete.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
-      postUrl
+      postUrl,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -4276,32 +4315,34 @@ async function handleArticlePrepareCreate(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.article.prepare_create.start", {
       profileName,
-      titleLength: title.length
+      titleLength: title.length,
     });
 
     const prepared = await runtime.articles.prepareCreate({
       profileName,
       title,
       body,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.article.prepare_create.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handleArticlePreparePublish(args: ToolArgs): Promise<ToolResult> {
+async function handleArticlePreparePublish(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
@@ -4311,32 +4352,34 @@ async function handleArticlePreparePublish(args: ToolArgs): Promise<ToolResult> 
 
     runtime.logger.log("info", "mcp.article.prepare_publish.start", {
       profileName,
-      draftUrl
+      draftUrl,
     });
 
     const prepared = await runtime.articles.preparePublish({
       profileName,
       draftUrl,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.article.prepare_publish.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
-      draftUrl
+      draftUrl,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handleNewsletterPrepareCreate(args: ToolArgs): Promise<ToolResult> {
+async function handleNewsletterPrepareCreate(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
@@ -4348,7 +4391,7 @@ async function handleNewsletterPrepareCreate(args: ToolArgs): Promise<ToolResult
 
     runtime.logger.log("info", "mcp.newsletter.prepare_create.start", {
       profileName,
-      cadence
+      cadence,
     });
 
     const prepared = await runtime.newsletters.prepareCreate({
@@ -4356,19 +4399,19 @@ async function handleNewsletterPrepareCreate(args: ToolArgs): Promise<ToolResult
       title,
       description,
       cadence,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.newsletter.prepare_create.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
-      cadence
+      cadence,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -4376,7 +4419,7 @@ async function handleNewsletterPrepareCreate(args: ToolArgs): Promise<ToolResult
 }
 
 async function handleNewsletterPreparePublishIssue(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -4389,7 +4432,7 @@ async function handleNewsletterPreparePublishIssue(
 
     runtime.logger.log("info", "mcp.newsletter.prepare_publish_issue.start", {
       profileName,
-      newsletter
+      newsletter,
     });
 
     const prepared = await runtime.newsletters.preparePublishIssue({
@@ -4397,19 +4440,19 @@ async function handleNewsletterPreparePublishIssue(
       newsletter,
       title,
       body,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.newsletter.prepare_publish_issue.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
-      newsletter
+      newsletter,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -4423,22 +4466,22 @@ async function handleNewsletterList(args: ToolArgs): Promise<ToolResult> {
     const profileName = readString(args, "profileName", "default");
 
     runtime.logger.log("info", "mcp.newsletter.list.start", {
-      profileName
+      profileName,
     });
 
     const newsletters = await runtime.newsletters.list({
-      profileName
+      profileName,
     });
 
     runtime.logger.log("info", "mcp.newsletter.list.done", {
       profileName,
-      count: newsletters.count
+      count: newsletters.count,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...newsletters
+      ...newsletters,
     });
   } finally {
     runtime.close();
@@ -4457,7 +4500,7 @@ async function handleActivityWatchCreate(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.activity_watch.create.start", {
       profileName,
-      kind
+      kind,
     });
 
     const watch = runtime.activityWatches.createWatch({
@@ -4465,19 +4508,19 @@ async function handleActivityWatchCreate(args: ToolArgs): Promise<ToolResult> {
       kind,
       ...(target ? { target } : {}),
       ...(typeof intervalSeconds === "number" ? { intervalSeconds } : {}),
-      ...(cron ? { cron } : {})
+      ...(cron ? { cron } : {}),
     });
 
     runtime.logger.log("info", "mcp.activity_watch.create.done", {
       profileName,
       watchId: watch.id,
-      kind: watch.kind
+      kind: watch.kind,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      watch
+      watch,
     });
   } finally {
     runtime.close();
@@ -4493,24 +4536,24 @@ async function handleActivityWatchList(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.activity_watch.list.start", {
       profileName,
-      status: status ?? null
+      status: status ?? null,
     });
 
     const watches = runtime.activityWatches.listWatches({
       profileName,
-      ...(status ? { status } : {})
+      ...(status ? { status } : {}),
     });
 
     runtime.logger.log("info", "mcp.activity_watch.list.done", {
       profileName,
-      count: watches.length
+      count: watches.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
       count: watches.length,
-      watches
+      watches,
     });
   } finally {
     runtime.close();
@@ -4525,7 +4568,7 @@ async function handleActivityWatchPause(args: ToolArgs): Promise<ToolResult> {
     const watch = runtime.activityWatches.pauseWatch(watchId);
     return toToolResult({
       run_id: runtime.runId,
-      watch
+      watch,
     });
   } finally {
     runtime.close();
@@ -4540,7 +4583,7 @@ async function handleActivityWatchResume(args: ToolArgs): Promise<ToolResult> {
     const watch = runtime.activityWatches.resumeWatch(watchId);
     return toToolResult({
       run_id: runtime.runId,
-      watch
+      watch,
     });
   } finally {
     runtime.close();
@@ -4556,14 +4599,16 @@ async function handleActivityWatchRemove(args: ToolArgs): Promise<ToolResult> {
     return toToolResult({
       run_id: runtime.runId,
       watch_id: watchId,
-      removed
+      removed,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handleActivityWebhookCreate(args: ToolArgs): Promise<ToolResult> {
+async function handleActivityWebhookCreate(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
@@ -4575,7 +4620,7 @@ async function handleActivityWebhookCreate(args: ToolArgs): Promise<ToolResult> 
 
     runtime.logger.log("info", "mcp.activity_webhook.create.start", {
       watchId,
-      eventTypeCount: eventTypes?.length ?? 0
+      eventTypeCount: eventTypes?.length ?? 0,
     });
 
     const subscription = runtime.activityWatches.createWebhookSubscription({
@@ -4583,17 +4628,17 @@ async function handleActivityWebhookCreate(args: ToolArgs): Promise<ToolResult> 
       deliveryUrl,
       ...(eventTypes ? { eventTypes } : {}),
       ...(signingSecret ? { signingSecret } : {}),
-      ...(typeof maxAttempts === "number" ? { maxAttempts } : {})
+      ...(typeof maxAttempts === "number" ? { maxAttempts } : {}),
     });
 
     runtime.logger.log("info", "mcp.activity_webhook.create.done", {
       watchId,
-      subscriptionId: subscription.id
+      subscriptionId: subscription.id,
     });
 
     return toToolResult({
       run_id: runtime.runId,
-      subscription
+      subscription,
     });
   } finally {
     runtime.close();
@@ -4611,14 +4656,14 @@ async function handleActivityWebhookList(args: ToolArgs): Promise<ToolResult> {
     const subscriptions = runtime.activityWatches.listWebhookSubscriptions({
       profileName,
       ...(watchId ? { watchId } : {}),
-      ...(status ? { status } : {})
+      ...(status ? { status } : {}),
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
       count: subscriptions.length,
-      subscriptions
+      subscriptions,
     });
   } finally {
     runtime.close();
@@ -4630,47 +4675,48 @@ async function handleActivityWebhookPause(args: ToolArgs): Promise<ToolResult> {
 
   try {
     const subscriptionId = readRequiredString(args, "subscriptionId");
-    const subscription = runtime.activityWatches.pauseWebhookSubscription(
-      subscriptionId
-    );
+    const subscription =
+      runtime.activityWatches.pauseWebhookSubscription(subscriptionId);
     return toToolResult({
       run_id: runtime.runId,
-      subscription
+      subscription,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handleActivityWebhookResume(args: ToolArgs): Promise<ToolResult> {
+async function handleActivityWebhookResume(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
     const subscriptionId = readRequiredString(args, "subscriptionId");
-    const subscription = runtime.activityWatches.resumeWebhookSubscription(
-      subscriptionId
-    );
+    const subscription =
+      runtime.activityWatches.resumeWebhookSubscription(subscriptionId);
     return toToolResult({
       run_id: runtime.runId,
-      subscription
+      subscription,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handleActivityWebhookRemove(args: ToolArgs): Promise<ToolResult> {
+async function handleActivityWebhookRemove(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
     const subscriptionId = readRequiredString(args, "subscriptionId");
-    const removed = runtime.activityWatches.removeWebhookSubscription(
-      subscriptionId
-    );
+    const removed =
+      runtime.activityWatches.removeWebhookSubscription(subscriptionId);
     return toToolResult({
       run_id: runtime.runId,
       subscription_id: subscriptionId,
-      removed
+      removed,
     });
   } finally {
     runtime.close();
@@ -4687,21 +4733,23 @@ async function handleActivityEventsList(args: ToolArgs): Promise<ToolResult> {
     const events = runtime.activityWatches.listEvents({
       profileName,
       ...(watchId ? { watchId } : {}),
-      limit
+      limit,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
       count: events.length,
-      events
+      events,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handleActivityDeliveriesList(args: ToolArgs): Promise<ToolResult> {
+async function handleActivityDeliveriesList(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
@@ -4715,45 +4763,47 @@ async function handleActivityDeliveriesList(args: ToolArgs): Promise<ToolResult>
       ...(watchId ? { watchId } : {}),
       ...(subscriptionId ? { subscriptionId } : {}),
       ...(status ? { status } : {}),
-      limit
+      limit,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
       count: deliveries.length,
-      deliveries
+      deliveries,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handleActivityPollerRunOnce(args: ToolArgs): Promise<ToolResult> {
+async function handleActivityPollerRunOnce(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
     const profileName = readString(args, "profileName", "default");
 
     runtime.logger.log("info", "mcp.activity_poller.run_once.start", {
-      profileName
+      profileName,
     });
 
     const result = await runtime.activityPoller.runTick({
       profileName,
-      workerId: `mcp:${runtime.runId}`
+      workerId: `mcp:${runtime.runId}`,
     });
 
     runtime.logger.log("info", "mcp.activity_poller.run_once.done", {
       profileName,
       emittedEvents: result.emittedEvents,
-      deliveredAttempts: result.deliveredAttempts
+      deliveredAttempts: result.deliveredAttempts,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      result
+      result,
     });
   } finally {
     runtime.close();
@@ -4768,11 +4818,11 @@ async function handleConfirm(args: ToolArgs): Promise<ToolResult> {
     const token = readRequiredString(args, "token");
 
     runtime.logger.log("info", "mcp.actions.confirm.start", {
-      profileName
+      profileName,
     });
 
     const preview = runtime.twoPhaseCommit.getPreparedActionPreviewByToken({
-      confirmToken: token
+      confirmToken: token,
     });
 
     const preparedProfileName = readTargetProfileName(preview.target);
@@ -4782,25 +4832,25 @@ async function handleConfirm(args: ToolArgs): Promise<ToolResult> {
         `Prepared action belongs to profile "${preparedProfileName}", but "${profileName}" was provided.`,
         {
           expected_profile_name: preparedProfileName,
-          provided_profile_name: profileName
-        }
+          provided_profile_name: profileName,
+        },
       );
     }
 
     const result = await runtime.twoPhaseCommit.confirmByToken({
-      confirmToken: token
+      confirmToken: token,
     });
 
     runtime.logger.log("info", "mcp.actions.confirm.done", {
       profileName,
-      preparedActionId: result.preparedActionId
+      preparedActionId: result.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
       preview,
-      result
+      result,
     });
   } finally {
     runtime.close();
@@ -4810,2958 +4860,2995 @@ async function handleConfirm(args: ToolArgs): Promise<ToolResult> {
 const server = new Server(
   {
     name: "linkedin-mcp",
-    version: packageJson.version
+    version: packageJson.version,
   },
   {
     capabilities: {
-      tools: {}
-    }
-  }
+      tools: {},
+    },
+  },
 );
 
 export const LINKEDIN_MCP_TOOL_DEFINITIONS: LinkedInMcpToolDefinition[] = [
-      {
-        name: SUBMIT_FEEDBACK_TOOL,
-        description:
-          "File agent feedback as a GitHub issue or save it locally when GitHub CLI authentication is unavailable.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["type", "title", "description"],
-          properties: {
-            type: {
-              type: "string",
-              enum: ["bug", "feature", "improvement"],
-              description: "Feedback classification chosen by the agent."
-            },
-            title: {
-              type: "string",
-              description: "Short summary for the feedback issue."
-            },
-            description: {
-              type: "string",
-              description: "Detailed explanation of the bug, feature request, or improvement."
-            }
-          }
-        }
-      },
-      {
-        name: LINKEDIN_SESSION_STATUS_TOOL,
-        description:
-          "Check LinkedIn session authentication status for a profile, including the resolved anti-bot evasion configuration.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_SESSION_OPEN_LOGIN_TOOL,
-        description: "Open LinkedIn login and wait for authentication in a profile.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            timeoutMs: {
-              type: "number",
-              description: "Maximum time to wait for authentication, in milliseconds."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_SESSION_HEALTH_TOOL,
-        description:
-          "Check browser connectivity and LinkedIn session health for a profile, including the resolved anti-bot evasion configuration.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_SEARCH_RECIPIENTS_TOOL,
-        description: withSelectorAuditHint(
-          "Search LinkedIn people to resolve recipient identities for messaging flows."
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["query"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            query: {
-              type: "string",
-              description: "Recipient keywords to search for."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of recipients to return. Defaults to 10."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_LIST_THREADS_TOOL,
-        description: withSelectorAuditHint(
-          "List LinkedIn inbox threads for a profile."
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of threads to return."
-            },
-            unreadOnly: {
-              type: "boolean",
-              description: "If true, only unread threads are returned."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_GET_THREAD_TOOL,
-        description: withSelectorAuditHint(
-          "Get one LinkedIn thread with recent messages."
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["thread"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            thread: {
-              type: "string",
-              description: "Thread id or LinkedIn thread URL."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of messages to include."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_PREPARE_REPLY_TOOL,
-        description: "Prepare a two-phase send_message action for a thread.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["thread", "text"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            thread: {
-              type: "string",
-              description: "Thread id or LinkedIn thread URL."
-            },
-            text: {
-              type: "string",
-              description: "Message text to prepare for sending."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_PREPARE_NEW_THREAD_TOOL,
-        description:
-          "Prepare a two-phase first-message action for a new LinkedIn thread. Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["recipients", "text"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            recipients: {
-              type: "array",
-              items: {
-                type: "string"
-              },
-              description:
-                "Recipient LinkedIn profile URLs, /in/ paths, or vanity names. Use linkedin.inbox.search_recipients to resolve free-text names first."
-            },
-            text: {
-              type: "string",
-              description: "First message text to prepare."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note stored with the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_PREPARE_ADD_RECIPIENTS_TOOL,
-        description:
-          "Prepare a two-phase add_recipients action for an existing LinkedIn thread. Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["thread", "recipients"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            thread: {
-              type: "string",
-              description: "Thread id or LinkedIn thread URL."
-            },
-            recipients: {
-              type: "array",
-              items: {
-                type: "string"
-              },
-              description:
-                "Recipient LinkedIn profile URLs, /in/ paths, or vanity names to add to the thread."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note stored with the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_PREPARE_REACT_TOOL,
-        description:
-          "Prepare a two-phase reaction for a message in an existing LinkedIn thread. Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["thread"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            thread: {
-              type: "string",
-              description: "Thread id or LinkedIn thread URL."
-            },
-            reaction: {
-              type: "string",
-              description:
-                `Reaction to apply. Accepts canonical or alias values and normalizes to one of: ${LINKEDIN_INBOX_REACTION_TYPES.join(", ")}. Defaults to like.`
-            },
-            messageIndex: {
-              type: "integer",
-              description:
-                "Zero-based thread message index to react to. Defaults to the latest message returned by the thread."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note stored with the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_ARCHIVE_THREAD_TOOL,
-        description: withSelectorAuditHint(
-          "Archive a LinkedIn inbox thread immediately."
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["thread"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            thread: {
-              type: "string",
-              description: "Thread id or LinkedIn thread URL."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_UNARCHIVE_THREAD_TOOL,
-        description: withSelectorAuditHint(
-          "Move an archived LinkedIn inbox thread back to the main inbox immediately."
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["thread"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            thread: {
-              type: "string",
-              description: "Thread id or LinkedIn thread URL."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_MARK_UNREAD_TOOL,
-        description: withSelectorAuditHint(
-          "Mark a LinkedIn inbox thread as unread immediately."
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["thread"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            thread: {
-              type: "string",
-              description: "Thread id or LinkedIn thread URL."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_MUTE_THREAD_TOOL,
-        description: withSelectorAuditHint(
-          "Mute a LinkedIn inbox thread immediately."
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["thread"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            thread: {
-              type: "string",
-              description: "Thread id or LinkedIn thread URL."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_COMPANY_VIEW_TOOL,
-        description: withSelectorAuditHint(
-          "View a LinkedIn company page. Returns structured company overview, details, and current follow state."
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["target"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            target: {
-              type: "string",
-              description:
-                "Company slug, /company/ path, or LinkedIn company URL."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_VIEW_TOOL,
-        description:
-          withSelectorAuditHint(
-            "View a LinkedIn profile. Returns structured profile data including name, headline, location, about, experience, and education."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            target: {
-              type: "string",
-              description:
-                "Vanity name (e.g. 'johndoe'), profile URL, or 'me' for own profile. Defaults to 'me'."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_VIEW_EDITABLE_TOOL,
-        description: withSelectorAuditHint(
-          "Inspect the logged-in member's editable LinkedIn profile surface. Returns intro metadata, supported editable fields, stable-ish section item identifiers for structured profile sections, and featured item identifiers for remove/reorder workflows."
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_UPDATE_INTRO_TOOL,
-        description:
-          "Prepare a LinkedIn profile intro update (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            firstName: {
-              type: "string",
-              description: "Optional new first name."
-            },
-            lastName: {
-              type: "string",
-              description: "Optional new last name."
-            },
-            headline: {
-              type: "string",
-              description: "Optional new headline."
-            },
-            location: {
-              type: "string",
-              description: "Optional new location text."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_UPDATE_SETTINGS_TOOL,
-        description:
-          "Prepare a LinkedIn profile settings update (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["industry"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            industry: {
-              type: "string",
-              description: "Primary professional category / industry."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_UPDATE_PUBLIC_PROFILE_TOOL,
-        description:
-          "Prepare a LinkedIn public profile URL / vanity URL update (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            vanityName: {
-              type: "string",
-              description: "Requested public profile vanity name (slug only)."
-            },
-            customProfileUrl: {
-              type: "string",
-              description:
-                "Requested public profile vanity name or full LinkedIn profile URL. Alias for vanityName."
-            },
-            publicProfileUrl: {
-              type: "string",
-              description:
-                "Requested public profile URL. Use this instead of vanityName if you already have a linkedin.com/in/... URL."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_UPSERT_SECTION_ITEM_TOOL,
-        description:
-          "Prepare to create or update an editable LinkedIn profile section item (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["section", "values"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            section: {
-              type: "string",
-              enum: [
-                "about",
-                "experience",
-                "education",
-                "certifications",
-                "languages",
-                "projects",
-                "volunteer_experience",
-                "honors_awards"
-              ],
-              description: "Editable LinkedIn profile section to create or update."
-            },
-            itemId: {
-              type: "string",
-              description:
-                "Stable-ish item identifier returned by linkedin.profile.view_editable. Provide this (or match) to update an existing item. Omit both to create a new item."
-            },
-            match: {
-              type: "object",
-              additionalProperties: {
-                anyOf: [{ type: "string" }]
-              },
-              description:
-                "Optional optimistic matching object for legacy items when itemId is unavailable. Supported keys include sourceId, primaryText, secondaryText, tertiaryText, and rawText."
-            },
-            values: {
-              type: "object",
-              additionalProperties: {
-                anyOf: [{ type: "string" }, { type: "number" }, { type: "boolean" }]
-              },
-              description:
-                "Section field values to create or update. Use linkedin.profile.view_editable.supported_fields as the canonical field list for each section."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_REMOVE_SECTION_ITEM_TOOL,
-        description:
-          "Prepare to remove an editable LinkedIn profile section item (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["section"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            section: {
-              type: "string",
-              enum: [
-                "about",
-                "experience",
-                "education",
-                "certifications",
-                "languages",
-                "projects",
-                "volunteer_experience",
-                "honors_awards"
-              ],
-              description: "Editable LinkedIn profile section to remove from."
-            },
-            itemId: {
-              type: "string",
-              description:
-                "Stable-ish item identifier returned by linkedin.profile.view_editable. Optional for about; otherwise provide this or match."
-            },
-            match: {
-              type: "object",
-              additionalProperties: {
-                anyOf: [{ type: "string" }]
-              },
-              description:
-                "Optional optimistic matching object for legacy items when itemId is unavailable. Supported keys include sourceId, primaryText, secondaryText, tertiaryText, and rawText."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_UPLOAD_PHOTO_TOOL,
-        description:
-          "Prepare a LinkedIn profile photo upload (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["filePath"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            filePath: {
-              type: "string",
-              description: "Local path to a JPG or PNG file that will be staged into artifacts before confirm."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_UPLOAD_BANNER_TOOL,
-        description:
-          "Prepare a LinkedIn profile banner upload (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["filePath"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            filePath: {
-              type: "string",
-              description: "Local path to a JPG or PNG file that will be staged into artifacts before confirm."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_FEATURED_ADD_TOOL,
-        description:
-          "Prepare to add a Featured item (link, media, or post) on the logged-in member's LinkedIn profile. Returns a confirm token; use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["kind"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            kind: {
-              type: "string",
-              enum: ["link", "media", "post"],
-              description: "Featured item type to add."
-            },
-            url: {
-              type: "string",
-              description: "Required for link/post. External absolute URL for links, or a LinkedIn post/article/newsletter URL for post."
-            },
-            filePath: {
-              type: "string",
-              description: "Required for media. Local path to a supported document or image file that will be staged into artifacts before confirm."
-            },
-            title: {
-              type: "string",
-              description: "Optional title override for link/media flows when the dialog exposes it."
-            },
-            description: {
-              type: "string",
-              description: "Optional description override for link/media flows when the dialog exposes it."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_FEATURED_REMOVE_TOOL,
-        description:
-          "Prepare to remove one item from the LinkedIn Featured section (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            itemId: {
-              type: "string",
-              description:
-                "Stable-ish featured item identifier returned by linkedin.profile.view_editable.featured.items. Provide this or match."
-            },
-            match: {
-              type: "object",
-              additionalProperties: {
-                anyOf: [{ type: "string" }]
-              },
-              description:
-                "Optional optimistic matching object when itemId is unavailable. Supported keys include sourceId, url, title, subtitle, and rawText."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_FEATURED_REORDER_TOOL,
-        description:
-          "Prepare to reorder Featured items on the logged-in member's LinkedIn profile (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["itemIds"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            itemIds: {
-              type: "array",
-              items: {
-                type: "string"
-              },
-              description:
-                "Ordered featured item ids from linkedin.profile.view_editable.featured.items. The specified ids are moved to the top in the provided order."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_ADD_SKILL_TOOL,
-        description:
-          "Prepare to add one skill to the logged-in member's LinkedIn profile (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["skillName"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            skillName: {
-              type: "string",
-              description: "Skill name to add to the profile."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_REORDER_SKILLS_TOOL,
-        description:
-          "Prepare to reorder Skills on the logged-in member's LinkedIn profile (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["skillNames"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            skillNames: {
-              type: "array",
-              items: {
-                type: "string"
-              },
-              description:
-                "Ordered skill names to move to the top of the Skills section in the provided order."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_ENDORSE_SKILL_TOOL,
-        description:
-          "Prepare to endorse one visible skill on another member's LinkedIn profile (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["target", "skillName"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            target: {
-              type: "string",
-              description:
-                "Target member vanity name or LinkedIn profile URL. Must refer to another member, not 'me'."
-            },
-            skillName: {
-              type: "string",
-              description: "Skill name to endorse on the target profile."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_REQUEST_RECOMMENDATION_TOOL,
-        description:
-          "Prepare to request a LinkedIn recommendation from another member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["target"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            target: {
-              type: "string",
-              description:
-                "Target member vanity name or LinkedIn profile URL. Must refer to another member, not 'me'."
-            },
-            relationship: {
-              type: "string",
-              description: "Optional relationship selection for LinkedIn's recommendation dialog."
-            },
-            position: {
-              type: "string",
-              description: "Optional role/position selection for LinkedIn's recommendation dialog."
-            },
-            company: {
-              type: "string",
-              description: "Optional company selection for LinkedIn's recommendation dialog."
-            },
-            message: {
-              type: "string",
-              description: "Optional personal message to include with the request."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_WRITE_RECOMMENDATION_TOOL,
-        description:
-          "Prepare to write a LinkedIn recommendation for another member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["target", "text"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            target: {
-              type: "string",
-              description:
-                "Target member vanity name or LinkedIn profile URL. Must refer to another member, not 'me'."
-            },
-            text: {
-              type: "string",
-              description: "Recommendation text to submit."
-            },
-            relationship: {
-              type: "string",
-              description: "Optional relationship selection for LinkedIn's recommendation dialog."
-            },
-            position: {
-              type: "string",
-              description: "Optional role/position selection for LinkedIn's recommendation dialog."
-            },
-            company: {
-              type: "string",
-              description: "Optional company selection for LinkedIn's recommendation dialog."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ASSETS_GENERATE_PROFILE_IMAGES_TOOL,
-        description:
-          "Generate a LinkedIn-ready profile photo, banner, and reusable post images from a local persona JSON spec using OpenAI. Optionally uploads the photo and banner through the existing LinkedIn profile upload flow.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["specPath"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            specPath: {
-              type: "string",
-              description: "Local path to the JSON persona/profile seed spec."
-            },
-            postImageCount: {
-              type: "number",
-              description:
-                "Number of post images to generate. Defaults to 6 and must be 10 or fewer."
-            },
-            model: {
-              type: "string",
-              description: "Optional OpenAI image model override."
-            },
-            uploadProfileMedia: {
-              type: "boolean",
-              description:
-                "If true, upload the generated profile photo and banner after generation."
-            },
-            uploadDelayMs: {
-              type: "number",
-              description:
-                "Base delay between the photo and banner uploads when uploadProfileMedia is true. Defaults to 4500."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the upload actions."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ANALYTICS_PROFILE_VIEWS_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Read the logged-in member's LinkedIn profile-view analytics cards with normalized numeric metrics."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ANALYTICS_SEARCH_APPEARANCES_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Read the logged-in member's LinkedIn search-appearance analytics cards with normalized numeric metrics."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ANALYTICS_CONTENT_METRICS_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Read LinkedIn content and impression analytics cards from the logged-in member's profile analytics surface."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            limit: {
-              type: "number",
-              description:
-                "Maximum number of content analytics cards to return. Defaults to 4."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ANALYTICS_POST_METRICS_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Read normalized engagement metrics for one LinkedIn post URL, URN, or activity/share identifier."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_SEARCH_TOOL,
-        description: withSelectorAuditHint(
-          `Search LinkedIn for ${SEARCH_CATEGORIES.join(", ")}.`
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["query"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            query: {
-              type: "string",
-              description: "Search keywords."
-            },
-            category: {
-              type: "string",
-              enum: [...SEARCH_CATEGORIES],
-              description: "Search category. Defaults to people."
-            },
-            limit: {
-              type: "number",
-              description: "Max results. Defaults to 10."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_CONNECTIONS_LIST_TOOL,
-        description:
-          withSelectorAuditHint(
-            "List your LinkedIn connections. Returns connection names, headlines, profile URLs, and when connected."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of connections to return. Defaults to 40."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_CONNECTIONS_PENDING_TOOL,
-        description:
-          withSelectorAuditHint(
-            "List pending LinkedIn connection invitations (sent, received, or both)."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            filter: {
-              type: "string",
-              enum: ["sent", "received", "all"],
-              description:
-                "Filter invitations by direction. Defaults to all."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_CONNECTIONS_INVITE_TOOL,
-        description:
-          "Prepare a connection invitation to a LinkedIn user (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetProfile"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            targetProfile: {
-              type: "string",
-              description:
-                "Vanity name (e.g. 'johndoe') or full profile URL."
-            },
-            note: {
-              type: "string",
-              description: "Optional invitation note (max 300 chars)."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_CONNECTIONS_ACCEPT_TOOL,
-        description:
-          "Prepare to accept a pending connection invitation (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetProfile"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            targetProfile: {
-              type: "string",
-              description:
-                "Vanity name or profile URL of the person who sent the invitation."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_CONNECTIONS_WITHDRAW_TOOL,
-        description:
-          "Prepare to withdraw a sent connection invitation (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetProfile"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            targetProfile: {
-              type: "string",
-              description:
-                "Vanity name or profile URL of the person to withdraw the invitation from."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_CONNECTIONS_PREPARE_IGNORE_TOOL,
-        description:
-          "Prepare to ignore a received connection invitation (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetProfile"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            targetProfile: {
-              type: "string",
-              description:
-                "Vanity name or profile URL of the person whose received invitation should be ignored."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_CONNECTIONS_PREPARE_REMOVE_TOOL,
-        description:
-          "Prepare to remove an existing connection (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetProfile"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            targetProfile: {
-              type: "string",
-              description:
-                "Vanity name or profile URL of the existing connection to remove."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_COMPANY_PREPARE_FOLLOW_TOOL,
-        description:
-          "Prepare to follow a LinkedIn company page (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetCompany"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            targetCompany: {
-              type: "string",
-              description: "Company slug, /company/ path, or company URL."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_COMPANY_PREPARE_UNFOLLOW_TOOL,
-        description:
-          "Prepare to unfollow a LinkedIn company page (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetCompany"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            targetCompany: {
-              type: "string",
-              description: "Company slug, /company/ path, or company URL."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_CONNECTIONS_PREPARE_FOLLOW_TOOL,
-        description:
-          "Prepare to follow a LinkedIn member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetProfile"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            targetProfile: {
-              type: "string",
-              description:
-                "Vanity name or profile URL of the member to follow."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_CONNECTIONS_PREPARE_UNFOLLOW_TOOL,
-        description:
-          "Prepare to unfollow a LinkedIn member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetProfile"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            targetProfile: {
-              type: "string",
-              description:
-                "Vanity name or profile URL of the member to unfollow."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_MEMBERS_PREPARE_BLOCK_TOOL,
-        description:
-          "Prepare to block a LinkedIn member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetProfile"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            targetProfile: {
-              type: "string",
-              description:
-                "Vanity name or profile URL of the LinkedIn member to block."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_MEMBERS_PREPARE_UNBLOCK_TOOL,
-        description:
-          "Prepare to unblock a LinkedIn member from the blocked-members settings page (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetProfile"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            targetProfile: {
-              type: "string",
-              description:
-                "Vanity name or profile URL of the LinkedIn member to unblock."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_MEMBERS_PREPARE_REPORT_TOOL,
-        description:
-          "Prepare to report a LinkedIn member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetProfile", "reason"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            targetProfile: {
-              type: "string",
-              description:
-                "Vanity name or profile URL of the LinkedIn member to report."
-            },
-            reason: {
-              type: "string",
-              enum: [...LINKEDIN_MEMBER_REPORT_REASONS],
-              description: "Structured report reason for the dialog flow."
-            },
-            details: {
-              type: "string",
-              description:
-                "Optional free-text details that will be filled when the dialog exposes a text field."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PRIVACY_GET_SETTINGS_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Read the supported LinkedIn privacy settings surfaced by the automation runtime, including profile viewing mode and related visibility controls."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PRIVACY_PREPARE_UPDATE_SETTING_TOOL,
-        description:
-          "Prepare to update one supported LinkedIn privacy setting (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["settingKey", "value"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            settingKey: {
-              type: "string",
-              enum: [...LINKEDIN_PRIVACY_SETTING_KEYS],
-              description: "Supported LinkedIn privacy setting key."
-            },
-            value: {
-              type: "string",
-              description: "Requested setting value."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_NETWORK_PREPARE_FOLLOWUP_AFTER_ACCEPT_TOOL,
-        description:
-          "Detect newly accepted sent invitations and prepare follow-up messages (two-phase: returns confirm tokens). Use linkedin.actions.confirm to execute each prepared follow-up.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            since: {
-              type: "string",
-              description:
-                "Lookback window such as 30m, 12h, 7d, or 2w. Defaults to 7d."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note attached to each prepared follow-up."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_FEED_LIST_TOOL,
-        description:
-          withSelectorAuditHint(
-            "List posts from your LinkedIn feed with author, text, and engagement counts."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of feed posts to return. Defaults to 10."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_FEED_VIEW_POST_TOOL,
-        description: withSelectorAuditHint(
-          "View one LinkedIn feed post by URL, URN, or activity id."
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_FEED_LIKE_TOOL,
-        description:
-          "Prepare to react to a LinkedIn post (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            },
-            reaction: {
-              type: "string",
-              enum: [...LINKEDIN_FEED_REACTION_TYPES],
-              description: "Reaction type. Defaults to like."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_FEED_COMMENT_TOOL,
-        description:
-          "Prepare to comment on a LinkedIn post (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl", "text"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            },
-            text: {
-              type: "string",
-              description: "Comment text to prepare."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_FEED_PREPARE_REPOST_TOOL,
-        description:
-          "Prepare to repost a LinkedIn post (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_FEED_PREPARE_SHARE_TOOL,
-        description:
-          "Prepare to share a LinkedIn post with your own text (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl", "text"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            },
-            text: {
-              type: "string",
-              description: "Text to publish with the shared post."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_FEED_SAVE_POST_TOOL,
-        description:
-          "Prepare to save a LinkedIn post for later (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_FEED_UNSAVE_POST_TOOL,
-        description:
-          "Prepare to remove a LinkedIn post from your saved items (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_FEED_PREPARE_REMOVE_REACTION_TOOL,
-        description:
-          "Prepare to remove your current reaction from a LinkedIn post (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_POST_PREPARE_CREATE_TOOL,
-        description:
-          "Prepare a new LinkedIn post (two-phase: returns confirm token). Use linkedin.actions.confirm to publish.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["text"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            text: {
-              type: "string",
-              description: "Post text to prepare for publishing."
-            },
-            visibility: {
-              type: "string",
-              enum: [...LINKEDIN_POST_VISIBILITY_TYPES],
-              description: "Post visibility. Defaults to public."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_POST_PREPARE_CREATE_MEDIA_TOOL,
-        description:
-          "Prepare a new LinkedIn media post with attachments (two-phase: returns confirm token). Use linkedin.actions.confirm to publish.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["text", "mediaPaths"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            text: {
-              type: "string",
-              description: "Post text to publish alongside the media attachments."
-            },
-            mediaPaths: {
-              type: "array",
-              items: {
-                type: "string"
-              },
-              description:
-                "One or more local file paths for image/video attachments."
-            },
-            visibility: {
-              type: "string",
-              enum: [...LINKEDIN_POST_VISIBILITY_TYPES],
-              description: "Post visibility. Defaults to public."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_POST_PREPARE_CREATE_POLL_TOOL,
-        description:
-          "Prepare a new LinkedIn poll post (two-phase: returns confirm token). Use linkedin.actions.confirm to publish.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["question", "options"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            text: {
-              type: "string",
-              description: "Optional lead-in text that appears above the poll."
-            },
-            question: {
-              type: "string",
-              description: "Poll question to publish."
-            },
-            options: {
-              type: "array",
-              items: {
-                type: "string"
-              },
-              description: "Two to four poll options."
-            },
-            durationDays: {
-              type: "number",
-              description: "Poll duration in days. Supported values: 1, 3, 7, or 14."
-            },
-            visibility: {
-              type: "string",
-              enum: [...LINKEDIN_POST_VISIBILITY_TYPES],
-              description: "Post visibility. Defaults to public."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_POST_PREPARE_EDIT_TOOL,
-        description:
-          "Prepare to edit one of your LinkedIn posts (two-phase: returns confirm token). Use linkedin.actions.confirm to save the update.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl", "text"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            },
-            text: {
-              type: "string",
-              description: "Replacement post text to save."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_POST_PREPARE_DELETE_TOOL,
-        description:
-          "Prepare to delete one of your LinkedIn posts (two-phase: returns confirm token). Use linkedin.actions.confirm to execute the deletion.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ARTICLE_PREPARE_CREATE_TOOL,
-        description:
-          "Prepare a new LinkedIn long-form article draft (two-phase: returns confirm token). Use linkedin.actions.confirm to create the draft in the publishing editor.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["title", "body"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            title: {
-              type: "string",
-              description: "Article headline to stage in the publishing editor."
-            },
-            body: {
-              type: "string",
-              description:
-                "Plain-text article body. Paragraph breaks are preserved."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ARTICLE_PREPARE_PUBLISH_TOOL,
-        description:
-          "Prepare to publish an existing LinkedIn article draft (two-phase: returns confirm token). Use linkedin.actions.confirm to publish the draft.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["draftUrl"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            draftUrl: {
-              type: "string",
-              description:
-                "Absolute LinkedIn article editor or draft URL returned by linkedin.article.prepare_create."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_NEWSLETTER_PREPARE_CREATE_TOOL,
-        description:
-          "Prepare a new LinkedIn newsletter series (two-phase: returns confirm token). Use linkedin.actions.confirm to create the newsletter shell.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["title", "description", "cadence"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            title: {
-              type: "string",
-              description: "Newsletter title."
-            },
-            description: {
-              type: "string",
-              description: "Short newsletter description."
-            },
-            cadence: {
-              type: "string",
-              enum: [...LINKEDIN_NEWSLETTER_CADENCE_TYPES],
-              description: "Newsletter publish cadence."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_NEWSLETTER_PREPARE_PUBLISH_ISSUE_TOOL,
-        description:
-          "Prepare a new LinkedIn newsletter issue (two-phase: returns confirm token). Use linkedin.actions.confirm to publish the issue.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["newsletter", "title", "body"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            newsletter: {
-              type: "string",
-              description:
-                "Newsletter title as returned by linkedin.newsletter.list."
-            },
-            title: {
-              type: "string",
-              description: "Issue headline."
-            },
-            body: {
-              type: "string",
-              description:
-                "Plain-text issue body. Paragraph breaks are preserved."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_NEWSLETTER_LIST_TOOL,
-        description:
-          withSelectorAuditHint(
-            "List newsletter series currently available in the LinkedIn publishing editor."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_NOTIFICATIONS_LIST_TOOL,
-        description:
-          withSelectorAuditHint(
-            "List your LinkedIn notifications. Returns notification type, message, timestamp, link, and read/unread status."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of notifications to return. Defaults to 20."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_NOTIFICATIONS_MARK_READ_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Mark one LinkedIn notification as read by notification ID."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["notificationId"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            notificationId: {
-              type: "string",
-              description:
-                "Notification ID returned by linkedin.notifications.list."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_NOTIFICATIONS_DISMISS_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Prepare a dismiss action for one LinkedIn notification (two-phase: returns confirm token). Use linkedin.actions.confirm to execute."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["notificationId"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            notificationId: {
-              type: "string",
-              description:
-                "Notification ID returned by linkedin.notifications.list."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_NOTIFICATIONS_PREFERENCES_GET_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Read LinkedIn notification preference categories or one specific notification preference page."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            preferenceUrl: {
-              type: "string",
-              description:
-                "Optional LinkedIn notification preference URL. When omitted, returns the notifications preferences overview."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_NOTIFICATIONS_PREFERENCES_PREPARE_UPDATE_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Prepare a LinkedIn notification preference update (two-phase: returns confirm token). Use linkedin.actions.confirm to execute."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["preferenceUrl", "enabled"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            preferenceUrl: {
-              type: "string",
-              description:
-                "LinkedIn notification category or subcategory URL returned by linkedin.notifications.preferences.get."
-            },
-            enabled: {
-              type: "boolean",
-              description: "Whether the selected preference should be enabled."
-            },
-            channel: {
-              type: "string",
-              description:
-                "Optional channel key for subcategory pages: in_app, push, or email."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_JOBS_SEARCH_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Search for LinkedIn job postings by keyword and optional location."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["query"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            query: {
-              type: "string",
-              description: "Search keywords for jobs."
-            },
-            location: {
-              type: "string",
-              description: "Location filter for jobs."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of results to return. Defaults to 10."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_JOBS_VIEW_TOOL,
-        description:
-          withSelectorAuditHint(
-            "View details of a specific LinkedIn job posting by job ID."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["jobId"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            jobId: {
-              type: "string",
-              description: "LinkedIn job ID."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_JOBS_SAVE_TOOL,
-        description:
-          "Prepare to save a LinkedIn job for later (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["jobId"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            jobId: {
-              type: "string",
-              description: "LinkedIn job ID."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_JOBS_UNSAVE_TOOL,
-        description:
-          "Prepare to unsave a LinkedIn job (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["jobId"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            jobId: {
-              type: "string",
-              description: "LinkedIn job ID."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_JOBS_ALERTS_LIST_TOOL,
-        description:
-          withSelectorAuditHint("List LinkedIn job alerts for the current account."),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of alerts to return. Defaults to 20."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_JOBS_ALERTS_CREATE_TOOL,
-        description:
-          "Prepare to create a LinkedIn job alert from a search query (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["query"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            query: {
-              type: "string",
-              description: "Search keywords for the alert."
-            },
-            location: {
-              type: "string",
-              description: "Optional location filter for the alert."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_JOBS_ALERTS_REMOVE_TOOL,
-        description:
-          "Prepare to remove a LinkedIn job alert (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            alertId: {
-              type: "string",
-              description: "Alert id previously returned by linkedin.jobs.alerts.list."
-            },
-            searchUrl: {
-              type: "string",
-              description: "LinkedIn jobs search URL for the alert."
-            },
-            query: {
-              type: "string",
-              description: "Alert query if alertId or searchUrl are not available."
-            },
-            location: {
-              type: "string",
-              description: "Alert location if query is provided."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_JOBS_PREPARE_EASY_APPLY_TOOL,
-        description:
-          "Prepare a LinkedIn Easy Apply submission (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["jobId"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            jobId: {
-              type: "string",
-              description: "LinkedIn job ID."
-            },
-            phoneNumber: {
-              type: "string",
-              description: "Phone number value for Easy Apply forms."
-            },
-            email: {
-              type: "string",
-              description: "Email value for Easy Apply forms."
-            },
-            city: {
-              type: "string",
-              description: "City value for Easy Apply forms."
-            },
-            resumePath: {
-              type: "string",
-              description: "Absolute or relative path to the resume file to upload."
-            },
-            coverLetter: {
-              type: "string",
-              description: "Cover letter text for Easy Apply forms."
-            },
-            answers: {
-              type: "object",
-              description:
-                "Additional Easy Apply answers keyed by field label. Values may be strings, booleans, numbers, or string arrays."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_GROUPS_SEARCH_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Search LinkedIn groups by keyword and return matching communities."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["query"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            query: {
-              type: "string",
-              description: "Search keywords for LinkedIn groups."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of results to return. Defaults to 10."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_GROUPS_VIEW_TOOL,
-        description:
-          withSelectorAuditHint(
-            "View details of a specific LinkedIn group by URL or numeric group ID."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["group"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            group: {
-              type: "string",
-              description: "LinkedIn group URL or numeric group ID."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_GROUPS_PREPARE_JOIN_TOOL,
-        description:
-          "Prepare to join a LinkedIn group (two-phase: returns confirm token). Use linkedin.actions.confirm to request or complete the join.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["group"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            group: {
-              type: "string",
-              description: "LinkedIn group URL or numeric group ID."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_GROUPS_PREPARE_LEAVE_TOOL,
-        description:
-          "Prepare to leave a LinkedIn group (two-phase: returns confirm token). Use linkedin.actions.confirm to complete the leave flow.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["group"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            group: {
-              type: "string",
-              description: "LinkedIn group URL or numeric group ID."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_GROUPS_PREPARE_POST_TOOL,
-        description:
-          "Prepare a post inside a LinkedIn group (two-phase: returns confirm token). Use linkedin.actions.confirm to publish the post.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["group", "text"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            group: {
-              type: "string",
-              description: "LinkedIn group URL or numeric group ID."
-            },
-            text: {
-              type: "string",
-              description: "Post text to publish inside the group."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_EVENTS_SEARCH_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Search LinkedIn events by keyword and return matching event cards."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["query"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            query: {
-              type: "string",
-              description: "Search keywords for LinkedIn events."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of results to return. Defaults to 10."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_EVENTS_VIEW_TOOL,
-        description:
-          withSelectorAuditHint(
-            "View details of a specific LinkedIn event by URL or numeric event ID."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["event"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            event: {
-              type: "string",
-              description: "LinkedIn event URL or numeric event ID."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_EVENTS_PREPARE_RSVP_TOOL,
-        description:
-          "Prepare to RSVP attend for a LinkedIn event (two-phase: returns confirm token). Use linkedin.actions.confirm to complete the RSVP.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["event"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            event: {
-              type: "string",
-              description: "LinkedIn event URL or numeric event ID."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_WATCH_CREATE_TOOL,
-        description:
-          "Create a durable poll-based LinkedIn activity watch for one profile and activity source.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["kind"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            kind: {
-              type: "string",
-              enum: [...ACTIVITY_WATCH_KINDS],
-              description: "Activity watch kind."
-            },
-            target: {
-              type: "object",
-              description: "Optional watch target object for profile/feed/inbox filters."
-            },
-            intervalSeconds: {
-              type: "number",
-              description: "Optional polling interval in seconds."
-            },
-            cron: {
-              type: "string",
-              description: "Optional cron schedule expression."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_WATCH_LIST_TOOL,
-        description: "List configured LinkedIn activity watches for a profile.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            status: {
-              type: "string",
-              enum: [...ACTIVITY_WATCH_STATUSES],
-              description: "Optional watch status filter."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_WATCH_PAUSE_TOOL,
-        description: "Pause one activity watch by id.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["watchId"],
-          properties: withCdpSchemaProperties({
-            watchId: {
-              type: "string",
-              description: "Activity watch id."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_WATCH_RESUME_TOOL,
-        description: "Resume one activity watch by id and make it due immediately.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["watchId"],
-          properties: withCdpSchemaProperties({
-            watchId: {
-              type: "string",
-              description: "Activity watch id."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_WATCH_REMOVE_TOOL,
-        description: "Remove one activity watch by id.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["watchId"],
-          properties: withCdpSchemaProperties({
-            watchId: {
-              type: "string",
-              description: "Activity watch id."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_WEBHOOK_CREATE_TOOL,
-        description: "Create a webhook subscription for one activity watch.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["watchId", "deliveryUrl"],
-          properties: withCdpSchemaProperties({
-            watchId: {
-              type: "string",
-              description: "Activity watch id."
-            },
-            deliveryUrl: {
-              type: "string",
-              description: "Webhook delivery URL."
-            },
-            eventTypes: {
-              type: "array",
-              items: {
-                type: "string",
-                enum: [...ACTIVITY_EVENT_TYPES]
-              },
-              description: "Optional event filters for this subscription."
-            },
-            signingSecret: {
-              type: "string",
-              description: "Optional pre-shared signing secret."
-            },
-            maxAttempts: {
-              type: "number",
-              description: "Optional maximum delivery attempts."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_WEBHOOK_LIST_TOOL,
-        description: "List webhook subscriptions for activity watches.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            watchId: {
-              type: "string",
-              description: "Optional watch id filter."
-            },
-            status: {
-              type: "string",
-              enum: [...WEBHOOK_SUBSCRIPTION_STATUSES],
-              description: "Optional webhook subscription status filter."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_WEBHOOK_PAUSE_TOOL,
-        description: "Pause one activity webhook subscription by id.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["subscriptionId"],
-          properties: withCdpSchemaProperties({
-            subscriptionId: {
-              type: "string",
-              description: "Webhook subscription id."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_WEBHOOK_RESUME_TOOL,
-        description: "Resume one activity webhook subscription by id.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["subscriptionId"],
-          properties: withCdpSchemaProperties({
-            subscriptionId: {
-              type: "string",
-              description: "Webhook subscription id."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_WEBHOOK_REMOVE_TOOL,
-        description: "Remove one activity webhook subscription by id.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["subscriptionId"],
-          properties: withCdpSchemaProperties({
-            subscriptionId: {
-              type: "string",
-              description: "Webhook subscription id."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_EVENTS_LIST_TOOL,
-        description: "List emitted LinkedIn activity events from local persistent state.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            watchId: {
-              type: "string",
-              description: "Optional watch id filter."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of events to return. Defaults to 20."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_DELIVERIES_LIST_TOOL,
-        description: "List webhook delivery attempts from local persistent state.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            watchId: {
-              type: "string",
-              description: "Optional watch id filter."
-            },
-            subscriptionId: {
-              type: "string",
-              description: "Optional webhook subscription id filter."
-            },
-            status: {
-              type: "string",
-              enum: [...WEBHOOK_DELIVERY_ATTEMPT_STATUSES],
-              description: "Optional delivery status filter."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of delivery attempts to return. Defaults to 20."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_POLLER_RUN_ONCE_TOOL,
-        description:
-          "Run one local activity polling tick now and return the watch and delivery summary.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIONS_CONFIRM_TOOL,
-        description: "Confirm and execute a prepared action by confirm token.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["token"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent profile expected for this action."
-            },
-            token: {
-              type: "string",
-              description: "Confirmation token in ct_... format."
-            }
-          })
-        }
-      }
+  {
+    name: SUBMIT_FEEDBACK_TOOL,
+    description:
+      "File agent feedback as a GitHub issue or save it locally when GitHub CLI authentication is unavailable.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["type", "title", "description"],
+      properties: {
+        type: {
+          type: "string",
+          enum: ["bug", "feature", "improvement"],
+          description: "Feedback classification chosen by the agent.",
+        },
+        title: {
+          type: "string",
+          description: "Short summary for the feedback issue.",
+        },
+        description: {
+          type: "string",
+          description:
+            "Detailed explanation of the bug, feature request, or improvement.",
+        },
+      },
+    },
+  },
+  {
+    name: LINKEDIN_SESSION_STATUS_TOOL,
+    description:
+      "Check LinkedIn session authentication status for a profile, including the resolved anti-bot evasion configuration.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_SESSION_OPEN_LOGIN_TOOL,
+    description:
+      "Open LinkedIn login and wait for authentication in a profile.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        timeoutMs: {
+          type: "number",
+          description:
+            "Maximum time to wait for authentication, in milliseconds.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_SESSION_HEALTH_TOOL,
+    description:
+      "Check browser connectivity and LinkedIn session health for a profile, including the resolved anti-bot evasion configuration.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_SEARCH_RECIPIENTS_TOOL,
+    description: withSelectorAuditHint(
+      "Search LinkedIn people to resolve recipient identities for messaging flows.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["query"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        query: {
+          type: "string",
+          description: "Recipient keywords to search for.",
+        },
+        limit: {
+          type: "number",
+          description:
+            "Maximum number of recipients to return. Defaults to 10.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_LIST_THREADS_TOOL,
+    description: withSelectorAuditHint(
+      "List LinkedIn inbox threads for a profile.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of threads to return.",
+        },
+        unreadOnly: {
+          type: "boolean",
+          description: "If true, only unread threads are returned.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_GET_THREAD_TOOL,
+    description: withSelectorAuditHint(
+      "Get one LinkedIn thread with recent messages.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["thread"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        thread: {
+          type: "string",
+          description: "Thread id or LinkedIn thread URL.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of messages to include.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_PREPARE_REPLY_TOOL,
+    description: "Prepare a two-phase send_message action for a thread.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["thread", "text"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        thread: {
+          type: "string",
+          description: "Thread id or LinkedIn thread URL.",
+        },
+        text: {
+          type: "string",
+          description: "Message text to prepare for sending.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_PREPARE_NEW_THREAD_TOOL,
+    description:
+      "Prepare a two-phase first-message action for a new LinkedIn thread. Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["recipients", "text"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        recipients: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+          description:
+            "Recipient LinkedIn profile URLs, /in/ paths, or vanity names. Use linkedin.inbox.search_recipients to resolve free-text names first.",
+        },
+        text: {
+          type: "string",
+          description: "First message text to prepare.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note stored with the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_PREPARE_ADD_RECIPIENTS_TOOL,
+    description:
+      "Prepare a two-phase add_recipients action for an existing LinkedIn thread. Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["thread", "recipients"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        thread: {
+          type: "string",
+          description: "Thread id or LinkedIn thread URL.",
+        },
+        recipients: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+          description:
+            "Recipient LinkedIn profile URLs, /in/ paths, or vanity names to add to the thread.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note stored with the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_PREPARE_REACT_TOOL,
+    description:
+      "Prepare a two-phase reaction for a message in an existing LinkedIn thread. Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["thread"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        thread: {
+          type: "string",
+          description: "Thread id or LinkedIn thread URL.",
+        },
+        reaction: {
+          type: "string",
+          description: `Reaction to apply. Accepts canonical or alias values and normalizes to one of: ${LINKEDIN_INBOX_REACTION_TYPES.join(", ")}. Defaults to like.`,
+        },
+        messageIndex: {
+          type: "integer",
+          description:
+            "Zero-based thread message index to react to. Defaults to the latest message returned by the thread.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note stored with the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_ARCHIVE_THREAD_TOOL,
+    description: withSelectorAuditHint(
+      "Archive a LinkedIn inbox thread immediately.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["thread"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        thread: {
+          type: "string",
+          description: "Thread id or LinkedIn thread URL.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_UNARCHIVE_THREAD_TOOL,
+    description: withSelectorAuditHint(
+      "Move an archived LinkedIn inbox thread back to the main inbox immediately.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["thread"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        thread: {
+          type: "string",
+          description: "Thread id or LinkedIn thread URL.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_MARK_UNREAD_TOOL,
+    description: withSelectorAuditHint(
+      "Mark a LinkedIn inbox thread as unread immediately.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["thread"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        thread: {
+          type: "string",
+          description: "Thread id or LinkedIn thread URL.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_MUTE_THREAD_TOOL,
+    description: withSelectorAuditHint(
+      "Mute a LinkedIn inbox thread immediately.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["thread"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        thread: {
+          type: "string",
+          description: "Thread id or LinkedIn thread URL.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_COMPANY_VIEW_TOOL,
+    description: withSelectorAuditHint(
+      "View a LinkedIn company page. Returns structured company overview, details, and current follow state.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["target"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        target: {
+          type: "string",
+          description: "Company slug, /company/ path, or LinkedIn company URL.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_VIEW_TOOL,
+    description: withSelectorAuditHint(
+      "View a LinkedIn profile. Returns structured profile data including name, headline, location, about, experience, and education.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        target: {
+          type: "string",
+          description:
+            "Vanity name (e.g. 'johndoe'), profile URL, or 'me' for own profile. Defaults to 'me'.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_VIEW_EDITABLE_TOOL,
+    description: withSelectorAuditHint(
+      "Inspect the logged-in member's editable LinkedIn profile surface. Returns intro metadata, supported editable fields, stable-ish section item identifiers for structured profile sections, and featured item identifiers for remove/reorder workflows.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_UPDATE_INTRO_TOOL,
+    description:
+      "Prepare a LinkedIn profile intro update (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        firstName: {
+          type: "string",
+          description: "Optional new first name.",
+        },
+        lastName: {
+          type: "string",
+          description: "Optional new last name.",
+        },
+        headline: {
+          type: "string",
+          description: "Optional new headline.",
+        },
+        location: {
+          type: "string",
+          description: "Optional new location text.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_UPDATE_SETTINGS_TOOL,
+    description:
+      "Prepare a LinkedIn profile settings update (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["industry"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        industry: {
+          type: "string",
+          description: "Primary professional category / industry.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_UPDATE_PUBLIC_PROFILE_TOOL,
+    description:
+      "Prepare a LinkedIn public profile URL / vanity URL update (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        vanityName: {
+          type: "string",
+          description: "Requested public profile vanity name (slug only).",
+        },
+        customProfileUrl: {
+          type: "string",
+          description:
+            "Requested public profile vanity name or full LinkedIn profile URL. Alias for vanityName.",
+        },
+        publicProfileUrl: {
+          type: "string",
+          description:
+            "Requested public profile URL. Use this instead of vanityName if you already have a linkedin.com/in/... URL.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_UPSERT_SECTION_ITEM_TOOL,
+    description:
+      "Prepare to create or update an editable LinkedIn profile section item (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["section", "values"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        section: {
+          type: "string",
+          enum: [
+            "about",
+            "experience",
+            "education",
+            "certifications",
+            "languages",
+            "projects",
+            "volunteer_experience",
+            "honors_awards",
+          ],
+          description: "Editable LinkedIn profile section to create or update.",
+        },
+        itemId: {
+          type: "string",
+          description:
+            "Stable-ish item identifier returned by linkedin.profile.view_editable. Provide this (or match) to update an existing item. Omit both to create a new item.",
+        },
+        match: {
+          type: "object",
+          additionalProperties: {
+            anyOf: [{ type: "string" }],
+          },
+          description:
+            "Optional optimistic matching object for legacy items when itemId is unavailable. Supported keys include sourceId, primaryText, secondaryText, tertiaryText, and rawText.",
+        },
+        values: {
+          type: "object",
+          additionalProperties: {
+            anyOf: [
+              { type: "string" },
+              { type: "number" },
+              { type: "boolean" },
+            ],
+          },
+          description:
+            "Section field values to create or update. Use linkedin.profile.view_editable.supported_fields as the canonical field list for each section.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_REMOVE_SECTION_ITEM_TOOL,
+    description:
+      "Prepare to remove an editable LinkedIn profile section item (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["section"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        section: {
+          type: "string",
+          enum: [
+            "about",
+            "experience",
+            "education",
+            "certifications",
+            "languages",
+            "projects",
+            "volunteer_experience",
+            "honors_awards",
+          ],
+          description: "Editable LinkedIn profile section to remove from.",
+        },
+        itemId: {
+          type: "string",
+          description:
+            "Stable-ish item identifier returned by linkedin.profile.view_editable. Optional for about; otherwise provide this or match.",
+        },
+        match: {
+          type: "object",
+          additionalProperties: {
+            anyOf: [{ type: "string" }],
+          },
+          description:
+            "Optional optimistic matching object for legacy items when itemId is unavailable. Supported keys include sourceId, primaryText, secondaryText, tertiaryText, and rawText.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_UPLOAD_PHOTO_TOOL,
+    description:
+      "Prepare a LinkedIn profile photo upload (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["filePath"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        filePath: {
+          type: "string",
+          description:
+            "Local path to a JPG or PNG file that will be staged into artifacts before confirm.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_UPLOAD_BANNER_TOOL,
+    description:
+      "Prepare a LinkedIn profile banner upload (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["filePath"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        filePath: {
+          type: "string",
+          description:
+            "Local path to a JPG or PNG file that will be staged into artifacts before confirm.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_FEATURED_ADD_TOOL,
+    description:
+      "Prepare to add a Featured item (link, media, or post) on the logged-in member's LinkedIn profile. Returns a confirm token; use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["kind"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        kind: {
+          type: "string",
+          enum: ["link", "media", "post"],
+          description: "Featured item type to add.",
+        },
+        url: {
+          type: "string",
+          description:
+            "Required for link/post. External absolute URL for links, or a LinkedIn post/article/newsletter URL for post.",
+        },
+        filePath: {
+          type: "string",
+          description:
+            "Required for media. Local path to a supported document or image file that will be staged into artifacts before confirm.",
+        },
+        title: {
+          type: "string",
+          description:
+            "Optional title override for link/media flows when the dialog exposes it.",
+        },
+        description: {
+          type: "string",
+          description:
+            "Optional description override for link/media flows when the dialog exposes it.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_FEATURED_REMOVE_TOOL,
+    description:
+      "Prepare to remove one item from the LinkedIn Featured section (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        itemId: {
+          type: "string",
+          description:
+            "Stable-ish featured item identifier returned by linkedin.profile.view_editable.featured.items. Provide this or match.",
+        },
+        match: {
+          type: "object",
+          additionalProperties: {
+            anyOf: [{ type: "string" }],
+          },
+          description:
+            "Optional optimistic matching object when itemId is unavailable. Supported keys include sourceId, url, title, subtitle, and rawText.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_FEATURED_REORDER_TOOL,
+    description:
+      "Prepare to reorder Featured items on the logged-in member's LinkedIn profile (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["itemIds"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        itemIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+          description:
+            "Ordered featured item ids from linkedin.profile.view_editable.featured.items. The specified ids are moved to the top in the provided order.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_ADD_SKILL_TOOL,
+    description:
+      "Prepare to add one skill to the logged-in member's LinkedIn profile (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["skillName"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        skillName: {
+          type: "string",
+          description: "Skill name to add to the profile.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_REORDER_SKILLS_TOOL,
+    description:
+      "Prepare to reorder Skills on the logged-in member's LinkedIn profile (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["skillNames"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        skillNames: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+          description:
+            "Ordered skill names to move to the top of the Skills section in the provided order.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_ENDORSE_SKILL_TOOL,
+    description:
+      "Prepare to endorse one visible skill on another member's LinkedIn profile (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["target", "skillName"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        target: {
+          type: "string",
+          description:
+            "Target member vanity name or LinkedIn profile URL. Must refer to another member, not 'me'.",
+        },
+        skillName: {
+          type: "string",
+          description: "Skill name to endorse on the target profile.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_REQUEST_RECOMMENDATION_TOOL,
+    description:
+      "Prepare to request a LinkedIn recommendation from another member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["target"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        target: {
+          type: "string",
+          description:
+            "Target member vanity name or LinkedIn profile URL. Must refer to another member, not 'me'.",
+        },
+        relationship: {
+          type: "string",
+          description:
+            "Optional relationship selection for LinkedIn's recommendation dialog.",
+        },
+        position: {
+          type: "string",
+          description:
+            "Optional role/position selection for LinkedIn's recommendation dialog.",
+        },
+        company: {
+          type: "string",
+          description:
+            "Optional company selection for LinkedIn's recommendation dialog.",
+        },
+        message: {
+          type: "string",
+          description: "Optional personal message to include with the request.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_WRITE_RECOMMENDATION_TOOL,
+    description:
+      "Prepare to write a LinkedIn recommendation for another member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["target", "text"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        target: {
+          type: "string",
+          description:
+            "Target member vanity name or LinkedIn profile URL. Must refer to another member, not 'me'.",
+        },
+        text: {
+          type: "string",
+          description: "Recommendation text to submit.",
+        },
+        relationship: {
+          type: "string",
+          description:
+            "Optional relationship selection for LinkedIn's recommendation dialog.",
+        },
+        position: {
+          type: "string",
+          description:
+            "Optional role/position selection for LinkedIn's recommendation dialog.",
+        },
+        company: {
+          type: "string",
+          description:
+            "Optional company selection for LinkedIn's recommendation dialog.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ASSETS_GENERATE_PROFILE_IMAGES_TOOL,
+    description:
+      "Generate a LinkedIn-ready profile photo, banner, and reusable post images from a local persona JSON spec using OpenAI. Optionally uploads the photo and banner through the existing LinkedIn profile upload flow.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["specPath"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        specPath: {
+          type: "string",
+          description: "Local path to the JSON persona/profile seed spec.",
+        },
+        postImageCount: {
+          type: "number",
+          description:
+            "Number of post images to generate. Defaults to 6 and must be 10 or fewer.",
+        },
+        model: {
+          type: "string",
+          description: "Optional OpenAI image model override.",
+        },
+        uploadProfileMedia: {
+          type: "boolean",
+          description:
+            "If true, upload the generated profile photo and banner after generation.",
+        },
+        uploadDelayMs: {
+          type: "number",
+          description:
+            "Base delay between the photo and banner uploads when uploadProfileMedia is true. Defaults to 4500.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the upload actions.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ANALYTICS_PROFILE_VIEWS_TOOL,
+    description: withSelectorAuditHint(
+      "Read the logged-in member's LinkedIn profile-view analytics. Returns timestamped metric cards with numeric values, deltas, trend direction, and unit classification for each profile-view data point.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ANALYTICS_SEARCH_APPEARANCES_TOOL,
+    description: withSelectorAuditHint(
+      "Read the logged-in member's LinkedIn search-appearance analytics. Returns timestamped metric cards with numeric values, deltas, trend direction, and unit classification for each search-appearance data point.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ANALYTICS_CONTENT_METRICS_TOOL,
+    description: withSelectorAuditHint(
+      "Read LinkedIn content and impression analytics from the logged-in member's profile. Returns timestamped metric cards covering impressions, engagement, and creator analytics. Use limit to cap the number of returned cards.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        limit: {
+          type: "number",
+          description:
+            "Maximum number of content analytics cards to return (1–50). Defaults to 4.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ANALYTICS_POST_METRICS_TOOL,
+    description: withSelectorAuditHint(
+      "Read normalized engagement metrics (reactions, comments, reposts, engagement total) for a single LinkedIn post. Accepts a post URL, URN, or activity/share identifier. Also returns the post content and author metadata.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_SEARCH_TOOL,
+    description: withSelectorAuditHint(
+      `Search LinkedIn for ${SEARCH_CATEGORIES.join(", ")}.`,
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["query"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        query: {
+          type: "string",
+          description: "Search keywords.",
+        },
+        category: {
+          type: "string",
+          enum: [...SEARCH_CATEGORIES],
+          description: "Search category. Defaults to people.",
+        },
+        limit: {
+          type: "number",
+          description: "Max results. Defaults to 10.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_CONNECTIONS_LIST_TOOL,
+    description: withSelectorAuditHint(
+      "List your LinkedIn connections. Returns connection names, headlines, profile URLs, and when connected.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        limit: {
+          type: "number",
+          description:
+            "Maximum number of connections to return. Defaults to 40.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_CONNECTIONS_PENDING_TOOL,
+    description: withSelectorAuditHint(
+      "List pending LinkedIn connection invitations (sent, received, or both).",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        filter: {
+          type: "string",
+          enum: ["sent", "received", "all"],
+          description: "Filter invitations by direction. Defaults to all.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_CONNECTIONS_INVITE_TOOL,
+    description:
+      "Prepare a connection invitation to a LinkedIn user (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetProfile"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetProfile: {
+          type: "string",
+          description: "Vanity name (e.g. 'johndoe') or full profile URL.",
+        },
+        note: {
+          type: "string",
+          description: "Optional invitation note (max 300 chars).",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_CONNECTIONS_ACCEPT_TOOL,
+    description:
+      "Prepare to accept a pending connection invitation (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetProfile"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetProfile: {
+          type: "string",
+          description:
+            "Vanity name or profile URL of the person who sent the invitation.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_CONNECTIONS_WITHDRAW_TOOL,
+    description:
+      "Prepare to withdraw a sent connection invitation (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetProfile"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetProfile: {
+          type: "string",
+          description:
+            "Vanity name or profile URL of the person to withdraw the invitation from.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_CONNECTIONS_PREPARE_IGNORE_TOOL,
+    description:
+      "Prepare to ignore a received connection invitation (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetProfile"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetProfile: {
+          type: "string",
+          description:
+            "Vanity name or profile URL of the person whose received invitation should be ignored.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_CONNECTIONS_PREPARE_REMOVE_TOOL,
+    description:
+      "Prepare to remove an existing connection (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetProfile"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetProfile: {
+          type: "string",
+          description:
+            "Vanity name or profile URL of the existing connection to remove.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_COMPANY_PREPARE_FOLLOW_TOOL,
+    description:
+      "Prepare to follow a LinkedIn company page (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetCompany"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetCompany: {
+          type: "string",
+          description: "Company slug, /company/ path, or company URL.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_COMPANY_PREPARE_UNFOLLOW_TOOL,
+    description:
+      "Prepare to unfollow a LinkedIn company page (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetCompany"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetCompany: {
+          type: "string",
+          description: "Company slug, /company/ path, or company URL.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_CONNECTIONS_PREPARE_FOLLOW_TOOL,
+    description:
+      "Prepare to follow a LinkedIn member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetProfile"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetProfile: {
+          type: "string",
+          description: "Vanity name or profile URL of the member to follow.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_CONNECTIONS_PREPARE_UNFOLLOW_TOOL,
+    description:
+      "Prepare to unfollow a LinkedIn member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetProfile"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetProfile: {
+          type: "string",
+          description: "Vanity name or profile URL of the member to unfollow.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_MEMBERS_PREPARE_BLOCK_TOOL,
+    description:
+      "Prepare to block a LinkedIn member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetProfile"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetProfile: {
+          type: "string",
+          description:
+            "Vanity name or profile URL of the LinkedIn member to block.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_MEMBERS_PREPARE_UNBLOCK_TOOL,
+    description:
+      "Prepare to unblock a LinkedIn member from the blocked-members settings page (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetProfile"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetProfile: {
+          type: "string",
+          description:
+            "Vanity name or profile URL of the LinkedIn member to unblock.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_MEMBERS_PREPARE_REPORT_TOOL,
+    description:
+      "Prepare to report a LinkedIn member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetProfile", "reason"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetProfile: {
+          type: "string",
+          description:
+            "Vanity name or profile URL of the LinkedIn member to report.",
+        },
+        reason: {
+          type: "string",
+          enum: [...LINKEDIN_MEMBER_REPORT_REASONS],
+          description: "Structured report reason for the dialog flow.",
+        },
+        details: {
+          type: "string",
+          description:
+            "Optional free-text details that will be filled when the dialog exposes a text field.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PRIVACY_GET_SETTINGS_TOOL,
+    description: withSelectorAuditHint(
+      "Read the supported LinkedIn privacy settings surfaced by the automation runtime, including profile viewing mode and related visibility controls.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PRIVACY_PREPARE_UPDATE_SETTING_TOOL,
+    description:
+      "Prepare to update one supported LinkedIn privacy setting (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["settingKey", "value"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        settingKey: {
+          type: "string",
+          enum: [...LINKEDIN_PRIVACY_SETTING_KEYS],
+          description: "Supported LinkedIn privacy setting key.",
+        },
+        value: {
+          type: "string",
+          description: "Requested setting value.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_NETWORK_PREPARE_FOLLOWUP_AFTER_ACCEPT_TOOL,
+    description:
+      "Detect newly accepted sent invitations and prepare follow-up messages (two-phase: returns confirm tokens). Use linkedin.actions.confirm to execute each prepared follow-up.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        since: {
+          type: "string",
+          description:
+            "Lookback window such as 30m, 12h, 7d, or 2w. Defaults to 7d.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note attached to each prepared follow-up.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_FEED_LIST_TOOL,
+    description: withSelectorAuditHint(
+      "List posts from your LinkedIn feed with author, text, and engagement counts.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        limit: {
+          type: "number",
+          description:
+            "Maximum number of feed posts to return. Defaults to 10.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_FEED_VIEW_POST_TOOL,
+    description: withSelectorAuditHint(
+      "View one LinkedIn feed post by URL, URN, or activity id.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_FEED_LIKE_TOOL,
+    description:
+      "Prepare to react to a LinkedIn post (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+        reaction: {
+          type: "string",
+          enum: [...LINKEDIN_FEED_REACTION_TYPES],
+          description: "Reaction type. Defaults to like.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_FEED_COMMENT_TOOL,
+    description:
+      "Prepare to comment on a LinkedIn post (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl", "text"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+        text: {
+          type: "string",
+          description: "Comment text to prepare.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_FEED_PREPARE_REPOST_TOOL,
+    description:
+      "Prepare to repost a LinkedIn post (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_FEED_PREPARE_SHARE_TOOL,
+    description:
+      "Prepare to share a LinkedIn post with your own text (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl", "text"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+        text: {
+          type: "string",
+          description: "Text to publish with the shared post.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_FEED_SAVE_POST_TOOL,
+    description:
+      "Prepare to save a LinkedIn post for later (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_FEED_UNSAVE_POST_TOOL,
+    description:
+      "Prepare to remove a LinkedIn post from your saved items (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_FEED_PREPARE_REMOVE_REACTION_TOOL,
+    description:
+      "Prepare to remove your current reaction from a LinkedIn post (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_POST_PREPARE_CREATE_TOOL,
+    description:
+      "Prepare a new LinkedIn post (two-phase: returns confirm token). Use linkedin.actions.confirm to publish.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["text"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        text: {
+          type: "string",
+          description: "Post text to prepare for publishing.",
+        },
+        visibility: {
+          type: "string",
+          enum: [...LINKEDIN_POST_VISIBILITY_TYPES],
+          description: "Post visibility. Defaults to public.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_POST_PREPARE_CREATE_MEDIA_TOOL,
+    description:
+      "Prepare a new LinkedIn media post with attachments (two-phase: returns confirm token). Use linkedin.actions.confirm to publish.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["text", "mediaPaths"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        text: {
+          type: "string",
+          description: "Post text to publish alongside the media attachments.",
+        },
+        mediaPaths: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+          description:
+            "One or more local file paths for image/video attachments.",
+        },
+        visibility: {
+          type: "string",
+          enum: [...LINKEDIN_POST_VISIBILITY_TYPES],
+          description: "Post visibility. Defaults to public.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_POST_PREPARE_CREATE_POLL_TOOL,
+    description:
+      "Prepare a new LinkedIn poll post (two-phase: returns confirm token). Use linkedin.actions.confirm to publish.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["question", "options"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        text: {
+          type: "string",
+          description: "Optional lead-in text that appears above the poll.",
+        },
+        question: {
+          type: "string",
+          description: "Poll question to publish.",
+        },
+        options: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+          description: "Two to four poll options.",
+        },
+        durationDays: {
+          type: "number",
+          description:
+            "Poll duration in days. Supported values: 1, 3, 7, or 14.",
+        },
+        visibility: {
+          type: "string",
+          enum: [...LINKEDIN_POST_VISIBILITY_TYPES],
+          description: "Post visibility. Defaults to public.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_POST_PREPARE_EDIT_TOOL,
+    description:
+      "Prepare to edit one of your LinkedIn posts (two-phase: returns confirm token). Use linkedin.actions.confirm to save the update.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl", "text"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+        text: {
+          type: "string",
+          description: "Replacement post text to save.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_POST_PREPARE_DELETE_TOOL,
+    description:
+      "Prepare to delete one of your LinkedIn posts (two-phase: returns confirm token). Use linkedin.actions.confirm to execute the deletion.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ARTICLE_PREPARE_CREATE_TOOL,
+    description:
+      "Prepare a new LinkedIn long-form article draft (two-phase: returns confirm token). Use linkedin.actions.confirm to create the draft in the publishing editor.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["title", "body"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        title: {
+          type: "string",
+          description: "Article headline to stage in the publishing editor.",
+        },
+        body: {
+          type: "string",
+          description:
+            "Plain-text article body. Paragraph breaks are preserved.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ARTICLE_PREPARE_PUBLISH_TOOL,
+    description:
+      "Prepare to publish an existing LinkedIn article draft (two-phase: returns confirm token). Use linkedin.actions.confirm to publish the draft.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["draftUrl"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        draftUrl: {
+          type: "string",
+          description:
+            "Absolute LinkedIn article editor or draft URL returned by linkedin.article.prepare_create.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_NEWSLETTER_PREPARE_CREATE_TOOL,
+    description:
+      "Prepare a new LinkedIn newsletter series (two-phase: returns confirm token). Use linkedin.actions.confirm to create the newsletter shell.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["title", "description", "cadence"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        title: {
+          type: "string",
+          description: "Newsletter title.",
+        },
+        description: {
+          type: "string",
+          description: "Short newsletter description.",
+        },
+        cadence: {
+          type: "string",
+          enum: [...LINKEDIN_NEWSLETTER_CADENCE_TYPES],
+          description: "Newsletter publish cadence.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_NEWSLETTER_PREPARE_PUBLISH_ISSUE_TOOL,
+    description:
+      "Prepare a new LinkedIn newsletter issue (two-phase: returns confirm token). Use linkedin.actions.confirm to publish the issue.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["newsletter", "title", "body"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        newsletter: {
+          type: "string",
+          description:
+            "Newsletter title as returned by linkedin.newsletter.list.",
+        },
+        title: {
+          type: "string",
+          description: "Issue headline.",
+        },
+        body: {
+          type: "string",
+          description: "Plain-text issue body. Paragraph breaks are preserved.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_NEWSLETTER_LIST_TOOL,
+    description: withSelectorAuditHint(
+      "List newsletter series currently available in the LinkedIn publishing editor.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_NOTIFICATIONS_LIST_TOOL,
+    description: withSelectorAuditHint(
+      "List your LinkedIn notifications. Returns notification type, message, timestamp, link, and read/unread status.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        limit: {
+          type: "number",
+          description:
+            "Maximum number of notifications to return. Defaults to 20.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_NOTIFICATIONS_MARK_READ_TOOL,
+    description: withSelectorAuditHint(
+      "Mark one LinkedIn notification as read by notification ID.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["notificationId"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        notificationId: {
+          type: "string",
+          description:
+            "Notification ID returned by linkedin.notifications.list.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_NOTIFICATIONS_DISMISS_TOOL,
+    description: withSelectorAuditHint(
+      "Prepare a dismiss action for one LinkedIn notification (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["notificationId"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        notificationId: {
+          type: "string",
+          description:
+            "Notification ID returned by linkedin.notifications.list.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_NOTIFICATIONS_PREFERENCES_GET_TOOL,
+    description: withSelectorAuditHint(
+      "Read LinkedIn notification preference categories or one specific notification preference page.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        preferenceUrl: {
+          type: "string",
+          description:
+            "Optional LinkedIn notification preference URL. When omitted, returns the notifications preferences overview.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_NOTIFICATIONS_PREFERENCES_PREPARE_UPDATE_TOOL,
+    description: withSelectorAuditHint(
+      "Prepare a LinkedIn notification preference update (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["preferenceUrl", "enabled"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        preferenceUrl: {
+          type: "string",
+          description:
+            "LinkedIn notification category or subcategory URL returned by linkedin.notifications.preferences.get.",
+        },
+        enabled: {
+          type: "boolean",
+          description: "Whether the selected preference should be enabled.",
+        },
+        channel: {
+          type: "string",
+          description:
+            "Optional channel key for subcategory pages: in_app, push, or email.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_JOBS_SEARCH_TOOL,
+    description: withSelectorAuditHint(
+      "Search for LinkedIn job postings by keyword and optional location.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["query"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        query: {
+          type: "string",
+          description: "Search keywords for jobs.",
+        },
+        location: {
+          type: "string",
+          description: "Location filter for jobs.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of results to return. Defaults to 10.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_JOBS_VIEW_TOOL,
+    description: withSelectorAuditHint(
+      "View details of a specific LinkedIn job posting by job ID.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["jobId"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        jobId: {
+          type: "string",
+          description: "LinkedIn job ID.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_JOBS_SAVE_TOOL,
+    description:
+      "Prepare to save a LinkedIn job for later (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["jobId"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        jobId: {
+          type: "string",
+          description: "LinkedIn job ID.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_JOBS_UNSAVE_TOOL,
+    description:
+      "Prepare to unsave a LinkedIn job (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["jobId"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        jobId: {
+          type: "string",
+          description: "LinkedIn job ID.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_JOBS_ALERTS_LIST_TOOL,
+    description: withSelectorAuditHint(
+      "List LinkedIn job alerts for the current account.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of alerts to return. Defaults to 20.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_JOBS_ALERTS_CREATE_TOOL,
+    description:
+      "Prepare to create a LinkedIn job alert from a search query (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["query"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        query: {
+          type: "string",
+          description: "Search keywords for the alert.",
+        },
+        location: {
+          type: "string",
+          description: "Optional location filter for the alert.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_JOBS_ALERTS_REMOVE_TOOL,
+    description:
+      "Prepare to remove a LinkedIn job alert (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        alertId: {
+          type: "string",
+          description:
+            "Alert id previously returned by linkedin.jobs.alerts.list.",
+        },
+        searchUrl: {
+          type: "string",
+          description: "LinkedIn jobs search URL for the alert.",
+        },
+        query: {
+          type: "string",
+          description: "Alert query if alertId or searchUrl are not available.",
+        },
+        location: {
+          type: "string",
+          description: "Alert location if query is provided.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_JOBS_PREPARE_EASY_APPLY_TOOL,
+    description:
+      "Prepare a LinkedIn Easy Apply submission (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["jobId"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        jobId: {
+          type: "string",
+          description: "LinkedIn job ID.",
+        },
+        phoneNumber: {
+          type: "string",
+          description: "Phone number value for Easy Apply forms.",
+        },
+        email: {
+          type: "string",
+          description: "Email value for Easy Apply forms.",
+        },
+        city: {
+          type: "string",
+          description: "City value for Easy Apply forms.",
+        },
+        resumePath: {
+          type: "string",
+          description:
+            "Absolute or relative path to the resume file to upload.",
+        },
+        coverLetter: {
+          type: "string",
+          description: "Cover letter text for Easy Apply forms.",
+        },
+        answers: {
+          type: "object",
+          description:
+            "Additional Easy Apply answers keyed by field label. Values may be strings, booleans, numbers, or string arrays.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_GROUPS_SEARCH_TOOL,
+    description: withSelectorAuditHint(
+      "Search LinkedIn groups by keyword and return matching communities.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["query"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        query: {
+          type: "string",
+          description: "Search keywords for LinkedIn groups.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of results to return. Defaults to 10.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_GROUPS_VIEW_TOOL,
+    description: withSelectorAuditHint(
+      "View details of a specific LinkedIn group by URL or numeric group ID.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["group"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        group: {
+          type: "string",
+          description: "LinkedIn group URL or numeric group ID.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_GROUPS_PREPARE_JOIN_TOOL,
+    description:
+      "Prepare to join a LinkedIn group (two-phase: returns confirm token). Use linkedin.actions.confirm to request or complete the join.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["group"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        group: {
+          type: "string",
+          description: "LinkedIn group URL or numeric group ID.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_GROUPS_PREPARE_LEAVE_TOOL,
+    description:
+      "Prepare to leave a LinkedIn group (two-phase: returns confirm token). Use linkedin.actions.confirm to complete the leave flow.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["group"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        group: {
+          type: "string",
+          description: "LinkedIn group URL or numeric group ID.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_GROUPS_PREPARE_POST_TOOL,
+    description:
+      "Prepare a post inside a LinkedIn group (two-phase: returns confirm token). Use linkedin.actions.confirm to publish the post.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["group", "text"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        group: {
+          type: "string",
+          description: "LinkedIn group URL or numeric group ID.",
+        },
+        text: {
+          type: "string",
+          description: "Post text to publish inside the group.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_EVENTS_SEARCH_TOOL,
+    description: withSelectorAuditHint(
+      "Search LinkedIn events by keyword and return matching event cards.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["query"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        query: {
+          type: "string",
+          description: "Search keywords for LinkedIn events.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of results to return. Defaults to 10.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_EVENTS_VIEW_TOOL,
+    description: withSelectorAuditHint(
+      "View details of a specific LinkedIn event by URL or numeric event ID.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["event"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        event: {
+          type: "string",
+          description: "LinkedIn event URL or numeric event ID.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_EVENTS_PREPARE_RSVP_TOOL,
+    description:
+      "Prepare to RSVP attend for a LinkedIn event (two-phase: returns confirm token). Use linkedin.actions.confirm to complete the RSVP.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["event"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        event: {
+          type: "string",
+          description: "LinkedIn event URL or numeric event ID.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_WATCH_CREATE_TOOL,
+    description:
+      "Create a durable poll-based LinkedIn activity watch for one profile and activity source.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["kind"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        kind: {
+          type: "string",
+          enum: [...ACTIVITY_WATCH_KINDS],
+          description: "Activity watch kind.",
+        },
+        target: {
+          type: "object",
+          description:
+            "Optional watch target object for profile/feed/inbox filters.",
+        },
+        intervalSeconds: {
+          type: "number",
+          description: "Optional polling interval in seconds.",
+        },
+        cron: {
+          type: "string",
+          description: "Optional cron schedule expression.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_WATCH_LIST_TOOL,
+    description: "List configured LinkedIn activity watches for a profile.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        status: {
+          type: "string",
+          enum: [...ACTIVITY_WATCH_STATUSES],
+          description: "Optional watch status filter.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_WATCH_PAUSE_TOOL,
+    description: "Pause one activity watch by id.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["watchId"],
+      properties: withCdpSchemaProperties({
+        watchId: {
+          type: "string",
+          description: "Activity watch id.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_WATCH_RESUME_TOOL,
+    description: "Resume one activity watch by id and make it due immediately.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["watchId"],
+      properties: withCdpSchemaProperties({
+        watchId: {
+          type: "string",
+          description: "Activity watch id.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_WATCH_REMOVE_TOOL,
+    description: "Remove one activity watch by id.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["watchId"],
+      properties: withCdpSchemaProperties({
+        watchId: {
+          type: "string",
+          description: "Activity watch id.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_WEBHOOK_CREATE_TOOL,
+    description: "Create a webhook subscription for one activity watch.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["watchId", "deliveryUrl"],
+      properties: withCdpSchemaProperties({
+        watchId: {
+          type: "string",
+          description: "Activity watch id.",
+        },
+        deliveryUrl: {
+          type: "string",
+          description: "Webhook delivery URL.",
+        },
+        eventTypes: {
+          type: "array",
+          items: {
+            type: "string",
+            enum: [...ACTIVITY_EVENT_TYPES],
+          },
+          description: "Optional event filters for this subscription.",
+        },
+        signingSecret: {
+          type: "string",
+          description: "Optional pre-shared signing secret.",
+        },
+        maxAttempts: {
+          type: "number",
+          description: "Optional maximum delivery attempts.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_WEBHOOK_LIST_TOOL,
+    description: "List webhook subscriptions for activity watches.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        watchId: {
+          type: "string",
+          description: "Optional watch id filter.",
+        },
+        status: {
+          type: "string",
+          enum: [...WEBHOOK_SUBSCRIPTION_STATUSES],
+          description: "Optional webhook subscription status filter.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_WEBHOOK_PAUSE_TOOL,
+    description: "Pause one activity webhook subscription by id.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["subscriptionId"],
+      properties: withCdpSchemaProperties({
+        subscriptionId: {
+          type: "string",
+          description: "Webhook subscription id.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_WEBHOOK_RESUME_TOOL,
+    description: "Resume one activity webhook subscription by id.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["subscriptionId"],
+      properties: withCdpSchemaProperties({
+        subscriptionId: {
+          type: "string",
+          description: "Webhook subscription id.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_WEBHOOK_REMOVE_TOOL,
+    description: "Remove one activity webhook subscription by id.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["subscriptionId"],
+      properties: withCdpSchemaProperties({
+        subscriptionId: {
+          type: "string",
+          description: "Webhook subscription id.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_EVENTS_LIST_TOOL,
+    description:
+      "List emitted LinkedIn activity events from local persistent state.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        watchId: {
+          type: "string",
+          description: "Optional watch id filter.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of events to return. Defaults to 20.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_DELIVERIES_LIST_TOOL,
+    description: "List webhook delivery attempts from local persistent state.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        watchId: {
+          type: "string",
+          description: "Optional watch id filter.",
+        },
+        subscriptionId: {
+          type: "string",
+          description: "Optional webhook subscription id filter.",
+        },
+        status: {
+          type: "string",
+          enum: [...WEBHOOK_DELIVERY_ATTEMPT_STATUSES],
+          description: "Optional delivery status filter.",
+        },
+        limit: {
+          type: "number",
+          description:
+            "Maximum number of delivery attempts to return. Defaults to 20.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_POLLER_RUN_ONCE_TOOL,
+    description:
+      "Run one local activity polling tick now and return the watch and delivery summary.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIONS_CONFIRM_TOOL,
+    description: "Confirm and execute a prepared action by confirm token.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["token"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description: "Persistent profile expected for this action.",
+        },
+        token: {
+          type: "string",
+          description: "Confirmation token in ct_... format.",
+        },
+      }),
+    },
+  },
 ];
 
 const TOOL_DEFINITION_BY_NAME = new Map(
-  LINKEDIN_MCP_TOOL_DEFINITIONS.map((tool) => [tool.name, tool] as const)
+  LINKEDIN_MCP_TOOL_DEFINITIONS.map((tool) => [tool.name, tool] as const),
 );
 
 export function validateToolArguments(name: string, args: unknown): ToolArgs {
   const definition = TOOL_DEFINITION_BY_NAME.get(name);
   if (!definition) {
     throw new LinkedInBuddyError("TARGET_NOT_FOUND", `Unknown tool: ${name}.`, {
-      tool: name
+      tool: name,
     });
   }
 
@@ -7771,7 +7858,7 @@ export function validateToolArguments(name: string, args: unknown): ToolArgs {
 
 server.setRequestHandler(ListToolsRequestSchema, async () => {
   return {
-    tools: LINKEDIN_MCP_TOOL_DEFINITIONS
+    tools: LINKEDIN_MCP_TOOL_DEFINITIONS,
   };
 });
 
@@ -7804,7 +7891,8 @@ const TOOL_HANDLERS: Record<string, ToolHandler> = {
   [LINKEDIN_PROFILE_PREPARE_REMOVE_SECTION_ITEM_TOOL]:
     handleProfilePrepareRemoveSectionItem,
   [LINKEDIN_PROFILE_PREPARE_UPLOAD_PHOTO_TOOL]: handleProfilePrepareUploadPhoto,
-  [LINKEDIN_PROFILE_PREPARE_UPLOAD_BANNER_TOOL]: handleProfilePrepareUploadBanner,
+  [LINKEDIN_PROFILE_PREPARE_UPLOAD_BANNER_TOOL]:
+    handleProfilePrepareUploadBanner,
   [LINKEDIN_PROFILE_PREPARE_FEATURED_ADD_TOOL]: handleProfilePrepareFeaturedAdd,
   [LINKEDIN_PROFILE_PREPARE_FEATURED_REMOVE_TOOL]:
     handleProfilePrepareFeaturedRemove,
@@ -7837,14 +7925,16 @@ const TOOL_HANDLERS: Record<string, ToolHandler> = {
   [LINKEDIN_COMPANY_PREPARE_FOLLOW_TOOL]: handleCompanyPrepareFollow,
   [LINKEDIN_COMPANY_PREPARE_UNFOLLOW_TOOL]: handleCompanyPrepareUnfollow,
   [LINKEDIN_CONNECTIONS_PREPARE_FOLLOW_TOOL]: handleConnectionsPrepareFollow,
-  [LINKEDIN_CONNECTIONS_PREPARE_UNFOLLOW_TOOL]: handleConnectionsPrepareUnfollow,
+  [LINKEDIN_CONNECTIONS_PREPARE_UNFOLLOW_TOOL]:
+    handleConnectionsPrepareUnfollow,
   [LINKEDIN_MEMBERS_PREPARE_BLOCK_TOOL]: handleMembersPrepareBlock,
   [LINKEDIN_MEMBERS_PREPARE_UNBLOCK_TOOL]: handleMembersPrepareUnblock,
   [LINKEDIN_MEMBERS_PREPARE_REPORT_TOOL]: handleMembersPrepareReport,
   [LINKEDIN_PRIVACY_GET_SETTINGS_TOOL]: handlePrivacyGetSettings,
   [LINKEDIN_PRIVACY_PREPARE_UPDATE_SETTING_TOOL]:
     handlePrivacyPrepareUpdateSetting,
-  [LINKEDIN_NETWORK_PREPARE_FOLLOWUP_AFTER_ACCEPT_TOOL]: handlePrepareFollowupAfterAccept,
+  [LINKEDIN_NETWORK_PREPARE_FOLLOWUP_AFTER_ACCEPT_TOOL]:
+    handlePrepareFollowupAfterAccept,
   [LINKEDIN_FEED_LIST_TOOL]: handleFeedList,
   [LINKEDIN_FEED_VIEW_POST_TOOL]: handleFeedViewPost,
   [LINKEDIN_FEED_LIKE_TOOL]: handleFeedLike,
@@ -7868,7 +7958,8 @@ const TOOL_HANDLERS: Record<string, ToolHandler> = {
   [LINKEDIN_NOTIFICATIONS_LIST_TOOL]: handleNotificationsList,
   [LINKEDIN_NOTIFICATIONS_MARK_READ_TOOL]: handleNotificationsMarkRead,
   [LINKEDIN_NOTIFICATIONS_DISMISS_TOOL]: handleNotificationsDismiss,
-  [LINKEDIN_NOTIFICATIONS_PREFERENCES_GET_TOOL]: handleNotificationPreferencesGet,
+  [LINKEDIN_NOTIFICATIONS_PREFERENCES_GET_TOOL]:
+    handleNotificationPreferencesGet,
   [LINKEDIN_NOTIFICATIONS_PREFERENCES_PREPARE_UPDATE_TOOL]:
     handleNotificationPreferencesPrepareUpdate,
   [LINKEDIN_JOBS_SEARCH_TOOL]: handleJobsSearch,
@@ -7900,13 +7991,13 @@ const TOOL_HANDLERS: Record<string, ToolHandler> = {
   [LINKEDIN_ACTIVITY_EVENTS_LIST_TOOL]: handleActivityEventsList,
   [LINKEDIN_ACTIVITY_DELIVERIES_LIST_TOOL]: handleActivityDeliveriesList,
   [LINKEDIN_ACTIVITY_POLLER_RUN_ONCE_TOOL]: handleActivityPollerRunOnce,
-  [LINKEDIN_ACTIONS_CONFIRM_TOOL]: handleConfirm
+  [LINKEDIN_ACTIONS_CONFIRM_TOOL]: handleConfirm,
 };
 
 /** Dispatches one MCP tool call to the registered LinkedIn tool handlers. */
 export async function handleToolCall(
   name: string,
-  args: ToolArgs = {}
+  args: ToolArgs = {},
 ): Promise<ToolResult | ToolErrorResult> {
   let errorForTracking: unknown;
 
@@ -7915,7 +8006,7 @@ export async function handleToolCall(
     if (handler) {
       const validatedArgs = validateToolArguments(name, args);
       const profileName = trimOrUndefined(
-        readString(validatedArgs, "profileName", "")
+        readString(validatedArgs, "profileName", ""),
       );
       const result = await handler(validatedArgs);
 
@@ -7927,7 +8018,7 @@ export async function handleToolCall(
         source: "mcp",
         invocationName: name,
         mcpToolName: name,
-        ...(profileName ? { activeProfileName: profileName } : {})
+        ...(profileName ? { activeProfileName: profileName } : {}),
       });
 
       return decision.showHint ? addFeedbackHintToResult(result) : result;
@@ -7935,7 +8026,7 @@ export async function handleToolCall(
 
     errorForTracking = new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      `Unknown tool: ${name}`
+      `Unknown tool: ${name}`,
     );
     const unknownToolResult = toErrorResult(errorForTracking);
 
@@ -7947,7 +8038,7 @@ export async function handleToolCall(
       source: "mcp",
       invocationName: name,
       mcpToolName: name,
-      error: errorForTracking
+      error: errorForTracking,
     });
 
     return decision.showHint
@@ -7962,32 +8053,36 @@ export async function handleToolCall(
     }
 
     try {
-      const validatedArgs = name in TOOL_HANDLERS
-        ? validateToolArguments(name, args)
-        : args;
+      const validatedArgs =
+        name in TOOL_HANDLERS ? validateToolArguments(name, args) : args;
       const profileName = trimOrUndefined(
-        readString(validatedArgs, "profileName", "")
+        readString(validatedArgs, "profileName", ""),
       );
       const decision = await recordFeedbackInvocation({
         source: "mcp",
         invocationName: name,
         mcpToolName: name,
         ...(profileName ? { activeProfileName: profileName } : {}),
-        error: errorForTracking
+        error: errorForTracking,
       });
 
-      return decision.showHint ? addFeedbackHintToResult(errorResult) : errorResult;
+      return decision.showHint
+        ? addFeedbackHintToResult(errorResult)
+        : errorResult;
     } catch {
       return errorResult;
     }
   }
 }
 
-server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
-  const name = request.params.name;
-  const args = (request.params.arguments ?? {}) as ToolArgs;
-  return handleToolCall(name, args);
-});
+server.setRequestHandler(
+  CallToolRequestSchema,
+  async (request: CallToolRequest) => {
+    const name = request.params.name;
+    const args = (request.params.arguments ?? {}) as ToolArgs;
+    return handleToolCall(name, args);
+  },
+);
 
 async function startLinkedInMcpServer(): Promise<void> {
   const transport = new StdioServerTransport();
@@ -8006,7 +8101,11 @@ function isDirectExecution(moduleUrl: string): boolean {
 if (isDirectExecution(import.meta.url)) {
   startLinkedInMcpServer().catch((error: unknown) => {
     console.error(
-      JSON.stringify(toLinkedInBuddyErrorPayload(error, mcpPrivacyConfig), null, 2)
+      JSON.stringify(
+        toLinkedInBuddyErrorPayload(error, mcpPrivacyConfig),
+        null,
+        2,
+      ),
     );
     process.exit(1);
   });


### PR DESCRIPTION
## Summary

Quality pass for Analytics & Insights surfaces (phases 3–8 from #353). The original implementation shipped in #303 as a single-agent spawn; this PR runs the remaining pipeline phases.

## Changes

### Phase 3 — Simplify + Refactor
- Extracted shared `fetchProfileSurface()` helper to DRY the three profile analytics methods (`getProfileViews`, `getSearchAppearances`, `getContentMetrics`)
- **Fixed bug**: `getContentMetrics` checked `cards.length === 0` instead of `matchedCards.length === 0` — the empty-match error path was unreachable
- Inlined `flattenCardMetrics` one-liner
- Added `resolveProfileName()` for consistent profile name normalization

### Phase 4 — Test
- Comprehensive unit tests for `parseLinkedInAnalyticsNumber` edge cases (negative, European decimals, B/T suffixes, zero, non-numeric)
- Tests for `toLinkedInAnalyticsMetricKey`, `inferAnalyticsMetricUnit`, `inferAnalyticsMetricTrend`
- Tests for `toAbsoluteLinkedInUrl`, `readAnalyticsLimit`, `ensureMatchingCards`, `matchesAnalyticsCard`
- MCP contract tests for `search_appearances` and `content_metrics` (previously untested)
- Test count: 941 → 992 (includes new tests merged from main)

### Phase 5 — Harden
- Capped `readAnalyticsLimit` upper bound to 50 (prevents unbounded scraping)
- Added explicit page navigation timeout (30s)
- Enriched error messages with `profileName` context

### Phase 6 — UX/QoL
- Enriched all 4 analytics MCP tool descriptions with return shape hints
- Documented limit range (1–50) in `content_metrics` schema

### Phase 7 — Verify
- E2E requires live LinkedIn session — validated through comprehensive unit + MCP contract tests

### Phase 8 — Docs
- Added `docs/analytics.md` covering surfaces, MCP tools, TypeScript API, return types, limits, and error handling

## Testing

- `npm test`: 992 tests passing (102 files)
- `npm run lint`: Clean
- `npm run typecheck` / `npm run build`: Pre-existing failures in `packages/cli` and `packages/mcp` (module resolution for `@linkedin-buddy/core`) — identical on `main`, unrelated to this PR

## Files changed

| File | What |
|------|------|
| `packages/core/src/linkedinAnalytics.ts` | Refactored, hardened, bug-fixed |
| `packages/core/src/__tests__/linkedinAnalytics.test.ts` | Comprehensive unit tests |
| `packages/mcp/src/__tests__/linkedinMcp.test.ts` | Added search_appearances + content_metrics contract tests |
| `packages/mcp/src/bin/linkedin-mcp.ts` | Improved tool descriptions |
| `docs/analytics.md` | New documentation |

Closes #353
