### PR TITLE
feat: improve headless login with overlay dismissal, direct fill fallback, and headed mode

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -10,7 +10,7 @@ import {
   readdir,
   stat,
   unlink,
-  writeFile
+  writeFile,
 } from "node:fs/promises";
 import path from "node:path";
 import { createInterface } from "node:readline/promises";
@@ -120,34 +120,34 @@ import {
   type FeedbackType,
   type WriteValidationAccountTargets,
   type WriteValidationActionPreview,
-  type WriteValidationReport
+  type WriteValidationReport,
 } from "@linkedin-buddy/core";
 import {
   DraftQualityProgressReporter,
   formatDraftQualityError,
   formatDraftQualityReport,
-  resolveDraftQualityOutputMode
+  resolveDraftQualityOutputMode,
 } from "../draftQualityOutput.js";
 import {
   ReadOnlyValidationProgressReporter,
   formatReadOnlyValidationError,
   formatReadOnlyValidationReport,
   resolveReadOnlyValidationOutputMode,
-  type ReadOnlyValidationOutputMode
+  type ReadOnlyValidationOutputMode,
 } from "../liveValidationOutput.js";
 import { HeadlessLoginProgressReporter } from "../headlessLoginOutput.js";
 import {
   formatSelectorAuditError,
   formatSelectorAuditReport,
   resolveSelectorAuditOutputMode,
-  SelectorAuditProgressReporter
+  SelectorAuditProgressReporter,
 } from "../selectorAuditOutput.js";
 import {
   formatWriteValidationError,
   formatWriteValidationReport,
   resolveWriteValidationOutputMode,
   WriteValidationProgressReporter,
-  type WriteValidationOutputMode
+  type WriteValidationOutputMode,
 } from "../writeValidationOutput.js";
 import {
   formatSchedulerError,
@@ -162,7 +162,7 @@ import {
   type SchedulerRunOnceReport,
   type SchedulerStartReport,
   type SchedulerStatusReport,
-  type SchedulerStopReport
+  type SchedulerStopReport,
 } from "../schedulerOutput.js";
 import {
   formatActivityDeliveryListReport,
@@ -197,7 +197,7 @@ import {
   type ActivityWebhookAddReport,
   type ActivityWebhookListReport,
   type ActivityWebhookMutationReport,
-  type ActivityWebhookRemovalReport
+  type ActivityWebhookRemovalReport,
 } from "../activityOutput.js";
 import {
   formatKeepAliveError,
@@ -209,7 +209,7 @@ import {
   type KeepAliveRecentEvent,
   type KeepAliveStartReport,
   type KeepAliveStatusReport,
-  type KeepAliveStopReport
+  type KeepAliveStopReport,
 } from "../keepAliveOutput.js";
 import {
   parseActivitySeedGeneratedImageManifest,
@@ -217,19 +217,18 @@ import {
   type ActivitySeedGeneratedPostImage,
   type ActivitySeedSpec,
   type ActivitySeedPostSpec,
-  type ActivitySeedJobSearchSpec
+  type ActivitySeedJobSearchSpec,
 } from "../activitySeed.js";
 import {
   createProfileSeedPlan,
   parseProfileSeedSpec,
   type ProfileSeedPlanAction,
-  type ProfileSeedUnsupportedField
+  type ProfileSeedUnsupportedField,
 } from "../profileSeed.js";
 
 const cliPrivacyConfig = resolvePrivacyConfig();
 const SELECTOR_AUDIT_DOC_PATH = "docs/selector-audit.md";
-const SELECTOR_AUDIT_DOC_REFERENCE =
-  `See ${SELECTOR_AUDIT_DOC_PATH} for sample output, configuration, and troubleshooting.`;
+const SELECTOR_AUDIT_DOC_REFERENCE = `See ${SELECTOR_AUDIT_DOC_PATH} for sample output, configuration, and troubleshooting.`;
 const MAX_JSON_INPUT_BYTES = 10 * 1024 * 1024;
 const LIVE_VALIDATION_HELP_COMMAND = "linkedin test live --help";
 const LIVE_VALIDATION_FAIL_EXIT_CODE = 1;
@@ -258,7 +257,7 @@ function writeCliNotice(message: string): void {
 function maybeWarnAboutSelectorLocaleConfig(selectorLocale?: string): void {
   const warning = getLinkedInSelectorLocaleConfigWarning(
     resolveLinkedInSelectorLocaleConfigResolution(selectorLocale),
-    "cli"
+    "cli",
   );
 
   if (!warning) {
@@ -297,7 +296,7 @@ function coercePositiveInt(value: string, label: string): number {
   if (!/^\d+$/u.test(normalized) || !Number.isFinite(parsed) || parsed <= 0) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      `${label} must be a positive integer.`
+      `${label} must be a positive integer.`,
     );
   }
   return parsed;
@@ -309,7 +308,7 @@ function coerceNonNegativeInt(value: string, label: string): number {
   if (!/^\d+$/u.test(normalized) || !Number.isFinite(parsed) || parsed < 0) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      `${label} must be a non-negative integer.`
+      `${label} must be a non-negative integer.`,
     );
   }
   return parsed;
@@ -322,7 +321,7 @@ function coerceSearchCategory(value: string): SearchCategory {
 
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    `category must be one of: ${SEARCH_CATEGORIES.join(", ")}.`
+    `category must be one of: ${SEARCH_CATEGORIES.join(", ")}.`,
   );
 }
 
@@ -331,14 +330,14 @@ function coerceProfileName(value: string, label: string = "profile"): string {
   if (normalized.length === 0) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      `${label} must not be empty.`
+      `${label} must not be empty.`,
     );
   }
 
   if (normalized === "." || normalized === ".." || /[\\/]/.test(normalized)) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      `${label} must not contain path separators or relative path segments.`
+      `${label} must not contain path separators or relative path segments.`,
     );
   }
 
@@ -347,7 +346,11 @@ function coerceProfileName(value: string, label: string = "profile"): string {
 
 function printJson(value: unknown): void {
   console.log(
-    JSON.stringify(redactStructuredValue(value, cliPrivacyConfig, "cli"), null, 2)
+    JSON.stringify(
+      redactStructuredValue(value, cliPrivacyConfig, "cli"),
+      null,
+      2,
+    ),
   );
 }
 
@@ -360,8 +363,8 @@ function createRuntime(cdpUrl?: string) {
       [
         "[linkedin] Warning: --cdp-url attaches to an existing browser session.",
         "This can share cookies/state with other Chrome sessions.",
-        "For an isolated tool-only profile, omit --cdp-url."
-      ].join(" ")
+        "For an isolated tool-only profile, omit --cdp-url.",
+      ].join(" "),
     );
     process.stderr.write("\n");
   }
@@ -371,13 +374,13 @@ function createRuntime(cdpUrl?: string) {
           cdpUrl,
           ...(evasionLevel ? { evasionLevel } : {}),
           privacy: cliPrivacyConfig,
-          ...(cliSelectorLocale ? { selectorLocale: cliSelectorLocale } : {})
+          ...(cliSelectorLocale ? { selectorLocale: cliSelectorLocale } : {}),
         }
       : {
           ...(evasionLevel ? { evasionLevel } : {}),
           privacy: cliPrivacyConfig,
-          ...(cliSelectorLocale ? { selectorLocale: cliSelectorLocale } : {})
-        }
+          ...(cliSelectorLocale ? { selectorLocale: cliSelectorLocale } : {}),
+        },
   );
 }
 
@@ -394,9 +397,9 @@ function resolveCliEvasionRuntimeConfig() {
   return resolveEvasionConfig(
     evasionLevel
       ? {
-          level: evasionLevel
+          level: evasionLevel,
         }
-      : {}
+      : {},
   );
 }
 
@@ -404,7 +407,7 @@ const DEFAULT_FIXTURE_RECORD_PROFILE = "fixtures";
 const DEFAULT_FIXTURE_RECORD_SET = "manual";
 const DEFAULT_FIXTURE_VIEWPORT = {
   width: 1440,
-  height: 900
+  height: 900,
 } as const;
 const FIXTURE_ROUTE_FILE_NAME = "routes.json";
 const FIXTURE_RESPONSE_DIR_NAME = "responses";
@@ -417,7 +420,8 @@ const FIXTURE_CAPTURE_URLS: Record<LinkedInReplayPageType, string> = {
   messaging: "https://www.linkedin.com/messaging/",
   notifications: "https://www.linkedin.com/notifications/",
   profile: "https://www.linkedin.com/in/me/",
-  search: "https://www.linkedin.com/search/results/people/?keywords=Simon%20Miller"
+  search:
+    "https://www.linkedin.com/search/results/people/?keywords=Simon%20Miller",
 };
 
 interface FixtureRecordInput {
@@ -430,7 +434,9 @@ interface FixtureRecordInput {
   width: number;
 }
 
-function isFixtureReplayPageType(value: string): value is LinkedInReplayPageType {
+function isFixtureReplayPageType(
+  value: string,
+): value is LinkedInReplayPageType {
   return (LINKEDIN_REPLAY_PAGE_TYPES as readonly string[]).includes(value);
 }
 
@@ -442,13 +448,13 @@ function coerceFixtureReplayPageType(value: string): LinkedInReplayPageType {
 
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    `page must be one of: ${LINKEDIN_REPLAY_PAGE_TYPES.join(", ")}.`
+    `page must be one of: ${LINKEDIN_REPLAY_PAGE_TYPES.join(", ")}.`,
   );
 }
 
 function collectFixtureReplayPageTypes(
   value: string,
-  previous: LinkedInReplayPageType[]
+  previous: LinkedInReplayPageType[],
 ): LinkedInReplayPageType[] {
   const nextValues = value
     .split(",")
@@ -459,7 +465,7 @@ function collectFixtureReplayPageTypes(
   if (nextValues.length === 0) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "page must include at least one page type when --page is provided."
+      "page must include at least one page type when --page is provided.",
     );
   }
 
@@ -475,7 +481,7 @@ function collectNonEmptyStrings(value: string, previous: string[]): string[] {
   if (nextValues.length === 0) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "Option must include at least one value when provided."
+      "Option must include at least one value when provided.",
     );
   }
 
@@ -483,7 +489,7 @@ function collectNonEmptyStrings(value: string, previous: string[]): string[] {
 }
 
 function uniqueFixtureReplayPageTypes(
-  pageTypes: LinkedInReplayPageType[]
+  pageTypes: LinkedInReplayPageType[],
 ): LinkedInReplayPageType[] {
   return Array.from(new Set(pageTypes));
 }
@@ -494,7 +500,7 @@ function sanitizeFixtureFileStem(value: string): string {
 
 function guessFixtureResponseExtension(
   contentType: string | undefined,
-  url: string
+  url: string,
 ): string {
   const normalizedType = (contentType ?? "").toLowerCase();
   if (normalizedType.includes("text/html")) {
@@ -529,7 +535,7 @@ function guessFixtureResponseExtension(
 }
 
 async function loadFixtureManifestOrCreate(
-  manifestPath: string
+  manifestPath: string,
 ): Promise<LinkedInFixtureManifest> {
   if (!existsSync(manifestPath)) {
     return createEmptyFixtureManifest();
@@ -541,7 +547,7 @@ async function loadFixtureManifestOrCreate(
 async function loadExistingFixtureRoutes(
   manifestPath: string,
   setName: string,
-  setSummary: LinkedInFixtureSetSummary | undefined
+  setSummary: LinkedInFixtureSetSummary | undefined,
 ): Promise<LinkedInFixtureRoute[]> {
   if (!setSummary) {
     return [];
@@ -550,7 +556,7 @@ async function loadExistingFixtureRoutes(
   const routesPath = path.resolve(
     path.dirname(manifestPath),
     setSummary.rootDir,
-    setSummary.routesPath
+    setSummary.routesPath,
   );
   if (!existsSync(routesPath)) {
     return [];
@@ -561,7 +567,7 @@ async function loadExistingFixtureRoutes(
 
 function mergeFixtureRoutes(
   existingRoutes: LinkedInFixtureRoute[],
-  nextRoutes: LinkedInFixtureRoute[]
+  nextRoutes: LinkedInFixtureRoute[],
 ): LinkedInFixtureRoute[] {
   const merged = new Map<string, LinkedInFixtureRoute>();
   for (const route of existingRoutes) {
@@ -574,7 +580,7 @@ function mergeFixtureRoutes(
   }
 
   return Array.from(merged.values()).sort((left, right) =>
-    buildFixtureRouteKey(left).localeCompare(buildFixtureRouteKey(right))
+    buildFixtureRouteKey(left).localeCompare(buildFixtureRouteKey(right)),
   );
 }
 
@@ -588,7 +594,9 @@ interface FixtureCaptureResponse {
   url(): string;
 }
 
-async function withFixtureReplayDisabled<T>(callback: () => Promise<T>): Promise<T> {
+async function withFixtureReplayDisabled<T>(
+  callback: () => Promise<T>,
+): Promise<T> {
   const previousValues = new Map<string, string | undefined>();
   // Recording must always talk to live LinkedIn, even if the caller currently
   // has replay mode enabled in the shell.
@@ -613,7 +621,7 @@ async function withFixtureReplayDisabled<T>(callback: () => Promise<T>): Promise
 async function captureFixtureResponse(
   response: FixtureCaptureResponse,
   setDir: string,
-  index: number
+  index: number,
 ): Promise<LinkedInFixtureRoute | null> {
   const url = response.url();
   if (!isLinkedInFixtureReplayUrl(url)) {
@@ -630,14 +638,17 @@ async function captureFixtureResponse(
   try {
     const parsed = new URL(url);
     const pathStem = sanitizeFixtureFileStem(
-      `${parsed.hostname}${parsed.pathname === "/" ? "/root" : parsed.pathname}`
+      `${parsed.hostname}${parsed.pathname === "/" ? "/root" : parsed.pathname}`,
     );
     fileStem = `${fileStem}-${pathStem}`;
   } catch {
     // Use the fallback sequence number stem.
   }
 
-  const relativeBodyPath = path.join(FIXTURE_RESPONSE_DIR_NAME, `${fileStem}${extension}`);
+  const relativeBodyPath = path.join(
+    FIXTURE_RESPONSE_DIR_NAME,
+    `${fileStem}${extension}`,
+  );
   const absoluteBodyPath = path.join(setDir, relativeBodyPath);
   const bodyBuffer = await response.body().catch(() => Buffer.from(""));
   await mkdir(path.dirname(absoluteBodyPath), { recursive: true });
@@ -648,7 +659,7 @@ async function captureFixtureResponse(
     url,
     status: response.status(),
     headers,
-    bodyPath: relativeBodyPath
+    bodyPath: relativeBodyPath,
   };
 }
 
@@ -661,7 +672,7 @@ async function runFixturesCheck(input: {
   const maxAgeDays = input.maxAgeDays ?? DEFAULT_FIXTURE_STALENESS_DAYS;
   const warnings = await checkLinkedInFixtureStaleness(manifestPath, {
     maxAgeDays,
-    ...(input.setName ? { setName: input.setName } : {})
+    ...(input.setName ? { setName: input.setName } : {}),
   });
 
   for (const warning of warnings) {
@@ -674,7 +685,7 @@ async function runFixturesCheck(input: {
     set_name: input.setName ?? null,
     stale: warnings.length > 0,
     warning_count: warnings.length,
-    warnings
+    warnings,
   });
 }
 
@@ -682,7 +693,7 @@ async function runFixturesRecord(input: FixtureRecordInput): Promise<void> {
   if (!stdin.isTTY || !stdout.isTTY) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "fixtures:record requires an interactive terminal because it pauses for manual navigation."
+      "fixtures:record requires an interactive terminal because it pauses for manual navigation.",
     );
   }
 
@@ -692,20 +703,24 @@ async function runFixturesRecord(input: FixtureRecordInput): Promise<void> {
   const previousSetSummary = manifest.sets[setName];
   const setRootDir = path.resolve(
     path.dirname(manifestPath),
-    previousSetSummary?.rootDir ?? setName
+    previousSetSummary?.rootDir ?? setName,
   );
   const pagesDir = path.join(setRootDir, FIXTURE_PAGES_DIR_NAME);
   const harRelativePath = input.har ? "session.har" : undefined;
-  const harAbsolutePath = harRelativePath ? path.join(setRootDir, harRelativePath) : undefined;
+  const harAbsolutePath = harRelativePath
+    ? path.join(setRootDir, harRelativePath)
+    : undefined;
   const existingRoutes = await loadExistingFixtureRoutes(
     manifestPath,
     setName,
-    previousSetSummary
+    previousSetSummary,
   );
   const capturedRoutes = new Map<string, LinkedInFixtureRoute>();
   const captureJobs: Array<Promise<void>> = [];
-  const pageEntries: Partial<Record<LinkedInReplayPageType, LinkedInFixturePageEntry>> = {
-    ...(previousSetSummary?.pages ?? {})
+  const pageEntries: Partial<
+    Record<LinkedInReplayPageType, LinkedInFixturePageEntry>
+  > = {
+    ...(previousSetSummary?.pages ?? {}),
   };
 
   await mkdir(path.dirname(manifestPath), { recursive: true });
@@ -713,12 +728,12 @@ async function runFixturesRecord(input: FixtureRecordInput): Promise<void> {
   await mkdir(pagesDir, { recursive: true });
 
   const profileManager = new ProfileManager(resolveConfigPaths(), {
-    evasion: resolveCliEvasionRuntimeConfig()
+    evasion: resolveCliEvasionRuntimeConfig(),
   });
   let captureLocale = previousSetSummary?.locale ?? "en-US";
   let captureViewport: { width: number; height: number } = {
     width: input.width,
-    height: input.height
+    height: input.height,
   };
 
   await withFixtureReplayDisabled(async () => {
@@ -729,16 +744,16 @@ async function runFixturesRecord(input: FixtureRecordInput): Promise<void> {
         launchOptions: {
           viewport: {
             width: input.width,
-            height: input.height
+            height: input.height,
           },
           ...(harAbsolutePath
             ? {
                 recordHar: {
-                  path: harAbsolutePath
-                }
+                  path: harAbsolutePath,
+                },
               }
-            : {})
-        }
+            : {}),
+        },
       },
       async (context) => {
         let responseIndex = existingRoutes.length;
@@ -746,13 +761,20 @@ async function runFixturesRecord(input: FixtureRecordInput): Promise<void> {
           // Increment synchronously before the async body write starts so the
           // route file and response filenames stay deterministic.
           responseIndex += 1;
-          const captureJob = captureFixtureResponse(response, setRootDir, responseIndex)
+          const captureJob = captureFixtureResponse(
+            response,
+            setRootDir,
+            responseIndex,
+          )
             .then((capturedRoute) => {
               if (!capturedRoute) {
                 return;
               }
 
-              capturedRoutes.set(buildFixtureRouteKey(capturedRoute), capturedRoute);
+              capturedRoutes.set(
+                buildFixtureRouteKey(capturedRoute),
+                capturedRoute,
+              );
             })
             .catch(() => undefined);
           captureJobs.push(captureJob);
@@ -761,34 +783,46 @@ async function runFixturesRecord(input: FixtureRecordInput): Promise<void> {
         const page = context.pages()[0] ?? (await context.newPage());
         const prompt = createInterface({
           input: stdin,
-          output: stdout
+          output: stdout,
         });
 
         try {
           for (const pageType of input.pageTypes) {
             const suggestedUrl = FIXTURE_CAPTURE_URLS[pageType];
             if (suggestedUrl) {
-              await page.goto(suggestedUrl, { waitUntil: "domcontentloaded" }).catch(() => undefined);
+              await page
+                .goto(suggestedUrl, { waitUntil: "domcontentloaded" })
+                .catch(() => undefined);
             }
 
             writeCliNotice(
-              `Navigate the browser to the LinkedIn ${pageType} page you want to capture.`
+              `Navigate the browser to the LinkedIn ${pageType} page you want to capture.`,
             );
             await prompt.question(
-              `Press Enter to capture ${pageType} (current page: ${page.url() || suggestedUrl}). `
+              `Press Enter to capture ${pageType} (current page: ${page.url() || suggestedUrl}). `,
             );
 
-            const htmlRelativePath = path.join(FIXTURE_PAGES_DIR_NAME, `${pageType}.html`);
+            const htmlRelativePath = path.join(
+              FIXTURE_PAGES_DIR_NAME,
+              `${pageType}.html`,
+            );
             const htmlAbsolutePath = path.join(setRootDir, htmlRelativePath);
-            await writeFile(htmlAbsolutePath, `${await page.content()}\n`, "utf8");
+            await writeFile(
+              htmlAbsolutePath,
+              `${await page.content()}\n`,
+              "utf8",
+            );
 
             const currentUrl = page.url();
             const pageTitle = await page.title().catch(() => undefined);
-            const pageLocale = await page.evaluate(() => navigator.language).catch(() => undefined);
+            const pageLocale = await page
+              .evaluate(() => navigator.language)
+              .catch(() => undefined);
             const viewport = page.viewportSize();
-            captureLocale = typeof pageLocale === "string" && pageLocale.trim().length > 0
-              ? pageLocale.trim()
-              : captureLocale;
+            captureLocale =
+              typeof pageLocale === "string" && pageLocale.trim().length > 0
+                ? pageLocale.trim()
+                : captureLocale;
             if (viewport) {
               captureViewport = viewport;
             }
@@ -800,7 +834,7 @@ async function runFixturesRecord(input: FixtureRecordInput): Promise<void> {
               recordedAt: new Date().toISOString(),
               ...(typeof pageTitle === "string" && pageTitle.trim().length > 0
                 ? { title: pageTitle.trim() }
-                : {})
+                : {}),
             };
           }
 
@@ -808,26 +842,28 @@ async function runFixturesRecord(input: FixtureRecordInput): Promise<void> {
         } finally {
           prompt.close();
         }
-      }
+      },
     );
   });
 
   // Finish any in-flight response writes before rewriting the route index.
   await Promise.allSettled(captureJobs);
 
-  const mergedRoutes = mergeFixtureRoutes(existingRoutes, [...capturedRoutes.values()]);
+  const mergedRoutes = mergeFixtureRoutes(existingRoutes, [
+    ...capturedRoutes.values(),
+  ]);
   await writeFile(
     path.join(setRootDir, FIXTURE_ROUTE_FILE_NAME),
     `${JSON.stringify(
       {
         format: LINKEDIN_FIXTURE_MANIFEST_FORMAT_VERSION,
         setName,
-        routes: mergedRoutes
+        routes: mergedRoutes,
       },
       null,
-      2
+      2,
     )}\n`,
-    "utf8"
+    "utf8",
   );
 
   const capturedAt = new Date().toISOString();
@@ -842,7 +878,7 @@ async function runFixturesRecord(input: FixtureRecordInput): Promise<void> {
     description:
       previousSetSummary?.description ??
       "Recorded manually through the LinkedIn fixture replay workflow.",
-    pages: pageEntries
+    pages: pageEntries,
   };
 
   manifest.sets[setName] = setSummary;
@@ -861,7 +897,9 @@ async function runFixturesRecord(input: FixtureRecordInput): Promise<void> {
     pages: pageEntries,
     routes_path: path.join(setSummary.rootDir, FIXTURE_ROUTE_FILE_NAME),
     route_count: mergedRoutes.length,
-    ...(harRelativePath ? { har_path: path.join(setSummary.rootDir, harRelativePath) } : {})
+    ...(harRelativePath
+      ? { har_path: path.join(setSummary.rootDir, harRelativePath) }
+      : {}),
   });
 }
 
@@ -952,7 +990,7 @@ function getKeepAliveFiles(profileName: string): KeepAliveFiles {
     dir,
     pidPath: path.join(dir, `${slug}.pid`),
     statePath: path.join(dir, `${slug}.state.json`),
-    logPath: path.join(dir, `${slug}.events.jsonl`)
+    logPath: path.join(dir, `${slug}.events.jsonl`),
   };
 }
 
@@ -963,7 +1001,7 @@ function getSchedulerFiles(profileName: string): SchedulerFiles {
     dir,
     pidPath: path.join(dir, `${slug}.pid`),
     statePath: path.join(dir, `${slug}.state.json`),
-    logPath: path.join(dir, `${slug}.events.jsonl`)
+    logPath: path.join(dir, `${slug}.events.jsonl`),
   };
 }
 
@@ -980,11 +1018,7 @@ async function readJsonFile<T>(filePath: string): Promise<T | null> {
     const raw = await readFile(filePath, "utf8");
     return JSON.parse(raw) as T;
   } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
       return null;
     }
     if (error instanceof SyntaxError) {
@@ -998,7 +1032,10 @@ async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
   await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
 }
 
-async function readJsonInputFile(filePath: string, label: string): Promise<unknown> {
+async function readJsonInputFile(
+  filePath: string,
+  label: string,
+): Promise<unknown> {
   const resolvedPath = path.resolve(filePath);
   let raw: string;
 
@@ -1009,8 +1046,8 @@ async function readJsonInputFile(filePath: string, label: string): Promise<unkno
         "ACTION_PRECONDITION_FAILED",
         `Expected ${label} path to point to a file.`,
         {
-          path: resolvedPath
-        }
+          path: resolvedPath,
+        },
       );
     }
 
@@ -1021,8 +1058,8 @@ async function readJsonInputFile(filePath: string, label: string): Promise<unkno
         {
           path: resolvedPath,
           size_bytes: fileStats.size,
-          limit_bytes: MAX_JSON_INPUT_BYTES
-        }
+          limit_bytes: MAX_JSON_INPUT_BYTES,
+        },
       );
     }
 
@@ -1032,19 +1069,15 @@ async function readJsonInputFile(filePath: string, label: string): Promise<unkno
       throw error;
     }
 
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
         `Could not read ${label}.`,
         {
           path: resolvedPath,
-          cause: "ENOENT"
+          cause: "ENOENT",
         },
-        { cause: error }
+        { cause: error },
       );
     }
 
@@ -1053,9 +1086,9 @@ async function readJsonInputFile(filePath: string, label: string): Promise<unkno
       `Could not read ${label}.`,
       {
         path: resolvedPath,
-        cause: error instanceof Error ? error.message : String(error)
+        cause: error instanceof Error ? error.message : String(error),
       },
-      error instanceof Error ? { cause: error } : undefined
+      error instanceof Error ? { cause: error } : undefined,
     );
   }
 
@@ -1067,14 +1100,17 @@ async function readJsonInputFile(filePath: string, label: string): Promise<unkno
       `Could not parse ${label} as JSON.`,
       {
         path: resolvedPath,
-        cause: error instanceof Error ? error.message : String(error)
+        cause: error instanceof Error ? error.message : String(error),
       },
-      error instanceof Error ? { cause: error } : undefined
+      error instanceof Error ? { cause: error } : undefined,
     );
   }
 }
 
-async function writeOutputJsonFile(filePath: string, value: unknown): Promise<string> {
+async function writeOutputJsonFile(
+  filePath: string,
+  value: unknown,
+): Promise<string> {
   const resolvedPath = path.resolve(filePath);
   await mkdir(path.dirname(resolvedPath), { recursive: true });
   await writeJsonFile(resolvedPath, value);
@@ -1082,24 +1118,24 @@ async function writeOutputJsonFile(filePath: string, value: unknown): Promise<st
 }
 
 function createDraftQualityProgressLogger(
-  onLog: (entry: { event: string; payload: Record<string, unknown> }) => void
+  onLog: (entry: { event: string; payload: Record<string, unknown> }) => void,
 ): {
   log(
     level: "debug" | "info" | "warn" | "error",
     event: string,
-    payload?: Record<string, unknown>
+    payload?: Record<string, unknown>,
   ): void;
 } {
   return {
     log(_level, event, payload = {}) {
       onLog({ event, payload });
-    }
+    },
   };
 }
 
 function attachHeadlessLoginLogObserver(
   logger: Pick<JsonEventLogger, "log">,
-  onLog: (entry: JsonLogEntry) => void
+  onLog: (entry: JsonLogEntry) => void,
 ): void {
   const originalLog = logger.log.bind(logger) as (
     ...args: Parameters<JsonEventLogger["log"]>
@@ -1119,18 +1155,17 @@ async function readKeepAlivePid(profileName: string): Promise<number | null> {
     const pid = Number.parseInt(raw.trim(), 10);
     return Number.isInteger(pid) && pid > 0 ? pid : null;
   } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
       return null;
     }
     throw error;
   }
 }
 
-async function writeKeepAlivePid(profileName: string, pid: number): Promise<void> {
+async function writeKeepAlivePid(
+  profileName: string,
+  pid: number,
+): Promise<void> {
   const files = getKeepAliveFiles(profileName);
   await ensureKeepAliveDir(files);
   await writeFile(files.pidPath, `${pid}\n`, "utf8");
@@ -1141,11 +1176,7 @@ async function removeKeepAlivePid(profileName: string): Promise<void> {
   try {
     await unlink(files.pidPath);
   } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
       return;
     }
     throw error;
@@ -1153,7 +1184,7 @@ async function removeKeepAlivePid(profileName: string): Promise<void> {
 }
 
 async function readKeepAliveState(
-  profileName: string
+  profileName: string,
 ): Promise<KeepAliveState | null> {
   const files = getKeepAliveFiles(profileName);
   return readJsonFile<KeepAliveState>(files.statePath);
@@ -1161,7 +1192,7 @@ async function readKeepAliveState(
 
 async function writeKeepAliveState(
   profileName: string,
-  state: KeepAliveState
+  state: KeepAliveState,
 ): Promise<void> {
   const files = getKeepAliveFiles(profileName);
   await ensureKeepAliveDir(files);
@@ -1170,7 +1201,7 @@ async function writeKeepAliveState(
 
 async function appendKeepAliveEvent(
   profileName: string,
-  event: Record<string, unknown>
+  event: Record<string, unknown>,
 ): Promise<void> {
   const files = getKeepAliveFiles(profileName);
   await ensureKeepAliveDir(files);
@@ -1200,13 +1231,13 @@ function asKeepAliveRecentEvent(value: unknown): KeepAliveRecentEvent | null {
   return {
     ...value,
     ts,
-    event
+    event,
   } as KeepAliveRecentEvent;
 }
 
 async function readKeepAliveRecentEvents(
   profileName: string,
-  limit: number = 5
+  limit: number = 5,
 ): Promise<KeepAliveRecentEvent[]> {
   const files = getKeepAliveFiles(profileName);
 
@@ -1228,11 +1259,7 @@ async function readKeepAliveRecentEvents(
 
     return events;
   } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
       return [];
     }
 
@@ -1247,18 +1274,17 @@ async function readSchedulerPid(profileName: string): Promise<number | null> {
     const pid = Number.parseInt(raw.trim(), 10);
     return Number.isInteger(pid) && pid > 0 ? pid : null;
   } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
       return null;
     }
     throw error;
   }
 }
 
-async function writeSchedulerPid(profileName: string, pid: number): Promise<void> {
+async function writeSchedulerPid(
+  profileName: string,
+  pid: number,
+): Promise<void> {
   const files = getSchedulerFiles(profileName);
   await ensureSchedulerDir(files);
   await writeFile(files.pidPath, `${pid}\n`, "utf8");
@@ -1269,11 +1295,7 @@ async function removeSchedulerPid(profileName: string): Promise<void> {
   try {
     await unlink(files.pidPath);
   } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
       return;
     }
     throw error;
@@ -1281,7 +1303,7 @@ async function removeSchedulerPid(profileName: string): Promise<void> {
 }
 
 async function readSchedulerState(
-  profileName: string
+  profileName: string,
 ): Promise<SchedulerState | null> {
   const files = getSchedulerFiles(profileName);
   return readJsonFile<SchedulerState>(files.statePath);
@@ -1289,7 +1311,7 @@ async function readSchedulerState(
 
 async function writeSchedulerState(
   profileName: string,
-  state: SchedulerState
+  state: SchedulerState,
 ): Promise<void> {
   const files = getSchedulerFiles(profileName);
   await ensureSchedulerDir(files);
@@ -1298,7 +1320,7 @@ async function writeSchedulerState(
 
 async function appendSchedulerEvent(
   profileName: string,
-  event: Record<string, unknown>
+  event: Record<string, unknown>,
 ): Promise<void> {
   const files = getSchedulerFiles(profileName);
   await ensureSchedulerDir(files);
@@ -1337,15 +1359,17 @@ async function sleep(ms: number): Promise<void> {
 
 async function promptYesNo(
   question: string,
-  output: typeof stdout | typeof process.stderr = stdout
+  output: typeof stdout | typeof process.stderr = stdout,
 ): Promise<boolean> {
   const readline = createInterface({
     input: stdin,
-    output
+    output,
   });
 
   try {
-    const response = await readline.question(`${question} Type "yes" to confirm: `);
+    const response = await readline.question(
+      `${question} Type "yes" to confirm: `,
+    );
     return response.trim().toLowerCase() === "yes";
   } finally {
     readline.close();
@@ -1354,11 +1378,11 @@ async function promptYesNo(
 
 async function promptTextInput(
   question: string,
-  output: typeof stdout | typeof process.stderr = process.stderr
+  output: typeof stdout | typeof process.stderr = process.stderr,
 ): Promise<string> {
   const readline = createInterface({
     input: stdin,
-    output
+    output,
   });
 
   try {
@@ -1370,11 +1394,11 @@ async function promptTextInput(
 
 async function promptMultilineInput(
   question: string,
-  output: typeof stdout | typeof process.stderr = process.stderr
+  output: typeof stdout | typeof process.stderr = process.stderr,
 ): Promise<string> {
   const readline = createInterface({
     input: stdin,
-    output
+    output,
   });
 
   try {
@@ -1396,9 +1420,7 @@ async function promptMultilineInput(
   }
 }
 
-function shouldUseAnsiColor(
-  stream: { isTTY?: boolean }
-): boolean {
+function shouldUseAnsiColor(stream: { isTTY?: boolean }): boolean {
   return (
     Boolean(stream.isTTY) &&
     typeof process.env.NO_COLOR === "undefined" &&
@@ -1411,7 +1433,7 @@ function assertInteractiveTerminal(operation: string): void {
   if (!stdin.isTTY || !stdout.isTTY) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      `Refusing to ${operation} in non-interactive mode.`
+      `Refusing to ${operation} in non-interactive mode.`,
     );
   }
 }
@@ -1427,11 +1449,12 @@ function trimOptionalCliText(value: string | undefined): string | undefined {
 
 function readCommandProfileName(command: Command): string | undefined {
   const options = command.opts<Record<string, unknown>>();
-  const profileValue = typeof options.profile === "string"
-    ? options.profile
-    : typeof options.profileName === "string"
-      ? options.profileName
-      : undefined;
+  const profileValue =
+    typeof options.profile === "string"
+      ? options.profile
+      : typeof options.profileName === "string"
+        ? options.profileName
+        : undefined;
 
   return trimOptionalCliText(profileValue);
 }
@@ -1467,8 +1490,10 @@ async function maybeEmitCliFeedbackHint(error?: unknown): Promise<void> {
     const decision = await recordFeedbackInvocation({
       source: "cli",
       invocationName: invocation.commandName,
-      ...(invocation.profileName ? { activeProfileName: invocation.profileName } : {}),
-      ...(typeof error !== "undefined" ? { error } : {})
+      ...(invocation.profileName
+        ? { activeProfileName: invocation.profileName }
+        : {}),
+      ...(typeof error !== "undefined" ? { error } : {}),
     });
 
     if (decision.showHint) {
@@ -1476,7 +1501,7 @@ async function maybeEmitCliFeedbackHint(error?: unknown): Promise<void> {
     }
   } catch (trackingError) {
     writeCliWarning(
-      `Could not update feedback hint state: ${asLinkedInBuddyError(trackingError).message}`
+      `Could not update feedback hint state: ${asLinkedInBuddyError(trackingError).message}`,
     );
   }
 }
@@ -1486,11 +1511,7 @@ async function pathExists(targetPath: string): Promise<boolean> {
     await access(targetPath);
     return true;
   } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
       return false;
     }
 
@@ -1501,7 +1522,7 @@ async function pathExists(targetPath: string): Promise<boolean> {
 function pluralize(
   count: number,
   singular: string,
-  plural: string = `${singular}s`
+  plural: string = `${singular}s`,
 ): string {
   return count === 1 ? singular : plural;
 }
@@ -1510,7 +1531,7 @@ function resolveLocalDataDeleteLabel(
   targetPath: string,
   paths: ReturnType<typeof resolveConfigPaths>,
   keepAliveDir: string,
-  legacyRateLimitStatePath: string
+  legacyRateLimitStatePath: string,
 ): string {
   if (targetPath === path.resolve(paths.dbPath)) {
     return "SQLite database";
@@ -1552,13 +1573,13 @@ function resolveLocalDataDeleteLabel(
 }
 
 async function createLocalDataDeletionPreview(
-  includeProfile: boolean
+  includeProfile: boolean,
 ): Promise<LocalDataDeletionPreview> {
   const deletionPlan = createLocalDataDeletionPlan({ includeProfile });
   const resolvedPaths = resolveConfigPaths(deletionPlan.baseDir);
   const keepAliveDir = resolveKeepAliveDir(deletionPlan.baseDir);
   const legacyRateLimitStatePath = path.resolve(
-    resolveLegacyRateLimitStateFilePath()
+    resolveLegacyRateLimitStateFilePath(),
   );
 
   const deleteItems = await Promise.all(
@@ -1568,15 +1589,15 @@ async function createLocalDataDeletionPreview(
         targetPath,
         resolvedPaths,
         keepAliveDir,
-        legacyRateLimitStatePath
+        legacyRateLimitStatePath,
       ),
       ...(targetPath === path.resolve(resolvedPaths.profilesDir)
         ? {
-            note: "Deletes tool-owned cookies, local storage, and saved browser sessions."
+            note: "Deletes tool-owned cookies, local storage, and saved browser sessions.",
           }
         : {}),
-      path: targetPath
-    }))
+      path: targetPath,
+    })),
   );
 
   const preserveItems = await Promise.all(
@@ -1586,19 +1607,19 @@ async function createLocalDataDeletionPreview(
             {
               label: "Browser profiles",
               note: "Preserved unless you rerun with --include-profile.",
-              path: path.resolve(resolvedPaths.profilesDir)
-            }
+              path: path.resolve(resolvedPaths.profilesDir),
+            },
           ]
         : []),
       {
         label: "Config file",
         note: "Preserved by design. Delete manually only if you want a full local reset.",
-        path: path.resolve(path.join(deletionPlan.baseDir, "config.json"))
-      }
+        path: path.resolve(path.join(deletionPlan.baseDir, "config.json")),
+      },
     ].map(async (item) => ({
       ...item,
-      exists: await pathExists(item.path)
-    }))
+      exists: await pathExists(item.path),
+    })),
   );
 
   return {
@@ -1611,13 +1632,13 @@ async function createLocalDataDeletionPreview(
     missingDeletePaths: deleteItems
       .filter((item) => !item.exists)
       .map((item) => item.path),
-    preserveItems
+    preserveItems,
   };
 }
 
 function printLocalDataPreviewSection(
   title: string,
-  items: LocalDataPreviewItem[]
+  items: LocalDataPreviewItem[],
 ): void {
   if (items.length === 0) {
     return;
@@ -1627,19 +1648,21 @@ function printLocalDataPreviewSection(
   for (const item of items) {
     const note = item.note ? ` — ${item.note}` : "";
     console.log(
-      `- ${item.label}: ${item.path} (${item.exists ? "present" : "already absent"})${note}`
+      `- ${item.label}: ${item.path} (${item.exists ? "present" : "already absent"})${note}`,
     );
   }
 }
 
 function printLocalDataDeletionPreview(
   preview: LocalDataDeletionPreview,
-  destructiveMode: boolean
+  destructiveMode: boolean,
 ): void {
   if (destructiveMode) {
     console.log("Local data deletion requested.");
   } else {
-    console.log("Local data deletion preview (dry-run). No files were removed.");
+    console.log(
+      "Local data deletion preview (dry-run). No files were removed.",
+    );
   }
 
   console.log(`Assistant home: ${preview.baseDir}`);
@@ -1647,34 +1670,36 @@ function printLocalDataDeletionPreview(
   printLocalDataPreviewSection("Preserved paths:", preview.preserveItems);
 
   if (preview.existingDeletePaths.length === 0) {
-    console.log("Nothing to delete. Tool-owned runtime state is already absent.");
+    console.log(
+      "Nothing to delete. Tool-owned runtime state is already absent.",
+    );
     return;
   }
 
   if (!destructiveMode) {
     console.log(
-      `Rerun with --confirm to permanently delete ${preview.existingDeletePaths.length} existing ${pluralize(preview.existingDeletePaths.length, "path")}.`
+      `Rerun with --confirm to permanently delete ${preview.existingDeletePaths.length} existing ${pluralize(preview.existingDeletePaths.length, "path")}.`,
     );
     if (preview.includeProfileRequested) {
       console.log(
-        "Browser profiles are included in this preview and still require a second confirmation during deletion."
+        "Browser profiles are included in this preview and still require a second confirmation during deletion.",
       );
     }
     return;
   }
 
   console.log(
-    `Ready to delete ${preview.existingDeletePaths.length} existing ${pluralize(preview.existingDeletePaths.length, "path")} after confirmation.`
+    `Ready to delete ${preview.existingDeletePaths.length} existing ${pluralize(preview.existingDeletePaths.length, "path")} after confirmation.`,
   );
   if (preview.includeProfileRequested) {
     console.log(
-      "Deleting browser profiles requires a second confirmation because signed-in browser state will be lost."
+      "Deleting browser profiles requires a second confirmation because signed-in browser state will be lost.",
     );
   }
 }
 
 function isLocalDataDeletionFailure(
-  value: unknown
+  value: unknown,
 ): value is LocalDataDeletionFailure {
   if (!value || typeof value !== "object") {
     return false;
@@ -1691,7 +1716,7 @@ function isLocalDataDeletionFailure(
 }
 
 function extractLocalDataDeletionFailures(
-  value: unknown
+  value: unknown,
 ): LocalDataDeletionFailure[] {
   if (!Array.isArray(value)) {
     return [];
@@ -1704,10 +1729,10 @@ function formatLocalDataDeletionError(error: unknown): LinkedInBuddyError {
   const assistantError = asLinkedInBuddyError(
     error,
     "UNKNOWN",
-    "Local data deletion failed."
+    "Local data deletion failed.",
   );
   const failedPaths = extractLocalDataDeletionFailures(
-    assistantError.details.failed_paths
+    assistantError.details.failed_paths,
   );
   if (failedPaths.length === 0) {
     return assistantError;
@@ -1726,12 +1751,14 @@ function formatLocalDataDeletionError(error: unknown): LinkedInBuddyError {
     assistantError.code,
     `Local data deletion completed with ${failedPaths.length} ${pluralize(failedPaths.length, "failure")}. ${deletedSummary} First blocked path: ${firstFailure.path}. ${firstFailure.recoveryHint ?? "Review failed_paths for recovery guidance and retry."}`,
     assistantError.details,
-    { cause: assistantError }
+    { cause: assistantError },
   );
 }
 
 function printLocalDataDeletionFailure(error: LinkedInBuddyError): void {
-  const failedPaths = extractLocalDataDeletionFailures(error.details.failed_paths);
+  const failedPaths = extractLocalDataDeletionFailures(
+    error.details.failed_paths,
+  );
   if (failedPaths.length === 0) {
     return;
   }
@@ -1739,14 +1766,14 @@ function printLocalDataDeletionFailure(error: LinkedInBuddyError): void {
   console.error("Local data deletion could not finish cleanly.");
   for (const failure of failedPaths.slice(0, 3)) {
     console.error(
-      `- ${failure.path}: ${failure.message}${failure.recoveryHint ? ` ${failure.recoveryHint}` : ""}`
+      `- ${failure.path}: ${failure.message}${failure.recoveryHint ? ` ${failure.recoveryHint}` : ""}`,
     );
   }
 
   if (failedPaths.length > 3) {
     const remainingFailures = failedPaths.length - 3;
     console.error(
-      `- ${remainingFailures} more ${pluralize(remainingFailures, "failure")} not shown. Inspect failed_paths in the JSON error output for the full list.`
+      `- ${remainingFailures} more ${pluralize(remainingFailures, "failure")} not shown. Inspect failed_paths in the JSON error output for the full list.`,
     );
   }
 }
@@ -1759,11 +1786,11 @@ function printLocalDataDeletionSummary(input: {
 }): void {
   console.log("Local data deletion completed.");
   console.log(
-    `- Removed ${input.deletedCount} ${pluralize(input.deletedCount, "path")}.`
+    `- Removed ${input.deletedCount} ${pluralize(input.deletedCount, "path")}.`,
   );
   if (input.missingCount > 0) {
     console.log(
-      `- Skipped ${input.missingCount} already-absent ${pluralize(input.missingCount, "path")}.`
+      `- Skipped ${input.missingCount} already-absent ${pluralize(input.missingCount, "path")}.`,
     );
   }
   if (input.includeProfileRequested && !input.includeProfileDeleted) {
@@ -1779,11 +1806,7 @@ async function findRunningKeepAlivePids(): Promise<number[]> {
   try {
     entries = await readdir(keepAliveDir, { withFileTypes: true });
   } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
       return [];
     }
 
@@ -1829,7 +1852,7 @@ function assertCdpUrlUnsupportedForDataDelete(cdpUrl?: string): void {
 
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    "The data delete command only deletes tool-owned local filesystem state and does not support --cdp-url."
+    "The data delete command only deletes tool-owned local filesystem state and does not support --cdp-url.",
   );
 }
 
@@ -1843,8 +1866,8 @@ async function assertNoRunningKeepAliveDaemons(): Promise<void> {
     "ACTION_PRECONDITION_FAILED",
     `Stop running keepalive daemons before deleting local data. Active PID${runningKeepAlivePids.length === 1 ? "" : "s"}: ${runningKeepAlivePids.join(", ")}.`,
     {
-      running_keepalive_pids: runningKeepAlivePids
-    }
+      running_keepalive_pids: runningKeepAlivePids,
+    },
   );
 }
 
@@ -1867,7 +1890,7 @@ async function runDataDelete(input: {
       missing_paths: preview.missingDeletePaths,
       nothing_to_delete: preview.existingDeletePaths.length === 0,
       preserved_paths: preview.preserveItems.map((item) => item.path),
-      would_delete_paths: preview.deleteItems.map((item) => item.path)
+      would_delete_paths: preview.deleteItems.map((item) => item.path),
     });
     return;
   }
@@ -1881,7 +1904,7 @@ async function runDataDelete(input: {
       include_profile_requested: input.includeProfile,
       missing_paths: preview.missingDeletePaths,
       nothing_to_delete: true,
-      preserved_paths: preview.preserveItems.map((item) => item.path)
+      preserved_paths: preview.preserveItems.map((item) => item.path),
     });
     return;
   }
@@ -1900,25 +1923,29 @@ async function runDataDelete(input: {
       include_profile_deleted: false,
       include_profile_requested: input.includeProfile,
       preserved_paths: preview.preserveItems.map((item) => item.path),
-      would_delete_paths: preview.existingDeletePaths
+      would_delete_paths: preview.existingDeletePaths,
     });
     return;
   }
 
   const profileItem = preview.deleteItems.find(
-    (item) => item.label === "Browser profiles"
+    (item) => item.label === "Browser profiles",
   );
   let includeProfile = false;
   if (input.includeProfile && profileItem?.exists) {
     includeProfile = await promptYesNo(
-      `Delete browser profile data at ${profileItem.path}? This removes saved sessions and cookies.`
+      `Delete browser profile data at ${profileItem.path}? This removes saved sessions and cookies.`,
     );
 
     if (!includeProfile) {
-      console.log("Browser profile deletion declined. Profiles will be preserved.");
+      console.log(
+        "Browser profile deletion declined. Profiles will be preserved.",
+      );
     }
   } else if (input.includeProfile) {
-    console.log("Browser profiles are already absent. Skipping the extra profile confirmation.");
+    console.log(
+      "Browser profiles are already absent. Skipping the extra profile confirmation.",
+    );
   }
 
   try {
@@ -1927,7 +1954,7 @@ async function runDataDelete(input: {
       deletedCount: deletionResult.deletedPaths.length,
       includeProfileDeleted: includeProfile,
       includeProfileRequested: input.includeProfile,
-      missingCount: deletionResult.missingPaths.length
+      missingCount: deletionResult.missingPaths.length,
     });
 
     printJson({
@@ -1940,7 +1967,7 @@ async function runDataDelete(input: {
       started_at: deletionResult.startedAt,
       completed_at: deletionResult.completedAt,
       deleted_paths: deletionResult.deletedPaths,
-      failed_paths: deletionResult.failedPaths
+      failed_paths: deletionResult.failedPaths,
     });
   } catch (error) {
     const formattedError = formatLocalDataDeletionError(error);
@@ -1959,7 +1986,7 @@ async function runStatus(profileName: string, cdpUrl?: string): Promise<void> {
       profileName,
       authenticated: status.authenticated,
       evasion_level: status.evasion?.level,
-      evasion_diagnostics_enabled: status.evasion?.diagnosticsEnabled ?? false
+      evasion_diagnostics_enabled: status.evasion?.diagnosticsEnabled ?? false,
     });
     printJson({ run_id: runtime.runId, profile_name: profileName, ...status });
   } finally {
@@ -1970,7 +1997,7 @@ async function runStatus(profileName: string, cdpUrl?: string): Promise<void> {
 function buildFeedbackJsonResult(
   result:
     | Awaited<ReturnType<typeof submitFeedback>>
-    | Awaited<ReturnType<typeof submitPendingFeedback>>
+    | Awaited<ReturnType<typeof submitPendingFeedback>>,
 ): Record<string, unknown> {
   if ("submittedCount" in result) {
     return {
@@ -1981,12 +2008,12 @@ function buildFeedbackJsonResult(
         file_path: formatFeedbackDisplayPath(item.filePath),
         title: item.title,
         type: item.type,
-        url: item.url
+        url: item.url,
       })),
       failures: result.failures.map((item) => ({
         file_path: formatFeedbackDisplayPath(item.filePath),
-        error: item.error
-      }))
+        error: item.error,
+      })),
     };
   }
 
@@ -2000,9 +2027,9 @@ function buildFeedbackJsonResult(
     ...(result.url ? { url: result.url } : {}),
     ...(result.pendingFilePath
       ? {
-          pending_file_path: formatFeedbackDisplayPath(result.pendingFilePath)
+          pending_file_path: formatFeedbackDisplayPath(result.pendingFilePath),
         }
-      : {})
+      : {}),
   };
 }
 
@@ -2010,7 +2037,7 @@ function printFeedbackResult(
   result:
     | Awaited<ReturnType<typeof submitFeedback>>
     | Awaited<ReturnType<typeof submitPendingFeedback>>,
-  json: boolean
+  json: boolean,
 ): void {
   if (json) {
     printJson(buildFeedbackJsonResult(result));
@@ -2024,22 +2051,22 @@ function printFeedbackResult(
     }
 
     const lines = [
-      `Submitted ${result.submittedCount} pending feedback file(s) to ${result.repository}.`
+      `Submitted ${result.submittedCount} pending feedback file(s) to ${result.repository}.`,
     ];
 
     for (const item of result.submitted) {
       lines.push(
-        `- ${formatFeedbackDisplayPath(item.filePath)} -> ${item.url}`
+        `- ${formatFeedbackDisplayPath(item.filePath)} -> ${item.url}`,
       );
     }
 
     if (result.failureCount > 0) {
       lines.push(
-        `${result.failureCount} pending feedback file(s) could not be submitted.`
+        `${result.failureCount} pending feedback file(s) could not be submitted.`,
       );
       for (const item of result.failures) {
         lines.push(
-          `- ${formatFeedbackDisplayPath(item.filePath)}: ${item.error}`
+          `- ${formatFeedbackDisplayPath(item.filePath)}: ${item.error}`,
         );
       }
     }
@@ -2056,8 +2083,8 @@ function printFeedbackResult(
   console.log(
     [
       `Feedback saved locally: ${formatFeedbackDisplayPath(result.pendingFilePath ?? "")}`,
-      "To submit: run `gh auth login` then `linkedin-buddy feedback --submit-pending`"
-    ].join("\n")
+      "To submit: run `gh auth login` then `linkedin-buddy feedback --submit-pending`",
+    ].join("\n"),
   );
 }
 
@@ -2067,15 +2094,13 @@ async function promptForFeedbackType(): Promise<FeedbackType> {
   while (true) {
     const value = await promptTextInput(
       `Feedback type (${FEEDBACK_TYPES.join("/")})`,
-      process.stderr
+      process.stderr,
     );
 
     try {
       return normalizeFeedbackInputType(value);
     } catch {
-      writeCliWarning(
-        `Please enter one of: ${FEEDBACK_TYPES.join(", ")}.`
-      );
+      writeCliWarning(`Please enter one of: ${FEEDBACK_TYPES.join(", ")}.`);
     }
   }
 }
@@ -2083,7 +2108,7 @@ async function promptForFeedbackType(): Promise<FeedbackType> {
 async function promptForRequiredFeedbackText(
   label: string,
   question: string,
-  multiline: boolean = false
+  multiline: boolean = false,
 ): Promise<string> {
   assertInteractiveTerminal("collect feedback interactively");
 
@@ -2126,7 +2151,7 @@ async function runFeedbackCommand(input: {
     (await promptForRequiredFeedbackText(
       "description",
       "Detailed explanation.",
-      true
+      true,
     ));
 
   const result = await submitFeedback({
@@ -2136,21 +2161,23 @@ async function runFeedbackCommand(input: {
     technicalContext: createFeedbackTechnicalContext({
       cliVersion: packageJson.version,
       snapshot,
-      source: "cli"
-    })
+      source: "cli",
+    }),
   });
 
   printFeedbackResult(result, input.json);
 }
 
-function assertNoExternalSessionOverrideForStoredSession(cdpUrl?: string): void {
+function assertNoExternalSessionOverrideForStoredSession(
+  cdpUrl?: string,
+): void {
   if (!cdpUrl) {
     return;
   }
 
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    "Stored-session auth and read-only live validation do not support --cdp-url. Omit --cdp-url to use the encrypted stored session flow."
+    "Stored-session auth and read-only live validation do not support --cdp-url. Omit --cdp-url to use the encrypted stored session flow.",
   );
 }
 
@@ -2159,25 +2186,28 @@ async function captureStoredSession(input: {
   timeoutMinutes: number;
 }): Promise<Awaited<ReturnType<typeof captureLinkedInSession>>> {
   writeCliNotice(
-    `Opening a dedicated Chromium window to capture session "${input.sessionName}".`
+    `Opening a dedicated Chromium window to capture session "${input.sessionName}".`,
   );
   writeCliNotice(
-    "Sign in manually. The browser closes automatically after the authenticated session is stored."
+    "Sign in manually. The browser closes automatically after the authenticated session is stored.",
   );
   writeCliNotice(
-    "Leave the LinkedIn window open after sign-in until the CLI confirms the session was captured. Press Ctrl+C if you need to cancel."
+    "Leave the LinkedIn window open after sign-in until the CLI confirms the session was captured. Press Ctrl+C if you need to cancel.",
   );
 
   return captureLinkedInSession({
     sessionName: input.sessionName,
-    timeoutMs: input.timeoutMinutes * 60_000
+    timeoutMs: input.timeoutMinutes * 60_000,
   });
 }
 
-async function runAuthSessionCapture(input: {
-  sessionName: string;
-  timeoutMinutes: number;
-}, cdpUrl?: string): Promise<void> {
+async function runAuthSessionCapture(
+  input: {
+    sessionName: string;
+    timeoutMinutes: number;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   assertNoExternalSessionOverrideForStoredSession(cdpUrl);
   assertInteractiveTerminal("capture a stored LinkedIn session");
 
@@ -2189,7 +2219,7 @@ async function runAuthSessionCapture(input: {
     current_url: result.currentUrl,
     li_at_expires_at: result.liAtCookieExpiresAt,
     session_file: result.filePath,
-    session_name: result.sessionName
+    session_name: result.sessionName,
   });
 }
 
@@ -2207,9 +2237,14 @@ async function maybeRefreshStoredSession(
     yes: boolean;
   },
   error: unknown,
-  promptOutput: typeof stdout | typeof process.stderr
+  promptOutput: typeof stdout | typeof process.stderr,
 ): Promise<boolean> {
-  if (input.yes || !stdin.isTTY || !stdout.isTTY || !isStoredSessionRefreshError(error)) {
+  if (
+    input.yes ||
+    !stdin.isTTY ||
+    !stdout.isTTY ||
+    !isStoredSessionRefreshError(error)
+  ) {
     return false;
   }
 
@@ -2217,11 +2252,11 @@ async function maybeRefreshStoredSession(
   writeCliNotice(
     errorPayload.code === "CAPTCHA_OR_CHALLENGE"
       ? "LinkedIn requested extra verification before the validation could continue."
-      : `Stored session "${input.sessionName}" needs to be refreshed before the validation can continue.`
+      : `Stored session "${input.sessionName}" needs to be refreshed before the validation can continue.`,
   );
   const confirmed = await promptYesNo(
     `Capture a fresh stored session named "${input.sessionName}" now?`,
-    promptOutput
+    promptOutput,
   );
   if (!confirmed) {
     return false;
@@ -2229,26 +2264,29 @@ async function maybeRefreshStoredSession(
 
   await captureStoredSession({
     sessionName: input.sessionName,
-    timeoutMinutes: input.timeoutMinutes
+    timeoutMinutes: input.timeoutMinutes,
   });
   return true;
 }
 
 function createReadOnlyValidationPrompter(
   sessionName: string,
-  promptOutput: typeof stdout | typeof process.stderr
+  promptOutput: typeof stdout | typeof process.stderr,
 ): (operation: LinkedInReadOnlyValidationOperation) => Promise<void> {
   return async (operation) => {
     promptOutput.write(`Read-only step: ${operation.summary}\n`);
-    const confirmed = await promptYesNo("Continue with this step?", promptOutput);
+    const confirmed = await promptYesNo(
+      "Continue with this step?",
+      promptOutput,
+    );
     if (!confirmed) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
         "Read-only live validation was cancelled by the operator.",
         {
           operation: operation.id,
-          session_name: sessionName
-        }
+          session_name: sessionName,
+        },
       );
     }
   };
@@ -2256,7 +2294,7 @@ function createReadOnlyValidationPrompter(
 
 function emitReadOnlyValidationResult(
   report: ReadOnlyValidationReport,
-  outputMode: ReadOnlyValidationOutputMode
+  outputMode: ReadOnlyValidationOutputMode,
 ): void {
   if (outputMode === "json") {
     printJson(report);
@@ -2264,12 +2302,12 @@ function emitReadOnlyValidationResult(
     const redactedReport = redactStructuredValue(
       report,
       cliPrivacyConfig,
-      "cli"
+      "cli",
     ) as typeof report;
     console.log(
       formatReadOnlyValidationReport(redactedReport, {
-        color: shouldUseAnsiColor(stdout)
-      })
+        color: shouldUseAnsiColor(stdout),
+      }),
     );
   }
 
@@ -2280,7 +2318,7 @@ function emitReadOnlyValidationResult(
 
 function emitReadOnlyValidationFailure(
   error: unknown,
-  outputMode: ReadOnlyValidationOutputMode
+  outputMode: ReadOnlyValidationOutputMode,
 ): void {
   process.exitCode = LIVE_VALIDATION_ERROR_EXIT_CODE;
 
@@ -2292,8 +2330,8 @@ function emitReadOnlyValidationFailure(
   process.stderr.write(
     `${formatReadOnlyValidationError(errorPayload, {
       color: shouldUseAnsiColor(process.stderr),
-      helpCommand: LIVE_VALIDATION_HELP_COMMAND
-    })}\n`
+      helpCommand: LIVE_VALIDATION_HELP_COMMAND,
+    })}\n`,
   );
 }
 
@@ -2307,34 +2345,37 @@ function validateReadOnlyValidationCliInput(input: {
       "retry-max-delay-ms must be greater than or equal to retry-base-delay-ms.",
       {
         retry_base_delay_ms: input.retryBaseDelayMs,
-        retry_max_delay_ms: input.retryMaxDelayMs
-      }
+        retry_max_delay_ms: input.retryMaxDelayMs,
+      },
     );
   }
 }
 
-async function runLiveReadOnlyValidation(input: {
-  json: boolean;
-  maxRequests: number;
-  maxRetries: number;
-  minIntervalMs: number;
-  progress: boolean;
-  readOnly: boolean;
-  retryBaseDelayMs: number;
-  retryMaxDelayMs: number;
-  sessionName: string;
-  timeoutSeconds: number;
-  yes: boolean;
-}, cdpUrl?: string): Promise<void> {
+async function runLiveReadOnlyValidation(
+  input: {
+    json: boolean;
+    maxRequests: number;
+    maxRetries: number;
+    minIntervalMs: number;
+    progress: boolean;
+    readOnly: boolean;
+    retryBaseDelayMs: number;
+    retryMaxDelayMs: number;
+    sessionName: string;
+    timeoutSeconds: number;
+    yes: boolean;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const outputMode = resolveReadOnlyValidationOutputMode(
     { json: input.json },
-    Boolean(stdout.isTTY)
+    Boolean(stdout.isTTY),
   );
   const promptOutput = outputMode === "json" ? process.stderr : stdout;
   const progressEnabled =
     outputMode === "human" && input.progress && Boolean(process.stderr.isTTY);
   const progressReporter = new ReadOnlyValidationProgressReporter({
-    enabled: progressEnabled
+    enabled: progressEnabled,
   });
 
   try {
@@ -2344,12 +2385,14 @@ async function runLiveReadOnlyValidation(input: {
     if (!input.readOnly) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        'Live validation is currently restricted to read-only mode. Rerun the command with "--read-only".'
+        'Live validation is currently restricted to read-only mode. Rerun the command with "--read-only".',
       );
     }
 
     if (!input.yes) {
-      assertInteractiveTerminal("run interactive live validation without --yes");
+      assertInteractiveTerminal(
+        "run interactive live validation without --yes",
+      );
     }
 
     const runValidation = async () => {
@@ -2365,14 +2408,14 @@ async function runLiveReadOnlyValidation(input: {
           ? {
               onLog: (entry) => {
                 progressReporter.handleLog(entry);
-              }
+              },
             }
           : {}),
         sessionName: input.sessionName,
         ...(onBeforeOperation ? { onBeforeOperation } : {}),
         retryBaseDelayMs: input.retryBaseDelayMs,
         retryMaxDelayMs: input.retryMaxDelayMs,
-        timeoutMs: input.timeoutSeconds * 1_000
+        timeoutMs: input.timeoutSeconds * 1_000,
       });
     };
 
@@ -2384,10 +2427,10 @@ async function runLiveReadOnlyValidation(input: {
         {
           sessionName: input.sessionName,
           timeoutMinutes: Math.max(1, Math.ceil(input.timeoutSeconds / 60)),
-          yes: input.yes
+          yes: input.yes,
         },
         error,
-        promptOutput
+        promptOutput,
       );
 
       if (refreshed) {
@@ -2411,7 +2454,7 @@ async function runRateLimitStatus(clear: boolean): Promise<void> {
   if (clear) {
     await clearRateLimitState();
     printJson({
-      cleared: true
+      cleared: true,
     });
     return;
   }
@@ -2428,7 +2471,7 @@ interface KeepAliveCliOutputOptions {
 
 function emitKeepAliveStartReport(
   report: KeepAliveStartReport,
-  options: KeepAliveCliOutputOptions
+  options: KeepAliveCliOutputOptions,
 ): void {
   if (options.outputMode === "json") {
     printJson(report);
@@ -2437,18 +2480,22 @@ function emitKeepAliveStartReport(
 
   console.log(
     formatKeepAliveStartReport(
-      redactStructuredValue(report, cliPrivacyConfig, "cli") as KeepAliveStartReport,
+      redactStructuredValue(
+        report,
+        cliPrivacyConfig,
+        "cli",
+      ) as KeepAliveStartReport,
       {
         quiet: options.quiet,
-        verbose: options.verbose
-      }
-    )
+        verbose: options.verbose,
+      },
+    ),
   );
 }
 
 function emitKeepAliveStatusReport(
   report: KeepAliveStatusReport,
-  options: KeepAliveCliOutputOptions
+  options: KeepAliveCliOutputOptions,
 ): void {
   if (options.outputMode === "json") {
     printJson(report);
@@ -2457,18 +2504,22 @@ function emitKeepAliveStatusReport(
 
   console.log(
     formatKeepAliveStatusReport(
-      redactStructuredValue(report, cliPrivacyConfig, "cli") as KeepAliveStatusReport,
+      redactStructuredValue(
+        report,
+        cliPrivacyConfig,
+        "cli",
+      ) as KeepAliveStatusReport,
       {
         quiet: options.quiet,
-        verbose: options.verbose
-      }
-    )
+        verbose: options.verbose,
+      },
+    ),
   );
 }
 
 function emitKeepAliveStopReport(
   report: KeepAliveStopReport,
-  options: KeepAliveCliOutputOptions
+  options: KeepAliveCliOutputOptions,
 ): void {
   if (options.outputMode === "json") {
     printJson(report);
@@ -2477,19 +2528,23 @@ function emitKeepAliveStopReport(
 
   console.log(
     formatKeepAliveStopReport(
-      redactStructuredValue(report, cliPrivacyConfig, "cli") as KeepAliveStopReport,
+      redactStructuredValue(
+        report,
+        cliPrivacyConfig,
+        "cli",
+      ) as KeepAliveStopReport,
       {
         quiet: options.quiet,
-        verbose: options.verbose
-      }
-    )
+        verbose: options.verbose,
+      },
+    ),
   );
 }
 
 function writeKeepAliveProgressNotice(
   outputMode: KeepAliveOutputMode,
   quiet: boolean,
-  message: string
+  message: string,
 ): void {
   if (outputMode === "human" && !quiet) {
     writeCliNotice(message);
@@ -2497,8 +2552,12 @@ function writeKeepAliveProgressNotice(
 }
 
 function warnAboutExternalCdpDaemonSession(): void {
-  writeCliWarning("--cdp-url attaches this daemon to an existing browser session.");
-  writeCliNotice("The daemon will share cookies and session state with that browser until you stop it.");
+  writeCliWarning(
+    "--cdp-url attaches this daemon to an existing browser session.",
+  );
+  writeCliNotice(
+    "The daemon will share cookies and session state with that browser until you stop it.",
+  );
   writeCliNotice("For an isolated tool-owned profile, omit --cdp-url.");
 }
 
@@ -2509,19 +2568,19 @@ function assertKeepAliveVerbosityOptions(input: {
   if (input.quiet && input.verbose) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      'Choose either "--quiet" or "--verbose", not both.'
+      'Choose either "--quiet" or "--verbose", not both.',
     );
   }
 }
 
 async function runKeepAliveCliAction(
   input: { json?: boolean; quiet?: boolean; verbose?: boolean },
-  action: (options: KeepAliveCliOutputOptions) => Promise<void>
+  action: (options: KeepAliveCliOutputOptions) => Promise<void>,
 ): Promise<void> {
   const options: KeepAliveCliOutputOptions = {
     outputMode: resolveKeepAliveOutputMode(input, Boolean(stdout.isTTY)),
     quiet: Boolean(input.quiet),
-    verbose: Boolean(input.verbose)
+    verbose: Boolean(input.verbose),
   };
 
   try {
@@ -2533,16 +2592,19 @@ async function runKeepAliveCliAction(
     }
 
     process.stderr.write(
-      `${formatKeepAliveError(toLinkedInBuddyErrorPayload(error, cliPrivacyConfig), {
-        quiet: options.quiet
-      })}\n`
+      `${formatKeepAliveError(
+        toLinkedInBuddyErrorPayload(error, cliPrivacyConfig),
+        {
+          quiet: options.quiet,
+        },
+      )}\n`,
     );
     process.exitCode = 1;
   }
 }
 
 async function buildKeepAliveStatusReport(
-  profileName: string
+  profileName: string,
 ): Promise<KeepAliveStatusReport> {
   const normalizedProfileName = coerceProfileName(profileName);
   const pid = await readKeepAlivePid(normalizedProfileName);
@@ -2558,34 +2620,43 @@ async function buildKeepAliveStatusReport(
     stale_pid_file: Boolean(pid && !running),
     state_path: files.statePath,
     log_path: files.logPath,
-    recent_events: await readKeepAliveRecentEvents(normalizedProfileName)
+    recent_events: await readKeepAliveRecentEvents(normalizedProfileName),
   };
 }
 
-async function runKeepAliveStart(input: {
-  profileName: string;
-  intervalSeconds: number;
-  jitterSeconds: number;
-  maxConsecutiveFailures: number;
-}, options: KeepAliveCliOutputOptions, cdpUrl?: string): Promise<void> {
+async function runKeepAliveStart(
+  input: {
+    profileName: string;
+    intervalSeconds: number;
+    jitterSeconds: number;
+    maxConsecutiveFailures: number;
+  },
+  options: KeepAliveCliOutputOptions,
+  cdpUrl?: string,
+): Promise<void> {
   const profileName = coerceProfileName(input.profileName);
   const files = getKeepAliveFiles(profileName);
   const existingPid = await readKeepAlivePid(profileName);
   if (existingPid && isProcessRunning(existingPid)) {
     const currentState = await readKeepAliveState(profileName);
-    emitKeepAliveStartReport({
-      started: false,
-      reason: "Keepalive daemon is already running for this profile.",
-      profile_name: profileName,
-      pid: existingPid,
-      state: currentState,
-      state_path: files.statePath,
-      log_path: files.logPath
-    }, options);
+    emitKeepAliveStartReport(
+      {
+        started: false,
+        reason: "Keepalive daemon is already running for this profile.",
+        profile_name: profileName,
+        pid: existingPid,
+        state: currentState,
+        state_path: files.statePath,
+        log_path: files.logPath,
+      },
+      options,
+    );
     return;
   }
 
-  const recoveredStalePid = Boolean(existingPid && !isProcessRunning(existingPid));
+  const recoveredStalePid = Boolean(
+    existingPid && !isProcessRunning(existingPid),
+  );
   if (existingPid && !isProcessRunning(existingPid)) {
     await removeKeepAlivePid(profileName);
   }
@@ -2597,14 +2668,14 @@ async function runKeepAliveStart(input: {
   writeKeepAliveProgressNotice(
     options.outputMode,
     options.quiet,
-    `Starting keepalive daemon for profile ${profileName}.`
+    `Starting keepalive daemon for profile ${profileName}.`,
   );
 
   const cliEntrypoint = resolveKeepAliveCliEntrypoint();
   if (!cliEntrypoint) {
     throw new LinkedInBuddyError(
       "UNKNOWN",
-      "Could not resolve CLI entrypoint for keepalive daemon startup."
+      "Could not resolve CLI entrypoint for keepalive daemon startup.",
     );
   }
 
@@ -2625,20 +2696,20 @@ async function runKeepAliveStart(input: {
     "--jitter-seconds",
     String(input.jitterSeconds),
     "--max-consecutive-failures",
-    String(input.maxConsecutiveFailures)
+    String(input.maxConsecutiveFailures),
   );
 
   const daemon = spawn(process.execPath, daemonArgs, {
     detached: true,
     stdio: "ignore",
-    env: process.env
+    env: process.env,
   });
   daemon.unref();
 
   if (!daemon.pid) {
     throw new LinkedInBuddyError(
       "UNKNOWN",
-      "Keepalive daemon did not return a process id."
+      "Keepalive daemon did not return a process id.",
     );
   }
 
@@ -2654,7 +2725,7 @@ async function runKeepAliveStart(input: {
     maxConsecutiveFailures: input.maxConsecutiveFailures,
     consecutiveFailures: 0,
     healthCheckInProgress: false,
-    ...(cdpUrl ? { cdpUrl } : {})
+    ...(cdpUrl ? { cdpUrl } : {}),
   };
 
   await writeKeepAlivePid(profileName, daemon.pid);
@@ -2663,18 +2734,21 @@ async function runKeepAliveStart(input: {
   writeKeepAliveProgressNotice(
     options.outputMode,
     options.quiet,
-    "The first session health check will continue in the background; use `linkedin keepalive status` to inspect it."
+    "The first session health check will continue in the background; use `linkedin keepalive status` to inspect it.",
   );
 
-  emitKeepAliveStartReport({
-    started: true,
-    profile_name: profileName,
-    pid: daemon.pid,
-    state: initialState,
-    state_path: files.statePath,
-    log_path: files.logPath,
-    ...(recoveredStalePid ? { recovered_stale_pid: true } : {})
-  }, options);
+  emitKeepAliveStartReport(
+    {
+      started: true,
+      profile_name: profileName,
+      pid: daemon.pid,
+      state: initialState,
+      state_path: files.statePath,
+      log_path: files.logPath,
+      ...(recoveredStalePid ? { recovered_stale_pid: true } : {}),
+    },
+    options,
+  );
 }
 
 function resolveKeepAliveCliEntrypoint(): string | undefined {
@@ -2685,7 +2759,7 @@ function resolveKeepAliveCliEntrypoint(): string | undefined {
 
   const compiledEntrypoint = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
-    "../../dist/bin/linkedin.js"
+    "../../dist/bin/linkedin.js",
   );
   if (existsSync(compiledEntrypoint)) {
     return compiledEntrypoint;
@@ -2696,14 +2770,17 @@ function resolveKeepAliveCliEntrypoint(): string | undefined {
 
 async function runKeepAliveStatus(
   profileName: string,
-  options: KeepAliveCliOutputOptions
+  options: KeepAliveCliOutputOptions,
 ): Promise<void> {
-  emitKeepAliveStatusReport(await buildKeepAliveStatusReport(profileName), options);
+  emitKeepAliveStatusReport(
+    await buildKeepAliveStatusReport(profileName),
+    options,
+  );
 }
 
 async function runKeepAliveStop(
   profileName: string,
-  options: KeepAliveCliOutputOptions
+  options: KeepAliveCliOutputOptions,
 ): Promise<void> {
   const normalizedProfileName = coerceProfileName(profileName);
   const files = getKeepAliveFiles(normalizedProfileName);
@@ -2711,14 +2788,17 @@ async function runKeepAliveStop(
   const previousState = await readKeepAliveState(normalizedProfileName);
 
   if (!pid) {
-    emitKeepAliveStopReport({
-      stopped: false,
-      profile_name: normalizedProfileName,
-      reason: "No keepalive daemon is currently running for this profile.",
-      state: previousState,
-      state_path: files.statePath,
-      log_path: files.logPath
-    }, options);
+    emitKeepAliveStopReport(
+      {
+        stopped: false,
+        profile_name: normalizedProfileName,
+        reason: "No keepalive daemon is currently running for this profile.",
+        state: previousState,
+        state_path: files.statePath,
+        log_path: files.logPath,
+      },
+      options,
+    );
     return;
   }
 
@@ -2731,25 +2811,28 @@ async function runKeepAliveStop(
         status: "stopped",
         updatedAt: now,
         stoppedAt: now,
-        lastError: "Recovered from stale pid file."
+        lastError: "Recovered from stale pid file.",
       });
     }
-    emitKeepAliveStopReport({
-      stopped: true,
-      profile_name: normalizedProfileName,
-      pid,
-      reason: "Removed a stale keepalive PID file for this profile.",
-      state: await readKeepAliveState(normalizedProfileName),
-      state_path: files.statePath,
-      log_path: files.logPath
-    }, options);
+    emitKeepAliveStopReport(
+      {
+        stopped: true,
+        profile_name: normalizedProfileName,
+        pid,
+        reason: "Removed a stale keepalive PID file for this profile.",
+        state: await readKeepAliveState(normalizedProfileName),
+        state_path: files.statePath,
+        log_path: files.logPath,
+      },
+      options,
+    );
     return;
   }
 
   writeKeepAliveProgressNotice(
     options.outputMode,
     options.quiet,
-    `Stopping keepalive daemon for profile ${normalizedProfileName}.`
+    `Stopping keepalive daemon for profile ${normalizedProfileName}.`,
   );
 
   try {
@@ -2761,8 +2844,8 @@ async function runKeepAliveStop(
       {
         profile_name: normalizedProfileName,
         pid,
-        cause: error instanceof Error ? error.message : String(error)
-      }
+        cause: error instanceof Error ? error.message : String(error),
+      },
     );
   }
 
@@ -2790,31 +2873,37 @@ async function runKeepAliveStop(
       stoppedAt: now,
       ...(running
         ? { lastError: "Keepalive daemon required SIGKILL to stop." }
-        : {})
+        : {}),
     });
   }
 
   const nextState = await readKeepAliveState(normalizedProfileName);
-  emitKeepAliveStopReport({
-    stopped: true,
-    profile_name: normalizedProfileName,
-    pid,
-    forced: running,
-    reason: running
-      ? "Keepalive daemon did not exit after SIGTERM, so it was force-stopped."
-      : "Keepalive daemon exited cleanly.",
-    state: nextState,
-    state_path: files.statePath,
-    log_path: files.logPath
-  }, options);
+  emitKeepAliveStopReport(
+    {
+      stopped: true,
+      profile_name: normalizedProfileName,
+      pid,
+      forced: running,
+      reason: running
+        ? "Keepalive daemon did not exit after SIGTERM, so it was force-stopped."
+        : "Keepalive daemon exited cleanly.",
+      state: nextState,
+      state_path: files.statePath,
+      log_path: files.logPath,
+    },
+    options,
+  );
 }
 
-async function runKeepAliveDaemon(input: {
-  profileName: string;
-  intervalSeconds: number;
-  jitterSeconds: number;
-  maxConsecutiveFailures: number;
-}, cdpUrl?: string): Promise<void> {
+async function runKeepAliveDaemon(
+  input: {
+    profileName: string;
+    intervalSeconds: number;
+    jitterSeconds: number;
+    maxConsecutiveFailures: number;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
   const profileName = coerceProfileName(input.profileName);
   let stopRequested = false;
@@ -2837,7 +2926,7 @@ async function runKeepAliveDaemon(input: {
     maxConsecutiveFailures: input.maxConsecutiveFailures,
     consecutiveFailures: 0,
     healthCheckInProgress: false,
-    ...(cdpUrl ? { cdpUrl } : {})
+    ...(cdpUrl ? { cdpUrl } : {}),
   };
 
   await writeKeepAlivePid(profileName, process.pid);
@@ -2850,13 +2939,14 @@ async function runKeepAliveDaemon(input: {
     cdp_url: cdpUrl ?? null,
     interval_ms: input.intervalSeconds * 1_000,
     jitter_ms: input.jitterSeconds * 1_000,
-    max_consecutive_failures: input.maxConsecutiveFailures
+    max_consecutive_failures: input.maxConsecutiveFailures,
   });
 
   try {
     while (!stopRequested) {
       const tickAt = new Date().toISOString();
-      const currentState = (await readKeepAliveState(profileName)) ?? initialState;
+      const currentState =
+        (await readKeepAliveState(profileName)) ?? initialState;
       const inProgressState: KeepAliveState = {
         ...currentState,
         pid: process.pid,
@@ -2866,7 +2956,7 @@ async function runKeepAliveDaemon(input: {
         jitterMs: input.jitterSeconds * 1_000,
         maxConsecutiveFailures: input.maxConsecutiveFailures,
         lastCheckStartedAt: tickAt,
-        healthCheckInProgress: true
+        healthCheckInProgress: true,
       };
 
       await writeKeepAliveState(profileName, inProgressState);
@@ -2875,7 +2965,7 @@ async function runKeepAliveDaemon(input: {
         event: "keepalive.tick.started",
         profile_name: profileName,
         interval_ms: input.intervalSeconds * 1_000,
-        jitter_ms: input.jitterSeconds * 1_000
+        jitter_ms: input.jitterSeconds * 1_000,
       });
 
       try {
@@ -2901,7 +2991,7 @@ async function runKeepAliveDaemon(input: {
           browserHealthy: health.browser.healthy,
           currentUrl: health.session.currentUrl,
           reason: health.session.reason,
-          healthCheckInProgress: false
+          healthCheckInProgress: false,
         };
         if (healthy) {
           nextState.lastHealthyAt = tickAt;
@@ -2919,7 +3009,7 @@ async function runKeepAliveDaemon(input: {
           authenticated: health.session.authenticated,
           reason: health.session.reason,
           interval_ms: input.intervalSeconds * 1_000,
-          jitter_ms: input.jitterSeconds * 1_000
+          jitter_ms: input.jitterSeconds * 1_000,
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -2943,7 +3033,7 @@ async function runKeepAliveDaemon(input: {
           consecutiveFailures,
           lastTickAt: tickAt,
           lastError: message,
-          healthCheckInProgress: false
+          healthCheckInProgress: false,
         };
         await writeKeepAliveState(profileName, nextState);
         await appendKeepAliveEvent(profileName, {
@@ -2954,7 +3044,7 @@ async function runKeepAliveDaemon(input: {
           error: message,
           interval_ms: input.intervalSeconds * 1_000,
           jitter_ms: input.jitterSeconds * 1_000,
-          ...(lockHeld ? { reason: "profile_lock_held" } : {})
+          ...(lockHeld ? { reason: "profile_lock_held" } : {}),
         });
       }
 
@@ -2965,7 +3055,7 @@ async function runKeepAliveDaemon(input: {
       const jitter = (Math.random() * 2 - 1) * (input.jitterSeconds * 1_000);
       let sleepRemainingMs = Math.max(
         1_000,
-        input.intervalSeconds * 1_000 + jitter
+        input.intervalSeconds * 1_000 + jitter,
       );
       while (!stopRequested && sleepRemainingMs > 0) {
         const chunkMs = Math.min(500, sleepRemainingMs);
@@ -2986,14 +3076,14 @@ async function runKeepAliveDaemon(input: {
       status: "stopped",
       updatedAt: now,
       healthCheckInProgress: false,
-      stoppedAt: now
+      stoppedAt: now,
     });
     await appendKeepAliveEvent(profileName, {
       ts: now,
       event: "keepalive.daemon.stopped",
       pid: process.pid,
       profile_name: profileName,
-      final_consecutive_failures: consecutiveFailures
+      final_consecutive_failures: consecutiveFailures,
     });
 
     await removeKeepAlivePid(profileName).catch(() => undefined);
@@ -3001,7 +3091,9 @@ async function runKeepAliveDaemon(input: {
   }
 }
 
-function summarizeSchedulerTick(result: SchedulerTickResult): SchedulerStateSummary {
+function summarizeSchedulerTick(
+  result: SchedulerTickResult,
+): SchedulerStateSummary {
   return {
     skippedReason: result.skippedReason,
     discoveredAcceptedConnections: result.discoveredAcceptedConnections,
@@ -3012,20 +3104,22 @@ function summarizeSchedulerTick(result: SchedulerTickResult): SchedulerStateSumm
     claimedJobs: result.claimedJobs,
     preparedJobs: result.preparedJobs,
     rescheduledJobs: result.rescheduledJobs,
-    failedJobs: result.failedJobs
+    failedJobs: result.failedJobs,
   };
 }
 
 function writeSchedulerProgressNotice(
   outputMode: SchedulerOutputMode,
-  message: string
+  message: string,
 ): void {
   if (outputMode === "human" && process.stderr.isTTY) {
     writeCliNotice(message);
   }
 }
 
-function tryParseSchedulerJobTargetLabel(job: SchedulerJobRow): string | undefined {
+function tryParseSchedulerJobTargetLabel(
+  job: SchedulerJobRow,
+): string | undefined {
   let parsed: unknown;
 
   try {
@@ -3066,7 +3160,7 @@ function createSchedulerJobPreview(job: SchedulerJobRow): SchedulerJobPreview {
     maxAttempts: job.max_attempts,
     preparedActionId: job.prepared_action_id,
     lastErrorCode: job.last_error_code,
-    lastErrorMessage: job.last_error_message
+    lastErrorMessage: job.last_error_message,
   };
 }
 
@@ -3079,11 +3173,13 @@ function createEmptySchedulerJobCounts(): SchedulerJobCounts {
     leased: 0,
     prepared: 0,
     failed: 0,
-    cancelled: 0
+    cancelled: 0,
   };
 }
 
-async function listSchedulerJobRows(profileName: string): Promise<SchedulerJobRow[]> {
+async function listSchedulerJobRows(
+  profileName: string,
+): Promise<SchedulerJobRow[]> {
   const { dbPath } = resolveConfigPaths();
   if (!(await pathExists(dbPath))) {
     return [];
@@ -3144,7 +3240,9 @@ function summarizeSchedulerJobRows(input: {
   const recent_jobs = input.jobs
     .filter(
       (job) =>
-        job.status === "prepared" || job.status === "failed" || job.status === "cancelled"
+        job.status === "prepared" ||
+        job.status === "failed" ||
+        job.status === "cancelled",
     )
     .sort((left, right) => right.updated_at - left.updated_at)
     .slice(0, input.jobLimit)
@@ -3153,7 +3251,7 @@ function summarizeSchedulerJobRows(input: {
   return {
     job_counts: jobCounts,
     next_jobs,
-    recent_jobs
+    recent_jobs,
   };
 }
 
@@ -3163,38 +3261,44 @@ function resolveSchedulerStatusConfig(): Pick<
 > {
   try {
     return {
-      scheduler_config: resolveSchedulerConfig()
+      scheduler_config: resolveSchedulerConfig(),
     };
   } catch (error) {
     return {
-      scheduler_config_error: toLinkedInBuddyErrorPayload(error, cliPrivacyConfig)
+      scheduler_config_error: toLinkedInBuddyErrorPayload(
+        error,
+        cliPrivacyConfig,
+      ),
     };
   }
 }
 
 function inferSchedulerNextWindowStartAt(
   state: SchedulerState | null,
-  schedulerConfig?: SchedulerConfig
+  schedulerConfig?: SchedulerConfig,
 ): string | undefined {
   if (!state) {
     return undefined;
   }
 
-  if (typeof state.nextWindowStartAt === "string" || state.nextWindowStartAt === null) {
+  if (
+    typeof state.nextWindowStartAt === "string" ||
+    state.nextWindowStartAt === null
+  ) {
     return state.nextWindowStartAt ?? undefined;
   }
 
   const nowMs = Date.now();
   const alignedAtMs = alignToBusinessHours(
     nowMs,
-    schedulerConfig?.businessHours ?? state.businessHours
+    schedulerConfig?.businessHours ?? state.businessHours,
   );
   return alignedAtMs > nowMs ? new Date(alignedAtMs).toISOString() : undefined;
 }
 
 async function buildSchedulerStatusReport(
   profileName: string,
-  jobLimit: number
+  jobLimit: number,
 ): Promise<SchedulerStatusReport> {
   const pid = await readSchedulerPid(profileName);
   const state = await readSchedulerState(profileName);
@@ -3205,12 +3309,12 @@ async function buildSchedulerStatusReport(
   const jobSummary = summarizeSchedulerJobRows({
     jobs,
     nowMs: Date.now(),
-    jobLimit
+    jobLimit,
   });
 
   const nextWindowStartAt = inferSchedulerNextWindowStartAt(
     state,
-    configInfo.scheduler_config
+    configInfo.scheduler_config,
   );
 
   return {
@@ -3222,19 +3326,19 @@ async function buildSchedulerStatusReport(
         ? null
         : {
             ...state,
-            ...(nextWindowStartAt !== undefined ? { nextWindowStartAt } : {})
+            ...(nextWindowStartAt !== undefined ? { nextWindowStartAt } : {}),
           },
     stale_pid_file: Boolean(pid && !running),
     state_path: files.statePath,
     log_path: files.logPath,
     ...configInfo,
-    ...jobSummary
+    ...jobSummary,
   };
 }
 
 function emitSchedulerStartReport(
   report: SchedulerStartReport,
-  outputMode: SchedulerOutputMode
+  outputMode: SchedulerOutputMode,
 ): void {
   if (outputMode === "json") {
     printJson(report);
@@ -3243,14 +3347,18 @@ function emitSchedulerStartReport(
 
   console.log(
     formatSchedulerStartReport(
-      redactStructuredValue(report, cliPrivacyConfig, "cli") as SchedulerStartReport
-    )
+      redactStructuredValue(
+        report,
+        cliPrivacyConfig,
+        "cli",
+      ) as SchedulerStartReport,
+    ),
   );
 }
 
 function emitSchedulerStatusReport(
   report: SchedulerStatusReport,
-  outputMode: SchedulerOutputMode
+  outputMode: SchedulerOutputMode,
 ): void {
   if (outputMode === "json") {
     printJson(report);
@@ -3259,14 +3367,18 @@ function emitSchedulerStatusReport(
 
   console.log(
     formatSchedulerStatusReport(
-      redactStructuredValue(report, cliPrivacyConfig, "cli") as SchedulerStatusReport
-    )
+      redactStructuredValue(
+        report,
+        cliPrivacyConfig,
+        "cli",
+      ) as SchedulerStatusReport,
+    ),
   );
 }
 
 function emitSchedulerStopReport(
   report: SchedulerStopReport,
-  outputMode: SchedulerOutputMode
+  outputMode: SchedulerOutputMode,
 ): void {
   if (outputMode === "json") {
     printJson(report);
@@ -3275,14 +3387,18 @@ function emitSchedulerStopReport(
 
   console.log(
     formatSchedulerStopReport(
-      redactStructuredValue(report, cliPrivacyConfig, "cli") as SchedulerStopReport
-    )
+      redactStructuredValue(
+        report,
+        cliPrivacyConfig,
+        "cli",
+      ) as SchedulerStopReport,
+    ),
   );
 }
 
 function emitSchedulerRunOnceReport(
   report: SchedulerRunOnceReport,
-  outputMode: SchedulerOutputMode
+  outputMode: SchedulerOutputMode,
 ): void {
   if (outputMode === "json") {
     printJson(report);
@@ -3291,14 +3407,18 @@ function emitSchedulerRunOnceReport(
 
   console.log(
     formatSchedulerRunOnceReport(
-      redactStructuredValue(report, cliPrivacyConfig, "cli") as SchedulerRunOnceReport
-    )
+      redactStructuredValue(
+        report,
+        cliPrivacyConfig,
+        "cli",
+      ) as SchedulerRunOnceReport,
+    ),
   );
 }
 
 async function runSchedulerCliAction(
   input: { json?: boolean },
-  action: (outputMode: SchedulerOutputMode) => Promise<void>
+  action: (outputMode: SchedulerOutputMode) => Promise<void>,
 ): Promise<void> {
   const outputMode = resolveSchedulerOutputMode(input, Boolean(stdout.isTTY));
 
@@ -3311,8 +3431,8 @@ async function runSchedulerCliAction(
 
     process.stderr.write(
       `${formatSchedulerError(
-        toLinkedInBuddyErrorPayload(error, cliPrivacyConfig)
-      )}\n`
+        toLinkedInBuddyErrorPayload(error, cliPrivacyConfig),
+      )}\n`,
     );
     process.exitCode = 1;
   }
@@ -3321,12 +3441,12 @@ async function runSchedulerCliAction(
 async function runSchedulerRunOnce(
   profileName: string,
   outputMode: SchedulerOutputMode,
-  cdpUrl?: string
+  cdpUrl?: string,
 ): Promise<void> {
   const normalizedProfileName = coerceProfileName(profileName);
   writeSchedulerProgressNotice(
     outputMode,
-    `Running one scheduler tick for profile ${normalizedProfileName}; this may take a moment.`
+    `Running one scheduler tick for profile ${normalizedProfileName}; this may take a moment.`,
   );
   const runtime = createRuntime(cdpUrl);
   const schedulerConfig = resolveSchedulerConfig();
@@ -3336,22 +3456,25 @@ async function runSchedulerRunOnce(
       db: runtime.db,
       logger: runtime.logger,
       followups: runtime.followups,
-      schedulerConfig
+      schedulerConfig,
     });
     const result = await scheduler.runTick({
       profileName: normalizedProfileName,
-      workerId: `cli:${runtime.runId}`
+      workerId: `cli:${runtime.runId}`,
     });
 
     if (result.failedJobs > 0) {
       process.exitCode = 1;
     }
 
-    emitSchedulerRunOnceReport({
-      run_id: runtime.runId,
-      scheduler_config: schedulerConfig,
-      ...result
-    }, outputMode);
+    emitSchedulerRunOnceReport(
+      {
+        run_id: runtime.runId,
+        scheduler_config: schedulerConfig,
+        ...result,
+      },
+      outputMode,
+    );
   } finally {
     runtime.close();
   }
@@ -3360,23 +3483,26 @@ async function runSchedulerRunOnce(
 async function runSchedulerStart(
   profileName: string,
   outputMode: SchedulerOutputMode,
-  cdpUrl?: string
+  cdpUrl?: string,
 ): Promise<void> {
   const normalizedProfileName = coerceProfileName(profileName);
   const files = getSchedulerFiles(normalizedProfileName);
   const existingPid = await readSchedulerPid(normalizedProfileName);
   if (existingPid && isProcessRunning(existingPid)) {
     const currentState = await readSchedulerState(normalizedProfileName);
-    emitSchedulerStartReport({
-      started: false,
-      reason: "Scheduler daemon is already running for this profile.",
-      profile_name: normalizedProfileName,
-      pid: existingPid,
-      state: currentState,
-      state_path: files.statePath,
-      log_path: files.logPath,
-      ...resolveSchedulerStatusConfig()
-    }, outputMode);
+    emitSchedulerStartReport(
+      {
+        started: false,
+        reason: "Scheduler daemon is already running for this profile.",
+        profile_name: normalizedProfileName,
+        pid: existingPid,
+        state: currentState,
+        state_path: files.statePath,
+        log_path: files.logPath,
+        ...resolveSchedulerStatusConfig(),
+      },
+      outputMode,
+    );
     return;
   }
 
@@ -3388,14 +3514,14 @@ async function runSchedulerStart(
 
   writeSchedulerProgressNotice(
     outputMode,
-    `Starting scheduler daemon for profile ${normalizedProfileName}.`
+    `Starting scheduler daemon for profile ${normalizedProfileName}.`,
   );
   const schedulerConfig = resolveSchedulerConfig();
   const cliEntrypoint = resolveKeepAliveCliEntrypoint();
   if (!cliEntrypoint) {
     throw new LinkedInBuddyError(
       "UNKNOWN",
-      "Could not resolve CLI entrypoint for scheduler daemon startup."
+      "Could not resolve CLI entrypoint for scheduler daemon startup.",
     );
   }
 
@@ -3411,14 +3537,14 @@ async function runSchedulerStart(
   const daemon = spawn(process.execPath, daemonArgs, {
     detached: true,
     stdio: "ignore",
-    env: process.env
+    env: process.env,
   });
   daemon.unref();
 
   if (!daemon.pid) {
     throw new LinkedInBuddyError(
       "UNKNOWN",
-      "Scheduler daemon did not return a process id."
+      "Scheduler daemon did not return a process id.",
     );
   }
 
@@ -3435,35 +3561,41 @@ async function runSchedulerStart(
     maxActiveJobsPerProfile: schedulerConfig.maxActiveJobsPerProfile,
     consecutiveFailures: 0,
     maxConsecutiveFailures: SCHEDULER_DAEMON_MAX_CONSECUTIVE_FAILURES,
-    ...(cdpUrl ? { cdpUrl } : {})
+    ...(cdpUrl ? { cdpUrl } : {}),
   };
 
   await writeSchedulerPid(normalizedProfileName, daemon.pid);
   await writeSchedulerState(normalizedProfileName, initialState);
 
-  emitSchedulerStartReport({
-    started: true,
-    profile_name: normalizedProfileName,
-    pid: daemon.pid,
-    state_path: files.statePath,
-    log_path: files.logPath,
-    scheduler_config: schedulerConfig
-  }, outputMode);
+  emitSchedulerStartReport(
+    {
+      started: true,
+      profile_name: normalizedProfileName,
+      pid: daemon.pid,
+      state_path: files.statePath,
+      log_path: files.logPath,
+      scheduler_config: schedulerConfig,
+    },
+    outputMode,
+  );
 }
 
 async function runSchedulerStatus(
   profileName: string,
   outputMode: SchedulerOutputMode,
-  jobLimit: number
+  jobLimit: number,
 ): Promise<void> {
   const normalizedProfileName = coerceProfileName(profileName);
-  const report = await buildSchedulerStatusReport(normalizedProfileName, jobLimit);
+  const report = await buildSchedulerStatusReport(
+    normalizedProfileName,
+    jobLimit,
+  );
   emitSchedulerStatusReport(report, outputMode);
 }
 
 async function runSchedulerStop(
   profileName: string,
-  outputMode: SchedulerOutputMode
+  outputMode: SchedulerOutputMode,
 ): Promise<void> {
   const normalizedProfileName = coerceProfileName(profileName);
   const files = getSchedulerFiles(normalizedProfileName);
@@ -3471,13 +3603,16 @@ async function runSchedulerStop(
   const previousState = await readSchedulerState(normalizedProfileName);
 
   if (!pid) {
-    emitSchedulerStopReport({
-      stopped: false,
-      profile_name: normalizedProfileName,
-      reason: "No scheduler daemon is currently running for this profile.",
-      state_path: files.statePath,
-      log_path: files.logPath
-    }, outputMode);
+    emitSchedulerStopReport(
+      {
+        stopped: false,
+        profile_name: normalizedProfileName,
+        reason: "No scheduler daemon is currently running for this profile.",
+        state_path: files.statePath,
+        log_path: files.logPath,
+      },
+      outputMode,
+    );
     return;
   }
 
@@ -3490,23 +3625,26 @@ async function runSchedulerStop(
         status: "stopped",
         updatedAt: now,
         stoppedAt: now,
-        lastError: "Recovered from stale pid file."
+        lastError: "Recovered from stale pid file.",
       });
     }
-    emitSchedulerStopReport({
-      stopped: true,
-      profile_name: normalizedProfileName,
-      pid,
-      reason: "Removed a stale scheduler PID file for this profile.",
-      state_path: files.statePath,
-      log_path: files.logPath
-    }, outputMode);
+    emitSchedulerStopReport(
+      {
+        stopped: true,
+        profile_name: normalizedProfileName,
+        pid,
+        reason: "Removed a stale scheduler PID file for this profile.",
+        state_path: files.statePath,
+        log_path: files.logPath,
+      },
+      outputMode,
+    );
     return;
   }
 
   writeSchedulerProgressNotice(
     outputMode,
-    `Stopping scheduler daemon for profile ${normalizedProfileName}.`
+    `Stopping scheduler daemon for profile ${normalizedProfileName}.`,
   );
 
   try {
@@ -3518,8 +3656,8 @@ async function runSchedulerStop(
       {
         profile_name: normalizedProfileName,
         pid,
-        cause: error instanceof Error ? error.message : String(error)
-      }
+        cause: error instanceof Error ? error.message : String(error),
+      },
     );
   }
 
@@ -3547,26 +3685,29 @@ async function runSchedulerStop(
       stoppedAt: now,
       ...(running
         ? { lastError: "Scheduler daemon required SIGKILL to stop." }
-        : {})
+        : {}),
     });
   }
 
-  emitSchedulerStopReport({
-    stopped: true,
-    profile_name: normalizedProfileName,
-    pid,
-    forced: running,
-    reason: running
-      ? "Scheduler daemon did not exit after SIGTERM, so it was force-stopped."
-      : "Scheduler daemon exited cleanly.",
-    state_path: files.statePath,
-    log_path: files.logPath
-  }, outputMode);
+  emitSchedulerStopReport(
+    {
+      stopped: true,
+      profile_name: normalizedProfileName,
+      pid,
+      forced: running,
+      reason: running
+        ? "Scheduler daemon did not exit after SIGTERM, so it was force-stopped."
+        : "Scheduler daemon exited cleanly.",
+      state_path: files.statePath,
+      log_path: files.logPath,
+    },
+    outputMode,
+  );
 }
 
 async function runSchedulerDaemon(
   profileName: string,
-  cdpUrl?: string
+  cdpUrl?: string,
 ): Promise<void> {
   const schedulerConfig = resolveSchedulerConfig();
   let stopRequested = false;
@@ -3591,7 +3732,7 @@ async function runSchedulerDaemon(
     maxActiveJobsPerProfile: schedulerConfig.maxActiveJobsPerProfile,
     consecutiveFailures: 0,
     maxConsecutiveFailures: SCHEDULER_DAEMON_MAX_CONSECUTIVE_FAILURES,
-    ...(cdpUrl ? { cdpUrl } : {})
+    ...(cdpUrl ? { cdpUrl } : {}),
   };
 
   await writeSchedulerPid(profileName, process.pid);
@@ -3602,7 +3743,7 @@ async function runSchedulerDaemon(
     pid: process.pid,
     profile_name: profileName,
     cdp_url: cdpUrl ?? null,
-    scheduler_config: schedulerConfig
+    scheduler_config: schedulerConfig,
   });
 
   try {
@@ -3617,16 +3758,16 @@ async function runSchedulerDaemon(
             db: runtime.db,
             logger: runtime.logger,
             followups: runtime.followups,
-            schedulerConfig
+            schedulerConfig,
           });
           const result = await scheduler.runTick({
             profileName,
-            workerId: `scheduler-daemon:${process.pid}`
+            workerId: `scheduler-daemon:${process.pid}`,
           });
 
           consecutiveFailures = 0;
           const nextState: SchedulerState = {
-            ...(await readSchedulerState(profileName)) ?? initialState,
+            ...((await readSchedulerState(profileName)) ?? initialState),
             pid: process.pid,
             profileName,
             updatedAt: tickAt,
@@ -3646,7 +3787,7 @@ async function runSchedulerDaemon(
             lastTickAt: tickAt,
             lastSuccessfulTickAt: tickAt,
             nextWindowStartAt: result.nextWindowStartAt,
-            lastSummary: summarizeSchedulerTick(result)
+            lastSummary: summarizeSchedulerTick(result),
           };
           if (result.preparedJobs > 0) {
             nextState.lastPreparedAt = tickAt;
@@ -3657,11 +3798,13 @@ async function runSchedulerDaemon(
           await appendSchedulerEvent(profileName, {
             ts: tickAt,
             event:
-              result.skippedReason === null ? "scheduler.tick" : "scheduler.tick.skipped",
+              result.skippedReason === null
+                ? "scheduler.tick"
+                : "scheduler.tick.skipped",
             profile_name: profileName,
             summary: summarizeSchedulerTick(result),
             skipped_reason: result.skippedReason,
-            next_window_start_at: result.nextWindowStartAt
+            next_window_start_at: result.nextWindowStartAt,
           });
         } finally {
           runtime.close();
@@ -3674,7 +3817,7 @@ async function runSchedulerDaemon(
         }
 
         const nextState: SchedulerState = {
-          ...(await readSchedulerState(profileName)) ?? initialState,
+          ...((await readSchedulerState(profileName)) ?? initialState),
           pid: process.pid,
           profileName,
           updatedAt: tickAt,
@@ -3689,7 +3832,7 @@ async function runSchedulerDaemon(
           consecutiveFailures,
           maxConsecutiveFailures: SCHEDULER_DAEMON_MAX_CONSECUTIVE_FAILURES,
           lastTickAt: tickAt,
-          lastError: message
+          lastError: message,
         };
         await writeSchedulerState(profileName, nextState);
         await appendSchedulerEvent(profileName, {
@@ -3698,7 +3841,7 @@ async function runSchedulerDaemon(
           profile_name: profileName,
           consecutive_failures: consecutiveFailures,
           error: message,
-          ...(lockHeld ? { reason: "profile_lock_held" } : {})
+          ...(lockHeld ? { reason: "profile_lock_held" } : {}),
         });
       }
 
@@ -3722,13 +3865,13 @@ async function runSchedulerDaemon(
       profileName,
       status: "stopped",
       updatedAt: now,
-      stoppedAt: now
+      stoppedAt: now,
     });
     await appendSchedulerEvent(profileName, {
       ts: now,
       event: "scheduler.daemon.stopped",
       pid: process.pid,
-      profile_name: profileName
+      profile_name: profileName,
     });
 
     await removeSchedulerPid(profileName).catch(() => undefined);
@@ -3775,7 +3918,7 @@ function sanitizeDiagnosticText(value: string): string {
 
 function sanitizeActivityPersistenceValue(
   value: unknown,
-  key?: string
+  key?: string,
 ): unknown {
   if (Array.isArray(value)) {
     return value.map((entry) => sanitizeActivityPersistenceValue(entry));
@@ -3811,12 +3954,12 @@ function sanitizeActivityPersistenceValue(
 
 function sanitizeActivityPersistenceRecord<T extends object>(
   value: T,
-  surface: "log" | "storage"
+  surface: "log" | "storage",
 ): T {
   return redactStructuredValue(
     sanitizeActivityPersistenceValue(value) as T,
     cliPrivacyConfig,
-    surface
+    surface,
   );
 }
 
@@ -3824,7 +3967,7 @@ function asCliObject(value: unknown): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "Activity target must be a JSON object."
+      "Activity target must be a JSON object.",
     );
   }
 
@@ -3833,7 +3976,7 @@ function asCliObject(value: unknown): Record<string, unknown> {
 
 function parseJsonObjectString(
   value: string,
-  label: string
+  label: string,
 ): Record<string, unknown> {
   try {
     return asCliObject(JSON.parse(value));
@@ -3846,8 +3989,8 @@ function parseJsonObjectString(
       "ACTION_PRECONDITION_FAILED",
       `${label} must be valid JSON object text.`,
       {
-        cause: error instanceof Error ? error.message : String(error)
-      }
+        cause: error instanceof Error ? error.message : String(error),
+      },
     );
   }
 }
@@ -3863,7 +4006,7 @@ async function readActivityTargetInput(input: {
   if (target && targetFile) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "Specify either --target or --target-file, not both."
+      "Specify either --target or --target-file, not both.",
     );
   }
 
@@ -3881,7 +4024,7 @@ async function readActivityTargetInput(input: {
 function coerceEnumValue<T extends string>(
   value: string,
   allowed: readonly T[],
-  label: string
+  label: string,
 ): T {
   const normalized = value.trim();
   if ((allowed as readonly string[]).includes(normalized)) {
@@ -3890,19 +4033,19 @@ function coerceEnumValue<T extends string>(
 
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    `${label} must be one of: ${allowed.join(", ")}.`
+    `${label} must be one of: ${allowed.join(", ")}.`,
   );
 }
 
 function coerceActivityEventTypes(
-  values: string[] | undefined
+  values: string[] | undefined,
 ): ActivityEventType[] {
   if (!values || values.length === 0) {
     return [];
   }
 
   return values.map((value) =>
-    coerceEnumValue(value, ACTIVITY_EVENT_TYPES, "event")
+    coerceEnumValue(value, ACTIVITY_EVENT_TYPES, "event"),
   );
 }
 
@@ -3915,13 +4058,13 @@ function coerceActivityWatchStatusValue(value: string): ActivityWatchStatus {
 }
 
 function coerceWebhookSubscriptionStatusValue(
-  value: string
+  value: string,
 ): WebhookSubscriptionStatus {
   return coerceEnumValue(value, WEBHOOK_SUBSCRIPTION_STATUSES, "status");
 }
 
 function coerceWebhookDeliveryStatusValue(
-  value: string
+  value: string,
 ): WebhookDeliveryAttemptStatus {
   return coerceEnumValue(value, WEBHOOK_DELIVERY_ATTEMPT_STATUSES, "status");
 }
@@ -3933,7 +4076,7 @@ function getActivityFiles(profileName: string): ActivityFiles {
     dir,
     pidPath: path.join(dir, `${slug}.pid`),
     statePath: path.join(dir, `${slug}.state.json`),
-    logPath: path.join(dir, `${slug}.events.jsonl`)
+    logPath: path.join(dir, `${slug}.events.jsonl`),
   };
 }
 
@@ -3955,7 +4098,10 @@ async function readActivityPid(profileName: string): Promise<number | null> {
   }
 }
 
-async function writeActivityPid(profileName: string, pid: number): Promise<void> {
+async function writeActivityPid(
+  profileName: string,
+  pid: number,
+): Promise<void> {
   const files = getActivityFiles(profileName);
   await ensureActivityDir(files);
   await writeFile(files.pidPath, `${pid}\n`, "utf8");
@@ -3974,7 +4120,7 @@ async function removeActivityPid(profileName: string): Promise<void> {
 }
 
 async function readActivityState(
-  profileName: string
+  profileName: string,
 ): Promise<ActivityDaemonState | null> {
   const files = getActivityFiles(profileName);
   return readJsonFile<ActivityDaemonState>(files.statePath);
@@ -3982,31 +4128,31 @@ async function readActivityState(
 
 async function writeActivityState(
   profileName: string,
-  state: ActivityDaemonState
+  state: ActivityDaemonState,
 ): Promise<void> {
   const files = getActivityFiles(profileName);
   await ensureActivityDir(files);
   await writeJsonFile(
     files.statePath,
-    sanitizeActivityPersistenceRecord(state, "storage")
+    sanitizeActivityPersistenceRecord(state, "storage"),
   );
 }
 
 async function appendActivityEvent(
   profileName: string,
-  event: Record<string, unknown>
+  event: Record<string, unknown>,
 ): Promise<void> {
   const files = getActivityFiles(profileName);
   await ensureActivityDir(files);
   await appendFile(
     files.logPath,
     `${JSON.stringify(sanitizeActivityPersistenceRecord(event, "log"))}\n`,
-    "utf8"
+    "utf8",
   );
 }
 
 function summarizeActivityTick(
-  result: ActivityPollTickResult
+  result: ActivityPollTickResult,
 ): ActivityDaemonStateSummary {
   return {
     claimedWatches: result.claimedWatches,
@@ -4019,7 +4165,7 @@ function summarizeActivityTick(
     retriedDeliveries: result.retriedDeliveries,
     failedDeliveries: result.failedDeliveries,
     deadLetterDeliveries: result.deadLetterDeliveries,
-    disabledSubscriptions: result.disabledSubscriptions
+    disabledSubscriptions: result.disabledSubscriptions,
   };
 }
 
@@ -4029,11 +4175,14 @@ function resolveActivityStatusConfig(): Pick<
 > {
   try {
     return {
-      activity_config: resolveActivityWebhookConfig()
+      activity_config: resolveActivityWebhookConfig(),
     };
   } catch (error) {
     return {
-      activity_config_error: toLinkedInBuddyErrorPayload(error, cliPrivacyConfig)
+      activity_config_error: toLinkedInBuddyErrorPayload(
+        error,
+        cliPrivacyConfig,
+      ),
     };
   }
 }
@@ -4041,7 +4190,7 @@ function resolveActivityStatusConfig(): Pick<
 function emitActivityReport<Report extends object>(
   report: Report,
   outputMode: ActivityOutputMode,
-  formatter: (report: Report) => string
+  formatter: (report: Report) => string,
 ): void {
   if (outputMode === "json") {
     printJson(report);
@@ -4049,13 +4198,13 @@ function emitActivityReport<Report extends object>(
   }
 
   console.log(
-    formatter(redactStructuredValue(report, cliPrivacyConfig, "cli") as Report)
+    formatter(redactStructuredValue(report, cliPrivacyConfig, "cli") as Report),
   );
 }
 
 async function runActivityCliAction(
   input: { json?: boolean },
-  action: (outputMode: ActivityOutputMode) => Promise<void>
+  action: (outputMode: ActivityOutputMode) => Promise<void>,
 ): Promise<void> {
   const outputMode = resolveActivityOutputMode(input, Boolean(stdout.isTTY));
 
@@ -4068,20 +4217,24 @@ async function runActivityCliAction(
 
     process.stderr.write(
       `${formatActivityError(
-        toLinkedInBuddyErrorPayload(error, cliPrivacyConfig)
-      )}\n`
+        toLinkedInBuddyErrorPayload(error, cliPrivacyConfig),
+      )}\n`,
     );
     process.exitCode = 1;
   }
 }
 
-async function runActivityWatchAdd(input: {
-  profileName: string;
-  kind: ActivityWatchKind;
-  target?: Record<string, unknown>;
-  intervalSeconds?: number;
-  cron?: string;
-}, outputMode: ActivityOutputMode, cdpUrl?: string): Promise<void> {
+async function runActivityWatchAdd(
+  input: {
+    profileName: string;
+    kind: ActivityWatchKind;
+    target?: Record<string, unknown>;
+    intervalSeconds?: number;
+    cron?: string;
+  },
+  outputMode: ActivityOutputMode,
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
@@ -4089,7 +4242,7 @@ async function runActivityWatchAdd(input: {
       kind: input.kind,
       output_mode: outputMode,
       profile_name: input.profileName,
-      schedule_kind: input.cron ? "cron" : "interval"
+      schedule_kind: input.cron ? "cron" : "interval",
     });
 
     const watch = runtime.activityWatches.createWatch({
@@ -4099,19 +4252,19 @@ async function runActivityWatchAdd(input: {
       ...(typeof input.intervalSeconds === "number"
         ? { intervalSeconds: input.intervalSeconds }
         : {}),
-      ...(input.cron ? { cron: input.cron } : {})
+      ...(input.cron ? { cron: input.cron } : {}),
     });
 
     runtime.logger.log("info", "cli.activity.watch.add.done", {
       kind: watch.kind,
       profile_name: input.profileName,
-      watch_id: watch.id
+      watch_id: watch.id,
     });
 
     const report: ActivityWatchAddReport = {
       run_id: runtime.runId,
       profile_name: input.profileName,
-      watch
+      watch,
     };
     emitActivityReport(report, outputMode, formatActivityWatchAddReport);
   } finally {
@@ -4119,34 +4272,38 @@ async function runActivityWatchAdd(input: {
   }
 }
 
-async function runActivityWatchList(input: {
-  profileName: string;
-  status?: ActivityWatchStatus;
-}, outputMode: ActivityOutputMode, cdpUrl?: string): Promise<void> {
+async function runActivityWatchList(
+  input: {
+    profileName: string;
+    status?: ActivityWatchStatus;
+  },
+  outputMode: ActivityOutputMode,
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.activity.watch.list.start", {
       profile_name: input.profileName,
-      ...(input.status ? { status: input.status } : {})
+      ...(input.status ? { status: input.status } : {}),
     });
 
     const watches = runtime.activityWatches.listWatches({
       profileName: input.profileName,
-      ...(input.status ? { status: input.status } : {})
+      ...(input.status ? { status: input.status } : {}),
     });
 
     runtime.logger.log("info", "cli.activity.watch.list.done", {
       count: watches.length,
       profile_name: input.profileName,
-      ...(input.status ? { status: input.status } : {})
+      ...(input.status ? { status: input.status } : {}),
     });
 
     const report: ActivityWatchListReport = {
       run_id: runtime.runId,
       profile_name: input.profileName,
       count: watches.length,
-      watches
+      watches,
     };
     emitActivityReport(report, outputMode, formatActivityWatchListReport);
   } finally {
@@ -4157,28 +4314,28 @@ async function runActivityWatchList(input: {
 async function runActivityWatchPause(
   id: string,
   outputMode: ActivityOutputMode,
-  cdpUrl?: string
+  cdpUrl?: string,
 ): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.activity.watch.pause.start", {
-      watch_id: id
+      watch_id: id,
     });
 
     const watch = runtime.activityWatches.pauseWatch(id);
 
     runtime.logger.log("info", "cli.activity.watch.pause.done", {
       profile_name: watch.profileName,
-      watch_id: watch.id
+      watch_id: watch.id,
     });
 
     const report: ActivityWatchMutationReport = {
       run_id: runtime.runId,
-      watch
+      watch,
     };
     emitActivityReport(report, outputMode, (value) =>
-      formatActivityWatchMutationReport(value, "paused")
+      formatActivityWatchMutationReport(value, "paused"),
     );
   } finally {
     runtime.close();
@@ -4188,28 +4345,28 @@ async function runActivityWatchPause(
 async function runActivityWatchResume(
   id: string,
   outputMode: ActivityOutputMode,
-  cdpUrl?: string
+  cdpUrl?: string,
 ): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.activity.watch.resume.start", {
-      watch_id: id
+      watch_id: id,
     });
 
     const watch = runtime.activityWatches.resumeWatch(id);
 
     runtime.logger.log("info", "cli.activity.watch.resume.done", {
       profile_name: watch.profileName,
-      watch_id: watch.id
+      watch_id: watch.id,
     });
 
     const report: ActivityWatchMutationReport = {
       run_id: runtime.runId,
-      watch
+      watch,
     };
     emitActivityReport(report, outputMode, (value) =>
-      formatActivityWatchMutationReport(value, "resumed")
+      formatActivityWatchMutationReport(value, "resumed"),
     );
   } finally {
     runtime.close();
@@ -4219,26 +4376,26 @@ async function runActivityWatchResume(
 async function runActivityWatchRemove(
   id: string,
   outputMode: ActivityOutputMode,
-  cdpUrl?: string
+  cdpUrl?: string,
 ): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.activity.watch.remove.start", {
-      watch_id: id
+      watch_id: id,
     });
 
     const removed = runtime.activityWatches.removeWatch(id);
 
     runtime.logger.log("info", "cli.activity.watch.remove.done", {
       removed,
-      watch_id: id
+      watch_id: id,
     });
 
     const report: ActivityWatchRemovalReport = {
       run_id: runtime.runId,
       watch_id: id,
-      removed
+      removed,
     };
     emitActivityReport(report, outputMode, formatActivityWatchRemovalReport);
   } finally {
@@ -4246,20 +4403,24 @@ async function runActivityWatchRemove(
   }
 }
 
-async function runActivityWebhookAdd(input: {
-  watchId: string;
-  deliveryUrl: string;
-  eventTypes?: ActivityEventType[];
-  signingSecret?: string;
-  maxAttempts?: number;
-}, outputMode: ActivityOutputMode, cdpUrl?: string): Promise<void> {
+async function runActivityWebhookAdd(
+  input: {
+    watchId: string;
+    deliveryUrl: string;
+    eventTypes?: ActivityEventType[];
+    signingSecret?: string;
+    maxAttempts?: number;
+  },
+  outputMode: ActivityOutputMode,
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.activity.webhook.add.start", {
       delivery_url: input.deliveryUrl,
       output_mode: outputMode,
-      watch_id: input.watchId
+      watch_id: input.watchId,
     });
 
     const subscription = runtime.activityWatches.createWebhookSubscription({
@@ -4269,17 +4430,17 @@ async function runActivityWebhookAdd(input: {
       ...(input.signingSecret ? { signingSecret: input.signingSecret } : {}),
       ...(typeof input.maxAttempts === "number"
         ? { maxAttempts: input.maxAttempts }
-        : {})
+        : {}),
     });
 
     runtime.logger.log("info", "cli.activity.webhook.add.done", {
       webhook_subscription_id: subscription.id,
-      watch_id: subscription.watchId
+      watch_id: subscription.watchId,
     });
 
     const report: ActivityWebhookAddReport = {
       run_id: runtime.runId,
-      subscription
+      subscription,
     };
     emitActivityReport(report, outputMode, formatActivityWebhookAddReport);
   } finally {
@@ -4287,38 +4448,42 @@ async function runActivityWebhookAdd(input: {
   }
 }
 
-async function runActivityWebhookList(input: {
-  profileName: string;
-  watchId?: string;
-  status?: WebhookSubscriptionStatus;
-}, outputMode: ActivityOutputMode, cdpUrl?: string): Promise<void> {
+async function runActivityWebhookList(
+  input: {
+    profileName: string;
+    watchId?: string;
+    status?: WebhookSubscriptionStatus;
+  },
+  outputMode: ActivityOutputMode,
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.activity.webhook.list.start", {
       profile_name: input.profileName,
       ...(input.status ? { status: input.status } : {}),
-      ...(input.watchId ? { watch_id: input.watchId } : {})
+      ...(input.watchId ? { watch_id: input.watchId } : {}),
     });
 
     const subscriptions = runtime.activityWatches.listWebhookSubscriptions({
       profileName: input.profileName,
       ...(input.watchId ? { watchId: input.watchId } : {}),
-      ...(input.status ? { status: input.status } : {})
+      ...(input.status ? { status: input.status } : {}),
     });
 
     runtime.logger.log("info", "cli.activity.webhook.list.done", {
       count: subscriptions.length,
       profile_name: input.profileName,
       ...(input.status ? { status: input.status } : {}),
-      ...(input.watchId ? { watch_id: input.watchId } : {})
+      ...(input.watchId ? { watch_id: input.watchId } : {}),
     });
 
     const report: ActivityWebhookListReport = {
       run_id: runtime.runId,
       profile_name: input.profileName,
       count: subscriptions.length,
-      subscriptions
+      subscriptions,
     };
     emitActivityReport(report, outputMode, formatActivityWebhookListReport);
   } finally {
@@ -4329,28 +4494,28 @@ async function runActivityWebhookList(input: {
 async function runActivityWebhookPause(
   id: string,
   outputMode: ActivityOutputMode,
-  cdpUrl?: string
+  cdpUrl?: string,
 ): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.activity.webhook.pause.start", {
-      webhook_subscription_id: id
+      webhook_subscription_id: id,
     });
 
     const subscription = runtime.activityWatches.pauseWebhookSubscription(id);
 
     runtime.logger.log("info", "cli.activity.webhook.pause.done", {
       webhook_subscription_id: subscription.id,
-      watch_id: subscription.watchId
+      watch_id: subscription.watchId,
     });
 
     const report: ActivityWebhookMutationReport = {
       run_id: runtime.runId,
-      subscription
+      subscription,
     };
     emitActivityReport(report, outputMode, (value) =>
-      formatActivityWebhookMutationReport(value, "paused")
+      formatActivityWebhookMutationReport(value, "paused"),
     );
   } finally {
     runtime.close();
@@ -4360,28 +4525,28 @@ async function runActivityWebhookPause(
 async function runActivityWebhookResume(
   id: string,
   outputMode: ActivityOutputMode,
-  cdpUrl?: string
+  cdpUrl?: string,
 ): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.activity.webhook.resume.start", {
-      webhook_subscription_id: id
+      webhook_subscription_id: id,
     });
 
     const subscription = runtime.activityWatches.resumeWebhookSubscription(id);
 
     runtime.logger.log("info", "cli.activity.webhook.resume.done", {
       webhook_subscription_id: subscription.id,
-      watch_id: subscription.watchId
+      watch_id: subscription.watchId,
     });
 
     const report: ActivityWebhookMutationReport = {
       run_id: runtime.runId,
-      subscription
+      subscription,
     };
     emitActivityReport(report, outputMode, (value) =>
-      formatActivityWebhookMutationReport(value, "resumed")
+      formatActivityWebhookMutationReport(value, "resumed"),
     );
   } finally {
     runtime.close();
@@ -4391,26 +4556,26 @@ async function runActivityWebhookResume(
 async function runActivityWebhookRemove(
   id: string,
   outputMode: ActivityOutputMode,
-  cdpUrl?: string
+  cdpUrl?: string,
 ): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.activity.webhook.remove.start", {
-      webhook_subscription_id: id
+      webhook_subscription_id: id,
     });
 
     const removed = runtime.activityWatches.removeWebhookSubscription(id);
 
     runtime.logger.log("info", "cli.activity.webhook.remove.done", {
       removed,
-      webhook_subscription_id: id
+      webhook_subscription_id: id,
     });
 
     const report: ActivityWebhookRemovalReport = {
       run_id: runtime.runId,
       subscription_id: id,
-      removed
+      removed,
     };
     emitActivityReport(report, outputMode, formatActivityWebhookRemovalReport);
   } finally {
@@ -4418,37 +4583,41 @@ async function runActivityWebhookRemove(
   }
 }
 
-async function runActivityEventsList(input: {
-  profileName: string;
-  watchId?: string;
-  limit: number;
-}, outputMode: ActivityOutputMode, cdpUrl?: string): Promise<void> {
+async function runActivityEventsList(
+  input: {
+    profileName: string;
+    watchId?: string;
+    limit: number;
+  },
+  outputMode: ActivityOutputMode,
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.activity.events.list.start", {
       limit: input.limit,
       profile_name: input.profileName,
-      ...(input.watchId ? { watch_id: input.watchId } : {})
+      ...(input.watchId ? { watch_id: input.watchId } : {}),
     });
 
     const events = runtime.activityWatches.listEvents({
       profileName: input.profileName,
       ...(input.watchId ? { watchId: input.watchId } : {}),
-      limit: input.limit
+      limit: input.limit,
     });
 
     runtime.logger.log("info", "cli.activity.events.list.done", {
       count: events.length,
       profile_name: input.profileName,
-      ...(input.watchId ? { watch_id: input.watchId } : {})
+      ...(input.watchId ? { watch_id: input.watchId } : {}),
     });
 
     const report: ActivityEventListReport = {
       run_id: runtime.runId,
       profile_name: input.profileName,
       count: events.length,
-      events
+      events,
     };
     emitActivityReport(report, outputMode, formatActivityEventListReport);
   } finally {
@@ -4456,13 +4625,17 @@ async function runActivityEventsList(input: {
   }
 }
 
-async function runActivityDeliveriesList(input: {
-  profileName: string;
-  watchId?: string;
-  subscriptionId?: string;
-  status?: WebhookDeliveryAttemptStatus;
-  limit: number;
-}, outputMode: ActivityOutputMode, cdpUrl?: string): Promise<void> {
+async function runActivityDeliveriesList(
+  input: {
+    profileName: string;
+    watchId?: string;
+    subscriptionId?: string;
+    status?: WebhookDeliveryAttemptStatus;
+    limit: number;
+  },
+  outputMode: ActivityOutputMode,
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
@@ -4470,8 +4643,10 @@ async function runActivityDeliveriesList(input: {
       limit: input.limit,
       profile_name: input.profileName,
       ...(input.status ? { status: input.status } : {}),
-      ...(input.subscriptionId ? { subscription_id: input.subscriptionId } : {}),
-      ...(input.watchId ? { watch_id: input.watchId } : {})
+      ...(input.subscriptionId
+        ? { subscription_id: input.subscriptionId }
+        : {}),
+      ...(input.watchId ? { watch_id: input.watchId } : {}),
     });
 
     const deliveries = runtime.activityWatches.listDeliveries({
@@ -4479,22 +4654,24 @@ async function runActivityDeliveriesList(input: {
       ...(input.watchId ? { watchId: input.watchId } : {}),
       ...(input.subscriptionId ? { subscriptionId: input.subscriptionId } : {}),
       ...(input.status ? { status: input.status } : {}),
-      limit: input.limit
+      limit: input.limit,
     });
 
     runtime.logger.log("info", "cli.activity.deliveries.list.done", {
       count: deliveries.length,
       profile_name: input.profileName,
       ...(input.status ? { status: input.status } : {}),
-      ...(input.subscriptionId ? { subscription_id: input.subscriptionId } : {}),
-      ...(input.watchId ? { watch_id: input.watchId } : {})
+      ...(input.subscriptionId
+        ? { subscription_id: input.subscriptionId }
+        : {}),
+      ...(input.watchId ? { watch_id: input.watchId } : {}),
     });
 
     const report: ActivityDeliveryListReport = {
       run_id: runtime.runId,
       profile_name: input.profileName,
       count: deliveries.length,
-      deliveries
+      deliveries,
     };
     emitActivityReport(report, outputMode, formatActivityDeliveryListReport);
   } finally {
@@ -4505,7 +4682,7 @@ async function runActivityDeliveriesList(input: {
 async function runActivityRunOnce(
   profileName: string,
   outputMode: ActivityOutputMode,
-  cdpUrl?: string
+  cdpUrl?: string,
 ): Promise<void> {
   const normalizedProfileName = coerceProfileName(profileName);
   const runtime = createRuntime(cdpUrl);
@@ -4514,18 +4691,18 @@ async function runActivityRunOnce(
   try {
     runtime.logger.log("info", "cli.activity.run_once.start", {
       profile_name: normalizedProfileName,
-      worker_id: `cli:${runtime.runId}`
+      worker_id: `cli:${runtime.runId}`,
     });
 
     if (outputMode === "human") {
       writeCliNotice(
-        `Running one activity polling tick for profile "${normalizedProfileName}".`
+        `Running one activity polling tick for profile "${normalizedProfileName}".`,
       );
     }
 
     const result = await runtime.activityPoller.runTick({
       profileName: normalizedProfileName,
-      workerId: `cli:${runtime.runId}`
+      workerId: `cli:${runtime.runId}`,
     });
 
     if (
@@ -4541,14 +4718,14 @@ async function runActivityRunOnce(
       failed_deliveries: result.failedDeliveries,
       failed_watches: result.failedWatches,
       profile_name: normalizedProfileName,
-      worker_id: result.workerId
+      worker_id: result.workerId,
     });
 
     const report: ActivityRunOnceReport = {
       run_id: runtime.runId,
       profile_name: normalizedProfileName,
       activity_config: activityConfig,
-      ...result
+      ...result,
     };
     emitActivityReport(report, outputMode, formatActivityRunOnceReport);
   } finally {
@@ -4559,7 +4736,7 @@ async function runActivityRunOnce(
 async function runActivityStart(
   profileName: string,
   outputMode: ActivityOutputMode,
-  cdpUrl?: string
+  cdpUrl?: string,
 ): Promise<void> {
   const normalizedProfileName = coerceProfileName(profileName);
   const files = getActivityFiles(normalizedProfileName);
@@ -4573,7 +4750,7 @@ async function runActivityStart(
       state: await readActivityState(normalizedProfileName),
       state_path: files.statePath,
       log_path: files.logPath,
-      ...resolveActivityStatusConfig()
+      ...resolveActivityStatusConfig(),
     };
     emitActivityReport(report, outputMode, formatActivityStartReport);
     return;
@@ -4590,7 +4767,7 @@ async function runActivityStart(
 
   if (outputMode === "human") {
     writeCliNotice(
-      `Starting the activity daemon for profile "${normalizedProfileName}".`
+      `Starting the activity daemon for profile "${normalizedProfileName}".`,
     );
   }
 
@@ -4599,7 +4776,7 @@ async function runActivityStart(
   if (!cliEntrypoint) {
     throw new LinkedInBuddyError(
       "UNKNOWN",
-      "Could not resolve CLI entrypoint for activity daemon startup."
+      "Could not resolve CLI entrypoint for activity daemon startup.",
     );
   }
 
@@ -4615,14 +4792,14 @@ async function runActivityStart(
   const daemon = spawn(process.execPath, daemonArgs, {
     detached: true,
     stdio: "ignore",
-    env: process.env
+    env: process.env,
   });
   daemon.unref();
 
   if (!daemon.pid) {
     throw new LinkedInBuddyError(
       "UNKNOWN",
-      "Activity daemon did not return a process id."
+      "Activity daemon did not return a process id.",
     );
   }
 
@@ -4638,7 +4815,7 @@ async function runActivityStart(
     maxDeliveriesPerTick: activityConfig.maxDeliveriesPerTick,
     consecutiveFailures: 0,
     maxConsecutiveFailures: ACTIVITY_DAEMON_MAX_CONSECUTIVE_FAILURES,
-    ...(cdpUrl ? { cdpUrl } : {})
+    ...(cdpUrl ? { cdpUrl } : {}),
   };
 
   await writeActivityPid(normalizedProfileName, daemon.pid);
@@ -4650,14 +4827,14 @@ async function runActivityStart(
     pid: daemon.pid,
     state_path: files.statePath,
     log_path: files.logPath,
-    activity_config: activityConfig
+    activity_config: activityConfig,
   };
   emitActivityReport(report, outputMode, formatActivityStartReport);
 }
 
 async function runActivityStatus(
   profileName: string,
-  outputMode: ActivityOutputMode
+  outputMode: ActivityOutputMode,
 ): Promise<void> {
   const normalizedProfileName = coerceProfileName(profileName);
   const pid = await readActivityPid(normalizedProfileName);
@@ -4668,18 +4845,18 @@ async function runActivityStatus(
 
   try {
     const watches = db.listActivityWatches({
-      profileName: normalizedProfileName
+      profileName: normalizedProfileName,
     });
     const subscriptions = db.listWebhookSubscriptions({
-      profileName: normalizedProfileName
+      profileName: normalizedProfileName,
     });
     const recentEvents = db.listActivityEvents({
       profileName: normalizedProfileName,
-      limit: 5
+      limit: 5,
     });
     const recentDeliveries = db.listWebhookDeliveryAttempts({
       profileName: normalizedProfileName,
-      limit: 5
+      limit: 5,
     });
 
     const report: ActivityStatusReport = {
@@ -4691,14 +4868,15 @@ async function runActivityStatus(
       state_path: files.statePath,
       log_path: files.logPath,
       watch_count: watches.length,
-      active_watch_count: watches.filter((watch) => watch.status === "active").length,
+      active_watch_count: watches.filter((watch) => watch.status === "active")
+        .length,
       subscription_count: subscriptions.length,
       active_subscription_count: subscriptions.filter(
-        (subscription) => subscription.status === "active"
+        (subscription) => subscription.status === "active",
       ).length,
       recent_event_count: recentEvents.length,
       recent_delivery_count: recentDeliveries.length,
-      ...resolveActivityStatusConfig()
+      ...resolveActivityStatusConfig(),
     };
 
     if (report.activity_config_error) {
@@ -4713,7 +4891,7 @@ async function runActivityStatus(
 
 async function runActivityStop(
   profileName: string,
-  outputMode: ActivityOutputMode
+  outputMode: ActivityOutputMode,
 ): Promise<void> {
   const normalizedProfileName = coerceProfileName(profileName);
   const files = getActivityFiles(normalizedProfileName);
@@ -4726,7 +4904,7 @@ async function runActivityStop(
       profile_name: normalizedProfileName,
       reason: "No activity daemon is currently running for this profile.",
       state_path: files.statePath,
-      log_path: files.logPath
+      log_path: files.logPath,
     };
     emitActivityReport(report, outputMode, formatActivityStopReport);
     return;
@@ -4741,7 +4919,7 @@ async function runActivityStop(
         status: "stopped",
         updatedAt: now,
         stoppedAt: now,
-        lastError: "Recovered from stale pid file."
+        lastError: "Recovered from stale pid file.",
       });
     }
     const report: ActivityStopReport = {
@@ -4750,7 +4928,7 @@ async function runActivityStop(
       pid,
       reason: "Removed a stale activity PID file for this profile.",
       state_path: files.statePath,
-      log_path: files.logPath
+      log_path: files.logPath,
     };
     emitActivityReport(report, outputMode, formatActivityStopReport);
     return;
@@ -4758,7 +4936,7 @@ async function runActivityStop(
 
   if (outputMode === "human") {
     writeCliNotice(
-      `Stopping the activity daemon for profile "${normalizedProfileName}".`
+      `Stopping the activity daemon for profile "${normalizedProfileName}".`,
     );
   }
 
@@ -4771,8 +4949,8 @@ async function runActivityStop(
       {
         profile_name: normalizedProfileName,
         pid,
-        cause: error instanceof Error ? error.message : String(error)
-      }
+        cause: error instanceof Error ? error.message : String(error),
+      },
     );
   }
 
@@ -4798,7 +4976,9 @@ async function runActivityStop(
       status: "stopped",
       updatedAt: now,
       stoppedAt: now,
-      ...(running ? { lastError: "Activity daemon required SIGKILL to stop." } : {})
+      ...(running
+        ? { lastError: "Activity daemon required SIGKILL to stop." }
+        : {}),
     });
   }
 
@@ -4811,14 +4991,14 @@ async function runActivityStop(
       ? "Activity daemon did not exit after SIGTERM, so it was force-stopped."
       : "Activity daemon exited cleanly.",
     state_path: files.statePath,
-    log_path: files.logPath
+    log_path: files.logPath,
   };
   emitActivityReport(report, outputMode, formatActivityStopReport);
 }
 
 async function runActivityDaemon(
   profileName: string,
-  cdpUrl?: string
+  cdpUrl?: string,
 ): Promise<void> {
   const activityConfig = resolveActivityWebhookConfig();
   let stopRequested = false;
@@ -4842,7 +5022,7 @@ async function runActivityDaemon(
     maxDeliveriesPerTick: activityConfig.maxDeliveriesPerTick,
     consecutiveFailures: 0,
     maxConsecutiveFailures: ACTIVITY_DAEMON_MAX_CONSECUTIVE_FAILURES,
-    ...(cdpUrl ? { cdpUrl } : {})
+    ...(cdpUrl ? { cdpUrl } : {}),
   };
 
   await writeActivityPid(profileName, process.pid);
@@ -4853,7 +5033,7 @@ async function runActivityDaemon(
     pid: process.pid,
     profile_name: profileName,
     cdp_url: cdpUrl ?? null,
-    activity_config: activityConfig
+    activity_config: activityConfig,
   });
 
   try {
@@ -4866,7 +5046,7 @@ async function runActivityDaemon(
         try {
           const result = await runtime.activityPoller.runTick({
             profileName,
-            workerId: `activity-daemon:${process.pid}`
+            workerId: `activity-daemon:${process.pid}`,
           });
 
           consecutiveFailures = 0;
@@ -4890,7 +5070,7 @@ async function runActivityDaemon(
             maxConsecutiveFailures: ACTIVITY_DAEMON_MAX_CONSECUTIVE_FAILURES,
             lastTickAt: tickAt,
             lastSuccessfulTickAt: tickAt,
-            lastSummary: summarizeActivityTick(result)
+            lastSummary: summarizeActivityTick(result),
           };
           delete nextState.lastError;
 
@@ -4899,7 +5079,7 @@ async function runActivityDaemon(
             ts: tickAt,
             event: "activity.tick",
             profile_name: profileName,
-            summary: summarizeActivityTick(result)
+            summary: summarizeActivityTick(result),
           });
         } finally {
           runtime.close();
@@ -4926,7 +5106,7 @@ async function runActivityDaemon(
           consecutiveFailures,
           maxConsecutiveFailures: ACTIVITY_DAEMON_MAX_CONSECUTIVE_FAILURES,
           lastTickAt: tickAt,
-          lastError: message
+          lastError: message,
         };
         await writeActivityState(profileName, nextState);
         await appendActivityEvent(profileName, {
@@ -4935,7 +5115,7 @@ async function runActivityDaemon(
           profile_name: profileName,
           consecutive_failures: consecutiveFailures,
           error: message,
-          ...(lockHeld ? { reason: "profile_lock_held" } : {})
+          ...(lockHeld ? { reason: "profile_lock_held" } : {}),
         });
       }
 
@@ -4943,7 +5123,10 @@ async function runActivityDaemon(
         break;
       }
 
-      let sleepRemainingMs = Math.max(1_000, activityConfig.daemonPollIntervalMs);
+      let sleepRemainingMs = Math.max(
+        1_000,
+        activityConfig.daemonPollIntervalMs,
+      );
       while (!stopRequested && sleepRemainingMs > 0) {
         const chunkMs = Math.min(500, sleepRemainingMs);
         await sleep(chunkMs);
@@ -4959,13 +5142,13 @@ async function runActivityDaemon(
       profileName,
       status: "stopped",
       updatedAt: now,
-      stoppedAt: now
+      stoppedAt: now,
     });
     await appendActivityEvent(profileName, {
       ts: now,
       event: "activity.daemon.stopped",
       pid: process.pid,
-      profile_name: profileName
+      profile_name: profileName,
     });
 
     await removeActivityPid(profileName).catch(() => undefined);
@@ -4975,25 +5158,25 @@ async function runActivityDaemon(
 async function runLogin(
   profileName: string,
   timeoutMinutes: number,
-  cdpUrl?: string
+  cdpUrl?: string,
 ): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.login.start", {
       profileName,
-      timeoutMinutes
+      timeoutMinutes,
     });
 
     const result = await runtime.auth.openLogin({
       profileName,
-      timeoutMs: timeoutMinutes * 60_000
+      timeoutMs: timeoutMinutes * 60_000,
     });
 
     runtime.logger.log("info", "cli.login.done", {
       profileName,
       authenticated: result.authenticated,
-      timedOut: result.timedOut
+      timedOut: result.timedOut,
     });
 
     printJson({ run_id: runtime.runId, ...result });
@@ -5006,18 +5189,22 @@ async function runLogin(
   }
 }
 
-async function runHeadlessLogin(input: {
-  profileName: string;
-  email: string;
-  password: string;
-  mfaCode?: string;
-  mfaCallback?: () => Promise<string | undefined>;
-  timeoutMinutes: number;
-}, cdpUrl?: string): Promise<void> {
+async function runHeadlessLogin(
+  input: {
+    profileName: string;
+    email: string;
+    password: string;
+    headless?: boolean;
+    mfaCode?: string;
+    mfaCallback?: () => Promise<string | undefined>;
+    timeoutMinutes: number;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
   const progressEnabled = Boolean(process.stderr.isTTY);
   const progressReporter = new HeadlessLoginProgressReporter({
-    enabled: progressEnabled
+    enabled: progressEnabled,
   });
 
   if (progressEnabled) {
@@ -5029,16 +5216,20 @@ async function runHeadlessLogin(input: {
   try {
     runtime.logger.log("info", "cli.login.headless.start", {
       profileName: input.profileName,
-      email: input.email
+      email: input.email,
+      headless: input.headless ?? true,
     });
 
     const result = await runtime.auth.headlessLogin({
       profileName: input.profileName,
       email: input.email,
       password: input.password,
+      ...(typeof input.headless === "boolean"
+        ? { headless: input.headless }
+        : {}),
       ...(typeof input.mfaCode === "string" ? { mfaCode: input.mfaCode } : {}),
       ...(input.mfaCallback ? { mfaCallback: input.mfaCallback } : {}),
-      timeoutMs: input.timeoutMinutes * 60_000
+      timeoutMs: input.timeoutMinutes * 60_000,
     });
 
     runtime.logger.log("info", "cli.login.headless.done", {
@@ -5047,7 +5238,7 @@ async function runHeadlessLogin(input: {
       timedOut: result.timedOut,
       checkpoint: result.checkpoint,
       checkpointType: result.checkpointType,
-      mfaRequired: result.mfaRequired
+      mfaRequired: result.mfaRequired,
     });
 
     printJson({ run_id: runtime.runId, ...result });
@@ -5060,272 +5251,296 @@ async function runHeadlessLogin(input: {
   }
 }
 
-async function runInboxList(input: {
-  profileName: string;
-  limit: number;
-  unreadOnly: boolean;
-}, cdpUrl?: string): Promise<void> {
+async function runInboxList(
+  input: {
+    profileName: string;
+    limit: number;
+    unreadOnly: boolean;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.inbox.list.start", {
       profileName: input.profileName,
       limit: input.limit,
-      unreadOnly: input.unreadOnly
+      unreadOnly: input.unreadOnly,
     });
 
     const threads = await runtime.inbox.listThreads({
       profileName: input.profileName,
       limit: input.limit,
-      unreadOnly: input.unreadOnly
+      unreadOnly: input.unreadOnly,
     });
 
     runtime.logger.log("info", "cli.inbox.list.done", {
       profileName: input.profileName,
-      count: threads.length
+      count: threads.length,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
       count: threads.length,
-      threads
+      threads,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runInboxShow(input: {
-  profileName: string;
-  thread: string;
-  limit: number;
-}, cdpUrl?: string): Promise<void> {
+async function runInboxShow(
+  input: {
+    profileName: string;
+    thread: string;
+    limit: number;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.inbox.show.start", {
       profileName: input.profileName,
       thread: input.thread,
-      limit: input.limit
+      limit: input.limit,
     });
 
     const thread = await runtime.inbox.getThread({
       profileName: input.profileName,
       thread: input.thread,
-      limit: input.limit
+      limit: input.limit,
     });
 
     runtime.logger.log("info", "cli.inbox.show.done", {
       profileName: input.profileName,
-      threadId: thread.thread_id
+      threadId: thread.thread_id,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      thread
+      thread,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runPrepareReply(input: {
-  profileName: string;
-  thread: string;
-  text: string;
-}, cdpUrl?: string): Promise<void> {
+async function runPrepareReply(
+  input: {
+    profileName: string;
+    thread: string;
+    text: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.inbox.prepare_reply.start", {
       profileName: input.profileName,
-      thread: input.thread
+      thread: input.thread,
     });
 
     const prepared = await runtime.inbox.prepareReply({
       profileName: input.profileName,
       thread: input.thread,
-      text: input.text
+      text: input.text,
     });
 
     runtime.logger.log("info", "cli.inbox.prepare_reply.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runInboxSearchRecipients(input: {
-  profileName: string;
-  query: string;
-  limit: number;
-}, cdpUrl?: string): Promise<void> {
+async function runInboxSearchRecipients(
+  input: {
+    profileName: string;
+    query: string;
+    limit: number;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.inbox.search_recipients.start", {
       limit: input.limit,
       profileName: input.profileName,
-      query: input.query
+      query: input.query,
     });
 
     const result = await runtime.inbox.searchRecipients({
       profileName: input.profileName,
       query: input.query,
-      limit: input.limit
+      limit: input.limit,
     });
 
     runtime.logger.log("info", "cli.inbox.search_recipients.done", {
       count: result.count,
       profileName: input.profileName,
-      query: input.query
+      query: input.query,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runPrepareNewThread(input: {
-  profileName: string;
-  recipients: string[];
-  text: string;
-}, cdpUrl?: string): Promise<void> {
+async function runPrepareNewThread(
+  input: {
+    profileName: string;
+    recipients: string[];
+    text: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.inbox.prepare_new_thread.start", {
       profileName: input.profileName,
-      recipientCount: input.recipients.length
+      recipientCount: input.recipients.length,
     });
 
     const prepared = await runtime.inbox.prepareNewThread({
       profileName: input.profileName,
       recipients: input.recipients,
-      text: input.text
+      text: input.text,
     });
 
     runtime.logger.log("info", "cli.inbox.prepare_new_thread.done", {
       preparedActionId: prepared.preparedActionId,
       profileName: input.profileName,
-      recipientCount: input.recipients.length
+      recipientCount: input.recipients.length,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runPrepareAddRecipients(input: {
-  profileName: string;
-  recipients: string[];
-  thread: string;
-}, cdpUrl?: string): Promise<void> {
+async function runPrepareAddRecipients(
+  input: {
+    profileName: string;
+    recipients: string[];
+    thread: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.inbox.prepare_add_recipients.start", {
       profileName: input.profileName,
       recipientCount: input.recipients.length,
-      thread: input.thread
+      thread: input.thread,
     });
 
     const prepared = await runtime.inbox.prepareAddRecipients({
       profileName: input.profileName,
       recipients: input.recipients,
-      thread: input.thread
+      thread: input.thread,
     });
 
     runtime.logger.log("info", "cli.inbox.prepare_add_recipients.done", {
       preparedActionId: prepared.preparedActionId,
       profileName: input.profileName,
       recipientCount: input.recipients.length,
-      thread: input.thread
+      thread: input.thread,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runConnectionsList(input: {
-  profileName: string;
-  limit: number;
-}, cdpUrl?: string): Promise<void> {
+async function runConnectionsList(
+  input: {
+    profileName: string;
+    limit: number;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.connections.list.start", {
       profileName: input.profileName,
-      limit: input.limit
+      limit: input.limit,
     });
 
     const connections = await runtime.connections.listConnections({
       profileName: input.profileName,
-      limit: input.limit
+      limit: input.limit,
     });
 
     runtime.logger.log("info", "cli.connections.list.done", {
       profileName: input.profileName,
-      count: connections.length
+      count: connections.length,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
       count: connections.length,
-      connections
+      connections,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runConnectionsPending(input: {
-  profileName: string;
-  filter: "sent" | "received" | "all";
-}, cdpUrl?: string): Promise<void> {
+async function runConnectionsPending(
+  input: {
+    profileName: string;
+    filter: "sent" | "received" | "all";
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.connections.pending.start", {
       profileName: input.profileName,
-      filter: input.filter
+      filter: input.filter,
     });
 
     const invitations = await runtime.connections.listPendingInvitations({
       profileName: input.profileName,
-      filter: input.filter
+      filter: input.filter,
     });
 
     runtime.logger.log("info", "cli.connections.pending.done", {
       profileName: input.profileName,
-      count: invitations.length
+      count: invitations.length,
     });
 
     printJson({
@@ -5333,181 +5548,199 @@ async function runConnectionsPending(input: {
       profile_name: input.profileName,
       filter: input.filter,
       count: invitations.length,
-      invitations
+      invitations,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runConnectionsInvite(input: {
-  profileName: string;
-  targetProfile: string;
-  note?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runConnectionsInvite(
+  input: {
+    profileName: string;
+    targetProfile: string;
+    note?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.connections.invite.start", {
       profileName: input.profileName,
-      targetProfile: input.targetProfile
+      targetProfile: input.targetProfile,
     });
 
     const prepared = runtime.connections.prepareSendInvitation({
       profileName: input.profileName,
       targetProfile: input.targetProfile,
-      ...(input.note ? { note: input.note } : {})
+      ...(input.note ? { note: input.note } : {}),
     });
 
     runtime.logger.log("info", "cli.connections.invite.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runConnectionsAccept(input: {
-  profileName: string;
-  targetProfile: string;
-}, cdpUrl?: string): Promise<void> {
+async function runConnectionsAccept(
+  input: {
+    profileName: string;
+    targetProfile: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.connections.accept.start", {
       profileName: input.profileName,
-      targetProfile: input.targetProfile
+      targetProfile: input.targetProfile,
     });
 
     const prepared = runtime.connections.prepareAcceptInvitation({
       profileName: input.profileName,
-      targetProfile: input.targetProfile
+      targetProfile: input.targetProfile,
     });
 
     runtime.logger.log("info", "cli.connections.accept.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runConnectionsWithdraw(input: {
-  profileName: string;
-  targetProfile: string;
-}, cdpUrl?: string): Promise<void> {
+async function runConnectionsWithdraw(
+  input: {
+    profileName: string;
+    targetProfile: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.connections.withdraw.start", {
       profileName: input.profileName,
-      targetProfile: input.targetProfile
+      targetProfile: input.targetProfile,
     });
 
     const prepared = runtime.connections.prepareWithdrawInvitation({
       profileName: input.profileName,
-      targetProfile: input.targetProfile
+      targetProfile: input.targetProfile,
     });
 
     runtime.logger.log("info", "cli.connections.withdraw.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runMembersPrepareBlock(input: {
-  profileName: string;
-  targetProfile: string;
-}, cdpUrl?: string): Promise<void> {
+async function runMembersPrepareBlock(
+  input: {
+    profileName: string;
+    targetProfile: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.members.prepare_block.start", {
       profileName: input.profileName,
-      targetProfile: input.targetProfile
+      targetProfile: input.targetProfile,
     });
 
     const prepared = runtime.members.prepareBlockMember({
       profileName: input.profileName,
-      targetProfile: input.targetProfile
+      targetProfile: input.targetProfile,
     });
 
     runtime.logger.log("info", "cli.members.prepare_block.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runMembersPrepareUnblock(input: {
-  profileName: string;
-  targetProfile: string;
-}, cdpUrl?: string): Promise<void> {
+async function runMembersPrepareUnblock(
+  input: {
+    profileName: string;
+    targetProfile: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.members.prepare_unblock.start", {
       profileName: input.profileName,
-      targetProfile: input.targetProfile
+      targetProfile: input.targetProfile,
     });
 
     const prepared = runtime.members.prepareUnblockMember({
       profileName: input.profileName,
-      targetProfile: input.targetProfile
+      targetProfile: input.targetProfile,
     });
 
     runtime.logger.log("info", "cli.members.prepare_unblock.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runMembersPrepareReport(input: {
-  profileName: string;
-  targetProfile: string;
-  reason: string;
-  details?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runMembersPrepareReport(
+  input: {
+    profileName: string;
+    targetProfile: string;
+    reason: string;
+    details?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
   const reason = normalizeLinkedInMemberReportReason(input.reason);
 
@@ -5515,65 +5748,71 @@ async function runMembersPrepareReport(input: {
     runtime.logger.log("info", "cli.members.prepare_report.start", {
       profileName: input.profileName,
       targetProfile: input.targetProfile,
-      reason
+      reason,
     });
 
     const prepared = runtime.members.prepareReportMember({
       profileName: input.profileName,
       targetProfile: input.targetProfile,
       reason,
-      ...(input.details ? { details: input.details } : {})
+      ...(input.details ? { details: input.details } : {}),
     });
 
     runtime.logger.log("info", "cli.members.prepare_report.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runPrivacyGetSettings(input: {
-  profileName: string;
-}, cdpUrl?: string): Promise<void> {
+async function runPrivacyGetSettings(
+  input: {
+    profileName: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.privacy.get_settings.start", {
-      profileName: input.profileName
+      profileName: input.profileName,
     });
 
     const settings = await runtime.privacySettings.getSettings({
-      profileName: input.profileName
+      profileName: input.profileName,
     });
 
     runtime.logger.log("info", "cli.privacy.get_settings.done", {
       profileName: input.profileName,
-      count: settings.length
+      count: settings.length,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      settings
+      settings,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runPrivacyPrepareUpdateSetting(input: {
-  profileName: string;
-  settingKey: string;
-  value: string;
-}, cdpUrl?: string): Promise<void> {
+async function runPrivacyPrepareUpdateSetting(
+  input: {
+    profileName: string;
+    settingKey: string;
+    value: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
   const settingKey = normalizeLinkedInPrivacySettingKey(input.settingKey);
   const value = normalizeLinkedInPrivacySettingValue(settingKey, input.value);
@@ -5582,51 +5821,56 @@ async function runPrivacyPrepareUpdateSetting(input: {
     runtime.logger.log("info", "cli.privacy.prepare_update_setting.start", {
       profileName: input.profileName,
       settingKey,
-      value
+      value,
     });
 
     const prepared = runtime.privacySettings.prepareUpdateSetting({
       profileName: input.profileName,
       settingKey,
-      value
+      value,
     });
 
     runtime.logger.log("info", "cli.privacy.prepare_update_setting.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runFollowupsList(input: {
-  profileName: string;
-  since: string;
-}, cdpUrl?: string): Promise<void> {
+async function runFollowupsList(
+  input: {
+    profileName: string;
+    since: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
   const { since, sinceMs } = resolveFollowupSinceWindow(input.since);
 
   try {
     runtime.logger.log("info", "cli.followups.list.start", {
       profileName: input.profileName,
-      since
+      since,
     });
 
-    const acceptedConnections = await runtime.followups.listAcceptedConnections({
-      profileName: input.profileName,
-      since
-    });
+    const acceptedConnections = await runtime.followups.listAcceptedConnections(
+      {
+        profileName: input.profileName,
+        since,
+      },
+    );
 
     runtime.logger.log("info", "cli.followups.list.done", {
       profileName: input.profileName,
-      count: acceptedConnections.length
+      count: acceptedConnections.length,
     });
 
     printJson({
@@ -5636,35 +5880,38 @@ async function runFollowupsList(input: {
       since_ms: sinceMs,
       since_at: new Date(sinceMs).toISOString(),
       count: acceptedConnections.length,
-      accepted_connections: acceptedConnections
+      accepted_connections: acceptedConnections,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runFollowupsPrepare(input: {
-  profileName: string;
-  since: string;
-}, cdpUrl?: string): Promise<void> {
+async function runFollowupsPrepare(
+  input: {
+    profileName: string;
+    since: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
   const { since, sinceMs } = resolveFollowupSinceWindow(input.since);
 
   try {
     runtime.logger.log("info", "cli.followups.prepare.start", {
       profileName: input.profileName,
-      since
+      since,
     });
 
     const result = await runtime.followups.prepareFollowupsAfterAccept({
       profileName: input.profileName,
-      since
+      since,
     });
 
     runtime.logger.log("info", "cli.followups.prepare.done", {
       profileName: input.profileName,
       acceptedConnectionCount: result.acceptedConnections.length,
-      preparedCount: result.preparedFollowups.length
+      preparedCount: result.preparedFollowups.length,
     });
 
     printJson({
@@ -5676,84 +5923,93 @@ async function runFollowupsPrepare(input: {
       accepted_connection_count: result.acceptedConnections.length,
       prepared_count: result.preparedFollowups.length,
       accepted_connections: result.acceptedConnections,
-      prepared_followups: result.preparedFollowups
+      prepared_followups: result.preparedFollowups,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runFeedList(input: {
-  profileName: string;
-  limit: number;
-}, cdpUrl?: string): Promise<void> {
+async function runFeedList(
+  input: {
+    profileName: string;
+    limit: number;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.feed.list.start", {
       profileName: input.profileName,
-      limit: input.limit
+      limit: input.limit,
     });
 
     const posts = await runtime.feed.viewFeed({
       profileName: input.profileName,
-      limit: input.limit
+      limit: input.limit,
     });
 
     runtime.logger.log("info", "cli.feed.list.done", {
       profileName: input.profileName,
-      count: posts.length
+      count: posts.length,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
       count: posts.length,
-      posts
+      posts,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runFeedView(input: {
-  profileName: string;
-  postUrl: string;
-}, cdpUrl?: string): Promise<void> {
+async function runFeedView(
+  input: {
+    profileName: string;
+    postUrl: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.feed.view.start", {
       profileName: input.profileName,
-      postUrl: input.postUrl
+      postUrl: input.postUrl,
     });
 
     const post = await runtime.feed.viewPost({
       profileName: input.profileName,
-      postUrl: input.postUrl
+      postUrl: input.postUrl,
     });
 
     runtime.logger.log("info", "cli.feed.view.done", {
       profileName: input.profileName,
-      postId: post.post_id
+      postId: post.post_id,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      post
+      post,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runFeedLike(input: {
-  profileName: string;
-  postUrl: string;
-  reaction?: string;
-  operatorNote?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runFeedLike(
+  input: {
+    profileName: string;
+    postUrl: string;
+    reaction?: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
   const reaction = normalizeLinkedInFeedReaction(input.reaction, "like");
 
@@ -5761,499 +6017,552 @@ async function runFeedLike(input: {
     runtime.logger.log("info", "cli.feed.like.start", {
       profileName: input.profileName,
       postUrl: input.postUrl,
-      reaction
+      reaction,
     });
 
     const prepared = runtime.feed.prepareLikePost({
       profileName: input.profileName,
       postUrl: input.postUrl,
       reaction,
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
 
     runtime.logger.log("info", "cli.feed.like.done", {
       profileName: input.profileName,
       preparedActionId: prepared.preparedActionId,
-      reaction
+      reaction,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runFeedComment(input: {
-  profileName: string;
-  postUrl: string;
-  text: string;
-  operatorNote?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runFeedComment(
+  input: {
+    profileName: string;
+    postUrl: string;
+    text: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.feed.comment.start", {
       profileName: input.profileName,
-      postUrl: input.postUrl
+      postUrl: input.postUrl,
     });
 
     const prepared = runtime.feed.prepareCommentOnPost({
       profileName: input.profileName,
       postUrl: input.postUrl,
       text: input.text,
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
 
     runtime.logger.log("info", "cli.feed.comment.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runFeedRepost(input: {
-  profileName: string;
-  postUrl: string;
-  operatorNote?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runFeedRepost(
+  input: {
+    profileName: string;
+    postUrl: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.feed.repost.start", {
       profileName: input.profileName,
-      postUrl: input.postUrl
+      postUrl: input.postUrl,
     });
 
     const prepared = runtime.feed.prepareRepostPost({
       profileName: input.profileName,
       postUrl: input.postUrl,
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
 
     runtime.logger.log("info", "cli.feed.repost.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runFeedShare(input: {
-  profileName: string;
-  postUrl: string;
-  text: string;
-  operatorNote?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runFeedShare(
+  input: {
+    profileName: string;
+    postUrl: string;
+    text: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.feed.share.start", {
       profileName: input.profileName,
-      postUrl: input.postUrl
+      postUrl: input.postUrl,
     });
 
     const prepared = runtime.feed.prepareSharePost({
       profileName: input.profileName,
       postUrl: input.postUrl,
       text: input.text,
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
 
     runtime.logger.log("info", "cli.feed.share.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runFeedSave(input: {
-  profileName: string;
-  postUrl: string;
-  operatorNote?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runFeedSave(
+  input: {
+    profileName: string;
+    postUrl: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.feed.save.start", {
       profileName: input.profileName,
-      postUrl: input.postUrl
+      postUrl: input.postUrl,
     });
 
     const prepared = runtime.feed.prepareSavePost({
       profileName: input.profileName,
       postUrl: input.postUrl,
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
 
     runtime.logger.log("info", "cli.feed.save.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runFeedUnsave(input: {
-  profileName: string;
-  postUrl: string;
-  operatorNote?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runFeedUnsave(
+  input: {
+    profileName: string;
+    postUrl: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.feed.unsave.start", {
       profileName: input.profileName,
-      postUrl: input.postUrl
+      postUrl: input.postUrl,
     });
 
     const prepared = runtime.feed.prepareUnsavePost({
       profileName: input.profileName,
       postUrl: input.postUrl,
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
 
     runtime.logger.log("info", "cli.feed.unsave.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runFeedRemoveReaction(input: {
-  profileName: string;
-  postUrl: string;
-  operatorNote?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runFeedRemoveReaction(
+  input: {
+    profileName: string;
+    postUrl: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.feed.remove_reaction.start", {
       profileName: input.profileName,
-      postUrl: input.postUrl
+      postUrl: input.postUrl,
     });
 
     const prepared = runtime.feed.prepareRemoveReaction({
       profileName: input.profileName,
       postUrl: input.postUrl,
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
 
     runtime.logger.log("info", "cli.feed.remove_reaction.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runPostPrepare(input: {
-  profileName: string;
-  text: string;
-  visibility?: string;
-  operatorNote?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runPostPrepare(
+  input: {
+    profileName: string;
+    text: string;
+    visibility?: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
-  const visibility = normalizeLinkedInPostVisibility(input.visibility, "public");
+  const visibility = normalizeLinkedInPostVisibility(
+    input.visibility,
+    "public",
+  );
 
   try {
     runtime.logger.log("info", "cli.post.prepare.start", {
       profileName: input.profileName,
-      visibility
+      visibility,
     });
 
     const prepared = await runtime.posts.prepareCreate({
       profileName: input.profileName,
       text: input.text,
       visibility,
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
 
     runtime.logger.log("info", "cli.post.prepare.done", {
       profileName: input.profileName,
       preparedActionId: prepared.preparedActionId,
-      visibility
+      visibility,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runProfileView(input: {
-  profileName: string;
-  target: string;
-}, cdpUrl?: string): Promise<void> {
+async function runProfileView(
+  input: {
+    profileName: string;
+    target: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.profile.view.start", {
       profileName: input.profileName,
-      target: input.target
+      target: input.target,
     });
 
     const profile = await runtime.profile.viewProfile({
       profileName: input.profileName,
-      target: input.target
+      target: input.target,
     });
 
     runtime.logger.log("info", "cli.profile.view.done", {
       profileName: input.profileName,
-      fullName: profile.full_name
+      fullName: profile.full_name,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      profile
+      profile,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runCompanyPageView(input: {
-  profileName: string;
-  target: string;
-}, cdpUrl?: string): Promise<void> {
+async function runCompanyPageView(
+  input: {
+    profileName: string;
+    target: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.company.view.start", {
       profileName: input.profileName,
-      target: input.target
+      target: input.target,
     });
 
     const company = await runtime.companyPages.viewCompanyPage({
       profileName: input.profileName,
-      target: input.target
+      target: input.target,
     });
 
     runtime.logger.log("info", "cli.company.view.done", {
       profileName: input.profileName,
-      companyName: company.name
+      companyName: company.name,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      company
+      company,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runCompanyPrepareFollow(input: {
-  profileName: string;
-  targetCompany: string;
-  operatorNote?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runCompanyPrepareFollow(
+  input: {
+    profileName: string;
+    targetCompany: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.company.prepare_follow.start", {
       profileName: input.profileName,
-      targetCompany: input.targetCompany
+      targetCompany: input.targetCompany,
     });
 
     const prepared = runtime.companyPages.prepareFollowCompanyPage({
       profileName: input.profileName,
       targetCompany: input.targetCompany,
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
 
     runtime.logger.log("info", "cli.company.prepare_follow.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runCompanyPrepareUnfollow(input: {
-  profileName: string;
-  targetCompany: string;
-  operatorNote?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runCompanyPrepareUnfollow(
+  input: {
+    profileName: string;
+    targetCompany: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.company.prepare_unfollow.start", {
       profileName: input.profileName,
-      targetCompany: input.targetCompany
+      targetCompany: input.targetCompany,
     });
 
     const prepared = runtime.companyPages.prepareUnfollowCompanyPage({
       profileName: input.profileName,
       targetCompany: input.targetCompany,
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
 
     runtime.logger.log("info", "cli.company.prepare_unfollow.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runProfileViewEditable(input: {
-  profileName: string;
-}, cdpUrl?: string): Promise<void> {
+async function runProfileViewEditable(
+  input: {
+    profileName: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.profile.view_editable.start", {
-      profileName: input.profileName
+      profileName: input.profileName,
     });
 
     const profile = await runtime.profile.viewEditableProfile({
-      profileName: input.profileName
+      profileName: input.profileName,
     });
 
     runtime.logger.log("info", "cli.profile.view_editable.done", {
       profileName: input.profileName,
-      sectionCount: profile.sections.length
+      sectionCount: profile.sections.length,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      profile
+      profile,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runProfilePrepareUpdateSettings(input: {
-  profileName: string;
-  industry: string;
-  operatorNote?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runProfilePrepareUpdateSettings(
+  input: {
+    profileName: string;
+    industry: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.profile.prepare_update_settings.start", {
-      profileName: input.profileName
+      profileName: input.profileName,
     });
 
     const prepared = runtime.profile.prepareUpdateSettings({
       profileName: input.profileName,
       industry: input.industry,
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
 
     runtime.logger.log("info", "cli.profile.prepare_update_settings.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runProfilePrepareUpdatePublicProfile(input: {
-  profileName: string;
-  vanityName: string;
-  operatorNote?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runProfilePrepareUpdatePublicProfile(
+  input: {
+    profileName: string;
+    vanityName: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
-    runtime.logger.log("info", "cli.profile.prepare_update_public_profile.start", {
-      profileName: input.profileName
-    });
+    runtime.logger.log(
+      "info",
+      "cli.profile.prepare_update_public_profile.start",
+      {
+        profileName: input.profileName,
+      },
+    );
 
     const prepared = runtime.profile.prepareUpdatePublicProfile({
       profileName: input.profileName,
       vanityName: input.vanityName,
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
 
-    runtime.logger.log("info", "cli.profile.prepare_update_public_profile.done", {
-      profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
-    });
+    runtime.logger.log(
+      "info",
+      "cli.profile.prepare_update_public_profile.done",
+      {
+        profileName: input.profileName,
+        preparedActionId: prepared.preparedActionId,
+      },
+    );
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -6261,7 +6570,7 @@ async function runProfilePrepareUpdatePublicProfile(input: {
 }
 
 function summarizeProfileSeedUnsupportedFields(
-  unsupportedFields: readonly ProfileSeedUnsupportedField[]
+  unsupportedFields: readonly ProfileSeedUnsupportedField[],
 ): string {
   return unsupportedFields
     .map((field) => `${field.path} (#${field.issueNumber})`)
@@ -6269,7 +6578,7 @@ function summarizeProfileSeedUnsupportedFields(
 }
 
 function createProfileSeedUnsupportedFieldsError(
-  unsupportedFields: readonly ProfileSeedUnsupportedField[]
+  unsupportedFields: readonly ProfileSeedUnsupportedField[],
 ): LinkedInBuddyError {
   return new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
@@ -6278,9 +6587,9 @@ function createProfileSeedUnsupportedFieldsError(
       unsupported_fields: unsupportedFields.map((field) => ({
         path: field.path,
         issue_number: field.issueNumber,
-        reason: field.reason
-      }))
-    }
+        reason: field.reason,
+      })),
+    },
   );
 }
 
@@ -6299,7 +6608,7 @@ function sampleSeedDelay(baseDelayMs: number): number {
 
 function prepareProfileSeedAction(
   runtime: CliRuntime,
-  action: ProfileSeedPlanAction
+  action: ProfileSeedPlanAction,
 ) {
   switch (action.kind) {
     case "update_intro":
@@ -6330,14 +6639,18 @@ interface ActivitySeedPlanSummary {
   totalWriteActions: number;
 }
 
-function createActivitySeedPlanSummary(spec: ActivitySeedSpec): ActivitySeedPlanSummary {
+function createActivitySeedPlanSummary(
+  spec: ActivitySeedSpec,
+): ActivitySeedPlanSummary {
   const jobViewCount = spec.jobs.searches.reduce(
     (total, search) => total + (search.viewTop ?? 0),
-    0
+    0,
   );
   const totalWriteActions =
     spec.connections.invites.length +
-    (spec.connections.acceptPending ? spec.connections.acceptPending.limit : 0) +
+    (spec.connections.acceptPending
+      ? spec.connections.acceptPending.limit
+      : 0) +
     spec.posts.length +
     spec.feed.likes.length +
     spec.feed.comments.length +
@@ -6358,13 +6671,13 @@ function createActivitySeedPlanSummary(spec: ActivitySeedSpec): ActivitySeedPlan
     postCount: spec.posts.length,
     replyCount: spec.messaging.replies.length,
     totalReadSteps,
-    totalWriteActions
+    totalWriteActions,
   };
 }
 
 async function resolveActivitySeedGeneratedPostImages(
   spec: ActivitySeedSpec,
-  resolvedSpecPath: string
+  resolvedSpecPath: string,
 ): Promise<{
   manifestPath: string;
   postImages: ActivitySeedGeneratedPostImage[];
@@ -6376,24 +6689,24 @@ async function resolveActivitySeedGeneratedPostImages(
 
   const resolvedManifestPath = path.resolve(
     path.dirname(resolvedSpecPath),
-    manifestPathInput
+    manifestPathInput,
   );
   const rawManifest = await readJsonInputFile(
     resolvedManifestPath,
-    "activity seed generated image manifest"
+    "activity seed generated image manifest",
   );
   const manifest = parseActivitySeedGeneratedImageManifest(rawManifest);
 
   return {
     manifestPath: resolvedManifestPath,
-    postImages: manifest.postImages
+    postImages: manifest.postImages,
   };
 }
 
 function resolveActivitySeedPostMediaPath(
   post: ActivitySeedPostSpec,
   resolvedSpecPath: string,
-  generatedImages: readonly ActivitySeedGeneratedPostImage[]
+  generatedImages: readonly ActivitySeedGeneratedPostImage[],
 ): string | undefined {
   if (post.mediaPath) {
     return path.resolve(path.dirname(resolvedSpecPath), post.mediaPath);
@@ -6406,7 +6719,7 @@ function resolveActivitySeedPostMediaPath(
   if (generatedImages.length === 0) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "posts.generatedImageIndex requires assets.generatedImageManifestPath to be configured."
+      "posts.generatedImageIndex requires assets.generatedImageManifestPath to be configured.",
     );
   }
 
@@ -6414,7 +6727,7 @@ function resolveActivitySeedPostMediaPath(
   if (!generatedImage) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      `posts.generatedImageIndex ${post.generatedImageIndex} is out of range for the configured generated image manifest.`
+      `posts.generatedImageIndex ${post.generatedImageIndex} is out of range for the configured generated image manifest.`,
     );
   }
 
@@ -6439,7 +6752,7 @@ function normalizeComparableLinkedInIdentity(value: string): string {
 function createActivitySeedOperatorNote(
   resolvedSpecPath: string,
   sectionLabel: string,
-  explicitNote?: string
+  explicitNote?: string,
 ): string {
   const baseNote = explicitNote?.trim();
   if (baseNote) {
@@ -6461,7 +6774,7 @@ function summarizeConfirmedAction(confirmed: {
     prepared_action_id: confirmed.preparedActionId,
     status: confirmed.status,
     result: confirmed.result,
-    artifacts: confirmed.artifacts
+    artifacts: confirmed.artifacts,
   };
 }
 
@@ -6477,28 +6790,34 @@ async function maybeWarnAboutKeepAliveForSeeding(): Promise<number[]> {
   const runningKeepAlivePids = await findRunningKeepAlivePids();
   if (runningKeepAlivePids.length === 0) {
     writeCliWarning(
-      "No running keepalive daemon was detected. For long issue-212 seeding runs, start `linkedin keepalive start` in another terminal first."
+      "No running keepalive daemon was detected. For long issue-212 seeding runs, start `linkedin keepalive start` in another terminal first.",
     );
   } else {
     writeCliNotice(
-      `Detected keepalive daemon PID${runningKeepAlivePids.length === 1 ? "" : "s"}: ${runningKeepAlivePids.join(", ")}.`
+      `Detected keepalive daemon PID${runningKeepAlivePids.length === 1 ? "" : "s"}: ${runningKeepAlivePids.join(", ")}.`,
     );
   }
 
   return runningKeepAlivePids;
 }
 
-async function runProfileApplySpec(input: {
-  profileName: string;
-  specPath: string;
-  replace: boolean;
-  allowPartial: boolean;
-  delayMs: number;
-  yes: boolean;
-  outputPath?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runProfileApplySpec(
+  input: {
+    profileName: string;
+    specPath: string;
+    replace: boolean;
+    allowPartial: boolean;
+    delayMs: number;
+    yes: boolean;
+    outputPath?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const resolvedSpecPath = path.resolve(input.specPath);
-  const rawSpec = await readJsonInputFile(resolvedSpecPath, "profile seed spec");
+  const rawSpec = await readJsonInputFile(
+    resolvedSpecPath,
+    "profile seed spec",
+  );
   const spec = parseProfileSeedSpec(rawSpec);
   const runtime = createRuntime(cdpUrl);
 
@@ -6508,16 +6827,16 @@ async function runProfileApplySpec(input: {
       specPath: resolvedSpecPath,
       replace: input.replace,
       allowPartial: input.allowPartial,
-      delayMs: input.delayMs
+      delayMs: input.delayMs,
     });
 
     const editableProfile = await runtime.profile.viewEditableProfile({
-      profileName: input.profileName
+      profileName: input.profileName,
     });
     const plan = createProfileSeedPlan(editableProfile, spec, {
       profileName: input.profileName,
       operatorNote: `profile seed: ${path.basename(resolvedSpecPath)}`,
-      replace: input.replace
+      replace: input.replace,
     });
 
     if (plan.unsupportedFields.length > 0 && !input.allowPartial) {
@@ -6526,34 +6845,36 @@ async function runProfileApplySpec(input: {
 
     if (plan.unsupportedFields.length > 0) {
       writeCliWarning(
-        `Ignoring unsupported profile fields for this run: ${summarizeProfileSeedUnsupportedFields(plan.unsupportedFields)}.`
+        `Ignoring unsupported profile fields for this run: ${summarizeProfileSeedUnsupportedFields(plan.unsupportedFields)}.`,
       );
     }
 
     if (plan.actions.length > 0) {
       writeCliNotice(
-        `Loaded ${resolvedSpecPath} with ${plan.actions.length} supported profile ${plan.actions.length === 1 ? "edit" : "edits"}.`
+        `Loaded ${resolvedSpecPath} with ${plan.actions.length} supported profile ${plan.actions.length === 1 ? "edit" : "edits"}.`,
       );
     } else {
-      writeCliNotice(`Loaded ${resolvedSpecPath}; no supported profile edits are required.`);
+      writeCliNotice(
+        `Loaded ${resolvedSpecPath}; no supported profile edits are required.`,
+      );
     }
 
     if (!input.yes && plan.actions.length > 0) {
       if (!stdin.isTTY || !stdout.isTTY) {
         throw new LinkedInBuddyError(
           "ACTION_PRECONDITION_FAILED",
-          "Refusing to apply a profile seed spec without --yes in non-interactive mode."
+          "Refusing to apply a profile seed spec without --yes in non-interactive mode.",
         );
       }
 
       const confirmed = await promptYesNo(
         `Apply ${plan.actions.length} LinkedIn profile ${plan.actions.length === 1 ? "edit" : "edits"}?`,
-        process.stderr
+        process.stderr,
       );
       if (!confirmed) {
         throw new LinkedInBuddyError(
           "ACTION_PRECONDITION_FAILED",
-          "Operator declined profile seed execution."
+          "Operator declined profile seed execution.",
         );
       }
     }
@@ -6563,7 +6884,7 @@ async function runProfileApplySpec(input: {
       const action = plan.actions[index]!;
       const prepared = prepareProfileSeedAction(runtime, action);
       const confirmed = await runtime.twoPhaseCommit.confirmByToken({
-        confirmToken: prepared.confirmToken
+        confirmToken: prepared.confirmToken,
       });
 
       actionResults.push({
@@ -6572,7 +6893,7 @@ async function runProfileApplySpec(input: {
         prepared_action_id: confirmed.preparedActionId,
         status: confirmed.status,
         result: confirmed.result,
-        artifacts: confirmed.artifacts
+        artifacts: confirmed.artifacts,
       });
 
       if (index < plan.actions.length - 1 && input.delayMs > 0) {
@@ -6582,7 +6903,7 @@ async function runProfileApplySpec(input: {
 
     const finalProfile = await runtime.profile.viewProfile({
       profileName: input.profileName,
-      target: "me"
+      target: "me",
     });
 
     const report: Record<string, unknown> = {
@@ -6596,7 +6917,7 @@ async function runProfileApplySpec(input: {
       executed_action_count: actionResults.length,
       unsupported_fields: plan.unsupportedFields,
       actions: actionResults,
-      profile: finalProfile
+      profile: finalProfile,
     };
 
     if (input.outputPath) {
@@ -6608,7 +6929,7 @@ async function runProfileApplySpec(input: {
       specPath: resolvedSpecPath,
       plannedActionCount: plan.actions.length,
       executedActionCount: actionResults.length,
-      unsupportedFieldCount: plan.unsupportedFields.length
+      unsupportedFieldCount: plan.unsupportedFields.length,
     });
 
     printJson(report);
@@ -6620,13 +6941,13 @@ async function runProfileApplySpec(input: {
 async function runActivitySeedJobSearch(
   runtime: CliRuntime,
   profileName: string,
-  search: ActivitySeedJobSearchSpec
+  search: ActivitySeedJobSearchSpec,
 ): Promise<Record<string, unknown>> {
   const searchResult = await runtime.jobs.searchJobs({
     profileName,
     query: search.query,
     ...(search.location ? { location: search.location } : {}),
-    ...(search.limit ? { limit: search.limit } : {})
+    ...(search.limit ? { limit: search.limit } : {}),
   });
   const viewCount = Math.min(search.viewTop ?? 0, searchResult.results.length);
   const viewedJobs: Record<string, unknown>[] = [];
@@ -6634,7 +6955,7 @@ async function runActivitySeedJobSearch(
   for (const job of searchResult.results.slice(0, viewCount)) {
     const detail = await runtime.jobs.viewJob({
       profileName,
-      jobId: job.job_id
+      jobId: job.job_id,
     });
     viewedJobs.push(detail as unknown as Record<string, unknown>);
   }
@@ -6644,22 +6965,31 @@ async function runActivitySeedJobSearch(
     location: searchResult.location,
     count: searchResult.count,
     results: searchResult.results,
-    viewed_jobs: viewedJobs
+    viewed_jobs: viewedJobs,
   };
 }
 
-async function runSeedActivity(input: {
-  profileName: string;
-  specPath: string;
-  delayMs: number;
-  yes: boolean;
-  outputPath?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runSeedActivity(
+  input: {
+    profileName: string;
+    specPath: string;
+    delayMs: number;
+    yes: boolean;
+    outputPath?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const resolvedSpecPath = path.resolve(input.specPath);
-  const rawSpec = await readJsonInputFile(resolvedSpecPath, "activity seed spec");
+  const rawSpec = await readJsonInputFile(
+    resolvedSpecPath,
+    "activity seed spec",
+  );
   const spec = parseActivitySeedSpec(rawSpec);
   const planSummary = createActivitySeedPlanSummary(spec);
-  const generatedImages = await resolveActivitySeedGeneratedPostImages(spec, resolvedSpecPath);
+  const generatedImages = await resolveActivitySeedGeneratedPostImages(
+    spec,
+    resolvedSpecPath,
+  );
   const runtime = createRuntime(cdpUrl);
 
   try {
@@ -6668,18 +6998,18 @@ async function runSeedActivity(input: {
       specPath: resolvedSpecPath,
       delayMs: input.delayMs,
       totalWriteActions: planSummary.totalWriteActions,
-      totalReadSteps: planSummary.totalReadSteps
+      totalReadSteps: planSummary.totalReadSteps,
     });
 
     const keepAlivePids = await maybeWarnAboutKeepAliveForSeeding();
 
     if (planSummary.totalWriteActions > 0) {
       writeCliNotice(
-        `Loaded ${resolvedSpecPath} with ${planSummary.totalWriteActions} write ${planSummary.totalWriteActions === 1 ? "action" : "actions"} and ${planSummary.totalReadSteps} read-only verification ${planSummary.totalReadSteps === 1 ? "step" : "steps"}.`
+        `Loaded ${resolvedSpecPath} with ${planSummary.totalWriteActions} write ${planSummary.totalWriteActions === 1 ? "action" : "actions"} and ${planSummary.totalReadSteps} read-only verification ${planSummary.totalReadSteps === 1 ? "step" : "steps"}.`,
       );
     } else {
       writeCliNotice(
-        `Loaded ${resolvedSpecPath}; no write actions are configured, so this run will only perform read-only checks.`
+        `Loaded ${resolvedSpecPath}; no write actions are configured, so this run will only perform read-only checks.`,
       );
     }
 
@@ -6687,18 +7017,18 @@ async function runSeedActivity(input: {
       if (!stdin.isTTY || !stdout.isTTY) {
         throw new LinkedInBuddyError(
           "ACTION_PRECONDITION_FAILED",
-          "Refusing to apply an activity seed spec without --yes in non-interactive mode."
+          "Refusing to apply an activity seed spec without --yes in non-interactive mode.",
         );
       }
 
       const confirmed = await promptYesNo(
         `Execute ${planSummary.totalWriteActions} LinkedIn write ${planSummary.totalWriteActions === 1 ? "action" : "actions"} from this activity seed spec?`,
-        process.stderr
+        process.stderr,
       );
       if (!confirmed) {
         throw new LinkedInBuddyError(
           "ACTION_PRECONDITION_FAILED",
-          "Operator declined activity seed execution."
+          "Operator declined activity seed execution.",
         );
       }
     }
@@ -6712,21 +7042,26 @@ async function runSeedActivity(input: {
       keep_alive_running: keepAlivePids.length > 0,
       plan: planSummary,
       evasion: runtime.evasion,
-      ...(generatedImages ? { generated_image_manifest_path: generatedImages.manifestPath } : {})
+      ...(generatedImages
+        ? { generated_image_manifest_path: generatedImages.manifestPath }
+        : {}),
     };
 
     const connectionsSection: Record<string, unknown> = {
       accepted_pending: [] as Record<string, unknown>[],
       invites: [] as Record<string, unknown>[],
-      skipped_invites: [] as Record<string, unknown>[]
+      skipped_invites: [] as Record<string, unknown>[],
     };
 
     if (spec.connections.acceptPending) {
       const pendingReceived = await runtime.connections.listPendingInvitations({
         profileName: input.profileName,
-        filter: "received"
+        filter: "received",
       });
-      const pendingToAccept = pendingReceived.slice(0, spec.connections.acceptPending.limit);
+      const pendingToAccept = pendingReceived.slice(
+        0,
+        spec.connections.acceptPending.limit,
+      );
       connectionsSection.pending_received = pendingReceived;
 
       for (const [index, invitation] of pendingToAccept.entries()) {
@@ -6736,17 +7071,19 @@ async function runSeedActivity(input: {
           operatorNote: createActivitySeedOperatorNote(
             resolvedSpecPath,
             `accept pending ${index + 1}`,
-            undefined
-          )
+            undefined,
+          ),
         });
         const confirmed = await runtime.twoPhaseCommit.confirmByToken({
-          confirmToken: prepared.confirmToken
+          confirmToken: prepared.confirmToken,
         });
-        (connectionsSection.accepted_pending as Record<string, unknown>[]).push({
-          target_profile: invitation.profile_url,
-          full_name: invitation.full_name,
-          ...summarizeConfirmedAction(confirmed)
-        });
+        (connectionsSection.accepted_pending as Record<string, unknown>[]).push(
+          {
+            target_profile: invitation.profile_url,
+            full_name: invitation.full_name,
+            ...summarizeConfirmedAction(confirmed),
+          },
+        );
         await maybeSleepSeedDelay(input.delayMs);
       }
     }
@@ -6755,40 +7092,50 @@ async function runSeedActivity(input: {
       const [existingConnections, pendingSent] = await Promise.all([
         runtime.connections.listConnections({
           profileName: input.profileName,
-          limit: Math.max(40, spec.connections.invites.length + 20)
+          limit: Math.max(40, spec.connections.invites.length + 20),
         }),
         runtime.connections.listPendingInvitations({
           profileName: input.profileName,
-          filter: "sent"
-        })
+          filter: "sent",
+        }),
       ]);
       const existingTargets = new Set(
         existingConnections
-          .map((connection) => normalizeComparableLinkedInIdentity(connection.profile_url))
-          .filter((value) => value.length > 0)
+          .map((connection) =>
+            normalizeComparableLinkedInIdentity(connection.profile_url),
+          )
+          .filter((value) => value.length > 0),
       );
       const pendingTargets = new Set(
         pendingSent
-          .map((invitation) => normalizeComparableLinkedInIdentity(invitation.profile_url))
-          .filter((value) => value.length > 0)
+          .map((invitation) =>
+            normalizeComparableLinkedInIdentity(invitation.profile_url),
+          )
+          .filter((value) => value.length > 0),
       );
 
       connectionsSection.connections_before = existingConnections;
       connectionsSection.pending_sent = pendingSent;
 
       for (const [index, invite] of spec.connections.invites.entries()) {
-        const normalizedTarget = normalizeComparableLinkedInIdentity(invite.targetProfile);
+        const normalizedTarget = normalizeComparableLinkedInIdentity(
+          invite.targetProfile,
+        );
         if (existingTargets.has(normalizedTarget)) {
-          (connectionsSection.skipped_invites as Record<string, unknown>[]).push({
+          (
+            connectionsSection.skipped_invites as Record<string, unknown>[]
+          ).push({
             target_profile: invite.targetProfile,
-            reason: "already_connected"
+            reason: "already_connected",
           });
           continue;
         }
         if (pendingTargets.has(normalizedTarget)) {
-          (connectionsSection.skipped_invites as Record<string, unknown>[]).push({
+          (
+            connectionsSection.skipped_invites as Record<string, unknown>[]
+          ).push({
             target_profile: invite.targetProfile,
-            reason: "invitation_already_pending"
+            reason: "invitation_already_pending",
           });
           continue;
         }
@@ -6800,16 +7147,16 @@ async function runSeedActivity(input: {
           operatorNote: createActivitySeedOperatorNote(
             resolvedSpecPath,
             `invite ${index + 1}`,
-            invite.operatorNote
-          )
+            invite.operatorNote,
+          ),
         });
         const confirmed = await runtime.twoPhaseCommit.confirmByToken({
-          confirmToken: prepared.confirmToken
+          confirmToken: prepared.confirmToken,
         });
         (connectionsSection.invites as Record<string, unknown>[]).push({
           target_profile: invite.targetProfile,
           ...(invite.note ? { note: invite.note } : {}),
-          ...summarizeConfirmedAction(confirmed)
+          ...summarizeConfirmedAction(confirmed),
         });
         pendingTargets.add(normalizedTarget);
         await maybeSleepSeedDelay(input.delayMs);
@@ -6823,13 +7170,13 @@ async function runSeedActivity(input: {
       const mediaPath = resolveActivitySeedPostMediaPath(
         post,
         resolvedSpecPath,
-        generatedImages?.postImages ?? []
+        generatedImages?.postImages ?? [],
       );
       const visibility = post.visibility ?? "connections";
       const operatorNote = createActivitySeedOperatorNote(
         resolvedSpecPath,
         `post ${index + 1}`,
-        post.operatorNote
+        post.operatorNote,
       );
 
       const prepared = mediaPath
@@ -6838,16 +7185,16 @@ async function runSeedActivity(input: {
             text: post.text,
             mediaPaths: [mediaPath],
             visibility,
-            operatorNote
+            operatorNote,
           })
         : await runtime.posts.prepareCreate({
             profileName: input.profileName,
             text: post.text,
             visibility,
-            operatorNote
+            operatorNote,
           });
       const confirmed = await runtime.twoPhaseCommit.confirmByToken({
-        confirmToken: prepared.confirmToken
+        confirmToken: prepared.confirmToken,
       });
       const publishedPostUrl =
         typeof confirmed.result.published_post_url === "string" &&
@@ -6857,7 +7204,7 @@ async function runSeedActivity(input: {
       const verification = publishedPostUrl
         ? await runtime.feed.viewPost({
             profileName: input.profileName,
-            postUrl: publishedPostUrl
+            postUrl: publishedPostUrl,
           })
         : undefined;
 
@@ -6866,7 +7213,7 @@ async function runSeedActivity(input: {
         visibility,
         ...(mediaPath ? { media_path: mediaPath } : {}),
         ...summarizeConfirmedAction(confirmed),
-        ...(verification ? { verification } : {})
+        ...(verification ? { verification } : {}),
       });
       await maybeSleepSeedDelay(input.delayMs);
     }
@@ -6874,7 +7221,7 @@ async function runSeedActivity(input: {
 
     const feedSection: Record<string, unknown> = {
       liked: [] as Record<string, unknown>[],
-      commented: [] as Record<string, unknown>[]
+      commented: [] as Record<string, unknown>[],
     };
     if (
       spec.feed.discoveryLimit ||
@@ -6886,7 +7233,7 @@ async function runSeedActivity(input: {
         Math.max(10, spec.feed.likes.length + spec.feed.comments.length + 3);
       feedSection.feed_snapshot = await runtime.feed.viewFeed({
         profileName: input.profileName,
-        limit: discoveryLimit
+        limit: discoveryLimit,
       });
     }
 
@@ -6898,16 +7245,16 @@ async function runSeedActivity(input: {
         operatorNote: createActivitySeedOperatorNote(
           resolvedSpecPath,
           `feed like ${index + 1}`,
-          like.operatorNote
-        )
+          like.operatorNote,
+        ),
       });
       const confirmed = await runtime.twoPhaseCommit.confirmByToken({
-        confirmToken: prepared.confirmToken
+        confirmToken: prepared.confirmToken,
       });
       (feedSection.liked as Record<string, unknown>[]).push({
         post_url: like.postUrl,
         ...(like.reaction ? { reaction: like.reaction } : {}),
-        ...summarizeConfirmedAction(confirmed)
+        ...summarizeConfirmedAction(confirmed),
       });
       await maybeSleepSeedDelay(input.delayMs);
     }
@@ -6920,16 +7267,16 @@ async function runSeedActivity(input: {
         operatorNote: createActivitySeedOperatorNote(
           resolvedSpecPath,
           `feed comment ${index + 1}`,
-          comment.operatorNote
-        )
+          comment.operatorNote,
+        ),
       });
       const confirmed = await runtime.twoPhaseCommit.confirmByToken({
-        confirmToken: prepared.confirmToken
+        confirmToken: prepared.confirmToken,
       });
       (feedSection.commented as Record<string, unknown>[]).push({
         post_url: comment.postUrl,
         text: comment.text,
-        ...summarizeConfirmedAction(confirmed)
+        ...summarizeConfirmedAction(confirmed),
       });
       await maybeSleepSeedDelay(input.delayMs);
     }
@@ -6939,19 +7286,22 @@ async function runSeedActivity(input: {
     const jobsSection: Record<string, unknown>[] = [];
     for (const search of spec.jobs.searches) {
       jobsSection.push(
-        await runActivitySeedJobSearch(runtime, input.profileName, search)
+        await runActivitySeedJobSearch(runtime, input.profileName, search),
       );
     }
     report.jobs = jobsSection;
 
     const messagingSection: Record<string, unknown> = {
       new_threads: [] as Record<string, unknown>[],
-      replies: [] as Record<string, unknown>[]
+      replies: [] as Record<string, unknown>[],
     };
-    if (spec.messaging.newThreads.length > 0 || spec.messaging.replies.length > 0) {
+    if (
+      spec.messaging.newThreads.length > 0 ||
+      spec.messaging.replies.length > 0
+    ) {
       messagingSection.threads_before = await runtime.inbox.listThreads({
         profileName: input.profileName,
-        limit: 10
+        limit: 10,
       });
     }
 
@@ -6963,11 +7313,11 @@ async function runSeedActivity(input: {
         operatorNote: createActivitySeedOperatorNote(
           resolvedSpecPath,
           `new thread ${index + 1}`,
-          thread.operatorNote
-        )
+          thread.operatorNote,
+        ),
       });
       const confirmed = await runtime.twoPhaseCommit.confirmByToken({
-        confirmToken: prepared.confirmToken
+        confirmToken: prepared.confirmToken,
       });
       const threadUrl =
         typeof confirmed.result.thread_url === "string" &&
@@ -6978,14 +7328,14 @@ async function runSeedActivity(input: {
         ? await runtime.inbox.getThread({
             profileName: input.profileName,
             thread: threadUrl,
-            limit: 10
+            limit: 10,
           })
         : undefined;
       (messagingSection.new_threads as Record<string, unknown>[]).push({
         recipients: thread.recipients,
         text: thread.text,
         ...summarizeConfirmedAction(confirmed),
-        ...(verification ? { verification } : {})
+        ...(verification ? { verification } : {}),
       });
       await maybeSleepSeedDelay(input.delayMs);
     }
@@ -6998,11 +7348,11 @@ async function runSeedActivity(input: {
         operatorNote: createActivitySeedOperatorNote(
           resolvedSpecPath,
           `reply ${index + 1}`,
-          reply.operatorNote
-        )
+          reply.operatorNote,
+        ),
       });
       const confirmed = await runtime.twoPhaseCommit.confirmByToken({
-        confirmToken: prepared.confirmToken
+        confirmToken: prepared.confirmToken,
       });
       const threadUrl =
         typeof confirmed.result.thread_url === "string" &&
@@ -7012,13 +7362,13 @@ async function runSeedActivity(input: {
       const verification = await runtime.inbox.getThread({
         profileName: input.profileName,
         thread: threadUrl,
-        limit: 10
+        limit: 10,
       });
       (messagingSection.replies as Record<string, unknown>[]).push({
         thread: reply.thread,
         text: reply.text,
         ...summarizeConfirmedAction(confirmed),
-        verification
+        verification,
       });
       await maybeSleepSeedDelay(input.delayMs);
     }
@@ -7030,23 +7380,23 @@ async function runSeedActivity(input: {
         profileName: input.profileName,
         ...(typeof spec.notifications.limit === "number"
           ? { limit: spec.notifications.limit }
-          : {})
+          : {}),
       });
     }
 
     report.verification = {
       connections: await runtime.connections.listConnections({
         profileName: input.profileName,
-        limit: Math.max(20, spec.connections.invites.length + 10)
+        limit: Math.max(20, spec.connections.invites.length + 10),
       }),
       feed: await runtime.feed.viewFeed({
         profileName: input.profileName,
-        limit: Math.max(10, spec.posts.length + 5)
+        limit: Math.max(10, spec.posts.length + 5),
       }),
       inbox_threads: await runtime.inbox.listThreads({
         profileName: input.profileName,
-        limit: 10
-      })
+        limit: 10,
+      }),
     };
 
     if (input.outputPath) {
@@ -7057,7 +7407,7 @@ async function runSeedActivity(input: {
       profileName: input.profileName,
       specPath: resolvedSpecPath,
       totalWriteActions: planSummary.totalWriteActions,
-      totalReadSteps: planSummary.totalReadSteps
+      totalReadSteps: planSummary.totalReadSteps,
     });
 
     printJson(report);
@@ -7066,17 +7416,23 @@ async function runSeedActivity(input: {
   }
 }
 
-async function runAssetsGenerateProfileImages(input: {
-  profileName: string;
-  specPath: string;
-  postImageCount: number;
-  uploadProfileMedia: boolean;
-  uploadDelayMs: number;
-  model?: string;
-  outputPath?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runAssetsGenerateProfileImages(
+  input: {
+    profileName: string;
+    specPath: string;
+    postImageCount: number;
+    uploadProfileMedia: boolean;
+    uploadDelayMs: number;
+    model?: string;
+    outputPath?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const resolvedSpecPath = path.resolve(input.specPath);
-  const rawSpec = await readJsonInputFile(resolvedSpecPath, "image persona spec");
+  const rawSpec = await readJsonInputFile(
+    resolvedSpecPath,
+    "image persona spec",
+  );
   const persona = buildLinkedInImagePersonaFromProfileSeed(rawSpec);
   const runtime = createRuntime(cdpUrl);
 
@@ -7086,22 +7442,22 @@ async function runAssetsGenerateProfileImages(input: {
       specPath: resolvedSpecPath,
       postImageCount: input.postImageCount,
       uploadProfileMedia: input.uploadProfileMedia,
-      model: input.model ?? null
+      model: input.model ?? null,
     });
 
     const report: Record<string, unknown> = {
       run_id: runtime.runId,
       profile_name: input.profileName,
       spec_path: resolvedSpecPath,
-      ...await runtime.imageAssets.generatePersonaImageSet({
+      ...(await runtime.imageAssets.generatePersonaImageSet({
         persona,
         postImageCount: input.postImageCount,
         uploadProfileMedia: input.uploadProfileMedia,
         profileName: input.profileName,
         uploadDelayMs: input.uploadDelayMs,
         operatorNote: `issue-211 persona images: ${path.basename(resolvedSpecPath)}`,
-        ...(input.model ? { model: input.model } : {})
-      })
+        ...(input.model ? { model: input.model } : {}),
+      })),
     };
 
     if (input.outputPath) {
@@ -7112,7 +7468,7 @@ async function runAssetsGenerateProfileImages(input: {
       profileName: input.profileName,
       specPath: resolvedSpecPath,
       postImageCount: input.postImageCount,
-      uploadProfileMedia: input.uploadProfileMedia
+      uploadProfileMedia: input.uploadProfileMedia,
     });
 
     printJson(report);
@@ -7121,12 +7477,15 @@ async function runAssetsGenerateProfileImages(input: {
   }
 }
 
-async function runSearch(input: {
-  profileName: string;
-  query: string;
-  category?: SearchCategory;
-  limit?: number;
-}, cdpUrl?: string): Promise<void> {
+async function runSearch(
+  input: {
+    profileName: string;
+    query: string;
+    category?: SearchCategory;
+    limit?: number;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
@@ -7137,71 +7496,77 @@ async function runSearch(input: {
       profileName: input.profileName,
       query: input.query,
       category,
-      limit
+      limit,
     });
 
     const result = await runtime.search.search({
       profileName: input.profileName,
       query: input.query,
       ...(input.category ? { category: input.category } : {}),
-      ...(typeof input.limit === "number" ? { limit: input.limit } : {})
+      ...(typeof input.limit === "number" ? { limit: input.limit } : {}),
     });
 
     runtime.logger.log("info", "cli.search.done", {
       profileName: input.profileName,
       category: result.category,
-      count: result.count
+      count: result.count,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runNotificationsList(input: {
-  profileName: string;
-  limit: number;
-}, cdpUrl?: string): Promise<void> {
+async function runNotificationsList(
+  input: {
+    profileName: string;
+    limit: number;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.notifications.list.start", {
       profileName: input.profileName,
-      limit: input.limit
+      limit: input.limit,
     });
 
     const notifications = await runtime.notifications.listNotifications({
       profileName: input.profileName,
-      limit: input.limit
+      limit: input.limit,
     });
 
     runtime.logger.log("info", "cli.notifications.list.done", {
       profileName: input.profileName,
-      count: notifications.length
+      count: notifications.length,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
       count: notifications.length,
-      notifications
+      notifications,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runJobsSearch(input: {
-  profileName: string;
-  query: string;
-  location?: string;
-  limit: number;
-}, cdpUrl?: string): Promise<void> {
+async function runJobsSearch(
+  input: {
+    profileName: string;
+    query: string;
+    location?: string;
+    limit: number;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
@@ -7209,57 +7574,60 @@ async function runJobsSearch(input: {
       profileName: input.profileName,
       query: input.query,
       location: input.location ?? "",
-      limit: input.limit
+      limit: input.limit,
     });
 
     const result = await runtime.jobs.searchJobs({
       profileName: input.profileName,
       query: input.query,
       ...(input.location ? { location: input.location } : {}),
-      limit: input.limit
+      limit: input.limit,
     });
 
     runtime.logger.log("info", "cli.jobs.search.done", {
       profileName: input.profileName,
-      count: result.count
+      count: result.count,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runJobsView(input: {
-  profileName: string;
-  jobId: string;
-}, cdpUrl?: string): Promise<void> {
+async function runJobsView(
+  input: {
+    profileName: string;
+    jobId: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.jobs.view.start", {
       profileName: input.profileName,
-      jobId: input.jobId
+      jobId: input.jobId,
     });
 
     const job = await runtime.jobs.viewJob({
       profileName: input.profileName,
-      jobId: input.jobId
+      jobId: input.jobId,
     });
 
     runtime.logger.log("info", "cli.jobs.view.done", {
       profileName: input.profileName,
-      jobId: job.job_id
+      jobId: job.job_id,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      job
+      job,
     });
   } finally {
     runtime.close();
@@ -7267,7 +7635,7 @@ async function runJobsView(input: {
 }
 
 async function readEasyApplyAnswersFile(
-  filePath: string | undefined
+  filePath: string | undefined,
 ): Promise<Record<string, unknown> | undefined> {
   if (!filePath) {
     return undefined;
@@ -7277,158 +7645,173 @@ async function readEasyApplyAnswersFile(
   if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "Easy Apply answers file must contain a JSON object."
+      "Easy Apply answers file must contain a JSON object.",
     );
   }
 
   return raw as Record<string, unknown>;
 }
 
-async function runJobsSave(input: {
-  profileName: string;
-  jobId: string;
-  operatorNote?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runJobsSave(
+  input: {
+    profileName: string;
+    jobId: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.jobs.save.start", {
       profileName: input.profileName,
-      jobId: input.jobId
+      jobId: input.jobId,
     });
 
     const prepared = runtime.jobs.prepareSaveJob({
       profileName: input.profileName,
       jobId: input.jobId,
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
 
     runtime.logger.log("info", "cli.jobs.save.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runJobsUnsave(input: {
-  profileName: string;
-  jobId: string;
-  operatorNote?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runJobsUnsave(
+  input: {
+    profileName: string;
+    jobId: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.jobs.unsave.start", {
       profileName: input.profileName,
-      jobId: input.jobId
+      jobId: input.jobId,
     });
 
     const prepared = runtime.jobs.prepareUnsaveJob({
       profileName: input.profileName,
       jobId: input.jobId,
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
 
     runtime.logger.log("info", "cli.jobs.unsave.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runJobAlertsList(input: {
-  profileName: string;
-  limit: number;
-}, cdpUrl?: string): Promise<void> {
+async function runJobAlertsList(
+  input: {
+    profileName: string;
+    limit: number;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.jobs.alerts.list.start", {
       profileName: input.profileName,
-      limit: input.limit
+      limit: input.limit,
     });
 
     const result = await runtime.jobs.listJobAlerts({
       profileName: input.profileName,
-      limit: input.limit
+      limit: input.limit,
     });
 
     runtime.logger.log("info", "cli.jobs.alerts.list.done", {
       profileName: input.profileName,
-      count: result.count
+      count: result.count,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runJobAlertsCreate(input: {
-  profileName: string;
-  query: string;
-  location?: string;
-  operatorNote?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runJobAlertsCreate(
+  input: {
+    profileName: string;
+    query: string;
+    location?: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.jobs.alerts.create.start", {
       profileName: input.profileName,
       query: input.query,
-      location: input.location ?? ""
+      location: input.location ?? "",
     });
 
     const prepared = runtime.jobs.prepareCreateJobAlert({
       profileName: input.profileName,
       query: input.query,
       ...(input.location ? { location: input.location } : {}),
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
 
     runtime.logger.log("info", "cli.jobs.alerts.create.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runJobAlertsRemove(input: {
-  profileName: string;
-  alertId?: string;
-  searchUrl?: string;
-  query?: string;
-  location?: string;
-  operatorNote?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runJobAlertsRemove(
+  input: {
+    profileName: string;
+    alertId?: string;
+    searchUrl?: string;
+    query?: string;
+    location?: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
@@ -7436,7 +7819,7 @@ async function runJobAlertsRemove(input: {
       profileName: input.profileName,
       hasAlertId: Boolean(input.alertId),
       hasSearchUrl: Boolean(input.searchUrl),
-      hasQuery: Boolean(input.query)
+      hasQuery: Boolean(input.query),
     });
 
     const prepared = await runtime.jobs.prepareRemoveJobAlert({
@@ -7445,35 +7828,38 @@ async function runJobAlertsRemove(input: {
       ...(input.searchUrl ? { searchUrl: input.searchUrl } : {}),
       ...(input.query ? { query: input.query } : {}),
       ...(input.location ? { location: input.location } : {}),
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
 
     runtime.logger.log("info", "cli.jobs.alerts.remove.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runJobsEasyApplyPrepare(input: {
-  profileName: string;
-  jobId: string;
-  phone?: string;
-  email?: string;
-  city?: string;
-  resume?: string;
-  coverLetter?: string;
-  answersFile?: string;
-  operatorNote?: string;
-}, cdpUrl?: string): Promise<void> {
+async function runJobsEasyApplyPrepare(
+  input: {
+    profileName: string;
+    jobId: string;
+    phone?: string;
+    email?: string;
+    city?: string;
+    resume?: string;
+    coverLetter?: string;
+    answersFile?: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
@@ -7481,7 +7867,7 @@ async function runJobsEasyApplyPrepare(input: {
       profileName: input.profileName,
       jobId: input.jobId,
       hasResumePath: Boolean(input.resume),
-      hasAnswersFile: Boolean(input.answersFile)
+      hasAnswersFile: Boolean(input.answersFile),
     });
 
     const answers = await readEasyApplyAnswersFile(input.answersFile);
@@ -7494,39 +7880,40 @@ async function runJobsEasyApplyPrepare(input: {
       ...(input.resume ? { resumePath: input.resume } : {}),
       ...(input.coverLetter ? { coverLetter: input.coverLetter } : {}),
       ...(answers ? { answers } : {}),
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
 
     runtime.logger.log("info", "cli.jobs.easy_apply.done", {
       profileName: input.profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function runSelectorAudit(input: {
-  profileName: string;
-  json: boolean;
-  progress: boolean;
-  verbose: boolean;
-}, cdpUrl?: string): Promise<void> {
+async function runSelectorAudit(
+  input: {
+    profileName: string;
+    json: boolean;
+    progress: boolean;
+    verbose: boolean;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const outputMode = resolveSelectorAuditOutputMode(
     { json: input.json },
-    Boolean(stdout.isTTY)
+    Boolean(stdout.isTTY),
   );
   const progressReporter = new SelectorAuditProgressReporter({
     enabled:
-      outputMode === "human" &&
-      input.progress &&
-      Boolean(process.stderr.isTTY)
+      outputMode === "human" && input.progress && Boolean(process.stderr.isTTY),
   });
   let profileName = input.profileName;
   let runtime: ReturnType<typeof createRuntime> | undefined;
@@ -7537,7 +7924,9 @@ async function runSelectorAudit(input: {
     runtime = createRuntime(cdpUrl);
     const selectorAuditRuntime = runtime;
 
-    const originalLog = selectorAuditRuntime.logger.log.bind(selectorAuditRuntime.logger);
+    const originalLog = selectorAuditRuntime.logger.log.bind(
+      selectorAuditRuntime.logger,
+    );
     // Mirror stable selector-audit lifecycle logs into the optional progress
     // reporter without changing the core service API surface.
     selectorAuditRuntime.logger.log = ((level, event, payload = {}) => {
@@ -7553,10 +7942,12 @@ async function runSelectorAudit(input: {
       profileName,
       outputMode,
       verbose: input.verbose,
-      progress: outputMode === "human" && input.progress
+      progress: outputMode === "human" && input.progress,
     });
 
-    const report = await selectorAuditRuntime.selectorAudit.auditSelectors({ profileName });
+    const report = await selectorAuditRuntime.selectorAudit.auditSelectors({
+      profileName,
+    });
 
     selectorAuditRuntime.logger.log("info", "cli.audit.selectors.done", {
       profileName,
@@ -7564,7 +7955,7 @@ async function runSelectorAudit(input: {
       passCount: report.pass_count,
       failCount: report.fail_count,
       fallbackCount: report.fallback_count,
-      reportPath: report.report_path
+      reportPath: report.report_path,
     });
 
     if (outputMode === "json") {
@@ -7573,13 +7964,13 @@ async function runSelectorAudit(input: {
       const redactedReport = redactStructuredValue(
         report,
         cliPrivacyConfig,
-        "cli"
+        "cli",
       ) as SelectorAuditReport;
 
       console.log(
         formatSelectorAuditReport(redactedReport, {
-          verbose: input.verbose
-        })
+          verbose: input.verbose,
+        }),
       );
     }
 
@@ -7591,7 +7982,7 @@ async function runSelectorAudit(input: {
 
     runtime?.logger.log("error", "cli.audit.selectors.failed", {
       profileName,
-      error: errorPayload
+      error: errorPayload,
     });
 
     if (outputMode === "json") {
@@ -7616,12 +8007,12 @@ async function runDraftQualityAudit(input: {
 }): Promise<void> {
   const outputMode = resolveDraftQualityOutputMode(
     { json: input.json },
-    Boolean(stdout.isTTY)
+    Boolean(stdout.isTTY),
   );
   const progressEnabled =
     outputMode === "human" && input.progress && Boolean(process.stderr.isTTY);
   const progressReporter = new DraftQualityProgressReporter({
-    enabled: progressEnabled
+    enabled: progressEnabled,
   });
   const logger = progressEnabled
     ? createDraftQualityProgressLogger((entry) => {
@@ -7632,14 +8023,17 @@ async function runDraftQualityAudit(input: {
   try {
     const datasetPath = path.resolve(input.datasetPath);
     const dataset = parseDraftQualityDataset(
-      await readJsonInputFile(datasetPath, "draft-quality dataset")
+      await readJsonInputFile(datasetPath, "draft-quality dataset"),
     );
     const candidatesPath = input.candidatesPath
       ? path.resolve(input.candidatesPath)
       : undefined;
     const candidates = candidatesPath
       ? parseDraftQualityCandidateSet(
-          await readJsonInputFile(candidatesPath, "draft-quality candidates file")
+          await readJsonInputFile(
+            candidatesPath,
+            "draft-quality candidates file",
+          ),
         )
       : undefined;
     const report = await evaluateDraftQuality({
@@ -7647,7 +8041,7 @@ async function runDraftQualityAudit(input: {
       ...(candidates ? { candidates } : {}),
       ...(logger ? { logger } : {}),
       dataset_path: datasetPath,
-      ...(candidatesPath ? { candidates_path: candidatesPath } : {})
+      ...(candidatesPath ? { candidates_path: candidatesPath } : {}),
     });
     const writtenReportPath = input.outputPath
       ? await writeOutputJsonFile(input.outputPath, report)
@@ -7659,11 +8053,11 @@ async function runDraftQualityAudit(input: {
       const redactedReport = redactStructuredValue(
         report,
         cliPrivacyConfig,
-        "cli"
+        "cli",
       ) as DraftQualityReport;
       const output = formatDraftQualityReport(redactedReport, {
         verbose: input.verbose,
-        ...(writtenReportPath ? { reportPath: writtenReportPath } : {})
+        ...(writtenReportPath ? { reportPath: writtenReportPath } : {}),
       });
 
       console.log(output);
@@ -7683,7 +8077,9 @@ async function runDraftQualityAudit(input: {
   }
 }
 
-function readTargetProfileName(target: Record<string, unknown>): string | undefined {
+function readTargetProfileName(
+  target: Record<string, unknown>,
+): string | undefined {
   const value = target.profile_name;
   if (typeof value === "string" && value.trim().length > 0) {
     return value.trim();
@@ -7691,20 +8087,23 @@ function readTargetProfileName(target: Record<string, unknown>): string | undefi
   return undefined;
 }
 
-async function runConfirmAction(input: {
-  profileName: string;
-  token: string;
-  yes: boolean;
-}, cdpUrl?: string): Promise<void> {
+async function runConfirmAction(
+  input: {
+    profileName: string;
+    token: string;
+    yes: boolean;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const runtime = createRuntime(cdpUrl);
 
   try {
     runtime.logger.log("info", "cli.actions.confirm.start", {
-      profileName: input.profileName
+      profileName: input.profileName,
     });
 
     const preview = runtime.twoPhaseCommit.getPreparedActionPreviewByToken({
-      confirmToken: input.token
+      confirmToken: input.token,
     });
 
     const preparedProfileName = readTargetProfileName(preview.target);
@@ -7714,8 +8113,8 @@ async function runConfirmAction(input: {
         `Prepared action belongs to profile "${preparedProfileName}", but "${input.profileName}" was requested.`,
         {
           expected_profile_name: preparedProfileName,
-          provided_profile_name: input.profileName
-        }
+          provided_profile_name: input.profileName,
+        },
       );
     }
 
@@ -7726,7 +8125,7 @@ async function runConfirmAction(input: {
     const summaryPayload = redactStructuredValue(
       { summary },
       cliPrivacyConfig,
-      "cli"
+      "cli",
     );
 
     console.log(`Preview summary: ${summaryPayload.summary}`);
@@ -7735,14 +8134,14 @@ async function runConfirmAction(input: {
       action_type: preview.actionType,
       status: preview.status,
       expires_at_ms: preview.expiresAtMs,
-      preview: preview.preview
+      preview: preview.preview,
     });
 
     if (!input.yes) {
       if (!stdin.isTTY || !stdout.isTTY) {
         throw new LinkedInBuddyError(
           "ACTION_PRECONDITION_FAILED",
-          "Refusing to confirm action without --yes in non-interactive mode."
+          "Refusing to confirm action without --yes in non-interactive mode.",
         );
       }
 
@@ -7750,25 +8149,25 @@ async function runConfirmAction(input: {
       if (!confirmed) {
         throw new LinkedInBuddyError(
           "ACTION_PRECONDITION_FAILED",
-          "Operator declined action confirmation."
+          "Operator declined action confirmation.",
         );
       }
     }
 
     const result = await runtime.twoPhaseCommit.confirmByToken({
-      confirmToken: input.token
+      confirmToken: input.token,
     });
 
     runtime.logger.log("info", "cli.actions.confirm.done", {
       profileName: input.profileName,
       preparedActionId: result.preparedActionId,
-      status: result.status
+      status: result.status,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
@@ -7785,17 +8184,17 @@ export function createCliProgram(): Command {
     .version(packageJson.version)
     .option(
       "--cdp-url <url>",
-      "Connect to existing browser via CDP endpoint (e.g., http://127.0.0.1:18800)"
+      "Connect to existing browser via CDP endpoint (e.g., http://127.0.0.1:18800)",
     )
     .option(
       "--selector-locale <locale>",
       `Prefer localized LinkedIn UI text first (${LINKEDIN_SELECTOR_LOCALES.join(
-        ", "
-      )}; region tags like da-DK normalize to da)`
+        ", ",
+      )}; region tags like da-DK normalize to da)`,
     )
     .option(
       "--evasion-level <level>",
-      "Override anti-bot evasion level for this command (minimal, moderate, paranoid)"
+      "Override anti-bot evasion level for this command (minimal, moderate, paranoid)",
     )
     .option("--no-evasion", "Disable anti-bot evasion for this command")
     .addHelpText(
@@ -7810,13 +8209,14 @@ export function createCliProgram(): Command {
         "Diagnostics:",
         "  linkedin audit selectors --help",
         "  linkedin audit draft-quality --help",
-        `  ${SELECTOR_AUDIT_DOC_REFERENCE}`
-      ].join("\n")
+        `  ${SELECTOR_AUDIT_DOC_REFERENCE}`,
+      ].join("\n"),
     );
 
   const readCdpUrl = (): string | undefined => {
     const options = program.opts<{ cdpUrl?: string }>();
-    return typeof options.cdpUrl === "string" && options.cdpUrl.trim().length > 0
+    return typeof options.cdpUrl === "string" &&
+      options.cdpUrl.trim().length > 0
       ? options.cdpUrl.trim()
       : undefined;
   };
@@ -7849,7 +8249,7 @@ export function createCliProgram(): Command {
     const profileName = readCommandProfileName(actionCommand);
     activeCliInvocation = {
       commandName: describeCliCommand(actionCommand),
-      ...(profileName ? { profileName } : {})
+      ...(profileName ? { profileName } : {}),
     };
   });
 
@@ -7859,7 +8259,9 @@ export function createCliProgram(): Command {
 
   program
     .command("status")
-    .description("Check whether the persistent LinkedIn profile is authenticated")
+    .description(
+      "Check whether the persistent LinkedIn profile is authenticated",
+    )
     .option("-p, --profile <profile>", "Profile name", "default")
     .addHelpText(
       "after",
@@ -7868,8 +8270,8 @@ export function createCliProgram(): Command {
         "Diagnostics:",
         "  - output includes an evasion block with the resolved level, enabled features, and diagnostics flag",
         `  - ${LINKEDIN_BUDDY_EVASION_LEVEL_ENV}=minimal|moderate|paranoid sets the default anti-bot profile`,
-        `  - ${LINKEDIN_BUDDY_EVASION_DIAGNOSTICS_ENV}=true records debug evasion events in the run log`
-      ].join("\n")
+        `  - ${LINKEDIN_BUDDY_EVASION_DIAGNOSTICS_ENV}=true records debug evasion events in the run log`,
+      ].join("\n"),
     )
     .action(async (options: { profile: string }) => {
       await runStatus(options.profile, readCdpUrl());
@@ -7889,12 +8291,14 @@ export function createCliProgram(): Command {
 
   const configureAuthSessionCommand = (command: Command): void => {
     command
-      .description("Capture an encrypted LinkedIn session from a manual browser login")
+      .description(
+        "Capture an encrypted LinkedIn session from a manual browser login",
+      )
       .option("-s, --session <session>", "Stored session name", "default")
       .option(
         "-t, --timeout-minutes <minutes>",
         "How long to wait for the manual login to finish",
-        "10"
+        "10",
       )
       .addHelpText(
         "after",
@@ -7909,27 +8313,27 @@ export function createCliProgram(): Command {
           "Examples:",
           "  linkedin auth session",
           "  linkedin auth session --session smoke --timeout-minutes 15",
-          "  linkedin auth session --session smoke"
-        ].join("\n")
+          "  linkedin auth session --session smoke",
+        ].join("\n"),
       )
-      .action(
-        async (options: { session: string; timeoutMinutes: string }) => {
-          await runAuthSessionCapture(
-            {
-              sessionName: coerceProfileName(options.session, "session"),
-              timeoutMinutes: coercePositiveInt(
-                options.timeoutMinutes,
-                "timeout-minutes"
-              )
-            },
-            readCdpUrl()
-          );
-        }
-      );
+      .action(async (options: { session: string; timeoutMinutes: string }) => {
+        await runAuthSessionCapture(
+          {
+            sessionName: coerceProfileName(options.session, "session"),
+            timeoutMinutes: coercePositiveInt(
+              options.timeoutMinutes,
+              "timeout-minutes",
+            ),
+          },
+          readCdpUrl(),
+        );
+      });
   };
 
   configureAuthSessionCommand(authCommand.command("session"));
-  configureAuthSessionCommand(program.command("auth:session", { hidden: true }));
+  configureAuthSessionCommand(
+    program.command("auth:session", { hidden: true }),
+  );
 
   const accountsCommand = program
     .command("accounts")
@@ -7941,41 +8345,48 @@ export function createCliProgram(): Command {
       .description("Register or update a write-validation account")
       .requiredOption(
         "--designation <designation>",
-        "Whether the account is primary or secondary"
+        "Whether the account is primary or secondary",
       )
       .option("--label <label>", "Human-friendly account label")
       .option("--profile <profile>", "Profile name used for local DB state")
       .option(
         "--session <session>",
-        "Stored session name captured with linkedin auth session"
+        "Stored session name captured with linkedin auth session",
       )
       .option(
         "--message-thread <thread>",
-        "Approved thread id or URL for send_message"
+        "Approved thread id or URL for send_message",
       )
       .option(
         "--message-participant-pattern <pattern>",
-        "Optional regex used to double-check the approved thread participant"
+        "Optional regex used to double-check the approved thread participant",
       )
       .option(
         "--invite-profile <profile>",
-        "Approved profile URL or slug for connections.send_invitation"
+        "Approved profile URL or slug for connections.send_invitation",
       )
-      .option("--invite-note <note>", "Optional note for the approved invitation target")
+      .option(
+        "--invite-note <note>",
+        "Optional note for the approved invitation target",
+      )
       .option(
         "--followup-profile <profile>",
-        "Accepted connection profile URL or slug for network.followup_after_accept"
+        "Accepted connection profile URL or slug for network.followup_after_accept",
       )
       .option("--reaction-post <post>", "Approved post URL for feed.like_post")
       .option(
         "--reaction <reaction>",
-        `Reaction to use for feed.like_post (${LINKEDIN_FEED_REACTION_TYPES.join(", ")})`
+        `Reaction to use for feed.like_post (${LINKEDIN_FEED_REACTION_TYPES.join(", ")})`,
       )
       .option(
         "--post-visibility <visibility>",
-        `Visibility for post.create (${LINKEDIN_POST_VISIBILITY_TYPES.join(", ")})`
+        `Visibility for post.create (${LINKEDIN_POST_VISIBILITY_TYPES.join(", ")})`,
       )
-      .option("--force", "Overwrite an existing account with the same id", false)
+      .option(
+        "--force",
+        "Overwrite an existing account with the same id",
+        false,
+      )
       .addHelpText(
         "after",
         [
@@ -7987,8 +8398,8 @@ export function createCliProgram(): Command {
           "Notes:",
           "  - write validation refuses to run against accounts marked primary",
           "  - approved targets are stored in config.json under writeValidation.accounts",
-          "  - you can rerun with --force to replace an existing account definition"
-        ].join("\n")
+          "  - you can rerun with --force to replace an existing account definition",
+        ].join("\n"),
       )
       .action(
         async (
@@ -8007,7 +8418,7 @@ export function createCliProgram(): Command {
             reaction?: string;
             reactionPost?: string;
             session?: string;
-          }
+          },
         ) => {
           await runAccountsAdd({
             accountId,
@@ -8023,14 +8434,16 @@ export function createCliProgram(): Command {
             profileName: options.profile,
             reaction: options.reaction,
             reactionPost: options.reactionPost,
-            sessionName: options.session
+            sessionName: options.session,
           });
-        }
+        },
       );
   };
 
   configureAccountsAddCommand(accountsCommand.command("add"));
-  configureAccountsAddCommand(program.command("accounts:add", { hidden: true }));
+  configureAccountsAddCommand(
+    program.command("accounts:add", { hidden: true }),
+  );
 
   const testCommand = program
     .command("test")
@@ -8042,70 +8455,70 @@ export function createCliProgram(): Command {
       .option(
         "--read-only",
         "Confirm that the live validation should run in strictly read-only mode",
-        false
+        false,
       )
       .option(
         "--write-validation",
         "Run the Tier 3 real-action validation harness against a registered secondary account",
-        false
+        false,
       )
       .option(
         "--account <account>",
-        "Registered write-validation account id (required with --write-validation)"
+        "Registered write-validation account id (required with --write-validation)",
       )
       .option(
         "--cooldown-seconds <seconds>",
         "Cooldown between write-validation actions in seconds",
-        "10"
+        "10",
       )
       .option(
         "-s, --session <session>",
         "Stored session name captured by linkedin auth session",
-        "default"
+        "default",
       )
       .option(
         "--timeout-seconds <seconds>",
         "Navigation and selector timeout per validation step",
-        "30"
+        "30",
       )
       .option(
         "--max-requests <count>",
         "Maximum live page requests allowed before the run stops (retries included)",
-        "20"
+        "20",
       )
       .option(
         "--min-interval-ms <ms>",
         "Minimum delay between live page requests in milliseconds",
-        "5000"
+        "5000",
       )
       .option(
         "--max-retries <count>",
         "Retry transient timeout or network failures this many times per step",
-        "2"
+        "2",
       )
       .option(
         "--retry-base-delay-ms <ms>",
         "Initial exponential backoff delay for transient retries",
-        "1000"
+        "1000",
       )
       .option(
         "--retry-max-delay-ms <ms>",
         "Maximum exponential backoff delay for transient retries",
-        "10000"
+        "10000",
       )
       .option(
         "--no-progress",
-        "Hide per-step progress updates in human-readable output (stderr)"
+        "Hide per-step progress updates in human-readable output (stderr)",
       )
       .option(
         "-y, --yes",
         "Skip per-step confirmation prompts; read-only guardrails still apply",
-        false
+        false,
       )
       .option(
         "--json",
         "Print the structured report JSON to stdout (recommended for CI/scripts)",
-        false
+        false,
       )
       .addHelpText(
         "after",
@@ -8166,8 +8579,8 @@ export function createCliProgram(): Command {
           "Docs:",
           "  - docs/live-validation.md",
           "  - docs/live-validation-architecture.md",
-          `  - ${WRITE_VALIDATION_DOC_PATH}`
-        ].join("\n")
+          `  - ${WRITE_VALIDATION_DOC_PATH}`,
+        ].join("\n"),
       )
       .action(
         async (options: {
@@ -8192,7 +8605,7 @@ export function createCliProgram(): Command {
                 accountId: options.account,
                 cooldownSeconds: coerceNonNegativeInt(
                   options.cooldownSeconds,
-                  "cooldown-seconds"
+                  "cooldown-seconds",
                 ),
                 json: options.json,
                 progress: options.progress,
@@ -8200,11 +8613,11 @@ export function createCliProgram(): Command {
                 session: options.session,
                 timeoutSeconds: coercePositiveInt(
                   options.timeoutSeconds,
-                  "timeout-seconds"
+                  "timeout-seconds",
                 ),
-                yes: options.yes
+                yes: options.yes,
               },
-              readCdpUrl()
+              readCdpUrl(),
             );
             return;
           }
@@ -8212,37 +8625,45 @@ export function createCliProgram(): Command {
           await runLiveReadOnlyValidation(
             {
               json: options.json,
-              maxRequests: coercePositiveInt(options.maxRequests, "max-requests"),
-              maxRetries: coerceNonNegativeInt(options.maxRetries, "max-retries"),
+              maxRequests: coercePositiveInt(
+                options.maxRequests,
+                "max-requests",
+              ),
+              maxRetries: coerceNonNegativeInt(
+                options.maxRetries,
+                "max-retries",
+              ),
               minIntervalMs: coercePositiveInt(
                 options.minIntervalMs,
-                "min-interval-ms"
+                "min-interval-ms",
               ),
               progress: options.progress,
               readOnly: options.readOnly,
               retryBaseDelayMs: coercePositiveInt(
                 options.retryBaseDelayMs,
-                "retry-base-delay-ms"
+                "retry-base-delay-ms",
               ),
               retryMaxDelayMs: coercePositiveInt(
                 options.retryMaxDelayMs,
-                "retry-max-delay-ms"
+                "retry-max-delay-ms",
               ),
               sessionName: coerceProfileName(options.session, "session"),
               timeoutSeconds: coercePositiveInt(
                 options.timeoutSeconds,
-                "timeout-seconds"
+                "timeout-seconds",
               ),
-              yes: options.yes
+              yes: options.yes,
             },
-            readCdpUrl()
+            readCdpUrl(),
           );
-        }
+        },
       );
   };
 
   configureLiveValidationCommand(testCommand.command("live"));
-  configureLiveValidationCommand(program.command("test:live", { hidden: true }));
+  configureLiveValidationCommand(
+    program.command("test:live", { hidden: true }),
+  );
 
   const dataCommand = program
     .command("data")
@@ -8254,19 +8675,19 @@ export function createCliProgram(): Command {
       [
         "Preview local runtime data deletion; rerun with --confirm in an interactive terminal to delete.",
         "Default behavior is a dry-run preview of the shared local database, artifacts, keepalive state, and auth cooldown files. --include-profile expands the scope to all tool-owned browser profiles and adds a second confirmation before removing saved sessions and cookies.",
-        "Answering anything other than \"yes\" cancels safely. If some paths fail, the command reports failed_paths with recovery guidance after deleting what it can.",
-        "config.json is preserved by design. Stop keepalive daemons first. Data from external browsers attached with --cdp-url is never deleted."
-      ].join("\n\n")
+        'Answering anything other than "yes" cancels safely. If some paths fail, the command reports failed_paths with recovery guidance after deleting what it can.',
+        "config.json is preserved by design. Stop keepalive daemons first. Data from external browsers attached with --cdp-url is never deleted.",
+      ].join("\n\n"),
     )
     .option(
       "--confirm",
       "Permanently delete the listed tool-owned local data after interactive confirmation prompts",
-      false
+      false,
     )
     .option(
       "--include-profile",
       "Also preview/delete tool-owned browser profile data; destructive mode adds a second confirmation",
-      false
+      false,
     )
     .addHelpText(
       "after",
@@ -8287,39 +8708,38 @@ export function createCliProgram(): Command {
         "",
         "Interactive flow:",
         "  - --confirm requires an interactive terminal",
-        "  - answering anything other than \"yes\" cancels without deleting files",
+        '  - answering anything other than "yes" cancels without deleting files',
         "  - --include-profile adds a second prompt for browser sessions and cookies",
         "",
         "Partial failures:",
         "  - the command keeps deleting other targets when possible",
         "  - failed_paths reports path, code, message, and recoveryHint",
-        "  - fix the reported issue and rerun the same command"
-      ].join("\n")
+        "  - fix the reported issue and rerun the same command",
+      ].join("\n"),
     )
     .action(async (options: { confirm: boolean; includeProfile: boolean }) => {
       await runDataDelete({
         confirm: options.confirm,
         includeProfile: options.includeProfile,
-        cdpUrl: readCdpUrl()
+        cdpUrl: readCdpUrl(),
       });
     });
 
   program
     .command("feedback")
-    .description("File agent feedback as a GitHub issue or submit saved feedback")
-    .option(
-      "--type <type>",
-      `Feedback type (${FEEDBACK_TYPES.join(", ")})`
+    .description(
+      "File agent feedback as a GitHub issue or submit saved feedback",
     )
+    .option("--type <type>", `Feedback type (${FEEDBACK_TYPES.join(", ")})`)
     .option("--title <title>", "Short summary for the feedback issue")
     .option(
       "--description <description>",
-      "Detailed explanation. Omit to enter a multiline prompt interactively."
+      "Detailed explanation. Omit to enter a multiline prompt interactively.",
     )
     .option(
       "--submit-pending",
       "Submit all locally saved feedback files after authenticating with gh",
-      false
+      false,
     )
     .option("--json", "Print the structured feedback result as JSON", false)
     .addHelpText(
@@ -8338,8 +8758,8 @@ export function createCliProgram(): Command {
         "  - if `gh auth status` is not authenticated, feedback is saved under `.linkedin-buddy/pending-feedback/`",
         "  - later submit saved files with `gh auth login` then `linkedin-buddy feedback --submit-pending`",
         "",
-        `Encouragement hints appear once per active session, every ${DEFAULT_FEEDBACK_HINT_EVERY_N} invocations, and after errors.`
-      ].join("\n")
+        `Encouragement hints appear once per active session, every ${DEFAULT_FEEDBACK_HINT_EVERY_N} invocations, and after errors.`,
+      ].join("\n"),
     )
     .action(
       async (options: {
@@ -8354,15 +8774,15 @@ export function createCliProgram(): Command {
           submitPending: options.submitPending,
           ...(options.description ? { description: options.description } : {}),
           ...(options.title ? { title: options.title } : {}),
-          ...(options.type ? { type: options.type } : {})
+          ...(options.type ? { type: options.type } : {}),
         });
-      }
+      },
     );
 
   const keepAliveCommand = program
     .command("keepalive")
     .description(
-      "Manage the local session keepalive daemon that records background LinkedIn health checks to disk"
+      "Manage the local session keepalive daemon that records background LinkedIn health checks to disk",
     )
     .addHelpText(
       "after",
@@ -8378,33 +8798,37 @@ export function createCliProgram(): Command {
         "  linkedin keepalive start --profile default",
         "  linkedin keepalive status --profile default --verbose",
         "  linkedin keepalive stop --profile default",
-        "  linkedin keepalive status --profile smoke --json"
-      ].join("\n")
+        "  linkedin keepalive status --profile smoke --json",
+      ].join("\n"),
     );
 
   keepAliveCommand
     .command("start")
     .description(
-      "Start the local keepalive daemon for a profile and begin background session health checks"
+      "Start the local keepalive daemon for a profile and begin background session health checks",
     )
     .option("-p, --profile <profile>", "Profile name", "default")
     .option(
       "--interval-seconds <seconds>",
       "Health/refresh check interval in seconds",
-      "300"
+      "300",
     )
     .option(
       "--jitter-seconds <seconds>",
       "Random +/- jitter per interval in seconds",
-      "30"
+      "30",
     )
     .option(
       "--max-consecutive-failures <count>",
       "Mark daemon degraded after this many consecutive failures",
-      "5"
+      "5",
     )
     .option("--json", "Print the structured keepalive payload", false)
-    .option("--verbose", "Show extra diagnostics in human-readable output", false)
+    .option(
+      "--verbose",
+      "Show extra diagnostics in human-readable output",
+      false,
+    )
     .option("--quiet", "Print a concise human-readable summary", false)
     .addHelpText(
       "after",
@@ -8414,8 +8838,8 @@ export function createCliProgram(): Command {
         "Checks continue on the configured interval/jitter cadence and the saved state becomes degraded after the configured failure threshold.",
         "If a stale PID file already exists for this profile, start removes it before launching the new daemon.",
         "Human output shows a startup summary and reminds you how to inspect the first background health checks.",
-        "Use --quiet if you only need a compact confirmation message."
-      ].join("\n")
+        "Use --quiet if you only need a compact confirmation message.",
+      ].join("\n"),
     )
     .action(
       async (options: {
@@ -8433,30 +8857,36 @@ export function createCliProgram(): Command {
               profileName: options.profile,
               intervalSeconds: coercePositiveInt(
                 options.intervalSeconds,
-                "interval-seconds"
+                "interval-seconds",
               ),
               jitterSeconds: coerceNonNegativeInt(
                 options.jitterSeconds,
-                "jitter-seconds"
+                "jitter-seconds",
               ),
               maxConsecutiveFailures: coercePositiveInt(
                 options.maxConsecutiveFailures,
-                "max-consecutive-failures"
-              )
+                "max-consecutive-failures",
+              ),
             },
             outputOptions,
-            readCdpUrl()
+            readCdpUrl(),
           );
         });
-      }
+      },
     );
 
   keepAliveCommand
     .command("status")
-    .description("Show daemon health, the latest saved session check, and recovery guidance")
+    .description(
+      "Show daemon health, the latest saved session check, and recovery guidance",
+    )
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("--json", "Print the structured keepalive payload", false)
-    .option("--verbose", "Show recent daemon events and extra diagnostics", false)
+    .option(
+      "--verbose",
+      "Show recent daemon events and extra diagnostics",
+      false,
+    )
     .option("--quiet", "Print a concise human-readable summary", false)
     .addHelpText(
       "after",
@@ -8465,8 +8895,8 @@ export function createCliProgram(): Command {
         "Status reads the daemon state and recent keepalive events saved for the selected profile.",
         "Interactive terminals show a human summary with Next Steps and Action Needed guidance when recovery is needed.",
         "Use --verbose to include recent daemon events, timestamps, and extra session detail.",
-        "Use --json for automation or to inspect the raw saved state."
-      ].join("\n")
+        "Use --json for automation or to inspect the raw saved state.",
+      ].join("\n"),
     )
     .action(
       async (options: {
@@ -8478,17 +8908,21 @@ export function createCliProgram(): Command {
         await runKeepAliveCliAction(options, async (outputOptions) => {
           await runKeepAliveStatus(options.profile, outputOptions);
         });
-      }
+      },
     );
 
   keepAliveCommand
     .command("stop")
     .description(
-      "Stop the local keepalive daemon and preserve the last saved health state"
+      "Stop the local keepalive daemon and preserve the last saved health state",
     )
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("--json", "Print the structured keepalive payload", false)
-    .option("--verbose", "Show extra diagnostics in human-readable output", false)
+    .option(
+      "--verbose",
+      "Show extra diagnostics in human-readable output",
+      false,
+    )
     .option("--quiet", "Print a concise human-readable summary", false)
     .addHelpText(
       "after",
@@ -8496,8 +8930,8 @@ export function createCliProgram(): Command {
         "",
         "Stopping the daemon preserves the last saved state file and event log for later inspection.",
         "Use status after stopping if you want to confirm the daemon is idle or review the last recorded failure.",
-        "If the daemon ignores SIGTERM for 5 seconds, stop force-kills it and records that in the saved state."
-      ].join("\n")
+        "If the daemon ignores SIGTERM for 5 seconds, stop force-kills it and records that in the saved state.",
+      ].join("\n"),
     )
     .action(
       async (options: {
@@ -8509,7 +8943,7 @@ export function createCliProgram(): Command {
         await runKeepAliveCliAction(options, async (outputOptions) => {
           await runKeepAliveStop(options.profile, outputOptions);
         });
-      }
+      },
     );
 
   keepAliveCommand
@@ -8520,7 +8954,7 @@ export function createCliProgram(): Command {
     .requiredOption("--jitter-seconds <seconds>", "Interval jitter in seconds")
     .requiredOption(
       "--max-consecutive-failures <count>",
-      "Maximum failures before degraded status"
+      "Maximum failures before degraded status",
     )
     .action(
       async (options: {
@@ -8534,26 +8968,26 @@ export function createCliProgram(): Command {
             profileName: options.profile,
             intervalSeconds: coercePositiveInt(
               options.intervalSeconds,
-              "interval-seconds"
+              "interval-seconds",
             ),
             jitterSeconds: coerceNonNegativeInt(
               options.jitterSeconds,
-              "jitter-seconds"
+              "jitter-seconds",
             ),
             maxConsecutiveFailures: coercePositiveInt(
               options.maxConsecutiveFailures,
-              "max-consecutive-failures"
-            )
+              "max-consecutive-failures",
+            ),
           },
-          readCdpUrl()
+          readCdpUrl(),
         );
-      }
+      },
     );
 
   const schedulerCommand = program
     .command("scheduler")
     .description(
-      "Manage the local follow-up scheduler daemon. The scheduler only prepares follow-ups near their due time, and prepared actions still require manual confirmation."
+      "Manage the local follow-up scheduler daemon. The scheduler only prepares follow-ups near their due time, and prepared actions still require manual confirmation.",
     )
     .addHelpText(
       "afterAll",
@@ -8567,14 +9001,14 @@ export function createCliProgram(): Command {
         "  linkedin scheduler start --profile default",
         "  linkedin scheduler status --profile default --jobs 10",
         "  linkedin scheduler run-once --profile default --json",
-        "  linkedin scheduler stop --profile default"
-      ].join("\n")
+        "  linkedin scheduler stop --profile default",
+      ].join("\n"),
     );
 
   schedulerCommand
     .command("start")
     .description(
-      "Start the local scheduler daemon for a profile using the current poll interval and business-hours settings"
+      "Start the local scheduler daemon for a profile using the current poll interval and business-hours settings",
     )
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("--json", "Print the structured scheduler payload", false)
@@ -8584,8 +9018,8 @@ export function createCliProgram(): Command {
         "",
         "The daemon wakes up on the configured poll interval and respects scheduler business hours.",
         "It only prepares due follow-ups; confirmation always remains manual.",
-        "Use `linkedin scheduler status` to inspect queue counts, recent history, and state/log paths."
-      ].join("\n")
+        "Use `linkedin scheduler status` to inspect queue counts, recent history, and state/log paths.",
+      ].join("\n"),
     )
     .action(async (options: { profile: string; json: boolean }) => {
       await runSchedulerCliAction(options, async (outputMode) => {
@@ -8595,12 +9029,14 @@ export function createCliProgram(): Command {
 
   schedulerCommand
     .command("status")
-    .description("Show daemon health, queue summary, and recent scheduler history")
+    .description(
+      "Show daemon health, queue summary, and recent scheduler history",
+    )
     .option("-p, --profile <profile>", "Profile name", "default")
     .option(
       "--jobs <count>",
       "Show up to this many queued and recent jobs in the status output",
-      String(DEFAULT_SCHEDULER_STATUS_JOB_LIMIT)
+      String(DEFAULT_SCHEDULER_STATUS_JOB_LIMIT),
     )
     .option("--json", "Print the structured scheduler payload", false)
     .addHelpText(
@@ -8609,23 +9045,25 @@ export function createCliProgram(): Command {
         "",
         "Status output previews queued jobs and recent history for the selected profile.",
         "Use --jobs <count> to control how many queued and recent jobs are shown.",
-        "Use --json for automation or to inspect the full structured scheduler payload."
-      ].join("\n")
+        "Use --json for automation or to inspect the full structured scheduler payload.",
+      ].join("\n"),
     )
-    .action(async (options: { profile: string; jobs: string; json: boolean }) => {
-      await runSchedulerCliAction(options, async (outputMode) => {
-        await runSchedulerStatus(
-          options.profile,
-          outputMode,
-          coercePositiveInt(options.jobs, "jobs")
-        );
-      });
-    });
+    .action(
+      async (options: { profile: string; jobs: string; json: boolean }) => {
+        await runSchedulerCliAction(options, async (outputMode) => {
+          await runSchedulerStatus(
+            options.profile,
+            outputMode,
+            coercePositiveInt(options.jobs, "jobs"),
+          );
+        });
+      },
+    );
 
   schedulerCommand
     .command("stop")
     .description(
-      "Stop the local scheduler daemon and clean up stale state without deleting queued jobs"
+      "Stop the local scheduler daemon and clean up stale state without deleting queued jobs",
     )
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("--json", "Print the structured scheduler payload", false)
@@ -8634,8 +9072,8 @@ export function createCliProgram(): Command {
       [
         "",
         "Stopping the daemon does not delete queued jobs or prepared follow-up actions.",
-        "Use `linkedin scheduler status` after stopping if you want to confirm the daemon is idle."
-      ].join("\n")
+        "Use `linkedin scheduler status` after stopping if you want to confirm the daemon is idle.",
+      ].join("\n"),
     )
     .action(async (options: { profile: string; json: boolean }) => {
       await runSchedulerCliAction(options, async (outputMode) => {
@@ -8647,7 +9085,7 @@ export function createCliProgram(): Command {
     .command("run-once")
     .alias("tick")
     .description(
-      "Run one scheduler tick immediately, refresh queue state, and summarize the result"
+      "Run one scheduler tick immediately, refresh queue state, and summarize the result",
     )
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("--json", "Print the structured scheduler payload", false)
@@ -8657,8 +9095,8 @@ export function createCliProgram(): Command {
         "",
         "A tick refreshes accepted invitations, syncs queue state, and prepares any due follow-ups.",
         "Prepared actions still require manual confirmation after a successful tick.",
-        "Use this command when you want an immediate scheduler pass without starting the daemon."
-      ].join("\n")
+        "Use this command when you want an immediate scheduler pass without starting the daemon.",
+      ].join("\n"),
     )
     .action(async (options: { profile: string; json: boolean }) => {
       await runSchedulerCliAction(options, async (outputMode) => {
@@ -8677,7 +9115,7 @@ export function createCliProgram(): Command {
   const activityCommand = program
     .command("activity")
     .description(
-      "Use human-readable activity summaries by default in interactive terminals. Manage poll-based LinkedIn activity watches, webhook subscriptions, and the local activity daemon."
+      "Use human-readable activity summaries by default in interactive terminals. Manage poll-based LinkedIn activity watches, webhook subscriptions, and the local activity daemon.",
     )
     .addHelpText(
       "after",
@@ -8693,8 +9131,8 @@ export function createCliProgram(): Command {
         "  linkedin activity run-once --profile default --json",
         "  linkedin activity start --profile default",
         "  linkedin activity status --profile default",
-        "  linkedin activity stop --profile default"
-      ].join("\n")
+        "  linkedin activity stop --profile default",
+      ].join("\n"),
     );
 
   const activityWatchCommand = activityCommand
@@ -8704,7 +9142,10 @@ export function createCliProgram(): Command {
   activityWatchCommand
     .command("add")
     .description("Create a new activity watch")
-    .requiredOption("--kind <kind>", `Watch kind: ${ACTIVITY_WATCH_KINDS.join(", ")}`)
+    .requiredOption(
+      "--kind <kind>",
+      `Watch kind: ${ACTIVITY_WATCH_KINDS.join(", ")}`,
+    )
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("--interval-seconds <seconds>", "Poll interval in seconds")
     .option("--cron <expression>", "Cron schedule expression")
@@ -8731,18 +9172,18 @@ export function createCliProgram(): Command {
                 ? {
                     intervalSeconds: coercePositiveInt(
                       options.intervalSeconds,
-                      "interval-seconds"
-                    )
+                      "interval-seconds",
+                    ),
                   }
                 : {}),
               ...(options.cron ? { cron: options.cron } : {}),
-              ...(target ? { target } : {})
+              ...(target ? { target } : {}),
             },
             outputMode,
-            readCdpUrl()
+            readCdpUrl(),
           );
         });
-      }
+      },
     );
 
   activityWatchCommand
@@ -8751,23 +9192,25 @@ export function createCliProgram(): Command {
     .option("-p, --profile <profile>", "Profile name", "default")
     .option(
       "--status <status>",
-      `Filter by status: ${ACTIVITY_WATCH_STATUSES.join(", ")}`
+      `Filter by status: ${ACTIVITY_WATCH_STATUSES.join(", ")}`,
     )
     .option("--json", "Print the structured activity payload", false)
-    .action(async (options: { profile: string; status?: string; json: boolean }) => {
-      await runActivityCliAction(options, async (outputMode) => {
-        await runActivityWatchList(
-          {
-            profileName: options.profile,
-            ...(options.status
-              ? { status: coerceActivityWatchStatusValue(options.status) }
-              : {})
-          },
-          outputMode,
-          readCdpUrl()
-        );
-      });
-    });
+    .action(
+      async (options: { profile: string; status?: string; json: boolean }) => {
+        await runActivityCliAction(options, async (outputMode) => {
+          await runActivityWatchList(
+            {
+              profileName: options.profile,
+              ...(options.status
+                ? { status: coerceActivityWatchStatusValue(options.status) }
+                : {}),
+            },
+            outputMode,
+            readCdpUrl(),
+          );
+        });
+      },
+    );
 
   activityWatchCommand
     .command("pause")
@@ -8811,7 +9254,10 @@ export function createCliProgram(): Command {
     .description("Register a webhook subscription for one watch")
     .requiredOption("--watch <watchId>", "Activity watch id")
     .requiredOption("--url <deliveryUrl>", "Webhook delivery URL")
-    .option("-e, --event <eventType...>", `Event filters: ${ACTIVITY_EVENT_TYPES.join(", ")}`)
+    .option(
+      "-e, --event <eventType...>",
+      `Event filters: ${ACTIVITY_EVENT_TYPES.join(", ")}`,
+    )
     .option("--secret <secret>", "Webhook signing secret")
     .option("--max-attempts <count>", "Maximum delivery attempts")
     .option("--json", "Print the structured activity payload", false)
@@ -8837,16 +9283,16 @@ export function createCliProgram(): Command {
                 ? {
                     maxAttempts: coercePositiveInt(
                       options.maxAttempts,
-                      "max-attempts"
-                    )
+                      "max-attempts",
+                    ),
                   }
-                : {})
+                : {}),
             },
             outputMode,
-            readCdpUrl()
+            readCdpUrl(),
           );
         });
-      }
+      },
     );
 
   activityWebhookCommand
@@ -8856,25 +9302,34 @@ export function createCliProgram(): Command {
     .option("--watch <watchId>", "Filter by watch id")
     .option(
       "--status <status>",
-      `Filter by status: ${WEBHOOK_SUBSCRIPTION_STATUSES.join(", ")}`
+      `Filter by status: ${WEBHOOK_SUBSCRIPTION_STATUSES.join(", ")}`,
     )
     .option("--json", "Print the structured activity payload", false)
     .action(
-      async (options: { profile: string; watch?: string; status?: string; json: boolean }) => {
+      async (options: {
+        profile: string;
+        watch?: string;
+        status?: string;
+        json: boolean;
+      }) => {
         await runActivityCliAction(options, async (outputMode) => {
           await runActivityWebhookList(
             {
               profileName: options.profile,
               ...(options.watch ? { watchId: options.watch } : {}),
               ...(options.status
-                ? { status: coerceWebhookSubscriptionStatusValue(options.status) }
-                : {})
+                ? {
+                    status: coerceWebhookSubscriptionStatusValue(
+                      options.status,
+                    ),
+                  }
+                : {}),
             },
             outputMode,
-            readCdpUrl()
+            readCdpUrl(),
           );
         });
-      }
+      },
     );
 
   activityWebhookCommand
@@ -8895,7 +9350,11 @@ export function createCliProgram(): Command {
     .option("--json", "Print the structured activity payload", false)
     .action(async (subscriptionId: string, options: { json: boolean }) => {
       await runActivityCliAction(options, async (outputMode) => {
-        await runActivityWebhookResume(subscriptionId, outputMode, readCdpUrl());
+        await runActivityWebhookResume(
+          subscriptionId,
+          outputMode,
+          readCdpUrl(),
+        );
       });
     });
 
@@ -8906,7 +9365,11 @@ export function createCliProgram(): Command {
     .option("--json", "Print the structured activity payload", false)
     .action(async (subscriptionId: string, options: { json: boolean }) => {
       await runActivityCliAction(options, async (outputMode) => {
-        await runActivityWebhookRemove(subscriptionId, outputMode, readCdpUrl());
+        await runActivityWebhookRemove(
+          subscriptionId,
+          outputMode,
+          readCdpUrl(),
+        );
       });
     });
 
@@ -8917,29 +9380,39 @@ export function createCliProgram(): Command {
     .option("--watch <watchId>", "Filter by watch id")
     .option("-l, --limit <limit>", "Maximum events to return", "20")
     .option("--json", "Print the structured activity payload", false)
-    .action(async (options: { profile: string; watch?: string; limit: string; json: boolean }) => {
-      await runActivityCliAction(options, async (outputMode) => {
-        await runActivityEventsList(
-          {
-            profileName: options.profile,
-            ...(options.watch ? { watchId: options.watch } : {}),
-            limit: coercePositiveInt(options.limit, "limit")
-          },
-          outputMode,
-          readCdpUrl()
-        );
-      });
-    });
+    .action(
+      async (options: {
+        profile: string;
+        watch?: string;
+        limit: string;
+        json: boolean;
+      }) => {
+        await runActivityCliAction(options, async (outputMode) => {
+          await runActivityEventsList(
+            {
+              profileName: options.profile,
+              ...(options.watch ? { watchId: options.watch } : {}),
+              limit: coercePositiveInt(options.limit, "limit"),
+            },
+            outputMode,
+            readCdpUrl(),
+          );
+        });
+      },
+    );
 
   activityCommand
     .command("deliveries")
     .description("List recent webhook delivery attempts")
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("--watch <watchId>", "Filter by watch id")
-    .option("--subscription <subscriptionId>", "Filter by webhook subscription id")
+    .option(
+      "--subscription <subscriptionId>",
+      "Filter by webhook subscription id",
+    )
     .option(
       "--status <status>",
-      `Filter by status: ${WEBHOOK_DELIVERY_ATTEMPT_STATUSES.join(", ")}`
+      `Filter by status: ${WEBHOOK_DELIVERY_ATTEMPT_STATUSES.join(", ")}`,
     )
     .option("-l, --limit <limit>", "Maximum deliveries to return", "20")
     .option("--json", "Print the structured activity payload", false)
@@ -8957,17 +9430,19 @@ export function createCliProgram(): Command {
             {
               profileName: options.profile,
               ...(options.watch ? { watchId: options.watch } : {}),
-              ...(options.subscription ? { subscriptionId: options.subscription } : {}),
+              ...(options.subscription
+                ? { subscriptionId: options.subscription }
+                : {}),
               ...(options.status
                 ? { status: coerceWebhookDeliveryStatusValue(options.status) }
                 : {}),
-              limit: coercePositiveInt(options.limit, "limit")
+              limit: coercePositiveInt(options.limit, "limit"),
             },
             outputMode,
-            readCdpUrl()
+            readCdpUrl(),
           );
         });
-      }
+      },
     );
 
   activityCommand
@@ -9023,7 +9498,6 @@ export function createCliProgram(): Command {
       await runActivityDaemon(options.profile, readCdpUrl());
     });
 
-
   program
     .command("login")
     .description("Open LinkedIn login in a persistent Playwright profile")
@@ -9031,24 +9505,38 @@ export function createCliProgram(): Command {
     .option(
       "-t, --timeout-minutes <minutes>",
       "How long to wait for successful login",
-      "10"
+      "10",
     )
-    .option("--headless", "Authenticate headlessly with email and password", false)
+    .option(
+      "--headless",
+      "Authenticate headlessly with email and password",
+      false,
+    )
+    .option(
+      "--headed",
+      "Use a visible browser for credential-based login (avoids anti-bot captchas)",
+      false,
+    )
     .option("--email <email>", "LinkedIn email (or set LINKEDIN_EMAIL env var)")
     .option(
       "--password <password>",
-      "LinkedIn password (or set LINKEDIN_PASSWORD env var)"
+      "LinkedIn password (or set LINKEDIN_PASSWORD env var)",
     )
     .option(
       "--mfa-code <code>",
-      "MFA verification code (or set LINKEDIN_MFA_CODE env var)"
+      "MFA verification code (or set LINKEDIN_MFA_CODE env var)",
     )
-    .option("--mfa-interactive", "Prompt for MFA code interactively via stdin", false)
+    .option(
+      "--mfa-interactive",
+      "Prompt for MFA code interactively via stdin",
+      false,
+    )
     .action(
       async (options: {
         profile: string;
         timeoutMinutes: string;
         headless: boolean;
+        headed: boolean;
         email?: string;
         password?: string;
         mfaCode?: string;
@@ -9056,10 +9544,12 @@ export function createCliProgram(): Command {
       }) => {
         const timeoutMinutes = coercePositiveInt(
           options.timeoutMinutes,
-          "timeout-minutes"
+          "timeout-minutes",
         );
 
-        if (options.headless) {
+        const useCredentialLogin = options.headless || options.headed;
+
+        if (useCredentialLogin) {
           const email = options.email ?? process.env.LINKEDIN_EMAIL;
           const password = options.password ?? process.env.LINKEDIN_PASSWORD;
           const mfaCode = options.mfaCode ?? process.env.LINKEDIN_MFA_CODE;
@@ -9067,7 +9557,10 @@ export function createCliProgram(): Command {
           let mfaCallback: (() => Promise<string | undefined>) | undefined;
           if (options.mfaInteractive && !mfaCode) {
             mfaCallback = async () => {
-              const rl = createInterface({ input: stdin, output: process.stderr });
+              const rl = createInterface({
+                input: stdin,
+                output: process.stderr,
+              });
               try {
                 const code = await rl.question("LinkedIn verification code: ");
                 return code.trim() || undefined;
@@ -9080,14 +9573,14 @@ export function createCliProgram(): Command {
           if (!email) {
             throw new LinkedInBuddyError(
               "ACTION_PRECONDITION_FAILED",
-              "Headless login requires --email or LINKEDIN_EMAIL environment variable."
+              "Credential login requires --email or LINKEDIN_EMAIL environment variable.",
             );
           }
 
           if (!password) {
             throw new LinkedInBuddyError(
               "ACTION_PRECONDITION_FAILED",
-              "Headless login requires --password or LINKEDIN_PASSWORD environment variable."
+              "Credential login requires --password or LINKEDIN_PASSWORD environment variable.",
             );
           }
 
@@ -9096,16 +9589,17 @@ export function createCliProgram(): Command {
               profileName: options.profile,
               email,
               password,
+              headless: !options.headed,
               ...(typeof mfaCode === "string" ? { mfaCode } : {}),
               ...(mfaCallback ? { mfaCallback } : {}),
-              timeoutMinutes
+              timeoutMinutes,
             },
-            readCdpUrl()
+            readCdpUrl(),
           );
         } else {
           await runLogin(options.profile, timeoutMinutes, readCdpUrl());
         }
-      }
+      },
     );
 
   const runFixtureRecordCommand = async (options: {
@@ -9118,7 +9612,7 @@ export function createCliProgram(): Command {
     width: string;
   }) => {
     const pageTypes = uniqueFixtureReplayPageTypes(
-      options.page.length > 0 ? options.page : [...LINKEDIN_REPLAY_PAGE_TYPES]
+      options.page.length > 0 ? options.page : [...LINKEDIN_REPLAY_PAGE_TYPES],
     );
 
     await runFixturesRecord({
@@ -9128,7 +9622,7 @@ export function createCliProgram(): Command {
       pageTypes,
       profileName: coerceProfileName(options.profile),
       setName: coerceProfileName(options.set, "set"),
-      width: coercePositiveInt(options.width, "width")
+      width: coercePositiveInt(options.width, "width"),
     });
   };
 
@@ -9140,46 +9634,51 @@ export function createCliProgram(): Command {
     await runFixturesCheck({
       ...(options.manifest ? { manifestPath: options.manifest } : {}),
       maxAgeDays: coercePositiveInt(options.maxAgeDays, "max-age-days"),
-      ...(options.set ? { setName: coerceProfileName(options.set, "set") } : {})
+      ...(options.set
+        ? { setName: coerceProfileName(options.set, "set") }
+        : {}),
     });
   };
 
   const configureFixtureRecordCommand = (command: Command): Command =>
     command
       .description(
-        "Launch a manual Playwright capture flow and update a LinkedIn replay fixture set"
+        "Launch a manual Playwright capture flow and update a LinkedIn replay fixture set",
       )
       .option(
         "-p, --profile <profile>",
         "Profile name used for the manual LinkedIn browser session",
-        DEFAULT_FIXTURE_RECORD_PROFILE
+        DEFAULT_FIXTURE_RECORD_PROFILE,
       )
       .option(
         "-s, --set <name>",
         "Fixture set name stored under test/fixtures/",
-        DEFAULT_FIXTURE_RECORD_SET
+        DEFAULT_FIXTURE_RECORD_SET,
       )
       .option(
         "--page <type>",
         `Repeat or comma-separate page types (${LINKEDIN_REPLAY_PAGE_TYPES.join(", ")})`,
         collectFixtureReplayPageTypes,
-        [] as LinkedInReplayPageType[]
+        [] as LinkedInReplayPageType[],
       )
       .option(
         "--manifest <path>",
-        `Fixture manifest path (default: ${resolveFixtureManifestPath()})`
+        `Fixture manifest path (default: ${resolveFixtureManifestPath()})`,
       )
       .option(
         "--width <px>",
         "Viewport width in pixels",
-        String(DEFAULT_FIXTURE_VIEWPORT.width)
+        String(DEFAULT_FIXTURE_VIEWPORT.width),
       )
       .option(
         "--height <px>",
         "Viewport height in pixels",
-        String(DEFAULT_FIXTURE_VIEWPORT.height)
+        String(DEFAULT_FIXTURE_VIEWPORT.height),
       )
-      .option("--no-har", "Skip HAR capture and only save HTML snapshots + replay routes")
+      .option(
+        "--no-har",
+        "Skip HAR capture and only save HTML snapshots + replay routes",
+      )
       .addHelpText(
         "after",
         [
@@ -9195,26 +9694,28 @@ export function createCliProgram(): Command {
           "",
           "Next steps:",
           "  linkedin fixtures check --set <name>",
-          "  LINKEDIN_E2E_FIXTURE_SET=<name> npm run test:e2e:fixtures -- packages/core/src/__tests__/e2e/inbox.e2e.test.ts"
-        ].join("\n")
+          "  LINKEDIN_E2E_FIXTURE_SET=<name> npm run test:e2e:fixtures -- packages/core/src/__tests__/e2e/inbox.e2e.test.ts",
+        ].join("\n"),
       )
       .action(runFixtureRecordCommand);
 
   const configureFixtureCheckCommand = (command: Command): Command =>
     command
-      .description("Validate replay fixture freshness and print staleness warnings")
+      .description(
+        "Validate replay fixture freshness and print staleness warnings",
+      )
       .option(
         "-s, --set <name>",
-        "Only validate one fixture set from the manifest"
+        "Only validate one fixture set from the manifest",
       )
       .option(
         "--manifest <path>",
-        `Fixture manifest path (default: ${resolveFixtureManifestPath()})`
+        `Fixture manifest path (default: ${resolveFixtureManifestPath()})`,
       )
       .option(
         "--max-age-days <days>",
         "Warn when captured pages are older than this many days",
-        String(DEFAULT_FIXTURE_STALENESS_DAYS)
+        String(DEFAULT_FIXTURE_STALENESS_DAYS),
       )
       .addHelpText(
         "after",
@@ -9226,8 +9727,8 @@ export function createCliProgram(): Command {
           "",
           "Follow-up:",
           "  Re-record stale pages with linkedin fixtures record --set <name> --page <type>",
-          "  Replay a checked set with LINKEDIN_E2E_FIXTURE_SET=<name> npm run test:e2e:fixtures"
-        ].join("\n")
+          "  Replay a checked set with LINKEDIN_E2E_FIXTURE_SET=<name> npm run test:e2e:fixtures",
+        ].join("\n"),
       )
       .action(runFixtureCheckCommand);
 
@@ -9237,8 +9738,12 @@ export function createCliProgram(): Command {
 
   configureFixtureRecordCommand(fixturesCommand.command("record"));
   configureFixtureCheckCommand(fixturesCommand.command("check"));
-  configureFixtureRecordCommand(program.command("fixtures:record", { hidden: true }));
-  configureFixtureCheckCommand(program.command("fixtures:check", { hidden: true }));
+  configureFixtureRecordCommand(
+    program.command("fixtures:record", { hidden: true }),
+  );
+  configureFixtureCheckCommand(
+    program.command("fixtures:check", { hidden: true }),
+  );
 
   program
     .command("search")
@@ -9248,21 +9753,24 @@ export function createCliProgram(): Command {
     .option(
       "-c, --category <category>",
       `Search category: ${SEARCH_CATEGORIES.join(", ")}`,
-      "people"
+      "people",
     )
     .option("-l, --limit <limit>", "Max results", "10")
     .action(
       async (
         query: string,
-        options: { profile: string; category: string; limit: string }
+        options: { profile: string; category: string; limit: string },
       ) => {
-        await runSearch({
-          profileName: options.profile,
-          query,
-          category: coerceSearchCategory(options.category),
-          limit: coercePositiveInt(options.limit, "limit")
-        }, readCdpUrl());
-      }
+        await runSearch(
+          {
+            profileName: options.profile,
+            query,
+            category: coerceSearchCategory(options.category),
+            limit: coercePositiveInt(options.limit, "limit"),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   const inboxCommand = program
@@ -9277,12 +9785,15 @@ export function createCliProgram(): Command {
     .option("-l, --limit <limit>", "Max recipients", "10")
     .action(
       async (options: { profile: string; query: string; limit: string }) => {
-        await runInboxSearchRecipients({
-          profileName: options.profile,
-          query: options.query,
-          limit: coercePositiveInt(options.limit, "limit")
-        }, readCdpUrl());
-      }
+        await runInboxSearchRecipients(
+          {
+            profileName: options.profile,
+            query: options.query,
+            limit: coercePositiveInt(options.limit, "limit"),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   inboxCommand
@@ -9293,12 +9804,15 @@ export function createCliProgram(): Command {
     .option("-l, --limit <limit>", "Max threads", "20")
     .action(
       async (options: { profile: string; unread: boolean; limit: string }) => {
-        await runInboxList({
-          profileName: options.profile,
-          unreadOnly: options.unread,
-          limit: coercePositiveInt(options.limit, "limit")
-        }, readCdpUrl());
-      }
+        await runInboxList(
+          {
+            profileName: options.profile,
+            unreadOnly: options.unread,
+            limit: coercePositiveInt(options.limit, "limit"),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   inboxCommand
@@ -9309,12 +9823,15 @@ export function createCliProgram(): Command {
     .option("-l, --limit <limit>", "Max messages to return", "20")
     .action(
       async (options: { profile: string; thread: string; limit: string }) => {
-        await runInboxShow({
-          profileName: options.profile,
-          thread: options.thread,
-          limit: coercePositiveInt(options.limit, "limit")
-        }, readCdpUrl());
-      }
+        await runInboxShow(
+          {
+            profileName: options.profile,
+            thread: options.thread,
+            limit: coercePositiveInt(options.limit, "limit"),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   inboxCommand
@@ -9324,18 +9841,25 @@ export function createCliProgram(): Command {
       "-r, --recipient <recipient>",
       "LinkedIn profile URL, /in/ path, or vanity name",
       collectNonEmptyStrings,
-      [] as string[]
+      [] as string[],
     )
     .requiredOption("--text <text>", "First message text")
     .option("-p, --profile <profile>", "Profile name", "default")
     .action(
-      async (options: { profile: string; recipient: string[]; text: string }) => {
-        await runPrepareNewThread({
-          profileName: options.profile,
-          recipients: options.recipient,
-          text: options.text
-        }, readCdpUrl());
-      }
+      async (options: {
+        profile: string;
+        recipient: string[];
+        text: string;
+      }) => {
+        await runPrepareNewThread(
+          {
+            profileName: options.profile,
+            recipients: options.recipient,
+            text: options.text,
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   inboxCommand
@@ -9346,12 +9870,15 @@ export function createCliProgram(): Command {
     .option("-p, --profile <profile>", "Profile name", "default")
     .action(
       async (options: { profile: string; thread: string; text: string }) => {
-        await runPrepareReply({
-          profileName: options.profile,
-          thread: options.thread,
-          text: options.text
-        }, readCdpUrl());
-      }
+        await runPrepareReply(
+          {
+            profileName: options.profile,
+            thread: options.thread,
+            text: options.text,
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   inboxCommand
@@ -9362,17 +9889,24 @@ export function createCliProgram(): Command {
       "-r, --recipient <recipient>",
       "LinkedIn profile URL, /in/ path, or vanity name",
       collectNonEmptyStrings,
-      [] as string[]
+      [] as string[],
     )
     .option("-p, --profile <profile>", "Profile name", "default")
     .action(
-      async (options: { profile: string; recipient: string[]; thread: string }) => {
-        await runPrepareAddRecipients({
-          profileName: options.profile,
-          recipients: options.recipient,
-          thread: options.thread
-        }, readCdpUrl());
-      }
+      async (options: {
+        profile: string;
+        recipient: string[];
+        thread: string;
+      }) => {
+        await runPrepareAddRecipients(
+          {
+            profileName: options.profile,
+            recipients: options.recipient,
+            thread: options.thread,
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   const connectionsCommand = program
@@ -9384,39 +9918,37 @@ export function createCliProgram(): Command {
     .description("List your LinkedIn connections")
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("-l, --limit <limit>", "Max connections to return", "40")
-    .action(
-      async (options: { profile: string; limit: string }) => {
-        await runConnectionsList({
+    .action(async (options: { profile: string; limit: string }) => {
+      await runConnectionsList(
+        {
           profileName: options.profile,
-          limit: coercePositiveInt(options.limit, "limit")
-        }, readCdpUrl());
-      }
-    );
+          limit: coercePositiveInt(options.limit, "limit"),
+        },
+        readCdpUrl(),
+      );
+    });
 
   connectionsCommand
     .command("pending")
     .description("List pending connection invitations")
     .option("-p, --profile <profile>", "Profile name", "default")
-    .option(
-      "-f, --filter <filter>",
-      "Filter: sent, received, or all",
-      "all"
-    )
-    .action(
-      async (options: { profile: string; filter: string }) => {
-        const filter = options.filter as "sent" | "received" | "all";
-        if (!["sent", "received", "all"].includes(filter)) {
-          throw new LinkedInBuddyError(
-            "ACTION_PRECONDITION_FAILED",
-            "Filter must be 'sent', 'received', or 'all'."
-          );
-        }
-        await runConnectionsPending({
-          profileName: options.profile,
-          filter
-        }, readCdpUrl());
+    .option("-f, --filter <filter>", "Filter: sent, received, or all", "all")
+    .action(async (options: { profile: string; filter: string }) => {
+      const filter = options.filter as "sent" | "received" | "all";
+      if (!["sent", "received", "all"].includes(filter)) {
+        throw new LinkedInBuddyError(
+          "ACTION_PRECONDITION_FAILED",
+          "Filter must be 'sent', 'received', or 'all'.",
+        );
       }
-    );
+      await runConnectionsPending(
+        {
+          profileName: options.profile,
+          filter,
+        },
+        readCdpUrl(),
+      );
+    });
 
   connectionsCommand
     .command("invite")
@@ -9426,12 +9958,15 @@ export function createCliProgram(): Command {
     .option("-n, --note <note>", "Optional invitation note")
     .action(
       async (target: string, options: { profile: string; note?: string }) => {
-        await runConnectionsInvite({
-          profileName: options.profile,
-          targetProfile: target,
-          ...(options.note ? { note: options.note } : {})
-        }, readCdpUrl());
-      }
+        await runConnectionsInvite(
+          {
+            profileName: options.profile,
+            targetProfile: target,
+            ...(options.note ? { note: options.note } : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   connectionsCommand
@@ -9440,10 +9975,13 @@ export function createCliProgram(): Command {
     .argument("<target>", "Vanity name or profile URL of the sender")
     .option("-p, --profile <profile>", "Profile name", "default")
     .action(async (target: string, options: { profile: string }) => {
-      await runConnectionsAccept({
-        profileName: options.profile,
-        targetProfile: target
-      }, readCdpUrl());
+      await runConnectionsAccept(
+        {
+          profileName: options.profile,
+          targetProfile: target,
+        },
+        readCdpUrl(),
+      );
     });
 
   connectionsCommand
@@ -9452,10 +9990,13 @@ export function createCliProgram(): Command {
     .argument("<target>", "Vanity name or profile URL")
     .option("-p, --profile <profile>", "Profile name", "default")
     .action(async (target: string, options: { profile: string }) => {
-      await runConnectionsWithdraw({
-        profileName: options.profile,
-        targetProfile: target
-      }, readCdpUrl());
+      await runConnectionsWithdraw(
+        {
+          profileName: options.profile,
+          targetProfile: target,
+        },
+        readCdpUrl(),
+      );
     });
 
   const membersCommand = program
@@ -9468,10 +10009,13 @@ export function createCliProgram(): Command {
     .argument("<target>", "Vanity name or profile URL")
     .option("-p, --profile <profile>", "Profile name", "default")
     .action(async (target: string, options: { profile: string }) => {
-      await runMembersPrepareBlock({
-        profileName: options.profile,
-        targetProfile: target
-      }, readCdpUrl());
+      await runMembersPrepareBlock(
+        {
+          profileName: options.profile,
+          targetProfile: target,
+        },
+        readCdpUrl(),
+      );
     });
 
   membersCommand
@@ -9480,10 +10024,13 @@ export function createCliProgram(): Command {
     .argument("<target>", "Vanity name or profile URL")
     .option("-p, --profile <profile>", "Profile name", "default")
     .action(async (target: string, options: { profile: string }) => {
-      await runMembersPrepareUnblock({
-        profileName: options.profile,
-        targetProfile: target
-      }, readCdpUrl());
+      await runMembersPrepareUnblock(
+        {
+          profileName: options.profile,
+          targetProfile: target,
+        },
+        readCdpUrl(),
+      );
     });
 
   membersCommand
@@ -9492,9 +10039,12 @@ export function createCliProgram(): Command {
     .argument("<target>", "Vanity name or profile URL")
     .requiredOption(
       "-r, --reason <reason>",
-      `Report reason (${LINKEDIN_MEMBER_REPORT_REASONS.join(", ")})`
+      `Report reason (${LINKEDIN_MEMBER_REPORT_REASONS.join(", ")})`,
     )
-    .option("-d, --details <details>", "Optional report details for free-text steps")
+    .option(
+      "-d, --details <details>",
+      "Optional report details for free-text steps",
+    )
     .option("-p, --profile <profile>", "Profile name", "default")
     .action(
       async (
@@ -9503,15 +10053,18 @@ export function createCliProgram(): Command {
           details?: string;
           profile: string;
           reason: string;
-        }
+        },
       ) => {
-        await runMembersPrepareReport({
-          profileName: options.profile,
-          targetProfile: target,
-          reason: options.reason,
-          ...(options.details ? { details: options.details } : {})
-        }, readCdpUrl());
-      }
+        await runMembersPrepareReport(
+          {
+            profileName: options.profile,
+            targetProfile: target,
+            reason: options.reason,
+            ...(options.details ? { details: options.details } : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   const privacyCommand = program
@@ -9523,29 +10076,38 @@ export function createCliProgram(): Command {
     .description("Read supported LinkedIn privacy settings")
     .option("-p, --profile <profile>", "Profile name", "default")
     .action(async (options: { profile: string }) => {
-      await runPrivacyGetSettings({
-        profileName: options.profile
-      }, readCdpUrl());
+      await runPrivacyGetSettings(
+        {
+          profileName: options.profile,
+        },
+        readCdpUrl(),
+      );
     });
 
   privacyCommand
     .command("update")
     .description("Prepare to update a LinkedIn privacy setting (two-phase)")
-    .argument("<settingKey>", `Setting key (${LINKEDIN_PRIVACY_SETTING_KEYS.join(", ")})`)
+    .argument(
+      "<settingKey>",
+      `Setting key (${LINKEDIN_PRIVACY_SETTING_KEYS.join(", ")})`,
+    )
     .argument("<value>", "Requested setting value")
     .option("-p, --profile <profile>", "Profile name", "default")
     .action(
       async (
         settingKey: string,
         value: string,
-        options: { profile: string }
+        options: { profile: string },
       ) => {
-        await runPrivacyPrepareUpdateSetting({
-          profileName: options.profile,
-          settingKey,
-          value
-        }, readCdpUrl());
-      }
+        await runPrivacyPrepareUpdateSetting(
+          {
+            profileName: options.profile,
+            settingKey,
+            value,
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   const followupsCommand = program
@@ -9554,36 +10116,44 @@ export function createCliProgram(): Command {
 
   followupsCommand
     .command("list")
-    .description("List recently accepted connections detected from sent invites")
+    .description(
+      "List recently accepted connections detected from sent invites",
+    )
     .option("-p, --profile <profile>", "Profile name", "default")
     .option(
       "-s, --since <window>",
       "Lookback window such as 30m, 12h, 7d, or 2w",
-      DEFAULT_FOLLOWUP_SINCE
+      DEFAULT_FOLLOWUP_SINCE,
     )
     .action(async (options: { profile: string; since: string }) => {
-      await runFollowupsList({
-        profileName: options.profile,
-        since: options.since
-      }, readCdpUrl());
+      await runFollowupsList(
+        {
+          profileName: options.profile,
+          since: options.since,
+        },
+        readCdpUrl(),
+      );
     });
 
   followupsCommand
     .command("prepare")
     .description(
-      "Prepare follow-up messages for newly accepted connections (two-phase)"
+      "Prepare follow-up messages for newly accepted connections (two-phase)",
     )
     .option("-p, --profile <profile>", "Profile name", "default")
     .option(
       "-s, --since <window>",
       "Lookback window such as 30m, 12h, 7d, or 2w",
-      DEFAULT_FOLLOWUP_SINCE
+      DEFAULT_FOLLOWUP_SINCE,
     )
     .action(async (options: { profile: string; since: string }) => {
-      await runFollowupsPrepare({
-        profileName: options.profile,
-        since: options.since
-      }, readCdpUrl());
+      await runFollowupsPrepare(
+        {
+          profileName: options.profile,
+          since: options.since,
+        },
+        readCdpUrl(),
+      );
     });
 
   const feedCommand = program
@@ -9595,14 +10165,15 @@ export function createCliProgram(): Command {
     .description("List posts from your LinkedIn feed")
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("-l, --limit <limit>", "Max posts to return", "10")
-    .action(
-      async (options: { profile: string; limit: string }) => {
-        await runFeedList({
+    .action(async (options: { profile: string; limit: string }) => {
+      await runFeedList(
+        {
           profileName: options.profile,
-          limit: coercePositiveInt(options.limit, "limit")
-        }, readCdpUrl());
-      }
-    );
+          limit: coercePositiveInt(options.limit, "limit"),
+        },
+        readCdpUrl(),
+      );
+    });
 
   feedCommand
     .command("view")
@@ -9610,10 +10181,13 @@ export function createCliProgram(): Command {
     .argument("<post>", "Post URL, URN, or activity id")
     .option("-p, --profile <profile>", "Profile name", "default")
     .action(async (post: string, options: { profile: string }) => {
-      await runFeedView({
-        profileName: options.profile,
-        postUrl: post
-      }, readCdpUrl());
+      await runFeedView(
+        {
+          profileName: options.profile,
+          postUrl: post,
+        },
+        readCdpUrl(),
+      );
     });
 
   feedCommand
@@ -9625,21 +10199,26 @@ export function createCliProgram(): Command {
     .option(
       "-r, --reaction <reaction>",
       `Reaction type (${LINKEDIN_FEED_REACTION_TYPES.join(", ")})`,
-      "like"
+      "like",
     )
     .option("-o, --operator-note <note>", "Optional operator note")
     .action(
       async (
         post: string,
-        options: { profile: string; reaction: string; operatorNote?: string }
+        options: { profile: string; reaction: string; operatorNote?: string },
       ) => {
-        await runFeedLike({
-          profileName: options.profile,
-          postUrl: post,
-          reaction: options.reaction,
-          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
-        }, readCdpUrl());
-      }
+        await runFeedLike(
+          {
+            profileName: options.profile,
+            postUrl: post,
+            reaction: options.reaction,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   feedCommand
@@ -9652,15 +10231,20 @@ export function createCliProgram(): Command {
     .action(
       async (
         post: string,
-        options: { profile: string; text: string; operatorNote?: string }
+        options: { profile: string; text: string; operatorNote?: string },
       ) => {
-        await runFeedComment({
-          profileName: options.profile,
-          postUrl: post,
-          text: options.text,
-          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
-        }, readCdpUrl());
-      }
+        await runFeedComment(
+          {
+            profileName: options.profile,
+            postUrl: post,
+            text: options.text,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   feedCommand
@@ -9672,19 +10256,26 @@ export function createCliProgram(): Command {
     .action(
       async (
         post: string,
-        options: { profile: string; operatorNote?: string }
+        options: { profile: string; operatorNote?: string },
       ) => {
-        await runFeedRepost({
-          profileName: options.profile,
-          postUrl: post,
-          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
-        }, readCdpUrl());
-      }
+        await runFeedRepost(
+          {
+            profileName: options.profile,
+            postUrl: post,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   feedCommand
     .command("share")
-    .description("Prepare to share a LinkedIn post with your own text (two-phase)")
+    .description(
+      "Prepare to share a LinkedIn post with your own text (two-phase)",
+    )
     .argument("<post>", "Post URL, URN, or activity id")
     .requiredOption("--text <text>", "Share text")
     .option("-p, --profile <profile>", "Profile name", "default")
@@ -9692,15 +10283,20 @@ export function createCliProgram(): Command {
     .action(
       async (
         post: string,
-        options: { profile: string; text: string; operatorNote?: string }
+        options: { profile: string; text: string; operatorNote?: string },
       ) => {
-        await runFeedShare({
-          profileName: options.profile,
-          postUrl: post,
-          text: options.text,
-          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
-        }, readCdpUrl());
-      }
+        await runFeedShare(
+          {
+            profileName: options.profile,
+            postUrl: post,
+            text: options.text,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   feedCommand
@@ -9712,52 +10308,71 @@ export function createCliProgram(): Command {
     .action(
       async (
         post: string,
-        options: { profile: string; operatorNote?: string }
+        options: { profile: string; operatorNote?: string },
       ) => {
-        await runFeedSave({
-          profileName: options.profile,
-          postUrl: post,
-          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
-        }, readCdpUrl());
-      }
+        await runFeedSave(
+          {
+            profileName: options.profile,
+            postUrl: post,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   feedCommand
     .command("unsave")
-    .description("Prepare to remove a LinkedIn post from saved items (two-phase)")
+    .description(
+      "Prepare to remove a LinkedIn post from saved items (two-phase)",
+    )
     .argument("<post>", "Post URL, URN, or activity id")
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("-o, --operator-note <note>", "Optional operator note")
     .action(
       async (
         post: string,
-        options: { profile: string; operatorNote?: string }
+        options: { profile: string; operatorNote?: string },
       ) => {
-        await runFeedUnsave({
-          profileName: options.profile,
-          postUrl: post,
-          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
-        }, readCdpUrl());
-      }
+        await runFeedUnsave(
+          {
+            profileName: options.profile,
+            postUrl: post,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   feedCommand
     .command("remove-reaction")
-    .description("Prepare to remove your current reaction from a LinkedIn post (two-phase)")
+    .description(
+      "Prepare to remove your current reaction from a LinkedIn post (two-phase)",
+    )
     .argument("<post>", "Post URL, URN, or activity id")
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("-o, --operator-note <note>", "Optional operator note")
     .action(
       async (
         post: string,
-        options: { profile: string; operatorNote?: string }
+        options: { profile: string; operatorNote?: string },
       ) => {
-        await runFeedRemoveReaction({
-          profileName: options.profile,
-          postUrl: post,
-          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
-        }, readCdpUrl());
-      }
+        await runFeedRemoveReaction(
+          {
+            profileName: options.profile,
+            postUrl: post,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   const postCommand = program
@@ -9771,7 +10386,7 @@ export function createCliProgram(): Command {
     .option(
       "-v, --visibility <visibility>",
       `Visibility (${LINKEDIN_POST_VISIBILITY_TYPES.join(", ")})`,
-      "public"
+      "public",
     )
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("-o, --operator-note <note>", "Optional operator note")
@@ -9782,13 +10397,18 @@ export function createCliProgram(): Command {
         visibility: string;
         operatorNote?: string;
       }) => {
-        await runPostPrepare({
-          profileName: options.profile,
-          text: options.text,
-          visibility: options.visibility,
-          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
-        }, readCdpUrl());
-      }
+        await runPostPrepare(
+          {
+            profileName: options.profile,
+            text: options.text,
+            visibility: options.visibility,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   postCommand
@@ -9799,12 +10419,15 @@ export function createCliProgram(): Command {
     .option("-y, --yes", "Skip interactive confirmation prompt", false)
     .action(
       async (options: { profile: string; token: string; yes: boolean }) => {
-        await runConfirmAction({
-          profileName: options.profile,
-          token: options.token,
-          yes: options.yes
-        }, readCdpUrl());
-      }
+        await runConfirmAction(
+          {
+            profileName: options.profile,
+            token: options.token,
+            yes: options.yes,
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   const notificationsCommand = program
@@ -9816,14 +10439,15 @@ export function createCliProgram(): Command {
     .description("List your LinkedIn notifications")
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("-l, --limit <limit>", "Max notifications to return", "20")
-    .action(
-      async (options: { profile: string; limit: string }) => {
-        await runNotificationsList({
+    .action(async (options: { profile: string; limit: string }) => {
+      await runNotificationsList(
+        {
           profileName: options.profile,
-          limit: coercePositiveInt(options.limit, "limit")
-        }, readCdpUrl());
-      }
-    );
+          limit: coercePositiveInt(options.limit, "limit"),
+        },
+        readCdpUrl(),
+      );
+    });
 
   const jobsCommand = program
     .command("jobs")
@@ -9839,15 +10463,18 @@ export function createCliProgram(): Command {
     .action(
       async (
         query: string,
-        options: { profile: string; location?: string; limit: string }
+        options: { profile: string; location?: string; limit: string },
       ) => {
-        await runJobsSearch({
-          profileName: options.profile,
-          query,
-          ...(options.location ? { location: options.location } : {}),
-          limit: coercePositiveInt(options.limit, "limit")
-        }, readCdpUrl());
-      }
+        await runJobsSearch(
+          {
+            profileName: options.profile,
+            query,
+            ...(options.location ? { location: options.location } : {}),
+            limit: coercePositiveInt(options.limit, "limit"),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   jobsCommand
@@ -9856,10 +10483,13 @@ export function createCliProgram(): Command {
     .argument("<jobId>", "LinkedIn job ID")
     .option("-p, --profile <profile>", "Profile name", "default")
     .action(async (jobId: string, options: { profile: string }) => {
-      await runJobsView({
-        profileName: options.profile,
-        jobId
-      }, readCdpUrl());
+      await runJobsView(
+        {
+          profileName: options.profile,
+          jobId,
+        },
+        readCdpUrl(),
+      );
     });
 
   jobsCommand
@@ -9867,18 +10497,26 @@ export function createCliProgram(): Command {
     .description("Prepare to save a LinkedIn job for later (two-phase)")
     .argument("<jobId>", "LinkedIn job ID")
     .option("-p, --profile <profile>", "Profile name", "default")
-    .option("--operator-note <note>", "Optional note attached to the prepared action")
+    .option(
+      "--operator-note <note>",
+      "Optional note attached to the prepared action",
+    )
     .action(
       async (
         jobId: string,
-        options: { operatorNote?: string; profile: string }
+        options: { operatorNote?: string; profile: string },
       ) => {
-        await runJobsSave({
-          profileName: options.profile,
-          jobId,
-          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
-        }, readCdpUrl());
-      }
+        await runJobsSave(
+          {
+            profileName: options.profile,
+            jobId,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   jobsCommand
@@ -9886,18 +10524,26 @@ export function createCliProgram(): Command {
     .description("Prepare to unsave a LinkedIn job (two-phase)")
     .argument("<jobId>", "LinkedIn job ID")
     .option("-p, --profile <profile>", "Profile name", "default")
-    .option("--operator-note <note>", "Optional note attached to the prepared action")
+    .option(
+      "--operator-note <note>",
+      "Optional note attached to the prepared action",
+    )
     .action(
       async (
         jobId: string,
-        options: { operatorNote?: string; profile: string }
+        options: { operatorNote?: string; profile: string },
       ) => {
-        await runJobsUnsave({
-          profileName: options.profile,
-          jobId,
-          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
-        }, readCdpUrl());
-      }
+        await runJobsUnsave(
+          {
+            profileName: options.profile,
+            jobId,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   const jobsAlertsCommand = jobsCommand
@@ -9909,14 +10555,15 @@ export function createCliProgram(): Command {
     .description("List your LinkedIn job alerts")
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("-l, --limit <limit>", "Max alerts to return", "20")
-    .action(
-      async (options: { profile: string; limit: string }) => {
-        await runJobAlertsList({
+    .action(async (options: { profile: string; limit: string }) => {
+      await runJobAlertsList(
+        {
           profileName: options.profile,
-          limit: coercePositiveInt(options.limit, "limit")
-        }, readCdpUrl());
-      }
-    );
+          limit: coercePositiveInt(options.limit, "limit"),
+        },
+        readCdpUrl(),
+      );
+    });
 
   jobsAlertsCommand
     .command("create")
@@ -9924,7 +10571,10 @@ export function createCliProgram(): Command {
     .argument("<query>", "Search keywords")
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("--location <location>", "Location filter")
-    .option("--operator-note <note>", "Optional note attached to the prepared action")
+    .option(
+      "--operator-note <note>",
+      "Optional note attached to the prepared action",
+    )
     .action(
       async (
         query: string,
@@ -9932,15 +10582,20 @@ export function createCliProgram(): Command {
           location?: string;
           operatorNote?: string;
           profile: string;
-        }
+        },
       ) => {
-        await runJobAlertsCreate({
-          profileName: options.profile,
-          query,
-          ...(options.location ? { location: options.location } : {}),
-          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
-        }, readCdpUrl());
-      }
+        await runJobAlertsCreate(
+          {
+            profileName: options.profile,
+            query,
+            ...(options.location ? { location: options.location } : {}),
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   jobsAlertsCommand
@@ -9948,10 +10603,19 @@ export function createCliProgram(): Command {
     .description("Prepare to remove a LinkedIn job alert (two-phase)")
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("--alert-id <alertId>", "Alert id returned by jobs alerts list")
-    .option("--search-url <searchUrl>", "LinkedIn jobs search URL for the alert")
-    .option("--query <query>", "Alert query if no alert id or search URL is available")
+    .option(
+      "--search-url <searchUrl>",
+      "LinkedIn jobs search URL for the alert",
+    )
+    .option(
+      "--query <query>",
+      "Alert query if no alert id or search URL is available",
+    )
     .option("--location <location>", "Alert location filter")
-    .option("--operator-note <note>", "Optional note attached to the prepared action")
+    .option(
+      "--operator-note <note>",
+      "Optional note attached to the prepared action",
+    )
     .action(
       async (options: {
         alertId?: string;
@@ -9961,15 +10625,20 @@ export function createCliProgram(): Command {
         query?: string;
         searchUrl?: string;
       }) => {
-        await runJobAlertsRemove({
-          profileName: options.profile,
-          ...(options.alertId ? { alertId: options.alertId } : {}),
-          ...(options.searchUrl ? { searchUrl: options.searchUrl } : {}),
-          ...(options.query ? { query: options.query } : {}),
-          ...(options.location ? { location: options.location } : {}),
-          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
-        }, readCdpUrl());
-      }
+        await runJobAlertsRemove(
+          {
+            profileName: options.profile,
+            ...(options.alertId ? { alertId: options.alertId } : {}),
+            ...(options.searchUrl ? { searchUrl: options.searchUrl } : {}),
+            ...(options.query ? { query: options.query } : {}),
+            ...(options.location ? { location: options.location } : {}),
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   jobsCommand
@@ -9982,8 +10651,14 @@ export function createCliProgram(): Command {
     .option("--city <city>", "City field value for the application")
     .option("--resume <resumePath>", "Resume file to upload")
     .option("--cover-letter <coverLetter>", "Cover letter text")
-    .option("--answers-file <path>", "JSON object file with extra Easy Apply answers")
-    .option("--operator-note <note>", "Optional note attached to the prepared action")
+    .option(
+      "--answers-file <path>",
+      "JSON object file with extra Easy Apply answers",
+    )
+    .option(
+      "--operator-note <note>",
+      "Optional note attached to the prepared action",
+    )
     .action(
       async (
         jobId: string,
@@ -9996,20 +10671,29 @@ export function createCliProgram(): Command {
           phone?: string;
           profile: string;
           resume?: string;
-        }
+        },
       ) => {
-        await runJobsEasyApplyPrepare({
-          profileName: options.profile,
-          jobId,
-          ...(options.phone ? { phone: options.phone } : {}),
-          ...(options.email ? { email: options.email } : {}),
-          ...(options.city ? { city: options.city } : {}),
-          ...(options.resume ? { resume: options.resume } : {}),
-          ...(options.coverLetter ? { coverLetter: options.coverLetter } : {}),
-          ...(options.answersFile ? { answersFile: options.answersFile } : {}),
-          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
-        }, readCdpUrl());
-      }
+        await runJobsEasyApplyPrepare(
+          {
+            profileName: options.profile,
+            jobId,
+            ...(options.phone ? { phone: options.phone } : {}),
+            ...(options.email ? { email: options.email } : {}),
+            ...(options.city ? { city: options.city } : {}),
+            ...(options.resume ? { resume: options.resume } : {}),
+            ...(options.coverLetter
+              ? { coverLetter: options.coverLetter }
+              : {}),
+            ...(options.answersFile
+              ? { answersFile: options.answersFile }
+              : {}),
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   const profileCommand = program
@@ -10022,14 +10706,17 @@ export function createCliProgram(): Command {
     .argument(
       "[target]",
       "Vanity name, profile URL, or 'me' for own profile",
-      "me"
+      "me",
     )
     .option("-p, --profile <profile>", "Profile name", "default")
     .action(async (target: string, options: { profile: string }) => {
-      await runProfileView({
-        profileName: options.profile,
-        target
-      }, readCdpUrl());
+      await runProfileView(
+        {
+          profileName: options.profile,
+          target,
+        },
+        readCdpUrl(),
+      );
     });
 
   const companyCommand = program
@@ -10042,10 +10729,13 @@ export function createCliProgram(): Command {
     .argument("<target>", "Company slug, /company/ path, or company URL")
     .option("-p, --profile <profile>", "Profile name", "default")
     .action(async (target: string, options: { profile: string }) => {
-      await runCompanyPageView({
-        profileName: options.profile,
-        target
-      }, readCdpUrl());
+      await runCompanyPageView(
+        {
+          profileName: options.profile,
+          target,
+        },
+        readCdpUrl(),
+      );
     });
 
   companyCommand
@@ -10053,18 +10743,26 @@ export function createCliProgram(): Command {
     .description("Prepare to follow a LinkedIn company page (two-phase)")
     .argument("<target>", "Company slug, /company/ path, or company URL")
     .option("-p, --profile <profile>", "Profile name", "default")
-    .option("--operator-note <note>", "Optional note attached to the prepared action")
+    .option(
+      "--operator-note <note>",
+      "Optional note attached to the prepared action",
+    )
     .action(
       async (
         target: string,
-        options: { operatorNote?: string; profile: string }
+        options: { operatorNote?: string; profile: string },
       ) => {
-        await runCompanyPrepareFollow({
-          profileName: options.profile,
-          targetCompany: target,
-          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
-        }, readCdpUrl());
-      }
+        await runCompanyPrepareFollow(
+          {
+            profileName: options.profile,
+            targetCompany: target,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   companyCommand
@@ -10072,90 +10770,129 @@ export function createCliProgram(): Command {
     .description("Prepare to unfollow a LinkedIn company page (two-phase)")
     .argument("<target>", "Company slug, /company/ path, or company URL")
     .option("-p, --profile <profile>", "Profile name", "default")
-    .option("--operator-note <note>", "Optional note attached to the prepared action")
+    .option(
+      "--operator-note <note>",
+      "Optional note attached to the prepared action",
+    )
     .action(
       async (
         target: string,
-        options: { operatorNote?: string; profile: string }
+        options: { operatorNote?: string; profile: string },
       ) => {
-        await runCompanyPrepareUnfollow({
-          profileName: options.profile,
-          targetCompany: target,
-          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
-        }, readCdpUrl());
-      }
+        await runCompanyPrepareUnfollow(
+          {
+            profileName: options.profile,
+            targetCompany: target,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   profileCommand
     .command("editable")
-    .description("Inspect the logged-in member's editable LinkedIn profile surface")
+    .description(
+      "Inspect the logged-in member's editable LinkedIn profile surface",
+    )
     .option("-p, --profile <profile>", "Profile name", "default")
     .action(async (options: { profile: string }) => {
-      await runProfileViewEditable({
-        profileName: options.profile
-      }, readCdpUrl());
+      await runProfileViewEditable(
+        {
+          profileName: options.profile,
+        },
+        readCdpUrl(),
+      );
     });
 
   profileCommand
     .command("update-settings")
-    .description("Prepare to update LinkedIn profile-level settings (two-phase)")
-    .requiredOption("--industry <industry>", "Primary professional category / industry")
+    .description(
+      "Prepare to update LinkedIn profile-level settings (two-phase)",
+    )
+    .requiredOption(
+      "--industry <industry>",
+      "Primary professional category / industry",
+    )
     .option("-p, --profile <profile>", "Profile name", "default")
-    .option("--operator-note <note>", "Optional note attached to the prepared action")
+    .option(
+      "--operator-note <note>",
+      "Optional note attached to the prepared action",
+    )
     .action(
-      async (
-        options: {
-          industry: string;
-          operatorNote?: string;
-          profile: string;
-        }
-      ) => {
-        await runProfilePrepareUpdateSettings({
-          profileName: options.profile,
-          industry: options.industry,
-          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
-        }, readCdpUrl());
-      }
+      async (options: {
+        industry: string;
+        operatorNote?: string;
+        profile: string;
+      }) => {
+        await runProfilePrepareUpdateSettings(
+          {
+            profileName: options.profile,
+            industry: options.industry,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   profileCommand
     .command("update-public-profile")
-    .description("Prepare to update the LinkedIn custom public profile URL (two-phase)")
-    .argument("<vanityName>", "Custom public profile vanity name or linkedin.com/in/ URL")
+    .description(
+      "Prepare to update the LinkedIn custom public profile URL (two-phase)",
+    )
+    .argument(
+      "<vanityName>",
+      "Custom public profile vanity name or linkedin.com/in/ URL",
+    )
     .option("-p, --profile <profile>", "Profile name", "default")
-    .option("--operator-note <note>", "Optional note attached to the prepared action")
+    .option(
+      "--operator-note <note>",
+      "Optional note attached to the prepared action",
+    )
     .action(
       async (
         vanityName: string,
-        options: { operatorNote?: string; profile: string }
+        options: { operatorNote?: string; profile: string },
       ) => {
-        await runProfilePrepareUpdatePublicProfile({
-          profileName: options.profile,
-          vanityName,
-          ...(options.operatorNote ? { operatorNote: options.operatorNote } : {})
-        }, readCdpUrl());
-      }
+        await runProfilePrepareUpdatePublicProfile(
+          {
+            profileName: options.profile,
+            vanityName,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   profileCommand
     .command("apply-spec")
-    .description("Apply a JSON profile seed spec with paced LinkedIn profile edits")
+    .description(
+      "Apply a JSON profile seed spec with paced LinkedIn profile edits",
+    )
     .requiredOption("--spec <path>", "Path to a JSON profile seed spec")
     .option("-p, --profile <profile>", "Profile name", "default")
     .option(
       "--replace",
       "Remove unmatched supported section items for sections included in the spec",
-      false
+      false,
     )
     .option(
       "--allow-partial",
       "Continue when the spec includes unsupported fields such as skills",
-      false
+      false,
     )
     .option(
       "--delay-ms <ms>",
       "Base delay between confirmed profile edits",
-      "3500"
+      "3500",
     )
     .option("-y, --yes", "Skip the interactive confirmation prompt", false)
     .option("--output <path>", "Write the final JSON report to a file")
@@ -10167,8 +10904,8 @@ export function createCliProgram(): Command {
         "  - uses the existing two-phase profile edit actions under the hood and confirms them one by one",
         "  - paces edits with a randomized delay so large profile updates do not fire back-to-back",
         "  - unsupported fields currently include skills (#228)",
-        "  - run \"linkedin profile editable\" first if you want to inspect the current section structure"
-      ].join("\n")
+        '  - run "linkedin profile editable" first if you want to inspect the current section structure',
+      ].join("\n"),
     )
     .action(
       async (options: {
@@ -10180,16 +10917,19 @@ export function createCliProgram(): Command {
         yes: boolean;
         output?: string;
       }) => {
-        await runProfileApplySpec({
-          profileName: options.profile,
-          specPath: options.spec,
-          replace: options.replace,
-          allowPartial: options.allowPartial,
-          delayMs: coerceNonNegativeInt(options.delayMs, "delay-ms"),
-          yes: options.yes,
-          ...(options.output ? { outputPath: options.output } : {})
-        }, readCdpUrl());
-      }
+        await runProfileApplySpec(
+          {
+            profileName: options.profile,
+            specPath: options.spec,
+            replace: options.replace,
+            allowPartial: options.allowPartial,
+            delayMs: coerceNonNegativeInt(options.delayMs, "delay-ms"),
+            yes: options.yes,
+            ...(options.output ? { outputPath: options.output } : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   const assetsCommand = program
@@ -10198,7 +10938,9 @@ export function createCliProgram(): Command {
 
   assetsCommand
     .command("generate-profile-images")
-    .description("Generate a profile photo, banner, and post images from a persona spec")
+    .description(
+      "Generate a profile photo, banner, and post images from a persona spec",
+    )
     .requiredOption("--spec <path>", "Path to a JSON persona/profile seed spec")
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("--post-count <count>", "Number of post images to generate", "6")
@@ -10206,12 +10948,12 @@ export function createCliProgram(): Command {
     .option(
       "--upload-profile-media",
       "Upload the generated photo and banner through the existing LinkedIn profile flow",
-      false
+      false,
     )
     .option(
       "--upload-delay-ms <ms>",
       "Base delay between the photo and banner upload when --upload-profile-media is enabled",
-      "4500"
+      "4500",
     )
     .option("--output <path>", "Write the final JSON report to a file")
     .addHelpText(
@@ -10222,8 +10964,8 @@ export function createCliProgram(): Command {
         "  - requires OPENAI_API_KEY in the environment",
         "  - generated assets are stored in the run artifacts directory under linkedin-ai-assets/",
         "  - --upload-profile-media reuses the existing profile photo/banner upload actions and paces the two uploads",
-        "  - the issue-210 persona spec is a good default source for the test account"
-      ].join("\n")
+        "  - the issue-210 persona spec is a good default source for the test account",
+      ].join("\n"),
     )
     .action(
       async (options: {
@@ -10235,31 +10977,41 @@ export function createCliProgram(): Command {
         uploadDelayMs: string;
         output?: string;
       }) => {
-        await runAssetsGenerateProfileImages({
-          profileName: options.profile,
-          specPath: options.spec,
-          postImageCount: coercePositiveInt(options.postCount, "post-count"),
-          uploadProfileMedia: options.uploadProfileMedia,
-          uploadDelayMs: coerceNonNegativeInt(options.uploadDelayMs, "upload-delay-ms"),
-          ...(options.model ? { model: options.model } : {}),
-          ...(options.output ? { outputPath: options.output } : {})
-        }, readCdpUrl());
-      }
+        await runAssetsGenerateProfileImages(
+          {
+            profileName: options.profile,
+            specPath: options.spec,
+            postImageCount: coercePositiveInt(options.postCount, "post-count"),
+            uploadProfileMedia: options.uploadProfileMedia,
+            uploadDelayMs: coerceNonNegativeInt(
+              options.uploadDelayMs,
+              "upload-delay-ms",
+            ),
+            ...(options.model ? { model: options.model } : {}),
+            ...(options.output ? { outputPath: options.output } : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   const seedCommand = program
     .command("seed")
-    .description("Run reusable LinkedIn profile and activity seeding workflows");
+    .description(
+      "Run reusable LinkedIn profile and activity seeding workflows",
+    );
 
   seedCommand
     .command("activity")
-    .description("Apply a paced activity seed spec for connections, posts, engagement, jobs, messaging, and notifications")
+    .description(
+      "Apply a paced activity seed spec for connections, posts, engagement, jobs, messaging, and notifications",
+    )
     .requiredOption("--spec <path>", "Path to a JSON activity seed spec")
     .option("-p, --profile <profile>", "Profile name", "default")
     .option(
       "--delay-ms <ms>",
       "Base delay between confirmed write actions",
-      "4500"
+      "4500",
     )
     .option("-y, --yes", "Skip the interactive confirmation prompt", false)
     .option("--output <path>", "Write the final JSON report to a file")
@@ -10272,8 +11024,8 @@ export function createCliProgram(): Command {
         "  - start `linkedin keepalive start` first for longer seeding sessions",
         "  - posts default to `connections` visibility when the spec omits visibility",
         "  - generated-image posts can reuse the issue-211 image manifest via assets.generatedImageManifestPath",
-        "  - verification re-reads connections, feed, and inbox state at the end of the run"
-      ].join("\n")
+        "  - verification re-reads connections, feed, and inbox state at the end of the run",
+      ].join("\n"),
     )
     .action(
       async (options: {
@@ -10283,14 +11035,17 @@ export function createCliProgram(): Command {
         yes: boolean;
         output?: string;
       }) => {
-        await runSeedActivity({
-          profileName: options.profile,
-          specPath: options.spec,
-          delayMs: coerceNonNegativeInt(options.delayMs, "delay-ms"),
-          yes: options.yes,
-          ...(options.output ? { outputPath: options.output } : {})
-        }, readCdpUrl());
-      }
+        await runSeedActivity(
+          {
+            profileName: options.profile,
+            specPath: options.spec,
+            delayMs: coerceNonNegativeInt(options.delayMs, "delay-ms"),
+            yes: options.yes,
+            ...(options.output ? { outputPath: options.output } : {}),
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   const auditCommand = program
@@ -10299,56 +11054,79 @@ export function createCliProgram(): Command {
 
   auditCommand
     .command("selectors")
-    .description("Audit selector groups across key LinkedIn pages and capture failure artifacts")
+    .description(
+      "Audit selector groups across key LinkedIn pages and capture failure artifacts",
+    )
     .option("-p, --profile <profile>", "Profile name", "default")
-    .option("--json", "Print the full JSON report (recommended for automation)", false)
+    .option(
+      "--json",
+      "Print the full JSON report (recommended for automation)",
+      false,
+    )
     .option(
       "--verbose",
       "Show selector-by-selector details in human-readable output",
-      false
+      false,
     )
-    .option("--no-progress", "Hide per-page progress updates in human-readable output")
+    .option(
+      "--no-progress",
+      "Hide per-page progress updates in human-readable output",
+    )
     .addHelpText(
       "after",
       [
         "",
         "Interactive terminals default to a human-readable summary with per-page progress.",
         "Use --json for automation, piping, or other agent workflows.",
-        SELECTOR_AUDIT_DOC_REFERENCE
-      ].join("\n")
+        SELECTOR_AUDIT_DOC_REFERENCE,
+      ].join("\n"),
     )
-    .action(async (options: {
-      profile: string;
-      json: boolean;
-      progress: boolean;
-      verbose: boolean;
-    }) => {
-      await runSelectorAudit({
-        profileName: options.profile,
-        json: options.json,
-        progress: options.progress,
-        verbose: options.verbose
-      }, readCdpUrl());
-    });
+    .action(
+      async (options: {
+        profile: string;
+        json: boolean;
+        progress: boolean;
+        verbose: boolean;
+      }) => {
+        await runSelectorAudit(
+          {
+            profileName: options.profile,
+            json: options.json,
+            progress: options.progress,
+            verbose: options.verbose,
+          },
+          readCdpUrl(),
+        );
+      },
+    );
 
   auditCommand
     .command("draft-quality")
-    .description("Evaluate draft replies against case-specific quality expectations")
+    .description(
+      "Evaluate draft replies against case-specific quality expectations",
+    )
     .requiredOption(
       "--dataset <path>",
-      "Path to the draft-quality dataset JSON file (cases + expectations)"
+      "Path to the draft-quality dataset JSON file (cases + expectations)",
     )
     .option(
       "--candidates <path>",
-      "Optional JSON file with candidate drafts keyed by case_id/draft_id"
+      "Optional JSON file with candidate drafts keyed by case_id/draft_id",
     )
-    .option("--json", "Print the full JSON report (recommended for automation)", false)
+    .option(
+      "--json",
+      "Print the full JSON report (recommended for automation)",
+      false,
+    )
     .option(
       "--verbose",
       "Show per-draft metric details in human-readable output",
-      false
+      false,
     )
-    .option("--no-progress", "Hide per-case progress updates in human-readable output")
+    .option(
+      "--no-progress",
+      "Hide per-case progress updates in human-readable output",
+    )
     .option("--output <path>", "Write the JSON report to a file")
     .addHelpText(
       "after",
@@ -10361,26 +11139,28 @@ export function createCliProgram(): Command {
         "Examples:",
         "  linkedin audit draft-quality --dataset dataset.json",
         "  linkedin audit draft-quality --dataset dataset.json --candidates candidates.json --verbose",
-        "  linkedin audit draft-quality --dataset dataset.json --json --output reports/draft-quality.json"
-      ].join("\n")
+        "  linkedin audit draft-quality --dataset dataset.json --json --output reports/draft-quality.json",
+      ].join("\n"),
     )
-    .action(async (options: {
-      dataset: string;
-      candidates?: string;
-      json: boolean;
-      progress: boolean;
-      verbose: boolean;
-      output?: string;
-    }) => {
-      await runDraftQualityAudit({
-        datasetPath: options.dataset,
-        json: options.json,
-        progress: options.progress,
-        verbose: options.verbose,
-        ...(options.candidates ? { candidatesPath: options.candidates } : {}),
-        ...(options.output ? { outputPath: options.output } : {})
-      });
-    });
+    .action(
+      async (options: {
+        dataset: string;
+        candidates?: string;
+        json: boolean;
+        progress: boolean;
+        verbose: boolean;
+        output?: string;
+      }) => {
+        await runDraftQualityAudit({
+          datasetPath: options.dataset,
+          json: options.json,
+          progress: options.progress,
+          verbose: options.verbose,
+          ...(options.candidates ? { candidatesPath: options.candidates } : {}),
+          ...(options.output ? { outputPath: options.output } : {}),
+        });
+      },
+    );
 
   const actionsCommand = program
     .command("actions")
@@ -10394,12 +11174,15 @@ export function createCliProgram(): Command {
     .option("-y, --yes", "Skip interactive confirmation prompt", false)
     .action(
       async (options: { profile: string; token: string; yes: boolean }) => {
-        await runConfirmAction({
-          profileName: options.profile,
-          token: options.token,
-          yes: options.yes
-        }, readCdpUrl());
-      }
+        await runConfirmAction(
+          {
+            profileName: options.profile,
+            token: options.token,
+            yes: options.yes,
+          },
+          readCdpUrl(),
+        );
+      },
     );
 
   program
@@ -10413,24 +11196,31 @@ export function createCliProgram(): Command {
         "Diagnostics:",
         "  - output includes session.evasion with the resolved anti-bot profile and diagnostics status",
         `  - ${LINKEDIN_BUDDY_EVASION_LEVEL_ENV}=minimal|moderate|paranoid selects the default anti-bot profile`,
-        `  - ${LINKEDIN_BUDDY_EVASION_DIAGNOSTICS_ENV}=true records debug evasion events in the run log`
-      ].join("\n")
+        `  - ${LINKEDIN_BUDDY_EVASION_DIAGNOSTICS_ENV}=true records debug evasion events in the run log`,
+      ].join("\n"),
     )
     .action(async (options: { profile: string }) => {
       const runtime = createRuntime(readCdpUrl());
       try {
         runtime.logger.log("info", "cli.health.start", {
-          profileName: options.profile
+          profileName: options.profile,
         });
-        const health = await runtime.healthCheck({ profileName: options.profile });
+        const health = await runtime.healthCheck({
+          profileName: options.profile,
+        });
         runtime.logger.log("info", "cli.health.done", {
           profileName: options.profile,
           browser_healthy: health.browser.healthy,
           authenticated: health.session.authenticated,
           evasion_level: health.session.evasion.level,
-          evasion_diagnostics_enabled: health.session.evasion.diagnosticsEnabled
+          evasion_diagnostics_enabled:
+            health.session.evasion.diagnosticsEnabled,
         });
-        printJson({ run_id: runtime.runId, profile_name: options.profile, ...health });
+        printJson({
+          run_id: runtime.runId,
+          profile_name: options.profile,
+          ...health,
+        });
         if (!health.browser.healthy || !health.session.authenticated) {
           process.exitCode = 1;
         }
@@ -10465,14 +11255,15 @@ export async function runCli(argv: string[] = process.argv): Promise<void> {
 
 export function isDirectExecution(
   moduleUrl: string,
-  entrypoint: string | undefined = process.argv[1]
+  entrypoint: string | undefined = process.argv[1],
 ): boolean {
   if (!entrypoint) {
     return false;
   }
 
-  return resolveCliEntrypointPath(entrypoint) === resolveCliEntrypointPath(
-    fileURLToPath(moduleUrl)
+  return (
+    resolveCliEntrypointPath(entrypoint) ===
+    resolveCliEntrypointPath(fileURLToPath(moduleUrl))
   );
 }
 
@@ -10495,7 +11286,7 @@ if (isDirectExecution(import.meta.url)) {
 }
 
 function coerceWriteValidationDesignation(
-  value: string
+  value: string,
 ): "primary" | "secondary" {
   const normalized = value.trim().toLowerCase();
   if (normalized === "primary" || normalized === "secondary") {
@@ -10504,7 +11295,7 @@ function coerceWriteValidationDesignation(
 
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    'designation must be either "primary" or "secondary".'
+    'designation must be either "primary" or "secondary".',
   );
 }
 
@@ -10527,22 +11318,20 @@ function buildWriteValidationAccountTargets(input: {
       thread: input.messageThread,
       ...(messageParticipantPattern
         ? { participantPattern: messageParticipantPattern }
-        : {})
+        : {}),
     };
   }
 
   if (input.inviteProfile) {
     targets["connections.send_invitation"] = {
       targetProfile: input.inviteProfile,
-      ...(inviteNote
-        ? { note: inviteNote }
-        : {})
+      ...(inviteNote ? { note: inviteNote } : {}),
     };
   }
 
   if (input.followupProfile) {
     targets["network.followup_after_accept"] = {
-      profileUrlKey: input.followupProfile
+      profileUrlKey: input.followupProfile,
     };
   }
 
@@ -10551,13 +11340,16 @@ function buildWriteValidationAccountTargets(input: {
       postUrl: input.reactionPost,
       ...(input.reaction
         ? { reaction: normalizeLinkedInFeedReaction(input.reaction) }
-        : {})
+        : {}),
     };
   }
 
   if (input.postVisibility) {
     targets["post.create"] = {
-      visibility: normalizeLinkedInPostVisibility(input.postVisibility, "connections")
+      visibility: normalizeLinkedInPostVisibility(
+        input.postVisibility,
+        "connections",
+      ),
     };
   }
 
@@ -10572,21 +11364,21 @@ function resolveLiveWriteValidationAccountId(input: {
   if (input.readOnly) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      'Choose either "--read-only" or "--write-validation", not both.'
+      'Choose either "--read-only" or "--write-validation", not both.',
     );
   }
 
   if (!input.account) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      'Write validation requires "--account <id>".'
+      'Write validation requires "--account <id>".',
     );
   }
 
   if (input.session !== "default") {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      'Write validation resolves stored sessions through the account registry. Remove "--session" and rerun.'
+      'Write validation resolves stored sessions through the account registry. Remove "--session" and rerun.',
     );
   }
 
@@ -10595,7 +11387,7 @@ function resolveLiveWriteValidationAccountId(input: {
 
 function formatWriteValidationPrompt(
   preview: WriteValidationActionPreview,
-  actionIndex: number
+  actionIndex: number,
 ): string[] {
   return [
     `Action ${actionIndex}/${TOTAL_WRITE_VALIDATION_ACTIONS}: ${preview.action_type}`,
@@ -10603,12 +11395,12 @@ function formatWriteValidationPrompt(
     `Risk: ${preview.risk_class}`,
     `Target: ${JSON.stringify(preview.target)}`,
     `Payload: ${JSON.stringify(preview.outbound)}`,
-    `Expected: ${preview.expected_outcome}`
+    `Expected: ${preview.expected_outcome}`,
   ];
 }
 
 function createWriteValidationPrompter(
-  output: typeof stdout | typeof process.stderr
+  output: typeof stdout | typeof process.stderr,
 ): (preview: WriteValidationActionPreview) => Promise<boolean> {
   let nextActionIndex = 1;
   let firstPrompt = true;
@@ -10630,7 +11422,7 @@ function createWriteValidationPrompter(
 
 function emitWriteValidationResult(
   report: WriteValidationReport,
-  outputMode: WriteValidationOutputMode
+  outputMode: WriteValidationOutputMode,
 ): void {
   if (outputMode === "json") {
     printJson(report);
@@ -10638,12 +11430,12 @@ function emitWriteValidationResult(
     const redactedReport = redactStructuredValue(
       report,
       cliPrivacyConfig,
-      "cli"
+      "cli",
     ) as WriteValidationReport;
     console.log(
       formatWriteValidationReport(redactedReport, {
-        color: shouldUseAnsiColor(stdout)
-      })
+        color: shouldUseAnsiColor(stdout),
+      }),
     );
   }
 
@@ -10654,7 +11446,7 @@ function emitWriteValidationResult(
 
 function emitWriteValidationFailure(
   error: unknown,
-  outputMode: WriteValidationOutputMode
+  outputMode: WriteValidationOutputMode,
 ): void {
   process.exitCode = LIVE_VALIDATION_ERROR_EXIT_CODE;
 
@@ -10666,14 +11458,14 @@ function emitWriteValidationFailure(
   process.stderr.write(
     `${formatWriteValidationError(errorPayload, {
       color: shouldUseAnsiColor(process.stderr),
-      helpCommand: LIVE_VALIDATION_HELP_COMMAND
-    })}\n`
+      helpCommand: LIVE_VALIDATION_HELP_COMMAND,
+    })}\n`,
   );
 }
 
 function assertWriteValidationExecutionPreconditions(
   input: { yes: boolean },
-  cdpUrl?: string
+  cdpUrl?: string,
 ): void {
   assertNoExternalSessionOverrideForStoredSession(cdpUrl);
   assertInteractiveTerminal("run write validation");
@@ -10681,47 +11473,50 @@ function assertWriteValidationExecutionPreconditions(
   if (input.yes) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      'Write validation requires typing "yes" for every action. Remove "--yes" and rerun.'
+      'Write validation requires typing "yes" for every action. Remove "--yes" and rerun.',
     );
   }
 }
 
-async function runLiveWriteValidation(input: {
-  accountId?: string | undefined;
-  cooldownSeconds: number;
-  json: boolean;
-  progress: boolean;
-  readOnly: boolean;
-  session: string;
-  timeoutSeconds: number;
-  yes: boolean;
-}, cdpUrl?: string): Promise<void> {
+async function runLiveWriteValidation(
+  input: {
+    accountId?: string | undefined;
+    cooldownSeconds: number;
+    json: boolean;
+    progress: boolean;
+    readOnly: boolean;
+    session: string;
+    timeoutSeconds: number;
+    yes: boolean;
+  },
+  cdpUrl?: string,
+): Promise<void> {
   const outputMode = resolveWriteValidationOutputMode(
     { json: input.json },
-    Boolean(stdout.isTTY)
+    Boolean(stdout.isTTY),
   );
   const promptOutput = outputMode === "json" ? process.stderr : stdout;
   const progressEnabled =
     outputMode === "human" && input.progress && Boolean(process.stderr.isTTY);
   const progressReporter = new WriteValidationProgressReporter({
-    enabled: progressEnabled
+    enabled: progressEnabled,
   });
 
   try {
     const accountId = resolveLiveWriteValidationAccountId({
       account: input.accountId,
       readOnly: input.readOnly,
-      session: input.session
+      session: input.session,
     });
 
     assertWriteValidationExecutionPreconditions(input, cdpUrl);
 
     writeCliWarning(`${WRITE_VALIDATION_WARNING}.`);
     writeCliNotice(
-      `Running write validation against account "${accountId}". See ${WRITE_VALIDATION_DOC_PATH} for account setup and approved targets.`
+      `Running write validation against account "${accountId}". See ${WRITE_VALIDATION_DOC_PATH} for account setup and approved targets.`,
     );
     writeCliNotice(
-      "Preparing the stored session, validating approved targets, and opening the interactive harness."
+      "Preparing the stored session, validating approved targets, and opening the interactive harness.",
     );
 
     const report = await runLinkedInWriteValidation({
@@ -10732,11 +11527,11 @@ async function runLiveWriteValidation(input: {
         ? {
             onLog: (entry) => {
               progressReporter.handleLog(entry);
-            }
+            },
           }
         : {}),
       onBeforeAction: createWriteValidationPrompter(promptOutput),
-      timeoutMs: input.timeoutSeconds * 1_000
+      timeoutMs: input.timeoutSeconds * 1_000,
     });
 
     emitWriteValidationResult(report, outputMode);
@@ -10781,13 +11576,13 @@ async function runAccountsAdd(input: {
       messageThread: input.messageThread,
       postVisibility: input.postVisibility,
       reaction: input.reaction,
-      reactionPost: input.reactionPost
-    })
+      reactionPost: input.reactionPost,
+    }),
   });
 
   printJson({
     account: registry.accounts[accountId],
     config_path: registry.configPath,
-    saved: true
+    saved: true,
   });
 }

--- a/packages/core/src/auth/session.ts
+++ b/packages/core/src/auth/session.ts
@@ -2,28 +2,32 @@ import type { BrowserContext, Page } from "playwright-core";
 import { resolveEvasionConfig, type EvasionConfig } from "../config.js";
 import { detectCaptcha } from "../evasion/browser.js";
 import { LinkedInBuddyError } from "../errors.js";
-import { attachHumanizeLogger, detachHumanizeLogger, humanize } from "../humanize.js";
+import {
+  attachHumanizeLogger,
+  detachHumanizeLogger,
+  humanize,
+} from "../humanize.js";
 import type { JsonEventLogger } from "../logging.js";
 import { ProfileManager } from "../profileManager.js";
 import {
   inspectAuthenticatedLinkedInIdentity,
   inspectLinkedInSession,
   isRateLimitedChallengeUrl,
-  type LinkedInSessionIdentity
+  type LinkedInSessionIdentity,
 } from "./sessionInspection.js";
 import {
   LINKEDIN_LOGIN_EMAIL_INPUT_SELECTOR,
-  LINKEDIN_LOGIN_PASSWORD_INPUT_SELECTOR
+  LINKEDIN_LOGIN_PASSWORD_INPUT_SELECTOR,
 } from "./loginSelectors.js";
 import {
   DEFAULT_LINKEDIN_SELECTOR_LOCALE,
-  type LinkedInSelectorLocale
+  type LinkedInSelectorLocale,
 } from "../selectorLocale.js";
 import {
   clearRateLimitState,
   isInRateLimitCooldown,
   recordRateLimit,
-  type RateLimitState
+  type RateLimitState,
 } from "./rateLimitState.js";
 
 /** Authentication snapshot for a LinkedIn browser profile. */
@@ -64,6 +68,7 @@ export interface OpenLoginResult extends SessionStatus {
 export interface HeadlessLoginOptions extends SessionOptions {
   email: string;
   password: string;
+  headless?: boolean;
   mfaCode?: string;
   mfaCallback?: () => Promise<string | undefined>;
   timeoutMs?: number;
@@ -109,10 +114,66 @@ async function sleep(ms: number): Promise<void> {
   });
 }
 
-async function enrichAuthenticatedSessionStatus<T extends { authenticated: boolean }>(
+const LOGIN_OVERLAY_DISMISS_SELECTORS = [
+  "button[action-type='ACCEPT']",
+  "button[data-test-id='accept-cookies']",
+  "button.artdeco-global-alert__action",
+  "button[data-control-name='ga-cookie.consent.accept.v4']",
+  "button:has-text('Accept')",
+  "button:has-text('Accept & Continue')",
+  "button:has-text('Got it')",
+  "button:has-text('Agree')",
+];
+
+async function dismissLoginPageOverlays(page: Page): Promise<void> {
+  for (const selector of LOGIN_OVERLAY_DISMISS_SELECTORS) {
+    try {
+      const btn = page.locator(selector).first();
+      if (await btn.isVisible({ timeout: 500 })) {
+        await btn.click({ timeout: 2_000 });
+        await page.waitForTimeout(500);
+        return;
+      }
+    } catch {
+      continue;
+    }
+  }
+}
+
+/* eslint-disable no-undef -- DOM types are valid inside page.evaluate() */
+async function directFillLoginCredentials(
   page: Page,
-  status: T
-): Promise<T & { identity?: LinkedInSessionIdentity }> {
+  email: string,
+  password: string,
+): Promise<void> {
+  await page.evaluate(
+    ({ email: e, password: p }) => {
+      const emailInput = document.querySelector<HTMLInputElement>(
+        "input[name='session_key'], input#username",
+      );
+      const passwordInput = document.querySelector<HTMLInputElement>(
+        "input[name='session_password'], input#password",
+      );
+      if (emailInput) {
+        emailInput.value = e;
+        emailInput.dispatchEvent(new Event("input", { bubbles: true }));
+        emailInput.dispatchEvent(new Event("change", { bubbles: true }));
+      }
+      if (passwordInput) {
+        passwordInput.value = p;
+        passwordInput.dispatchEvent(new Event("input", { bubbles: true }));
+        passwordInput.dispatchEvent(new Event("change", { bubbles: true }));
+      }
+    },
+    { email, password },
+  );
+  await page.waitForTimeout(300);
+}
+/* eslint-enable no-undef */
+
+async function enrichAuthenticatedSessionStatus<
+  T extends { authenticated: boolean },
+>(page: Page, status: T): Promise<T & { identity?: LinkedInSessionIdentity }> {
   if (!status.authenticated) {
     return status;
   }
@@ -121,7 +182,7 @@ async function enrichAuthenticatedSessionStatus<T extends { authenticated: boole
   return identity
     ? {
         ...status,
-        identity
+        identity,
       }
     : status;
 }
@@ -130,10 +191,9 @@ export class LinkedInAuthService {
   constructor(
     private readonly profileManager: ProfileManager,
     private readonly cdpUrl?: string,
-    private readonly selectorLocale: LinkedInSelectorLocale =
-      DEFAULT_LINKEDIN_SELECTOR_LOCALE,
+    private readonly selectorLocale: LinkedInSelectorLocale = DEFAULT_LINKEDIN_SELECTOR_LOCALE,
     private readonly logger?: Pick<JsonEventLogger, "log">,
-    private readonly evasion: EvasionConfig = resolveEvasionConfig()
+    private readonly evasion: EvasionConfig = resolveEvasionConfig(),
   ) {}
 
   /** Checks whether the profile currently looks authenticated to LinkedIn. */
@@ -145,34 +205,34 @@ export class LinkedInAuthService {
       {
         cdpUrl,
         profileName,
-        headless: true
+        headless: true,
       },
       async (context) => {
         const page = await getPage(context);
         await page.goto("https://www.linkedin.com/feed/", {
-          waitUntil: "domcontentloaded"
+          waitUntil: "domcontentloaded",
         });
         const status = await inspectLinkedInSession(page, {
-          selectorLocale: this.selectorLocale
+          selectorLocale: this.selectorLocale,
         });
         if (status.authenticated) {
           await clearRateLimitState();
         }
         return enrichAuthenticatedSessionStatus(page, status);
-      }
+      },
     );
 
     if (status.authenticated) {
       const resolvedStatus = {
         ...status,
-        evasion: this.evasion
+        evasion: this.evasion,
       };
       this.logger?.log("debug", "auth.session.status.checked", {
         authenticated: true,
         current_url: status.currentUrl,
         evasion_level: this.evasion.level,
         profileName,
-        reason: status.reason
+        reason: status.reason,
       });
 
       return resolvedStatus;
@@ -185,7 +245,7 @@ export class LinkedInAuthService {
         evasion: this.evasion,
         reason: `${status.reason} Rate-limit cooldown is active until ${cooldown.state.rateLimitedUntil}.`,
         rateLimitActive: true,
-        rateLimitUntil: cooldown.state.rateLimitedUntil
+        rateLimitUntil: cooldown.state.rateLimitedUntil,
       };
 
       this.logger?.log("debug", "auth.session.status.checked", {
@@ -195,7 +255,7 @@ export class LinkedInAuthService {
         evasion_level: this.evasion.level,
         profileName,
         rate_limit_active: true,
-        reason: resolvedStatus.reason
+        reason: resolvedStatus.reason,
       });
 
       return resolvedStatus;
@@ -203,7 +263,7 @@ export class LinkedInAuthService {
 
     const resolvedStatus = {
       ...status,
-      evasion: this.evasion
+      evasion: this.evasion,
     };
     this.logger?.log("debug", "auth.session.status.checked", {
       authenticated: false,
@@ -212,14 +272,16 @@ export class LinkedInAuthService {
       evasion_level: this.evasion.level,
       profileName,
       rate_limit_active: false,
-      reason: status.reason
+      reason: status.reason,
     });
 
     return resolvedStatus;
   }
 
   /** Throws a structured error when the session is not currently authenticated. */
-  async ensureAuthenticated(options: SessionOptions = {}): Promise<SessionStatus> {
+  async ensureAuthenticated(
+    options: SessionOptions = {},
+  ): Promise<SessionStatus> {
     const status = await this.status(options);
 
     if (!status.authenticated) {
@@ -237,29 +299,27 @@ export class LinkedInAuthService {
         evasion_level: status.evasion?.level,
         profileName: options.profileName ?? "default",
         rate_limit_active: status.rateLimitActive ?? false,
-        reason: status.reason
+        reason: status.reason,
       });
-      throw new LinkedInBuddyError(
-        code,
-        `${status.reason} ${guidance}`,
-        {
-          profile_name: options.profileName ?? "default",
-          current_url: status.currentUrl,
-          checked_at: status.checkedAt,
-          ...(status.evasion ? { evasion_level: status.evasion.level } : {}),
-          rate_limit_active: status.rateLimitActive ?? false,
-          ...(status.rateLimitUntil
-            ? { rate_limit_until: status.rateLimitUntil }
-            : {})
-        }
-      );
+      throw new LinkedInBuddyError(code, `${status.reason} ${guidance}`, {
+        profile_name: options.profileName ?? "default",
+        current_url: status.currentUrl,
+        checked_at: status.checkedAt,
+        ...(status.evasion ? { evasion_level: status.evasion.level } : {}),
+        rate_limit_active: status.rateLimitActive ?? false,
+        ...(status.rateLimitUntil
+          ? { rate_limit_until: status.rateLimitUntil }
+          : {}),
+      });
     }
 
     return status;
   }
 
   /** Runs the headless login flow and optionally retries rate-limit checkpoints. */
-  async headlessLogin(options: HeadlessLoginOptions): Promise<HeadlessLoginResult> {
+  async headlessLogin(
+    options: HeadlessLoginOptions,
+  ): Promise<HeadlessLoginResult> {
     const cooldown = await isInRateLimitCooldown();
     if (cooldown.active && cooldown.state) {
       return {
@@ -271,7 +331,7 @@ export class LinkedInAuthService {
         timedOut: false,
         checkpoint: false,
         rateLimitActive: true,
-        rateLimitUntil: cooldown.state.rateLimitedUntil
+        rateLimitUntil: cooldown.state.rateLimitedUntil,
       };
     }
 
@@ -281,19 +341,20 @@ export class LinkedInAuthService {
 
     let result = {
       ...(await this.performHeadlessLogin(options)),
-      evasion: this.evasion
+      evasion: this.evasion,
     };
     if (!retryOnRateLimit || result.checkpointType !== "rate_limited") {
       return result;
     }
 
     for (let attempt = 1; attempt <= maxRetries; attempt += 1) {
-      const backoffMs = retryBaseDelayMs * 2 ** (attempt - 1) + Math.random() * 5_000;
+      const backoffMs =
+        retryBaseDelayMs * 2 ** (attempt - 1) + Math.random() * 5_000;
       await sleep(backoffMs);
 
       result = {
         ...(await this.performHeadlessLogin(options)),
-        evasion: this.evasion
+        evasion: this.evasion,
       };
       if (result.checkpointType !== "rate_limited") {
         return result;
@@ -304,45 +365,57 @@ export class LinkedInAuthService {
   }
 
   private async performHeadlessLogin(
-    options: HeadlessLoginOptions
+    options: HeadlessLoginOptions,
   ): Promise<HeadlessLoginResult> {
     const profileName = options.profileName ?? "default";
     const cdpUrl = options.cdpUrl ?? this.cdpUrl;
     const timeoutMs = options.timeoutMs ?? 60_000;
     const pollIntervalMs = options.pollIntervalMs ?? 2_000;
 
+    const headless = options.headless ?? true;
+
     return this.profileManager.runWithContext(
       {
         cdpUrl,
         profileName,
-        headless: true
+        headless,
       },
       async (context) => {
         const page = await getPage(context);
         await page.goto("https://www.linkedin.com/login", {
-          waitUntil: "domcontentloaded"
+          waitUntil: "domcontentloaded",
         });
 
         const currentUrl = page.url();
-        if (!currentUrl.includes("/login") && !currentUrl.includes("/checkpoint")) {
+        if (
+          !currentUrl.includes("/login") &&
+          !currentUrl.includes("/checkpoint")
+        ) {
           const earlyStatus = await inspectLinkedInSession(page, {
-            selectorLocale: this.selectorLocale
+            selectorLocale: this.selectorLocale,
           });
           if (earlyStatus.authenticated) {
             await clearRateLimitState();
             const resolvedEarlyStatus = await enrichAuthenticatedSessionStatus(
               page,
-              earlyStatus
+              earlyStatus,
             );
             return {
               ...resolvedEarlyStatus,
               timedOut: false,
-              checkpoint: false
+              checkpoint: false,
             };
           }
         }
 
-        // Human-like typing for credentials
+        // Dismiss common overlays (cookie consent, etc.) before interacting
+        await dismissLoginPageOverlays(page);
+
+        // Human-like typing for credentials — fall back to direct fill when
+        // the inputs are not visible (common in headless mode when LinkedIn
+        // renders cookie banners or anti-bot overlays that hide the form).
+        let credentialsFilled = false;
+
         if (this.logger) {
           attachHumanizeLogger(page, this.logger);
         }
@@ -350,19 +423,65 @@ export class LinkedInAuthService {
         try {
           const hp = humanize(page);
           await hp.type(LINKEDIN_LOGIN_EMAIL_INPUT_SELECTOR, options.email, {
-            fieldLabel: "email"
+            fieldLabel: "email",
           });
-          await hp.type(LINKEDIN_LOGIN_PASSWORD_INPUT_SELECTOR, options.password, {
-            fieldLabel: "password"
+          await hp.type(
+            LINKEDIN_LOGIN_PASSWORD_INPUT_SELECTOR,
+            options.password,
+            {
+              fieldLabel: "password",
+            },
+          );
+          credentialsFilled = true;
+        } catch (humanizeError: unknown) {
+          const isVisibility =
+            humanizeError instanceof Error &&
+            (humanizeError.message.includes("not visible") ||
+              humanizeError.message.includes("scrollIntoViewIfNeeded") ||
+              humanizeError.message.includes("element is not stable"));
+          if (!isVisibility) {
+            throw humanizeError;
+          }
+          this.logger?.log("warn", "auth.headless_login.humanize_fallback", {
+            reason: humanizeError.message.slice(0, 200),
           });
         } finally {
           detachHumanizeLogger(page);
         }
 
+        if (!credentialsFilled) {
+          // Retry overlay dismissal in case it loaded after first attempt
+          await dismissLoginPageOverlays(page);
+          await directFillLoginCredentials(
+            page,
+            options.email,
+            options.password,
+          );
+        }
+
         const signInButton = page.locator(
-          "button[type='submit'][data-litms-control-urn='login-submit'], button[type='submit']:has-text('Sign in')"
+          "button[type='submit'][data-litms-control-urn='login-submit'], button[type='submit']:has-text('Sign in')",
         );
-        await signInButton.first().click();
+
+        try {
+          await signInButton.first().click();
+        } catch {
+          /* eslint-disable no-undef -- DOM types are valid inside page.evaluate() */
+          await page.evaluate(() => {
+            const form = document.querySelector<HTMLFormElement>(
+              "form.login__form, form[action*='login-submit'], form[data-id='sign-in-form']",
+            );
+            if (form) {
+              form.submit();
+            } else {
+              const btn = document.querySelector<HTMLButtonElement>(
+                "button[type='submit']",
+              );
+              btn?.click();
+            }
+          });
+          /* eslint-enable no-undef */
+        }
 
         await page.waitForTimeout(2_000);
 
@@ -371,19 +490,19 @@ export class LinkedInAuthService {
 
         while (Date.now() < deadline) {
           const status = await inspectLinkedInSession(page, {
-            selectorLocale: this.selectorLocale
+            selectorLocale: this.selectorLocale,
           });
 
           if (status.authenticated) {
             await clearRateLimitState();
             const resolvedStatus = await enrichAuthenticatedSessionStatus(
               page,
-              status
+              status,
             );
             return {
               ...resolvedStatus,
               timedOut: false,
-              checkpoint: false
+              checkpoint: false,
             };
           }
 
@@ -405,13 +524,13 @@ export class LinkedInAuthService {
                 checkpoint: true,
                 checkpointType: "rate_limited",
                 rateLimitActive: true,
-                rateLimitUntil: rateLimitState.rateLimitedUntil
+                rateLimitUntil: rateLimitState.rateLimitedUntil,
               };
             }
 
             const hasCodeInput = await isVisibleSafe(
               page,
-              "input[name='pin'], input#input__phone_verification_pin, input[name*='verification'], input[name*='code']"
+              "input[name='pin'], input#input__phone_verification_pin, input[name*='verification'], input[name*='code']",
             );
             const hasCaptcha = await detectCaptcha(page);
 
@@ -419,7 +538,7 @@ export class LinkedInAuthService {
             if (!hasCodeInput && !hasCaptcha) {
               const hasAppApprovalMarker = await isVisibleSafe(
                 page,
-                "[data-test-id='auth-app-approval']"
+                "[data-test-id='auth-app-approval']",
               );
 
               if (hasAppApprovalMarker) {
@@ -451,12 +570,12 @@ export class LinkedInAuthService {
             if (checkpointType === "verification_code") {
               if (options.mfaCode && !mfaCodeSubmitted) {
                 const codeInput = page.locator(
-                  "input[name='pin'], input#input__phone_verification_pin, input[name*='verification'], input[name*='code']"
+                  "input[name='pin'], input#input__phone_verification_pin, input[name*='verification'], input[name*='code']",
                 );
                 await codeInput.first().fill(options.mfaCode);
 
                 const submitButton = page.locator(
-                  "button[type='submit'], button#two-step-submit-button"
+                  "button[type='submit'], button#two-step-submit-button",
                 );
                 await submitButton.first().click();
                 mfaCodeSubmitted = true;
@@ -468,22 +587,23 @@ export class LinkedInAuthService {
                     authenticated: false,
                     checkedAt: new Date().toISOString(),
                     currentUrl: "unknown (page closed)",
-                    reason: "Page closed after MFA code submission — code may be invalid or expired",
+                    reason:
+                      "Page closed after MFA code submission — code may be invalid or expired",
                     timedOut: false,
                     checkpoint: true,
                     checkpointType: "verification_code",
-                    mfaRequired: true
+                    mfaRequired: true,
                   };
                 }
               } else if (!mfaCodeSubmitted && options.mfaCallback) {
                 const interactiveCode = await options.mfaCallback();
                 if (interactiveCode) {
                   const codeInput = page.locator(
-                    "input[name='pin'], input#input__phone_verification_pin, input[name*='verification'], input[name*='code']"
+                    "input[name='pin'], input#input__phone_verification_pin, input[name*='verification'], input[name*='code']",
                   );
                   await codeInput.first().fill(interactiveCode);
                   const submitButton = page.locator(
-                    "button[type='submit'], button#two-step-submit-button"
+                    "button[type='submit'], button#two-step-submit-button",
                   );
                   await submitButton.first().click();
                   mfaCodeSubmitted = true;
@@ -494,11 +614,12 @@ export class LinkedInAuthService {
                       authenticated: false,
                       checkedAt: new Date().toISOString(),
                       currentUrl: "unknown (page closed)",
-                      reason: "Page closed after MFA code submission — code may be invalid or expired",
+                      reason:
+                        "Page closed after MFA code submission — code may be invalid or expired",
                       timedOut: false,
                       checkpoint: true,
                       checkpointType: "verification_code",
-                      mfaRequired: true
+                      mfaRequired: true,
                     };
                   }
                 } else {
@@ -507,7 +628,7 @@ export class LinkedInAuthService {
                     timedOut: false,
                     checkpoint: true,
                     checkpointType: "verification_code",
-                    mfaRequired: true
+                    mfaRequired: true,
                   };
                 }
               } else if (!options.mfaCode && !options.mfaCallback) {
@@ -516,31 +637,35 @@ export class LinkedInAuthService {
                   timedOut: false,
                   checkpoint: true,
                   checkpointType: "verification_code",
-                  mfaRequired: true
+                  mfaRequired: true,
                 };
               }
             } else if (checkpointType === "app_approval") {
               // Continue polling while LinkedIn awaits approval from a trusted device.
             } else if (checkpointType === "captcha") {
-              return {
-                ...status,
-                timedOut: false,
-                checkpoint: true,
-                checkpointType: "captcha"
-              };
-            } else {
-              return {
-                ...status,
-                timedOut: false,
-                checkpoint: true,
-                checkpointType: "unknown"
-              };
+              if (headless) {
+                return {
+                  ...status,
+                  timedOut: false,
+                  checkpoint: true,
+                  checkpointType: "captcha",
+                };
+              }
+            } else if (checkpointType === "unknown") {
+              if (headless) {
+                return {
+                  ...status,
+                  timedOut: false,
+                  checkpoint: true,
+                  checkpointType: "unknown",
+                };
+              }
             }
           }
 
           const loginErrorVisible = await isVisibleSafe(
             page,
-            "#error-for-password, #error-for-username, .form__label--error, div[role='alert']"
+            "#error-for-password, #error-for-username, .form__label--error, div[role='alert']",
           );
 
           if (loginErrorVisible) {
@@ -550,7 +675,7 @@ export class LinkedInAuthService {
               currentUrl: page.url(),
               reason: "Invalid credentials",
               timedOut: false,
-              checkpoint: false
+              checkpoint: false,
             };
           }
 
@@ -563,17 +688,17 @@ export class LinkedInAuthService {
               currentUrl: "unknown (page closed)",
               reason: "Page closed unexpectedly during login polling",
               timedOut: false,
-              checkpoint: false
+              checkpoint: false,
             };
           }
         }
 
         const finalStatus = await inspectLinkedInSession(page, {
-          selectorLocale: this.selectorLocale
+          selectorLocale: this.selectorLocale,
         });
         const resolvedFinalStatus = await enrichAuthenticatedSessionStatus(
           page,
-          finalStatus
+          finalStatus,
         );
         if (resolvedFinalStatus.authenticated) {
           await clearRateLimitState();
@@ -581,9 +706,9 @@ export class LinkedInAuthService {
         return {
           ...resolvedFinalStatus,
           timedOut: true,
-          checkpoint: false
+          checkpoint: false,
         };
-      }
+      },
     );
   }
 
@@ -604,16 +729,16 @@ export class LinkedInAuthService {
       {
         cdpUrl,
         profileName,
-        headless: false
+        headless: false,
       },
       async (context) => {
         const page = await getPage(context);
         await page.goto("https://www.linkedin.com/login", {
-          waitUntil: "domcontentloaded"
+          waitUntil: "domcontentloaded",
         });
 
         let status = await inspectLinkedInSession(page, {
-          selectorLocale: this.selectorLocale
+          selectorLocale: this.selectorLocale,
         });
         const deadline = Date.now() + timeoutMs;
 
@@ -623,16 +748,19 @@ export class LinkedInAuthService {
           } catch {
             return {
               ...status,
-              timedOut: false
+              timedOut: false,
             };
           }
 
           status = await inspectLinkedInSession(page, {
-            selectorLocale: this.selectorLocale
+            selectorLocale: this.selectorLocale,
           });
         }
 
-        const resolvedStatus = await enrichAuthenticatedSessionStatus(page, status);
+        const resolvedStatus = await enrichAuthenticatedSessionStatus(
+          page,
+          status,
+        );
 
         if (resolvedStatus.authenticated) {
           await clearRateLimitState();
@@ -640,9 +768,9 @@ export class LinkedInAuthService {
 
         return {
           ...resolvedStatus,
-          timedOut: !resolvedStatus.authenticated
+          timedOut: !resolvedStatus.authenticated,
         };
-      }
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary

Fixes the LinkedIn login flow that was failing due to GDPR cookie consent overlays blocking credential entry, and adds resilient fallback strategies for authentication.

- **Cookie consent overlay dismissal**: Automatically dismisses LinkedIn's GDPR consent banner before credential entry, which was the root cause of `scrollIntoViewIfNeeded` timeouts in headless mode
- **Direct fill fallback**: When humanized typing fails due to element visibility issues, falls back to `page.evaluate()` to set form values directly via DOM manipulation
- **Form submit fallback**: When the sign-in button click fails, falls back to direct DOM form submission
- **`--headed` CLI flag**: Enables credential-based login with a visible browser window, allowing manual CAPTCHA resolution (separate from `--headless` to avoid Commander.js `--no-X` negation conflict)
- **CAPTCHA wait in headed mode**: When running with `--headed` and a CAPTCHA is detected, continues polling instead of returning immediately — allows the user to manually solve the CAPTCHA

## Important Note

LinkedIn CAPTCHAs all automated login attempts regardless of evasion settings. After merging, a one-time manual CAPTCHA solve is required:

```bash
LINKEDIN_EMAIL=... LINKEDIN_PASSWORD=... linkedin login --headed
```

After manually solving the CAPTCHA once, subsequent headless sessions will use the persisted cookies.

## Quality Gates

- [x] TypeScript: 0 errors (core + CLI)
- [x] ESLint: 0 errors
- [x] Tests: 941/941 passing
- [x] Build: clean

## Changed Files

- `packages/core/src/auth/session.ts` — Login overlay dismissal, direct fill fallback, form submit fallback, headed mode CAPTCHA wait, `headless` option on `HeadlessLoginOptions`
- `packages/cli/src/bin/linkedin.ts` — `--headed` flag, credential login flow with headed browser support

Closes #369