### PR TITLE
feat: quality pass for notifications (#240)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ This project is **not** LinkedIn's official partner API. It is a local, Playwrig
 
 ## Feature Showcase
 
-| Surface | What it gives you |
-| --- | --- |
-| `linkedin` CLI | Search people, companies, jobs, groups, and events; inspect inbox, feed, notifications, profiles, and companies; run health checks and audits. |
-| `linkedin-mcp` | Expose LinkedIn tools to AI agents through Model Context Protocol, including search, inbox, jobs, feed, notifications, profile, company, and activity polling tools. |
-| `@linkedin-buddy/core` | Embed the runtime in TypeScript apps with shared services for search, inbox, feed, jobs, notifications, profile, analytics, and activity polling. |
-| Two-phase writes | Prepare, preview, and confirm real LinkedIn mutations such as replies, invites, comments, follows, profile edits, and posts. |
-| Local-first runtime | Persistent Playwright profiles, SQLite state, structured logs, screenshots, and trace artifacts stay on your machine. |
-| Activity + webhooks | Poll LinkedIn activity, manage watches, and fan out webhook deliveries from the shared local runtime. |
+| Surface                | What it gives you                                                                                                                                                    |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `linkedin` CLI         | Search people, companies, jobs, groups, and events; inspect inbox, feed, notifications, profiles, and companies; run health checks and audits.                       |
+| `linkedin-mcp`         | Expose LinkedIn tools to AI agents through Model Context Protocol, including search, inbox, jobs, feed, notifications, profile, company, and activity polling tools. |
+| `@linkedin-buddy/core` | Embed the runtime in TypeScript apps with shared services for search, inbox, feed, jobs, notifications, profile, analytics, and activity polling.                    |
+| Two-phase writes       | Prepare, preview, and confirm real LinkedIn mutations such as replies, invites, comments, follows, profile edits, and posts.                                         |
+| Local-first runtime    | Persistent Playwright profiles, SQLite state, structured logs, screenshots, and trace artifacts stay on your machine.                                                |
+| Activity + webhooks    | Poll LinkedIn activity, manage watches, and fan out webhook deliveries from the shared local runtime.                                                                |
 
 ## Quick Start
 
@@ -101,24 +101,24 @@ npm exec -w @linkedin-buddy/cli -- linkedin search "developer relations" --categ
 
 ## Visual Tour
 
-| Architecture | Workflow |
-| --- | --- |
+| Architecture                                                                                                                                                                                   | Workflow                                                                                                                               |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | ![System architecture diagram showing LinkedIn Buddy CLI, MCP server, shared runtime, persistent profile, SQLite state, and LinkedIn web app](./assets/media/diagrams/system-architecture.svg) | ![Workflow diagram showing install, build, login, read, prepare, and confirm stages](./assets/media/diagrams/install-to-daily-use.svg) |
 
-| Integrations |
-| --- |
+| Integrations                                                                                                                                                                                            |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | ![Integration diagram showing Claude Desktop, Cursor, Cline, GPT workflows, and local scripts connecting through linkedin-mcp to one local runtime](./assets/media/diagrams/mcp-client-integration.svg) |
 
 ### Feature illustrations
 
-| Search surface | Confirmed actions | Activity webhooks |
-| --- | --- | --- |
+| Search surface                                                                                                                                                      | Confirmed actions                                                                                                                              | Activity webhooks                                                                                                              |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | ![Annotated search illustration showing people and job search in the CLI with shared categories and structured results](./assets/media/features/search-surface.svg) | ![Prepare-and-confirm illustration showing preview, token, and confirm steps for write actions](./assets/media/features/confirmed-actions.svg) | ![Activity illustration showing watches, webhook delivery, and local artifacts](./assets/media/features/activity-webhooks.svg) |
 
 ### Terminal snapshots
 
-| Install and build | MCP quick connect | Confirm before write |
-| --- | --- | --- |
+| Install and build                                                                                                                            | MCP quick connect                                                                                                    | Confirm before write                                                                                                                |
+| -------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | ![Terminal screenshot showing git clone, npm install, Playwright install, and npm run build](./assets/media/terminals/install-and-build.svg) | ![Terminal screenshot showing MCP configuration JSON and next steps](./assets/media/terminals/mcp-quick-connect.svg) | ![Terminal screenshot showing prepare and confirm commands with preview details](./assets/media/terminals/confirm-before-write.svg) |
 
 See [`assets/media/README.md`](./assets/media/README.md) for the organized asset inventory and size budget, and [`docs/readme-media-research.md`](./docs/readme-media-research.md) for the research notes behind the chosen formats.
@@ -205,7 +205,7 @@ try {
     profileName: "default",
     category: "people",
     query: "developer relations",
-    limit: 5
+    limit: 5,
   });
 
   console.log(result.results.map((person) => person.name));
@@ -218,30 +218,31 @@ try {
 
 Quick positioning snapshot for people evaluating LinkedIn MCP, LinkedIn CLI, and LinkedIn API-style tools.
 
-| Tool | CLI | MCP server | Dev library / API | Confirm-before-write flow | Best fit |
-| --- | --- | --- | --- | --- | --- |
-| **LinkedIn Buddy** | Yes | Yes | Yes | Yes | Local-first LinkedIn workflows for operators and AI agents |
-| [`stickerdaniel/linkedin-mcp-server`](https://github.com/stickerdaniel/linkedin-mcp-server) | No advertised CLI | Yes | No advertised core package | No advertised confirm flow | MCP access focused on LinkedIn scraping and job search |
-| [`tigillo/linkedin-cli`](https://github.com/tigillo/linkedin-cli) | Yes | No | No advertised dev package | No advertised confirm flow | Terminal-oriented LinkedIn command usage |
-| [`alabarga/linkedin-api`](https://github.com/alabarga/linkedin-api) | No | No | Yes | No advertised confirm flow | Library-style LinkedIn integrations |
+| Tool                                                                                        | CLI               | MCP server | Dev library / API          | Confirm-before-write flow  | Best fit                                                   |
+| ------------------------------------------------------------------------------------------- | ----------------- | ---------- | -------------------------- | -------------------------- | ---------------------------------------------------------- |
+| **LinkedIn Buddy**                                                                          | Yes               | Yes        | Yes                        | Yes                        | Local-first LinkedIn workflows for operators and AI agents |
+| [`stickerdaniel/linkedin-mcp-server`](https://github.com/stickerdaniel/linkedin-mcp-server) | No advertised CLI | Yes        | No advertised core package | No advertised confirm flow | MCP access focused on LinkedIn scraping and job search     |
+| [`tigillo/linkedin-cli`](https://github.com/tigillo/linkedin-cli)                           | Yes               | No         | No advertised dev package  | No advertised confirm flow | Terminal-oriented LinkedIn command usage                   |
+| [`alabarga/linkedin-api`](https://github.com/alabarga/linkedin-api)                         | No                | No         | Yes                        | No advertised confirm flow | Library-style LinkedIn integrations                        |
 
 See [`docs/repository-seo.md`](./docs/repository-seo.md) for the keyword targets and the GitHub-search baseline captured for issue #245.
 
 ## Docs Map
 
-| Need | Doc |
-| --- | --- |
-| Repository SEO targets and metadata sync | [`docs/repository-seo.md`](./docs/repository-seo.md) |
-| Activity polling and webhooks | [`docs/activity-webhooks.md`](./docs/activity-webhooks.md) |
-| Anti-bot evasion profiles | [`docs/evasion.md`](./docs/evasion.md) |
-| E2E and replay testing | [`docs/e2e-testing.md`](./docs/e2e-testing.md) |
-| Live validation and account safety | [`docs/write-validation.md`](./docs/write-validation.md) |
-| Selector auditing | [`docs/selector-audit.md`](./docs/selector-audit.md) |
-| Draft quality evaluation | [`docs/draft-quality-evaluation.md`](./docs/draft-quality-evaluation.md) |
-| Brand and social preview assets | [`docs/brand-guidelines.md`](./docs/brand-guidelines.md) |
-| README media research | [`docs/readme-media-research.md`](./docs/readme-media-research.md) |
-| README media inventory | [`assets/media/README.md`](./assets/media/README.md) |
-| Articles and newsletters | [`docs/articles-newsletters.md`](./docs/articles-newsletters.md) |
+| Need                                     | Doc                                                                      |
+| ---------------------------------------- | ------------------------------------------------------------------------ |
+| Repository SEO targets and metadata sync | [`docs/repository-seo.md`](./docs/repository-seo.md)                     |
+| Activity polling and webhooks            | [`docs/activity-webhooks.md`](./docs/activity-webhooks.md)               |
+| Anti-bot evasion profiles                | [`docs/evasion.md`](./docs/evasion.md)                                   |
+| E2E and replay testing                   | [`docs/e2e-testing.md`](./docs/e2e-testing.md)                           |
+| Live validation and account safety       | [`docs/write-validation.md`](./docs/write-validation.md)                 |
+| Selector auditing                        | [`docs/selector-audit.md`](./docs/selector-audit.md)                     |
+| Draft quality evaluation                 | [`docs/draft-quality-evaluation.md`](./docs/draft-quality-evaluation.md) |
+| Brand and social preview assets          | [`docs/brand-guidelines.md`](./docs/brand-guidelines.md)                 |
+| README media research                    | [`docs/readme-media-research.md`](./docs/readme-media-research.md)       |
+| README media inventory                   | [`assets/media/README.md`](./assets/media/README.md)                     |
+| Articles and newsletters                 | [`docs/articles-newsletters.md`](./docs/articles-newsletters.md)         |
+| Notifications                            | [`docs/notifications.md`](./docs/notifications.md)                       |
 
 ## Contributing
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,230 @@
+# Notifications
+
+LinkedIn Buddy supports listing, reading, dismissing, and managing preferences for LinkedIn notifications through the CLI, MCP server, and TypeScript API.
+
+## Overview
+
+| Action                    | CLI                                        | MCP Tool                                            | Two-Phase |
+| ------------------------- | ------------------------------------------ | --------------------------------------------------- | --------- |
+| List notifications        | `notifications list`                       | `linkedin.notifications.list`                       | No        |
+| Mark notification as read | `notifications mark-read`                  | `linkedin.notifications.mark_read`                  | No        |
+| Dismiss notification      | `notifications dismiss`                    | `linkedin.notifications.dismiss`                    | Yes       |
+| View preferences          | `notifications preferences get`            | `linkedin.notifications.preferences.get`            | No        |
+| Update preference         | `notifications preferences prepare-update` | `linkedin.notifications.preferences.prepare_update` | Yes       |
+
+Dismiss and preference update operations follow the two-phase commit pattern: **prepare** returns a confirm token, then **confirm** executes the action. Read-only operations (list, mark-read, view preferences) execute immediately.
+
+## CLI Usage
+
+### List notifications
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin notifications list --limit 10
+```
+
+Returns an array of notifications with type, message, timestamp, link, and read/unread status.
+
+### Mark a notification as read
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin notifications mark-read <notificationId>
+```
+
+Opens the notification on LinkedIn to mark it as read. The `notificationId` comes from the list output.
+
+### Dismiss a notification
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin notifications dismiss <notificationId>
+```
+
+Returns a prepared action with a `confirmToken`. Use `linkedin actions confirm --token ct_...` to permanently remove the notification.
+
+### View notification preferences
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin notifications preferences get
+npm exec -w @linkedin-buddy/cli -- linkedin notifications preferences get \
+  --preference-url "https://www.linkedin.com/mypreferences/d/notification-categories/posting-and-commenting"
+```
+
+Without `--preference-url`, returns the top-level overview with all preference categories. With a URL, returns the category or subcategory detail page including current toggle states.
+
+### Update a notification preference
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin notifications preferences prepare-update \
+  --preference-url "https://www.linkedin.com/mypreferences/d/notification-categories/posting-and-commenting" \
+  --enabled false
+```
+
+For subcategory pages, specify the channel:
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin notifications preferences prepare-update \
+  --preference-url "https://www.linkedin.com/mypreferences/d/notification-subcategories/comments-and-reactions" \
+  --enabled false \
+  --channel in_app
+```
+
+### Common options
+
+All commands support:
+
+- `-p, --profile <profile>` — LinkedIn profile name (default: `default`)
+- `-o, --operator-note <note>` — Optional note attached to prepared actions
+- `--cdp-url <url>` — Connect to an existing Chrome DevTools Protocol session
+
+## MCP Usage
+
+### linkedin.notifications.list
+
+List your LinkedIn notifications.
+
+**Parameters:**
+
+| Name          | Type   | Required | Description                                             |
+| ------------- | ------ | -------- | ------------------------------------------------------- |
+| `profileName` | string | No       | Profile name (default: `default`)                       |
+| `limit`       | number | No       | Maximum notifications to return (default: 20, max: 100) |
+
+**Returns:** `{ count, notifications: [{ id, type, message, timestamp, link, is_read }] }`
+
+### linkedin.notifications.mark_read
+
+Mark one LinkedIn notification as read by notification ID.
+
+**Parameters:**
+
+| Name             | Type   | Required | Description                                      |
+| ---------------- | ------ | -------- | ------------------------------------------------ |
+| `notificationId` | string | Yes      | Notification ID returned by `notifications.list` |
+| `profileName`    | string | No       | Profile name                                     |
+
+**Returns:** `{ marked_read, was_already_read, notification_id, link, selector_key }`
+
+### linkedin.notifications.dismiss
+
+Prepare a dismiss action for one LinkedIn notification (two-phase).
+
+**Parameters:**
+
+| Name             | Type   | Required | Description                                      |
+| ---------------- | ------ | -------- | ------------------------------------------------ |
+| `notificationId` | string | Yes      | Notification ID returned by `notifications.list` |
+| `profileName`    | string | No       | Profile name                                     |
+| `operatorNote`   | string | No       | Optional operator note                           |
+
+**Returns:** `{ preparedActionId, confirmToken, expiresAtMs, preview }`
+
+### linkedin.notifications.preferences.get
+
+Read LinkedIn notification preference categories or a specific preference page.
+
+**Parameters:**
+
+| Name            | Type   | Required | Description                                                     |
+| --------------- | ------ | -------- | --------------------------------------------------------------- |
+| `preferenceUrl` | string | No       | Preference page URL. Omit for the overview with all categories. |
+| `profileName`   | string | No       | Profile name                                                    |
+
+**Returns:** One of three view types:
+
+- **overview** — `{ view_type: "overview", categories: [{ title, slug, preference_url }] }`
+- **category** — `{ view_type: "category", title, master_toggle, subcategories: [...] }`
+- **subcategory** — `{ view_type: "subcategory", title, channels: [{ label, enabled, channel_key }] }`
+
+### linkedin.notifications.preferences.prepare_update
+
+Prepare a LinkedIn notification preference update (two-phase).
+
+**Parameters:**
+
+| Name            | Type    | Required | Description                                                     |
+| --------------- | ------- | -------- | --------------------------------------------------------------- |
+| `preferenceUrl` | string  | Yes      | Category or subcategory URL from `preferences.get`              |
+| `enabled`       | boolean | Yes      | Whether the selected preference should be enabled               |
+| `channel`       | string  | No       | Channel key for subcategory pages: `in_app`, `push`, or `email` |
+| `profileName`   | string  | No       | Profile name                                                    |
+| `operatorNote`  | string  | No       | Optional operator note                                          |
+
+**Returns:** `{ preparedActionId, confirmToken, expiresAtMs, preview }`
+
+## Limits
+
+| Parameter  | Default | Maximum |
+| ---------- | ------- | ------- |
+| List limit | 20      | 100     |
+| Scan limit | 50      | 200     |
+
+The list limit controls how many notifications are returned. The scan limit controls how many cards are searched when locating a specific notification by ID.
+
+## TypeScript API
+
+```typescript
+import { createCoreRuntime } from "@linkedin-buddy/core";
+
+const runtime = createCoreRuntime();
+
+try {
+  // List notifications
+  const notifications = await runtime.notifications.listNotifications({
+    profileName: "default",
+    limit: 10,
+  });
+  console.log(notifications);
+
+  // Mark as read
+  const readResult = await runtime.notifications.markRead({
+    profileName: "default",
+    notificationId: notifications[0].id,
+  });
+  console.log(readResult);
+
+  // View preference overview
+  const overview = await runtime.notifications.getPreferences();
+  console.log(overview);
+
+  // Prepare a preference update
+  const prepared = await runtime.notifications.prepareUpdatePreference({
+    profileName: "default",
+    preferenceUrl:
+      "https://www.linkedin.com/mypreferences/d/notification-categories/posting-and-commenting",
+    enabled: false,
+  });
+  console.log(prepared.confirmToken);
+
+  // Confirm the action
+  const result = await runtime.twoPhaseCommit.confirmByToken({
+    confirmToken: prepared.confirmToken,
+  });
+  console.log(result);
+} finally {
+  runtime.close();
+}
+```
+
+## Error Codes
+
+| Code                         | When                                                                                          |
+| ---------------------------- | --------------------------------------------------------------------------------------------- |
+| `ACTION_PRECONDITION_FAILED` | Invalid input (empty ID, overview page for update, channel required, already at target state) |
+| `TARGET_NOT_FOUND`           | Notification or preference switch not found on the page                                       |
+| `AUTH_REQUIRED`              | LinkedIn session not authenticated                                                            |
+| `UI_CHANGED_SELECTOR_FAILED` | LinkedIn UI changed and selectors no longer match                                             |
+| `TIMEOUT`                    | Browser automation timed out                                                                  |
+| `NETWORK_ERROR`              | Network connectivity issue during automation                                                  |
+
+## Artifacts
+
+Dismiss and preference update operations capture:
+
+- **Screenshots**: Before and after screenshots of the LinkedIn notification page
+- **Traces**: Playwright browser traces (`.zip`) for debugging
+- **Error screenshots**: Captured on failure for diagnostic purposes
+
+Artifacts are stored under `~/.linkedin-buddy/linkedin-buddy/runs/<run-id>/`.
+
+## E2E Verification
+
+Read-only operations (list, mark-read, preferences get) can be verified against any authenticated profile. Write operations (dismiss, preference update) require manual E2E testing against an approved test account per the [E2E testing safety rules](./e2e-testing.md).

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -7817,6 +7817,166 @@ async function runNotificationsList(
   }
 }
 
+async function runNotificationsMarkRead(
+  input: {
+    profileName: string;
+    notificationId: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.notifications.mark_read.start", {
+      profileName: input.profileName,
+      notificationId: input.notificationId,
+    });
+
+    const result = await runtime.notifications.markRead({
+      profileName: input.profileName,
+      notificationId: input.notificationId,
+    });
+
+    runtime.logger.log("info", "cli.notifications.mark_read.done", {
+      profileName: input.profileName,
+      notificationId: input.notificationId,
+    });
+
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      ...result,
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function runNotificationsDismiss(
+  input: {
+    profileName: string;
+    notificationId: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.notifications.dismiss.start", {
+      profileName: input.profileName,
+      notificationId: input.notificationId,
+    });
+
+    const prepared = await runtime.notifications.prepareDismissNotification({
+      profileName: input.profileName,
+      notificationId: input.notificationId,
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
+    });
+
+    runtime.logger.log("info", "cli.notifications.dismiss.done", {
+      profileName: input.profileName,
+      notificationId: input.notificationId,
+      preparedActionId: prepared.preparedActionId,
+    });
+
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      ...prepared,
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function runNotificationsPreferencesGet(
+  input: {
+    profileName: string;
+    preferenceUrl?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.notifications.preferences.get.start", {
+      profileName: input.profileName,
+      preferenceUrl: input.preferenceUrl ?? null,
+    });
+
+    const preferences = await runtime.notifications.getPreferences({
+      profileName: input.profileName,
+      ...(input.preferenceUrl ? { preferenceUrl: input.preferenceUrl } : {}),
+    });
+
+    runtime.logger.log("info", "cli.notifications.preferences.get.done", {
+      profileName: input.profileName,
+      viewType: preferences.view_type,
+    });
+
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      preferences,
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function runNotificationsPreferencesPrepareUpdate(
+  input: {
+    profileName: string;
+    preferenceUrl: string;
+    enabled: boolean;
+    channel?: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log(
+      "info",
+      "cli.notifications.preferences.prepare_update.start",
+      {
+        profileName: input.profileName,
+        preferenceUrl: input.preferenceUrl,
+        enabled: input.enabled,
+        channel: input.channel ?? null,
+      },
+    );
+
+    const prepared = await runtime.notifications.prepareUpdatePreference({
+      profileName: input.profileName,
+      preferenceUrl: input.preferenceUrl,
+      enabled: input.enabled,
+      ...(input.channel ? { channel: input.channel } : {}),
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
+    });
+
+    runtime.logger.log(
+      "info",
+      "cli.notifications.preferences.prepare_update.done",
+      {
+        profileName: input.profileName,
+        preferenceUrl: input.preferenceUrl,
+        preparedActionId: prepared.preparedActionId,
+      },
+    );
+
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      ...prepared,
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
 async function runJobsSearch(
   input: {
     profileName: string;
@@ -10910,6 +11070,101 @@ export function createCliProgram(): Command {
         readCdpUrl(),
       );
     });
+
+  notificationsCommand
+    .command("mark-read")
+    .description("Mark a LinkedIn notification as read")
+    .argument("<notificationId>", "Notification ID from notifications list")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .action(async (notificationId: string, options: { profile: string }) => {
+      await runNotificationsMarkRead(
+        { profileName: options.profile, notificationId },
+        readCdpUrl(),
+      );
+    });
+
+  notificationsCommand
+    .command("dismiss")
+    .description("Prepare to dismiss a LinkedIn notification (two-phase)")
+    .argument("<notificationId>", "Notification ID from notifications list")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .option("-o, --operator-note <note>", "Internal note for audit")
+    .action(
+      async (
+        notificationId: string,
+        options: { profile: string; operatorNote?: string },
+      ) => {
+        await runNotificationsDismiss(
+          {
+            profileName: options.profile,
+            notificationId,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
+    );
+
+  const notificationPreferencesCommand = notificationsCommand
+    .command("preferences")
+    .description("Manage LinkedIn notification preferences");
+
+  notificationPreferencesCommand
+    .command("get")
+    .description("View LinkedIn notification preferences")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .option("--preference-url <url>", "Specific preference page URL")
+    .action(async (options: { profile: string; preferenceUrl?: string }) => {
+      await runNotificationsPreferencesGet(
+        {
+          profileName: options.profile,
+          ...(options.preferenceUrl
+            ? { preferenceUrl: options.preferenceUrl }
+            : {}),
+        },
+        readCdpUrl(),
+      );
+    });
+
+  notificationPreferencesCommand
+    .command("prepare-update")
+    .description("Prepare a notification preference update (two-phase)")
+    .requiredOption(
+      "--preference-url <url>",
+      "Preference page URL from preferences get",
+    )
+    .requiredOption("--enabled <enabled>", "Enable or disable (true/false)")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .option(
+      "--channel <channel>",
+      "Channel: in_app, push, or email (required for subcategories)",
+    )
+    .option("-o, --operator-note <note>", "Internal note for audit")
+    .action(
+      async (options: {
+        profile: string;
+        preferenceUrl: string;
+        enabled: string;
+        channel?: string;
+        operatorNote?: string;
+      }) => {
+        const enabled = options.enabled === "true";
+        await runNotificationsPreferencesPrepareUpdate(
+          {
+            profileName: options.profile,
+            preferenceUrl: options.preferenceUrl,
+            enabled,
+            ...(options.channel ? { channel: options.channel } : {}),
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
+    );
 
   const jobsCommand = program
     .command("jobs")

--- a/packages/core/src/__tests__/linkedinNotifications.test.ts
+++ b/packages/core/src/__tests__/linkedinNotifications.test.ts
@@ -3,33 +3,148 @@ import {
   DISMISS_NOTIFICATION_ACTION_TYPE,
   LINKEDIN_NOTIFICATION_PREFERENCE_CHANNELS,
   LinkedInNotificationsService,
+  NOTIFICATION_LIST_MAX_LIMIT,
+  NOTIFICATION_SCAN_MAX_LIMIT,
   UPDATE_NOTIFICATION_PREFERENCE_ACTION_TYPE,
   createNotificationActionExecutors,
   normalizeLinkedInNotificationPreferenceChannel,
   type LinkedInNotification,
-  type LinkedInNotificationsRuntime
+  type LinkedInNotificationsRuntime,
 } from "../linkedinNotifications.js";
 
+const DEFAULT_PREFERENCE_URL =
+  "https://www.linkedin.com/mypreferences/d/notification-categories/posting-and-commenting";
+const SUBCATEGORY_PREFERENCE_URL =
+  "https://www.linkedin.com/mypreferences/d/notification-subcategories/comments-and-reactions";
+
+function createPrepareMock() {
+  return vi.fn((input: { preview: Record<string, unknown> }) => ({
+    preparedActionId: "pa_test",
+    confirmToken: "ct_test",
+    expiresAtMs: 123,
+    preview: input.preview,
+  }));
+}
+
+function createNotificationsService(prepare = createPrepareMock()) {
+  const service = new LinkedInNotificationsService({
+    twoPhaseCommit: { prepare },
+  } as unknown as LinkedInNotificationsRuntime);
+
+  return {
+    service,
+    prepare,
+  };
+}
+
 describe("LinkedIn notification constants", () => {
+  it("uses a stable dismiss action type identifier", () => {
+    expect(DISMISS_NOTIFICATION_ACTION_TYPE).toBe("notifications.dismiss");
+  });
+
+  it("uses a stable update preference action type identifier", () => {
+    expect(UPDATE_NOTIFICATION_PREFERENCE_ACTION_TYPE).toBe(
+      "notifications.update_preference",
+    );
+  });
+
+  it("exposes the list notifications hard cap", () => {
+    expect(NOTIFICATION_LIST_MAX_LIMIT).toBe(100);
+  });
+
+  it("exposes the notification scan hard cap", () => {
+    expect(NOTIFICATION_SCAN_MAX_LIMIT).toBe(200);
+  });
+
   it("exposes the supported notification preference channels", () => {
     expect(LINKEDIN_NOTIFICATION_PREFERENCE_CHANNELS).toEqual([
       "in_app",
       "push",
-      "email"
+      "email",
     ]);
   });
 
   it("normalizes supported notification preference channels", () => {
-    expect(normalizeLinkedInNotificationPreferenceChannel("in_app")).toBe("in_app");
-    expect(normalizeLinkedInNotificationPreferenceChannel("In-app")).toBe("in_app");
+    expect(normalizeLinkedInNotificationPreferenceChannel("in_app")).toBe(
+      "in_app",
+    );
+    expect(normalizeLinkedInNotificationPreferenceChannel("In-app")).toBe(
+      "in_app",
+    );
     expect(normalizeLinkedInNotificationPreferenceChannel("push")).toBe("push");
-    expect(normalizeLinkedInNotificationPreferenceChannel("Email")).toBe("email");
+    expect(normalizeLinkedInNotificationPreferenceChannel("Email")).toBe(
+      "email",
+    );
   });
 
   it("rejects unsupported notification preference channels", () => {
-    expect(() =>
-      normalizeLinkedInNotificationPreferenceChannel("sms")
-    ).toThrow("channel must be one of");
+    expect(() => normalizeLinkedInNotificationPreferenceChannel("sms")).toThrow(
+      "channel must be one of",
+    );
+  });
+});
+
+describe("normalizeLinkedInNotificationPreferenceChannel", () => {
+  it("normalizes in_app to in_app", () => {
+    expect(normalizeLinkedInNotificationPreferenceChannel("in_app")).toBe(
+      "in_app",
+    );
+  });
+
+  it("normalizes In-app to in_app", () => {
+    expect(normalizeLinkedInNotificationPreferenceChannel("In-app")).toBe(
+      "in_app",
+    );
+  });
+
+  it("normalizes IN_APP to in_app", () => {
+    expect(normalizeLinkedInNotificationPreferenceChannel("IN_APP")).toBe(
+      "in_app",
+    );
+  });
+
+  it("normalizes push to push", () => {
+    expect(normalizeLinkedInNotificationPreferenceChannel("push")).toBe("push");
+  });
+
+  it("normalizes Push to push", () => {
+    expect(normalizeLinkedInNotificationPreferenceChannel("Push")).toBe("push");
+  });
+
+  it("normalizes email to email", () => {
+    expect(normalizeLinkedInNotificationPreferenceChannel("email")).toBe(
+      "email",
+    );
+  });
+
+  it("normalizes E-mail to email", () => {
+    expect(normalizeLinkedInNotificationPreferenceChannel("E-mail")).toBe(
+      "email",
+    );
+  });
+
+  it("normalizes EMAIL to email", () => {
+    expect(normalizeLinkedInNotificationPreferenceChannel("EMAIL")).toBe(
+      "email",
+    );
+  });
+
+  it("normalizes values with surrounding whitespace", () => {
+    expect(normalizeLinkedInNotificationPreferenceChannel("  push  ")).toBe(
+      "push",
+    );
+  });
+
+  it("rejects an empty channel", () => {
+    expect(() => normalizeLinkedInNotificationPreferenceChannel("")).toThrow(
+      "channel must be one of",
+    );
+  });
+
+  it("rejects unsupported channels", () => {
+    expect(() => normalizeLinkedInNotificationPreferenceChannel("sms")).toThrow(
+      "channel must be one of",
+    );
   });
 });
 
@@ -39,10 +154,41 @@ describe("createNotificationActionExecutors", () => {
 
     expect(Object.keys(executors)).toEqual([
       DISMISS_NOTIFICATION_ACTION_TYPE,
-      UPDATE_NOTIFICATION_PREFERENCE_ACTION_TYPE
+      UPDATE_NOTIFICATION_PREFERENCE_ACTION_TYPE,
     ]);
     expect(executors[DISMISS_NOTIFICATION_ACTION_TYPE]).toBeDefined();
     expect(executors[UPDATE_NOTIFICATION_PREFERENCE_ACTION_TYPE]).toBeDefined();
+  });
+
+  it("returns both expected executor keys", () => {
+    const executors = createNotificationActionExecutors();
+
+    expect(Object.keys(executors)).toEqual([
+      DISMISS_NOTIFICATION_ACTION_TYPE,
+      UPDATE_NOTIFICATION_PREFERENCE_ACTION_TYPE,
+    ]);
+  });
+
+  it("returns executors with execute methods", () => {
+    const executors = createNotificationActionExecutors();
+
+    expect(executors[DISMISS_NOTIFICATION_ACTION_TYPE]).toHaveProperty(
+      "execute",
+    );
+    expect(
+      executors[UPDATE_NOTIFICATION_PREFERENCE_ACTION_TYPE],
+    ).toHaveProperty("execute");
+  });
+
+  it("returns execute methods as functions", () => {
+    const executors = createNotificationActionExecutors();
+
+    expect(typeof executors[DISMISS_NOTIFICATION_ACTION_TYPE]?.execute).toBe(
+      "function",
+    );
+    expect(
+      typeof executors[UPDATE_NOTIFICATION_PREFERENCE_ACTION_TYPE]?.execute,
+    ).toBe("function");
   });
 });
 
@@ -52,10 +198,10 @@ describe("LinkedInNotificationsService prepare flows", () => {
       preparedActionId: "pa_test",
       confirmToken: "ct_test",
       expiresAtMs: 123,
-      preview: input.preview
+      preview: input.preview,
     }));
     const service = new LinkedInNotificationsService({
-      twoPhaseCommit: { prepare }
+      twoPhaseCommit: { prepare },
     } as unknown as LinkedInNotificationsRuntime);
     const listNotifications = vi
       .spyOn(service, "listNotifications")
@@ -66,12 +212,12 @@ describe("LinkedInNotificationsService prepare flows", () => {
           message: "Someone reacted to your post",
           timestamp: "2h",
           link: "https://www.linkedin.com/feed/update/urn:li:activity:123",
-          is_read: false
-        } satisfies LinkedInNotification
+          is_read: false,
+        } satisfies LinkedInNotification,
       ]);
 
     const prepared = await service.prepareDismissNotification({
-      notificationId: "notif_123"
+      notificationId: "notif_123",
     });
 
     expect(prepared.preview).toMatchObject({
@@ -79,24 +225,25 @@ describe("LinkedInNotificationsService prepare flows", () => {
       target: {
         profile_name: "default",
         notification_id: "notif_123",
-        notification_link: "https://www.linkedin.com/feed/update/urn:li:activity:123"
+        notification_link:
+          "https://www.linkedin.com/feed/update/urn:li:activity:123",
       },
       notification: {
         id: "notif_123",
-        is_read: false
-      }
+        is_read: false,
+      },
     });
     expect(prepare).toHaveBeenCalledWith(
       expect.objectContaining({
         actionType: DISMISS_NOTIFICATION_ACTION_TYPE,
         payload: {
-          notification_id: "notif_123"
-        }
-      })
+          notification_id: "notif_123",
+        },
+      }),
     );
     expect(listNotifications).toHaveBeenCalledWith({
       profileName: "default",
-      limit: 75
+      limit: 75,
     });
   });
 
@@ -105,10 +252,10 @@ describe("LinkedInNotificationsService prepare flows", () => {
       preparedActionId: "pa_pref",
       confirmToken: "ct_pref",
       expiresAtMs: 456,
-      preview: input.preview
+      preview: input.preview,
     }));
     const service = new LinkedInNotificationsService({
-      twoPhaseCommit: { prepare }
+      twoPhaseCommit: { prepare },
     } as unknown as LinkedInNotificationsRuntime);
     const getPreferences = vi
       .spyOn(service, "getPreferences")
@@ -121,15 +268,15 @@ describe("LinkedInNotificationsService prepare flows", () => {
         master_toggle: {
           label: "Allow post related notifications",
           enabled: true,
-          selector_key: "allPostingAndCommentingNotificationSettings"
+          selector_key: "allPostingAndCommentingNotificationSettings",
         },
-        subcategories: []
+        subcategories: [],
       });
 
     const prepared = await service.prepareUpdatePreference({
       preferenceUrl:
         "https://www.linkedin.com/mypreferences/d/notification-categories/posting-and-commenting",
-      enabled: false
+      enabled: false,
     });
 
     expect(prepared.preview).toMatchObject({
@@ -137,10 +284,10 @@ describe("LinkedInNotificationsService prepare flows", () => {
         'Set LinkedIn notification preference "Posting and commenting" to off',
       target: {
         profile_name: "default",
-        view_type: "category"
+        view_type: "category",
       },
       current_enabled: true,
-      enabled: false
+      enabled: false,
     });
     expect(prepare).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -148,22 +295,22 @@ describe("LinkedInNotificationsService prepare flows", () => {
         payload: {
           preference_url:
             "https://www.linkedin.com/mypreferences/d/notification-categories/posting-and-commenting",
-          enabled: false
-        }
-      })
+          enabled: false,
+        },
+      }),
     );
     expect(getPreferences).toHaveBeenCalledWith({
       profileName: "default",
       preferenceUrl:
-        "https://www.linkedin.com/mypreferences/d/notification-categories/posting-and-commenting"
+        "https://www.linkedin.com/mypreferences/d/notification-categories/posting-and-commenting",
     });
   });
 
   it("requires a channel when preparing subcategory notification preference updates", async () => {
     const service = new LinkedInNotificationsService({
       twoPhaseCommit: {
-        prepare: vi.fn()
-      }
+        prepare: vi.fn(),
+      },
     } as unknown as LinkedInNotificationsRuntime);
     vi.spyOn(service, "getPreferences").mockResolvedValue({
       view_type: "subcategory",
@@ -176,17 +323,589 @@ describe("LinkedInNotificationsService prepare flows", () => {
           channel_key: "in_app",
           label: "In-app notifications",
           enabled: true,
-          selector_key: "postCommentsAndReactionsViaInApp"
-        }
-      ]
+          selector_key: "postCommentsAndReactionsViaInApp",
+        },
+      ],
     });
 
     await expect(
       service.prepareUpdatePreference({
         preferenceUrl:
           "https://www.linkedin.com/mypreferences/d/notification-subcategories/comments-and-reactions",
-        enabled: false
-      })
+        enabled: false,
+      }),
     ).rejects.toThrow("channel is required");
+  });
+});
+
+describe("LinkedInNotificationsService.prepareDismissNotification", () => {
+  it("rejects empty notificationId", async () => {
+    const { service } = createNotificationsService();
+
+    await expect(
+      service.prepareDismissNotification({
+        notificationId: "",
+      }),
+    ).rejects.toMatchObject({
+      code: "ACTION_PRECONDITION_FAILED",
+    });
+    await expect(
+      service.prepareDismissNotification({
+        notificationId: "",
+      }),
+    ).rejects.toThrow("notificationId is required");
+  });
+
+  it("rejects whitespace-only notificationId", async () => {
+    const { service } = createNotificationsService();
+
+    await expect(
+      service.prepareDismissNotification({
+        notificationId: "   \n\t  ",
+      }),
+    ).rejects.toMatchObject({
+      code: "ACTION_PRECONDITION_FAILED",
+    });
+  });
+
+  it("returns TARGET_NOT_FOUND when notification is missing", async () => {
+    const { service } = createNotificationsService();
+    vi.spyOn(service, "listNotifications").mockResolvedValue([]);
+
+    await expect(
+      service.prepareDismissNotification({
+        notificationId: "notif_missing",
+      }),
+    ).rejects.toMatchObject({
+      code: "TARGET_NOT_FOUND",
+    });
+  });
+
+  it("returns structured preview for successful dismiss", async () => {
+    const { service } = createNotificationsService();
+    vi.spyOn(service, "listNotifications").mockResolvedValue([
+      {
+        id: "notif_123",
+        type: "mention",
+        message: "You were mentioned",
+        timestamp: "1h",
+        link: "https://www.linkedin.com/feed/update/urn:li:activity:123",
+        is_read: true,
+      },
+    ]);
+
+    const prepared = await service.prepareDismissNotification({
+      notificationId: "notif_123",
+    });
+
+    expect(prepared).toMatchObject({
+      preparedActionId: "pa_test",
+      confirmToken: "ct_test",
+      expiresAtMs: 123,
+      preview: {
+        summary: 'Dismiss LinkedIn notification "You were mentioned"',
+        target: {
+          profile_name: "default",
+          notification_id: "notif_123",
+          notification_type: "mention",
+        },
+        notification: {
+          id: "notif_123",
+          is_read: true,
+        },
+      },
+    });
+  });
+
+  it("uses default profile when none is provided", async () => {
+    const { service } = createNotificationsService();
+    const listNotifications = vi
+      .spyOn(service, "listNotifications")
+      .mockResolvedValue([
+        {
+          id: "notif_123",
+          type: "reaction",
+          message: "Someone reacted",
+          timestamp: "2h",
+          link: "https://www.linkedin.com/feed/update/urn:li:activity:321",
+          is_read: false,
+        },
+      ]);
+
+    await service.prepareDismissNotification({
+      notificationId: "notif_123",
+    });
+
+    expect(listNotifications).toHaveBeenCalledWith({
+      profileName: "default",
+      limit: 75,
+    });
+  });
+
+  it("forwards custom profile name", async () => {
+    const { service, prepare } = createNotificationsService();
+    vi.spyOn(service, "listNotifications").mockResolvedValue([
+      {
+        id: "notif_abc",
+        type: "job",
+        message: "New job alert",
+        timestamp: "3h",
+        link: "https://www.linkedin.com/jobs/view/123",
+        is_read: false,
+      },
+    ]);
+
+    await service.prepareDismissNotification({
+      profileName: "sales",
+      notificationId: "notif_abc",
+    });
+
+    expect(prepare).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({
+          profile_name: "sales",
+        }),
+      }),
+    );
+  });
+
+  it("forwards operator note when provided", async () => {
+    const { service, prepare } = createNotificationsService();
+    vi.spyOn(service, "listNotifications").mockResolvedValue([
+      {
+        id: "notif_abc",
+        type: "comment",
+        message: "New comment",
+        timestamp: "4h",
+        link: "https://www.linkedin.com/feed/update/urn:li:activity:999",
+        is_read: false,
+      },
+    ]);
+
+    await service.prepareDismissNotification({
+      notificationId: "notif_abc",
+      operatorNote: "Dismiss duplicate noise",
+    });
+
+    expect(prepare).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operatorNote: "Dismiss duplicate noise",
+      }),
+    );
+  });
+
+  it("omits operator note when not provided", async () => {
+    const { service, prepare } = createNotificationsService();
+    vi.spyOn(service, "listNotifications").mockResolvedValue([
+      {
+        id: "notif_abc",
+        type: "follow",
+        message: "You have a new follower",
+        timestamp: "5h",
+        link: "https://www.linkedin.com/in/test/",
+        is_read: false,
+      },
+    ]);
+
+    await service.prepareDismissNotification({
+      notificationId: "notif_abc",
+    });
+
+    const call = prepare.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(call).toBeDefined();
+    expect(call).not.toHaveProperty("operatorNote");
+  });
+
+  it("trims notificationId before lookup and payload", async () => {
+    const { service, prepare } = createNotificationsService();
+    vi.spyOn(service, "listNotifications").mockResolvedValue([
+      {
+        id: "notif_trimmed",
+        type: "reaction",
+        message: "Trimmed id",
+        timestamp: "6h",
+        link: "https://www.linkedin.com/feed/update/urn:li:activity:444",
+        is_read: false,
+      },
+    ]);
+
+    await service.prepareDismissNotification({
+      notificationId: "  notif_trimmed  ",
+    });
+
+    expect(prepare).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: {
+          notification_id: "notif_trimmed",
+        },
+      }),
+    );
+  });
+});
+
+describe("LinkedInNotificationsService.prepareUpdatePreference", () => {
+  it("rejects overview pages", async () => {
+    const { service } = createNotificationsService();
+    vi.spyOn(service, "getPreferences").mockResolvedValue({
+      view_type: "overview",
+      title: "Notifications",
+      preference_url:
+        "https://www.linkedin.com/mypreferences/d/categories/notifications",
+      categories: [],
+    });
+
+    await expect(
+      service.prepareUpdatePreference({
+        preferenceUrl: "categories/notifications",
+        enabled: false,
+      }),
+    ).rejects.toThrow("overview");
+  });
+
+  it("requires channel for subcategory pages", async () => {
+    const { service } = createNotificationsService();
+    vi.spyOn(service, "getPreferences").mockResolvedValue({
+      view_type: "subcategory",
+      title: "Comments and reactions",
+      preference_url: SUBCATEGORY_PREFERENCE_URL,
+      description: null,
+      channels: [
+        {
+          channel_key: "in_app",
+          label: "In-app notifications",
+          enabled: true,
+          selector_key: "selector_in_app",
+        },
+      ],
+    });
+
+    await expect(
+      service.prepareUpdatePreference({
+        preferenceUrl: SUBCATEGORY_PREFERENCE_URL,
+        enabled: false,
+      }),
+    ).rejects.toThrow("channel is required");
+  });
+
+  it("rejects category updates already enabled", async () => {
+    const { service } = createNotificationsService();
+    vi.spyOn(service, "getPreferences").mockResolvedValue({
+      view_type: "category",
+      title: "Posting and commenting",
+      preference_url: DEFAULT_PREFERENCE_URL,
+      description: null,
+      master_toggle: {
+        label: "Allow post related notifications",
+        enabled: true,
+        selector_key: "allPostingAndCommentingNotificationSettings",
+      },
+      subcategories: [],
+    });
+
+    await expect(
+      service.prepareUpdatePreference({
+        preferenceUrl: DEFAULT_PREFERENCE_URL,
+        enabled: true,
+      }),
+    ).rejects.toThrow("already enabled");
+  });
+
+  it("rejects category updates already disabled", async () => {
+    const { service } = createNotificationsService();
+    vi.spyOn(service, "getPreferences").mockResolvedValue({
+      view_type: "category",
+      title: "Posting and commenting",
+      preference_url: DEFAULT_PREFERENCE_URL,
+      description: null,
+      master_toggle: {
+        label: "Allow post related notifications",
+        enabled: false,
+        selector_key: "allPostingAndCommentingNotificationSettings",
+      },
+      subcategories: [],
+    });
+
+    await expect(
+      service.prepareUpdatePreference({
+        preferenceUrl: DEFAULT_PREFERENCE_URL,
+        enabled: false,
+      }),
+    ).rejects.toThrow("already disabled");
+  });
+
+  it("rejects subcategory updates already at target state", async () => {
+    const { service } = createNotificationsService();
+    vi.spyOn(service, "getPreferences").mockResolvedValue({
+      view_type: "subcategory",
+      title: "Comments and reactions",
+      preference_url: SUBCATEGORY_PREFERENCE_URL,
+      description: null,
+      channels: [
+        {
+          channel_key: "email",
+          label: "Email",
+          enabled: false,
+          selector_key: "selector_email",
+        },
+      ],
+    });
+
+    await expect(
+      service.prepareUpdatePreference({
+        preferenceUrl: SUBCATEGORY_PREFERENCE_URL,
+        channel: "email",
+        enabled: false,
+      }),
+    ).rejects.toThrow("already disabled");
+  });
+
+  it("returns TARGET_NOT_FOUND when channel does not exist on subcategory page", async () => {
+    const { service } = createNotificationsService();
+    vi.spyOn(service, "getPreferences").mockResolvedValue({
+      view_type: "subcategory",
+      title: "Comments and reactions",
+      preference_url: SUBCATEGORY_PREFERENCE_URL,
+      description: null,
+      channels: [
+        {
+          channel_key: "in_app",
+          label: "In-app notifications",
+          enabled: true,
+          selector_key: "selector_in_app",
+        },
+      ],
+    });
+
+    await expect(
+      service.prepareUpdatePreference({
+        preferenceUrl: SUBCATEGORY_PREFERENCE_URL,
+        channel: "push",
+        enabled: false,
+      }),
+    ).rejects.toMatchObject({
+      code: "TARGET_NOT_FOUND",
+    });
+  });
+
+  it("prepares category updates with expected preview and payload", async () => {
+    const { service, prepare } = createNotificationsService();
+    vi.spyOn(service, "getPreferences").mockResolvedValue({
+      view_type: "category",
+      title: "Posting and commenting",
+      preference_url: DEFAULT_PREFERENCE_URL,
+      description: null,
+      master_toggle: {
+        label: "Allow post related notifications",
+        enabled: true,
+        selector_key: "allPostingAndCommentingNotificationSettings",
+      },
+      subcategories: [],
+    });
+
+    const prepared = await service.prepareUpdatePreference({
+      preferenceUrl: DEFAULT_PREFERENCE_URL,
+      enabled: false,
+    });
+
+    expect(prepared.preview).toMatchObject({
+      summary:
+        'Set LinkedIn notification preference "Posting and commenting" to off',
+      target: {
+        profile_name: "default",
+        view_type: "category",
+        channel: null,
+      },
+      current_enabled: true,
+      enabled: false,
+    });
+
+    expect(prepare).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: {
+          preference_url: DEFAULT_PREFERENCE_URL,
+          enabled: false,
+        },
+      }),
+    );
+  });
+
+  it("prepares subcategory updates with channel in preview and payload", async () => {
+    const { service, prepare } = createNotificationsService();
+    vi.spyOn(service, "getPreferences").mockResolvedValue({
+      view_type: "subcategory",
+      title: "Comments and reactions",
+      preference_url: SUBCATEGORY_PREFERENCE_URL,
+      description: null,
+      channels: [
+        {
+          channel_key: "push",
+          label: "Push",
+          enabled: true,
+          selector_key: "selector_push",
+        },
+      ],
+    });
+
+    const prepared = await service.prepareUpdatePreference({
+      preferenceUrl: SUBCATEGORY_PREFERENCE_URL,
+      channel: "Push",
+      enabled: false,
+    });
+
+    expect(prepared.preview).toMatchObject({
+      summary:
+        'Set LinkedIn notification preference "Comments and reactions" (push) to off',
+      target: {
+        view_type: "subcategory",
+        channel: "push",
+      },
+      current_enabled: true,
+      enabled: false,
+    });
+
+    expect(prepare).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: {
+          preference_url: SUBCATEGORY_PREFERENCE_URL,
+          enabled: false,
+          channel: "push",
+        },
+      }),
+    );
+  });
+
+  it("forwards operator note for preference updates", async () => {
+    const { service, prepare } = createNotificationsService();
+    vi.spyOn(service, "getPreferences").mockResolvedValue({
+      view_type: "category",
+      title: "Posting and commenting",
+      preference_url: DEFAULT_PREFERENCE_URL,
+      description: null,
+      master_toggle: {
+        label: "Allow post related notifications",
+        enabled: true,
+        selector_key: "allPostingAndCommentingNotificationSettings",
+      },
+      subcategories: [],
+    });
+
+    await service.prepareUpdatePreference({
+      preferenceUrl: DEFAULT_PREFERENCE_URL,
+      enabled: false,
+      operatorNote: "Disable noisy category",
+    });
+
+    expect(prepare).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operatorNote: "Disable noisy category",
+      }),
+    );
+  });
+
+  it("uses default profile name when not provided", async () => {
+    const { service, prepare } = createNotificationsService();
+    const getPreferences = vi
+      .spyOn(service, "getPreferences")
+      .mockResolvedValue({
+        view_type: "category",
+        title: "Posting and commenting",
+        preference_url: DEFAULT_PREFERENCE_URL,
+        description: null,
+        master_toggle: {
+          label: "Allow post related notifications",
+          enabled: true,
+          selector_key: "allPostingAndCommentingNotificationSettings",
+        },
+        subcategories: [],
+      });
+
+    await service.prepareUpdatePreference({
+      preferenceUrl: DEFAULT_PREFERENCE_URL,
+      enabled: false,
+    });
+
+    expect(getPreferences).toHaveBeenCalledWith({
+      profileName: "default",
+      preferenceUrl: DEFAULT_PREFERENCE_URL,
+    });
+    expect(prepare).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({
+          profile_name: "default",
+        }),
+      }),
+    );
+  });
+
+  it("normalizes channel values with punctuation and case", async () => {
+    const { service, prepare } = createNotificationsService();
+    vi.spyOn(service, "getPreferences").mockResolvedValue({
+      view_type: "subcategory",
+      title: "Comments and reactions",
+      preference_url: SUBCATEGORY_PREFERENCE_URL,
+      description: null,
+      channels: [
+        {
+          channel_key: "email",
+          label: "Email",
+          enabled: true,
+          selector_key: "selector_email",
+        },
+      ],
+    });
+
+    await service.prepareUpdatePreference({
+      preferenceUrl: SUBCATEGORY_PREFERENCE_URL,
+      channel: "E-mail",
+      enabled: false,
+    });
+
+    expect(prepare).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          channel: "email",
+        }),
+      }),
+    );
+  });
+
+  it("rejects unsupported channel values", async () => {
+    const { service } = createNotificationsService();
+    const getPreferences = vi.spyOn(service, "getPreferences");
+
+    await expect(
+      service.prepareUpdatePreference({
+        preferenceUrl: SUBCATEGORY_PREFERENCE_URL,
+        channel: "sms",
+        enabled: false,
+      }),
+    ).rejects.toThrow("channel must be one of");
+
+    expect(getPreferences).not.toHaveBeenCalled();
+  });
+
+  it("omits operator note when empty string is provided", async () => {
+    const { service, prepare } = createNotificationsService();
+    vi.spyOn(service, "getPreferences").mockResolvedValue({
+      view_type: "category",
+      title: "Posting and commenting",
+      preference_url: DEFAULT_PREFERENCE_URL,
+      description: null,
+      master_toggle: {
+        label: "Allow post related notifications",
+        enabled: true,
+        selector_key: "allPostingAndCommentingNotificationSettings",
+      },
+      subcategories: [],
+    });
+
+    await service.prepareUpdatePreference({
+      preferenceUrl: DEFAULT_PREFERENCE_URL,
+      enabled: false,
+      operatorNote: "",
+    });
+
+    const call = prepare.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(call).not.toHaveProperty("operatorNote");
   });
 });

--- a/packages/core/src/linkedinNotifications.ts
+++ b/packages/core/src/linkedinNotifications.ts
@@ -4,10 +4,7 @@ import type { ArtifactHelpers } from "./artifacts.js";
 import type { LinkedInAuthService } from "./auth/session.js";
 import { executeConfirmActionWithArtifacts } from "./confirmArtifacts.js";
 import type { ConfirmFailureArtifactConfig } from "./config.js";
-import {
-  LinkedInBuddyError,
-  asLinkedInBuddyError
-} from "./errors.js";
+import { LinkedInBuddyError, asLinkedInBuddyError } from "./errors.js";
 import { scrollLinkedInPageToBottom } from "./linkedinPage.js";
 import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
@@ -17,7 +14,7 @@ import type {
   ActionExecutor,
   ActionExecutorInput,
   ActionExecutorResult,
-  TwoPhaseCommitService
+  TwoPhaseCommitService,
 } from "./twoPhaseCommit.js";
 
 export interface LinkedInNotification {
@@ -72,8 +69,7 @@ export interface NotificationPreferenceToggleState {
   selector_key: string | null;
 }
 
-export interface NotificationPreferenceChannelState
-  extends NotificationPreferenceToggleState {
+export interface NotificationPreferenceChannelState extends NotificationPreferenceToggleState {
   channel_key: LinkedInNotificationPreferenceChannel | null;
 }
 
@@ -114,7 +110,7 @@ export interface GetLinkedInNotificationPreferencesInput {
 export const LINKEDIN_NOTIFICATION_PREFERENCE_CHANNELS = [
   "in_app",
   "push",
-  "email"
+  "email",
 ] as const;
 
 export type LinkedInNotificationPreferenceChannel =
@@ -138,8 +134,7 @@ export interface LinkedInNotificationsExecutorRuntime {
   confirmFailureArtifacts: ConfirmFailureArtifactConfig;
 }
 
-export interface LinkedInNotificationsRuntime
-  extends LinkedInNotificationsExecutorRuntime {
+export interface LinkedInNotificationsRuntime extends LinkedInNotificationsExecutorRuntime {
   twoPhaseCommit: Pick<
     TwoPhaseCommitService<LinkedInNotificationsExecutorRuntime>,
     "prepare"
@@ -200,25 +195,30 @@ interface PreferenceSwitchLocatorMatch {
 
 const LINKEDIN_BASE_URL = "https://www.linkedin.com";
 const LINKEDIN_NOTIFICATIONS_URL = `${LINKEDIN_BASE_URL}/notifications/`;
-const LINKEDIN_NOTIFICATIONS_PREFERENCES_URL =
-  `${LINKEDIN_BASE_URL}/mypreferences/d/categories/notifications`;
+const LINKEDIN_NOTIFICATIONS_PREFERENCES_URL = `${LINKEDIN_BASE_URL}/mypreferences/d/categories/notifications`;
 const NOTIFICATION_CARD_SELECTOR =
   "article.nt-card, .notification-card, div[data-view-name='notification-card-container'], div[data-urn], article";
 const NOTIFICATION_CARD_ROOT_SELECTOR = `${NOTIFICATION_CARD_SELECTOR}, li`;
 
 const SETTINGS_MENU_LABELS = {
   en: ["Settings menu", "More actions"],
-  da: ["Indstillingsmenu", "Flere handlinger"]
+  da: ["Indstillingsmenu", "Flere handlinger"],
 } as const;
 
 const DELETE_NOTIFICATION_LABELS = {
   en: ["Delete notification"],
-  da: ["Slet notifikation", "Slet meddelelse"]
+  da: ["Slet notifikation", "Slet meddelelse"],
 } as const;
 
 export const DISMISS_NOTIFICATION_ACTION_TYPE = "notifications.dismiss";
 export const UPDATE_NOTIFICATION_PREFERENCE_ACTION_TYPE =
   "notifications.update_preference";
+
+/** Maximum number of notifications returned by {@link LinkedInNotificationsService.listNotifications}. */
+export const NOTIFICATION_LIST_MAX_LIMIT = 100;
+
+/** Maximum number of notification cards to scan when locating a specific notification by ID. */
+export const NOTIFICATION_SCAN_MAX_LIMIT = 200;
 
 function normalizeText(value: string | null | undefined): string {
   return (value ?? "").replace(/\s+/g, " ").trim();
@@ -248,10 +248,11 @@ function dedupePhrases(values: readonly string[]): string[] {
 
 function buildPhraseRegex(
   phrases: readonly string[],
-  options: { exact?: boolean } = {}
+  options: { exact?: boolean } = {},
 ): RegExp {
   const normalizedPhrases = dedupePhrases(phrases);
-  const body = normalizedPhrases.map((phrase) => escapeRegExp(phrase)).join("|") || "^$";
+  const body =
+    normalizedPhrases.map((phrase) => escapeRegExp(phrase)).join("|") || "^$";
   const pattern = options.exact ? `^(?:${body})$` : `(?:${body})`;
   return new RegExp(pattern, "iu");
 }
@@ -260,11 +261,11 @@ function buildLocalizedRegex(
   selectorLocale: LinkedInSelectorLocale,
   english: readonly string[],
   danish: readonly string[],
-  options: { exact?: boolean } = {}
+  options: { exact?: boolean } = {},
 ): RegExp {
   return buildPhraseRegex(
     selectorLocale === "da" ? [...danish, ...english] : [...english, ...danish],
-    options
+    options,
   );
 }
 
@@ -284,11 +285,11 @@ function readNotificationsLimit(value: number | undefined): number {
     return 20;
   }
 
-  return Math.max(1, Math.floor(value));
+  return Math.min(NOTIFICATION_LIST_MAX_LIMIT, Math.max(1, Math.floor(value)));
 }
 
 function readNotificationScanLimit(value: number = 50): number {
-  return Math.max(10, Math.floor(value));
+  return Math.min(NOTIFICATION_SCAN_MAX_LIMIT, Math.max(10, Math.floor(value)));
 }
 
 function splitPreferenceSummaryText(text: string): {
@@ -300,18 +301,18 @@ function splitPreferenceSummaryText(text: string): {
   if (!match?.[1]) {
     return {
       title: normalized,
-      summary: null
+      summary: null,
     };
   }
 
   return {
     title: normalizeText(match[1]),
-    summary: normalizeText(match[2])
+    summary: normalizeText(match[2]),
   };
 }
 
 function inferNotificationPreferenceChannel(
-  value: string
+  value: string,
 ): LinkedInNotificationPreferenceChannel | null {
   const normalized = normalizeText(value).toLowerCase();
   if (!normalized) {
@@ -337,10 +338,16 @@ function inferNotificationPreferenceChannel(
 }
 
 export function normalizeLinkedInNotificationPreferenceChannel(
-  value: string
+  value: string,
 ): LinkedInNotificationPreferenceChannel {
-  const normalized = normalizeText(value).toLowerCase().replace(/[-\s]+/gu, "_");
-  if (normalized === "in_app" || normalized === "push" || normalized === "email") {
+  const normalized = normalizeText(value)
+    .toLowerCase()
+    .replace(/[-\s]+/gu, "_");
+  if (
+    normalized === "in_app" ||
+    normalized === "push" ||
+    normalized === "email"
+  ) {
     return normalized;
   }
 
@@ -351,12 +358,12 @@ export function normalizeLinkedInNotificationPreferenceChannel(
 
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    `channel must be one of: ${LINKEDIN_NOTIFICATION_PREFERENCE_CHANNELS.join(", ")}.`
+    `channel must be one of: ${LINKEDIN_NOTIFICATION_PREFERENCE_CHANNELS.join(", ")}.`,
   );
 }
 
 function resolveLinkedInNotificationPreferenceUrl(
-  value: string | undefined
+  value: string | undefined,
 ): string {
   const normalized = normalizeText(value);
   if (!normalized) {
@@ -376,20 +383,22 @@ function resolveLinkedInNotificationPreferenceUrl(
     normalized.includes("/notification-subcategories/") ||
     normalized.includes("/categories/notifications")
   ) {
-    const path = normalized.startsWith("mypreferences/") ? `/${normalized}` : normalized;
+    const path = normalized.startsWith("mypreferences/")
+      ? `/${normalized}`
+      : normalized;
     return new URL(path, LINKEDIN_BASE_URL).toString();
   }
 
   return new URL(
     `/mypreferences/d/notification-categories/${encodeURIComponent(normalized)}`,
-    LINKEDIN_BASE_URL
+    LINKEDIN_BASE_URL,
   ).toString();
 }
 
 async function waitForCondition(
   condition: () => Promise<boolean>,
   timeoutMs: number,
-  intervalMs: number = 250
+  intervalMs: number = 250,
 ): Promise<boolean> {
   const deadline = Date.now() + Math.max(0, timeoutMs);
 
@@ -416,14 +425,14 @@ async function getOrCreatePage(context: BrowserContext): Promise<Page> {
 
 async function findVisibleLocator(
   root: Page | Locator,
-  candidates: readonly VisibleLocatorCandidate[]
+  candidates: readonly VisibleLocatorCandidate[],
 ): Promise<{ locator: Locator; key: string } | null> {
   for (const candidate of candidates) {
     const locator = candidate.locatorFactory(root).first();
     if (await locator.isVisible().catch(() => false)) {
       return {
         locator,
-        key: candidate.key
+        key: candidate.key,
       };
     }
   }
@@ -438,14 +447,14 @@ async function waitForNotificationsSurface(page: Page): Promise<void> {
     "div[data-view-name='notification-card-container']",
     "div[data-urn]",
     "article",
-    "main"
+    "main",
   ];
 
   for (const selector of selectors) {
     try {
       await page.locator(selector).first().waitFor({
         state: "visible",
-        timeout: 5_000
+        timeout: 5_000,
       });
       return;
     } catch {
@@ -458,14 +467,14 @@ async function waitForNotificationsSurface(page: Page): Promise<void> {
     "Could not locate LinkedIn notification content.",
     {
       current_url: page.url(),
-      attempted_selectors: selectors
-    }
+      attempted_selectors: selectors,
+    },
   );
 }
 
 async function openNotificationsPage(page: Page): Promise<void> {
   await page.goto(LINKEDIN_NOTIFICATIONS_URL, {
-    waitUntil: "domcontentloaded"
+    waitUntil: "domcontentloaded",
   });
   await waitForNetworkIdleBestEffort(page);
   await waitForNotificationsSurface(page);
@@ -473,13 +482,13 @@ async function openNotificationsPage(page: Page): Promise<void> {
 
 async function openNotificationPreferencesPage(
   page: Page,
-  preferenceUrl: string
+  preferenceUrl: string,
 ): Promise<void> {
   const expectedPath = new URL(preferenceUrl).pathname;
 
   for (let attempt = 0; attempt < 2; attempt += 1) {
     await page.goto(preferenceUrl, {
-      waitUntil: "domcontentloaded"
+      waitUntil: "domcontentloaded",
     });
     await waitForNetworkIdleBestEffort(page);
 
@@ -509,13 +518,13 @@ async function openNotificationPreferencesPage(
 /* eslint-disable no-undef -- DOM types are valid inside page.evaluate() */
 async function extractNotificationSnapshots(
   page: Page,
-  limit: number
+  limit: number,
 ): Promise<NotificationSnapshot[]> {
   const candidates = await page.evaluate(
     ({
       maxNotifications,
       cardSelector,
-      cardRootSelector
+      cardRootSelector,
     }: {
       maxNotifications: number;
       cardSelector: string;
@@ -550,10 +559,11 @@ async function extractNotificationSnapshots(
       const pickHref = (root: ParentNode, selectors: string[]): string => {
         for (const selector of selectors) {
           const linkElement = root.querySelector(
-            selector
+            selector,
           ) as HTMLAnchorElement | null;
           const href = toAbsoluteHref(
-            normalize(linkElement?.getAttribute("href")) || normalize(linkElement?.href)
+            normalize(linkElement?.getAttribute("href")) ||
+              normalize(linkElement?.href),
           );
           if (href) {
             return href;
@@ -578,8 +588,10 @@ async function extractNotificationSnapshots(
           normalize(root.querySelector("[data-urn]")?.getAttribute("data-urn")),
           normalize(root.querySelector("[data-id]")?.getAttribute("data-id")),
           normalize(
-            root.querySelector("[data-notification-id]")?.getAttribute("data-notification-id")
-          )
+            root
+              .querySelector("[data-notification-id]")
+              ?.getAttribute("data-notification-id"),
+          ),
         ];
 
         for (const candidate of idCandidates) {
@@ -600,9 +612,10 @@ async function extractNotificationSnapshots(
         }
 
         const iconElement = root.querySelector(
-          "[class*='icon'], [class*='badge'], [data-test-icon], svg"
+          "[class*='icon'], [class*='badge'], [data-test-icon], svg",
         );
-        const signal = `${readClassName(iconElement)} ${readClassName(root)}`.toLowerCase();
+        const signal =
+          `${readClassName(iconElement)} ${readClassName(root)}`.toLowerCase();
         if (signal.includes("message")) {
           return "message";
         }
@@ -637,14 +650,15 @@ async function extractNotificationSnapshots(
         }
 
         const unreadIndicator = root.querySelector(
-          ".notification-status--unread, .notification-card__unread, .notification-card__unread-dot, .nt-card__unread, [data-test-notification-unread], [aria-label*='Unread'], [aria-label*='unread']"
+          ".notification-status--unread, .notification-card__unread, .notification-card__unread-dot, .nt-card__unread, [data-test-notification-unread], [aria-label*='Unread'], [aria-label*='unread']",
         );
         if (unreadIndicator) {
           return false;
         }
 
         const unreadData = normalize(
-          root.getAttribute("data-unread") ?? root.getAttribute("data-is-unread")
+          root.getAttribute("data-unread") ??
+            root.getAttribute("data-is-unread"),
         ).toLowerCase();
         if (unreadData === "true" || unreadData === "1") {
           return false;
@@ -657,10 +671,10 @@ async function extractNotificationSnapshots(
           [
             root.getAttribute("aria-label"),
             root.getAttribute("aria-description"),
-            root.querySelector("[aria-label]")?.getAttribute("aria-label")
+            root.querySelector("[aria-label]")?.getAttribute("aria-label"),
           ]
             .filter((value): value is string => typeof value === "string")
-            .join(" ")
+            .join(" "),
         ).toLowerCase();
 
         if (ariaSignal.includes("unread") || ariaSignal.includes("new")) {
@@ -673,13 +687,13 @@ async function extractNotificationSnapshots(
         return true;
       };
 
-      const cardCandidates = Array.from(globalThis.document.querySelectorAll(cardSelector));
+      const cardCandidates = Array.from(
+        globalThis.document.querySelectorAll(cardSelector),
+      );
       const uniqueCards: Element[] = [];
       const seenCards = new Set<Element>();
       for (const candidate of cardCandidates) {
-        const root =
-          candidate.closest(cardRootSelector) ??
-          candidate;
+        const root = candidate.closest(cardRootSelector) ?? candidate;
         if (seenCards.has(root)) {
           continue;
         }
@@ -704,7 +718,7 @@ async function extractNotificationSnapshots(
           "a[href*='/analytics/']",
           "a[href*='/jobs/view/']",
           "a[href*='/in/']",
-          "a"
+          "a",
         ]);
         const message =
           pickText(card, [
@@ -717,7 +731,7 @@ async function extractNotificationSnapshots(
             ".notification-card__body",
             ".notification-card__content",
             "p",
-            "span[dir='ltr']"
+            "span[dir='ltr']",
           ]) || normalize(card.textContent);
 
         const timestamp =
@@ -726,9 +740,8 @@ async function extractNotificationSnapshots(
             ".nt-card__time-ago",
             ".notification-card__timestamp",
             ".notification-card__time",
-            "[data-test-time-ago]"
-          ]) ||
-          normalize(card.querySelector("time")?.getAttribute("datetime"));
+            "[data-test-time-ago]",
+          ]) || normalize(card.querySelector("time")?.getAttribute("datetime"));
 
         notifications.push({
           raw_id: readRawNotificationId(card),
@@ -737,7 +750,7 @@ async function extractNotificationSnapshots(
           timestamp,
           link,
           is_read: inferReadState(card),
-          card_index: i
+          card_index: i,
         });
 
         if (notifications.length >= maxNotifications) {
@@ -750,8 +763,8 @@ async function extractNotificationSnapshots(
     {
       maxNotifications: Math.max(1, limit),
       cardSelector: NOTIFICATION_CARD_SELECTOR,
-      cardRootSelector: NOTIFICATION_CARD_ROOT_SELECTOR
-    }
+      cardRootSelector: NOTIFICATION_CARD_ROOT_SELECTOR,
+    },
   );
 
   return candidates
@@ -765,21 +778,21 @@ async function extractNotificationSnapshots(
           hashNotificationFingerprint({
             link,
             message,
-            timestamp
+            timestamp,
           }),
         type: normalizeText(candidate.type) || "notification",
         message,
         timestamp,
         link,
         is_read: Boolean(candidate.is_read),
-        card_index: Math.max(0, Math.floor(candidate.card_index))
+        card_index: Math.max(0, Math.floor(candidate.card_index)),
       } satisfies NotificationSnapshot;
     })
     .filter(
       (notification) =>
         notification.id.length > 0 ||
         notification.message.length > 0 ||
-        notification.link.length > 0
+        notification.link.length > 0,
     )
     .slice(0, limit);
 }
@@ -787,7 +800,7 @@ async function extractNotificationSnapshots(
 
 async function loadNotificationSnapshots(
   page: Page,
-  limit: number
+  limit: number,
 ): Promise<NotificationSnapshot[]> {
   let notifications = await extractNotificationSnapshots(page, limit);
 
@@ -803,19 +816,24 @@ async function loadNotificationSnapshots(
 async function findNotificationCard(
   page: Page,
   notificationId: string,
-  searchLimit: number = 50
+  searchLimit: number = 50,
 ): Promise<NotificationCardMatch | null> {
   const normalizedId = normalizeText(notificationId);
-  const snapshots = await loadNotificationSnapshots(page, readNotificationScanLimit(searchLimit));
+  const snapshots = await loadNotificationSnapshots(
+    page,
+    readNotificationScanLimit(searchLimit),
+  );
   const snapshot = snapshots.find((candidate) => candidate.id === normalizedId);
   if (!snapshot) {
     return null;
   }
 
-  const locator = page.locator(NOTIFICATION_CARD_SELECTOR).nth(snapshot.card_index);
+  const locator = page
+    .locator(NOTIFICATION_CARD_SELECTOR)
+    .nth(snapshot.card_index);
   return {
     snapshot,
-    locator
+    locator,
   };
 }
 
@@ -823,7 +841,7 @@ async function waitForNotificationState(
   page: Page,
   notificationId: string,
   matcher: (notification: NotificationSnapshot | null) => boolean,
-  searchLimit: number = 50
+  searchLimit: number = 50,
 ): Promise<boolean> {
   return waitForCondition(async () => {
     await openNotificationsPage(page);
@@ -833,39 +851,43 @@ async function waitForNotificationState(
 }
 
 async function clickNotificationPrimaryAction(
-  card: Locator
+  card: Locator,
 ): Promise<string | null> {
   const candidates = [
     {
       key: "headline-link",
       selectorHint: "card.locator('a.nt-card__headline')",
-      locatorFactory: (root: Page | Locator) => root.locator("a.nt-card__headline")
+      locatorFactory: (root: Page | Locator) =>
+        root.locator("a.nt-card__headline"),
     },
     {
       key: "body-link-button",
       selectorHint: "card.locator(\"button[role='link']\")",
-      locatorFactory: (root: Page | Locator) => root.locator("button[role='link']")
+      locatorFactory: (root: Page | Locator) =>
+        root.locator("button[role='link']"),
     },
     {
       key: "feed-link",
       selectorHint: "card.locator(\"a[href*='/feed/update/']\")",
-      locatorFactory: (root: Page | Locator) => root.locator("a[href*='/feed/update/']")
+      locatorFactory: (root: Page | Locator) =>
+        root.locator("a[href*='/feed/update/']"),
     },
     {
       key: "analytics-link",
       selectorHint: "card.locator(\"a[href*='/analytics/']\")",
-      locatorFactory: (root: Page | Locator) => root.locator("a[href*='/analytics/']")
+      locatorFactory: (root: Page | Locator) =>
+        root.locator("a[href*='/analytics/']"),
     },
     {
       key: "profile-link",
       selectorHint: "card.locator(\"a[href*='/in/']\")",
-      locatorFactory: (root: Page | Locator) => root.locator("a[href*='/in/']")
+      locatorFactory: (root: Page | Locator) => root.locator("a[href*='/in/']"),
     },
     {
       key: "fallback-link",
       selectorHint: "card.locator('a[href]')",
-      locatorFactory: (root: Page | Locator) => root.locator("a[href]")
-    }
+      locatorFactory: (root: Page | Locator) => root.locator("a[href]"),
+    },
   ] satisfies VisibleLocatorCandidate[];
 
   const match = await findVisibleLocator(card, candidates);
@@ -874,8 +896,10 @@ async function clickNotificationPrimaryAction(
       "UI_CHANGED_SELECTOR_FAILED",
       "Could not find a clickable LinkedIn notification target to mark as read.",
       {
-        attempted_selectors: candidates.map((candidate) => candidate.selectorHint)
-      }
+        attempted_selectors: candidates.map(
+          (candidate) => candidate.selectorHint,
+        ),
+      },
     );
   }
 
@@ -885,36 +909,36 @@ async function clickNotificationPrimaryAction(
 
 async function openNotificationSettingsMenu(
   card: Locator,
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): Promise<string> {
   const regex = buildLocalizedRegex(
     selectorLocale,
     SETTINGS_MENU_LABELS.en,
-    SETTINGS_MENU_LABELS.da
+    SETTINGS_MENU_LABELS.da,
   );
   const candidates = [
     {
       key: "settings-trigger-data-attr",
       selectorHint: "card.locator('[data-nt-card-settings-dropdown-trigger]')",
       locatorFactory: (root: Page | Locator) =>
-        root.locator("[data-nt-card-settings-dropdown-trigger]")
+        root.locator("[data-nt-card-settings-dropdown-trigger]"),
     },
     {
       key: "settings-trigger-role",
       selectorHint: "card.getByRole(button, /settings menu/iu)",
       locatorFactory: (root: Page | Locator) =>
         root.getByRole("button", {
-          name: regex
-        })
+          name: regex,
+        }),
     },
     {
       key: "settings-trigger-aria-label",
       selectorHint: "card.locator('button[aria-label]')",
       locatorFactory: (root: Page | Locator) =>
         root.locator("button[aria-label]").filter({
-          hasText: /^$/u
-        })
-    }
+          hasText: /^$/u,
+        }),
+    },
   ] satisfies VisibleLocatorCandidate[];
 
   const match = await findVisibleLocator(card, candidates);
@@ -923,8 +947,10 @@ async function openNotificationSettingsMenu(
       "UI_CHANGED_SELECTOR_FAILED",
       "Could not find the LinkedIn notification settings menu trigger.",
       {
-        attempted_selectors: candidates.map((candidate) => candidate.selectorHint)
-      }
+        attempted_selectors: candidates.map(
+          (candidate) => candidate.selectorHint,
+        ),
+      },
     );
   }
 
@@ -935,12 +961,12 @@ async function openNotificationSettingsMenu(
 
 async function clickNotificationDismissAction(
   page: Page,
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): Promise<string> {
   const deleteRegex = buildLocalizedRegex(
     selectorLocale,
     DELETE_NOTIFICATION_LABELS.en,
-    DELETE_NOTIFICATION_LABELS.da
+    DELETE_NOTIFICATION_LABELS.da,
   );
   const candidates = [
     {
@@ -948,25 +974,27 @@ async function clickNotificationDismissAction(
       selectorHint: "page.getByRole(button, /Delete notification/iu)",
       locatorFactory: (root: Page | Locator) =>
         root.getByRole("button", {
-          name: deleteRegex
-        })
+          name: deleteRegex,
+        }),
     },
     {
       key: "dismiss-dropdown-button",
-      selectorHint: "page.locator('.nt-card-settings-dropdown__content button')",
+      selectorHint:
+        "page.locator('.nt-card-settings-dropdown__content button')",
       locatorFactory: (root: Page | Locator) =>
         root.locator(".nt-card-settings-dropdown__content button").filter({
-          hasText: deleteRegex
-        })
+          hasText: deleteRegex,
+        }),
     },
     {
       key: "dismiss-button-text",
-      selectorHint: "page.locator('button').filter({hasText: /Delete notification/iu})",
+      selectorHint:
+        "page.locator('button').filter({hasText: /Delete notification/iu})",
       locatorFactory: (root: Page | Locator) =>
         root.locator("button").filter({
-          hasText: deleteRegex
-        })
-    }
+          hasText: deleteRegex,
+        }),
+    },
   ] satisfies VisibleLocatorCandidate[];
 
   const match = await findVisibleLocator(page, candidates);
@@ -975,8 +1003,10 @@ async function clickNotificationDismissAction(
       "UI_CHANGED_SELECTOR_FAILED",
       "Could not find the dismiss action for the LinkedIn notification.",
       {
-        attempted_selectors: candidates.map((candidate) => candidate.selectorHint)
-      }
+        attempted_selectors: candidates.map(
+          (candidate) => candidate.selectorHint,
+        ),
+      },
     );
   }
 
@@ -987,7 +1017,7 @@ async function clickNotificationDismissAction(
 
 /* eslint-disable no-undef -- DOM types are valid inside page.evaluate() */
 async function readNotificationPreferencePageState(
-  page: Page
+  page: Page,
 ): Promise<NotificationPreferencePageState> {
   return page.evaluate(() => {
     const normalize = (value: string | null | undefined): string =>
@@ -998,7 +1028,9 @@ async function readNotificationPreferencePageState(
       if (labelledBy) {
         const ids = labelledBy.split(/\s+/u).filter(Boolean);
         const labels = ids
-          .map((id) => normalize(globalThis.document.getElementById(id)?.textContent))
+          .map((id) =>
+            normalize(globalThis.document.getElementById(id)?.textContent),
+          )
           .filter((value) => value.length > 0);
         if (labels.length > 0) {
           return labels.join(" ");
@@ -1012,7 +1044,9 @@ async function readNotificationPreferencePageState(
       return labelledText;
     };
 
-    const inferChannel = (value: string): LinkedInNotificationPreferenceChannel | null => {
+    const inferChannel = (
+      value: string,
+    ): LinkedInNotificationPreferenceChannel | null => {
       const normalized = normalize(value).toLowerCase();
       if (!normalized) {
         return null;
@@ -1038,7 +1072,7 @@ async function readNotificationPreferencePageState(
 
     const getDescription = (): string | null => {
       const paragraphs = Array.from(
-        globalThis.document.querySelectorAll("main p, [role='main'] p")
+        globalThis.document.querySelectorAll("main p, [role='main'] p"),
       )
         .map((element) => normalize(element.textContent))
         .filter((value) => value.length > 0);
@@ -1047,23 +1081,26 @@ async function readNotificationPreferencePageState(
 
     const readSwitches = (): NotificationPreferenceSwitchSnapshot[] => {
       return Array.from(
-        globalThis.document.querySelectorAll("input[role='switch']")
+        globalThis.document.querySelectorAll("input[role='switch']"),
       ).map((element) => {
         const input = element as HTMLInputElement;
         const selectorKey =
-          normalize(input.getAttribute("aria-labelledby")) || normalize(input.id) || null;
+          normalize(input.getAttribute("aria-labelledby")) ||
+          normalize(input.id) ||
+          null;
         const label = readSwitchLabel(input);
         return {
           label,
           enabled: Boolean(input.checked),
           selector_key: selectorKey,
-          channel_key: inferChannel(`${selectorKey ?? ""} ${label}`)
+          channel_key: inferChannel(`${selectorKey ?? ""} ${label}`),
         };
       });
     };
 
     const title =
-      normalize(globalThis.document.querySelector("h1")?.textContent) || "Notifications";
+      normalize(globalThis.document.querySelector("h1")?.textContent) ||
+      "Notifications";
     const preferenceUrl = globalThis.window.location.href;
     const pathName = globalThis.window.location.pathname;
     const description = getDescription();
@@ -1076,9 +1113,9 @@ async function readNotificationPreferencePageState(
           title,
           preference_url: preferenceUrl,
           description,
-          channels: switches
+          channels: switches,
         },
-        switches
+        switches,
       } satisfies NotificationPreferencePageState;
     }
 
@@ -1086,8 +1123,8 @@ async function readNotificationPreferencePageState(
       const switches = readSwitches();
       const subcategories = Array.from(
         globalThis.document.querySelectorAll(
-          "a[href*='/mypreferences/d/notification-subcategories/']"
-        )
+          "a[href*='/mypreferences/d/notification-subcategories/']",
+        ),
       )
         .map((element) => {
           const anchor = element as HTMLAnchorElement;
@@ -1098,10 +1135,13 @@ async function readNotificationPreferencePageState(
             title: normalize(match?.[1] ?? text),
             slug: href.replace(/\/+$/u, "").split("/").pop() ?? "",
             summary: normalize(match?.[2] ?? "") || null,
-            preference_url: href
+            preference_url: href,
           };
         })
-        .filter((subcategory) => subcategory.title.length > 0 && subcategory.preference_url);
+        .filter(
+          (subcategory) =>
+            subcategory.title.length > 0 && subcategory.preference_url,
+        );
 
       return {
         page: {
@@ -1113,19 +1153,19 @@ async function readNotificationPreferencePageState(
             ? {
                 label: switches[0].label,
                 enabled: switches[0].enabled,
-                selector_key: switches[0].selector_key
+                selector_key: switches[0].selector_key,
               }
             : null,
-          subcategories
+          subcategories,
         },
-        switches
+        switches,
       } satisfies NotificationPreferencePageState;
     }
 
     const categories = Array.from(
       globalThis.document.querySelectorAll(
-        "a[href*='/mypreferences/d/notification-categories/']"
-      )
+        "a[href*='/mypreferences/d/notification-categories/']",
+      ),
     )
       .map((element) => {
         const anchor = element as HTMLAnchorElement;
@@ -1133,19 +1173,21 @@ async function readNotificationPreferencePageState(
         return {
           title: normalize(anchor.textContent),
           slug: href.replace(/\/+$/u, "").split("/").pop() ?? "",
-          preference_url: href
+          preference_url: href,
         };
       })
-      .filter((category) => category.title.length > 0 && category.preference_url);
+      .filter(
+        (category) => category.title.length > 0 && category.preference_url,
+      );
 
     return {
       page: {
         view_type: "overview",
         title,
         preference_url: preferenceUrl,
-        categories
+        categories,
       },
-      switches: []
+      switches: [],
     } satisfies NotificationPreferencePageState;
   });
 }
@@ -1153,7 +1195,7 @@ async function readNotificationPreferencePageState(
 
 async function findPreferenceSwitchLocator(
   page: Page,
-  channel: LinkedInNotificationPreferenceChannel | undefined
+  channel: LinkedInNotificationPreferenceChannel | undefined,
 ): Promise<PreferenceSwitchLocatorMatch> {
   const switches = page.locator("input[role='switch']");
   const toggles = page.locator(".setting-toggle__toggle");
@@ -1170,7 +1212,9 @@ async function findPreferenceSwitchLocator(
           const ids = id.split(/\s+/u).filter(Boolean);
           return ids
             .map((part) => {
-              return (globalThis.document.getElementById(part)?.textContent ?? "")
+              return (
+                globalThis.document.getElementById(part)?.textContent ?? ""
+              )
                 .replace(/\s+/g, " ")
                 .trim();
             })
@@ -1179,7 +1223,7 @@ async function findPreferenceSwitchLocator(
         }, selectorKey)
       : "";
     const inferredChannel = inferNotificationPreferenceChannel(
-      `${selectorKey ?? ""} ${label}`
+      `${selectorKey ?? ""} ${label}`,
     );
 
     if (channel && inferredChannel !== channel) {
@@ -1193,27 +1237,27 @@ async function findPreferenceSwitchLocator(
       label: normalizeText(label),
       enabled: await locator.isChecked().catch(() => false),
       selectorKey,
-      channelKey: inferredChannel
+      channelKey: inferredChannel,
     };
   }
 
   if (channel) {
     throw new LinkedInBuddyError(
       "TARGET_NOT_FOUND",
-      `Could not find the ${channel} notification preference switch on the page.`
+      `Could not find the ${channel} notification preference switch on the page.`,
     );
   }
 
   throw new LinkedInBuddyError(
     "TARGET_NOT_FOUND",
-    "Could not find a notification preference switch on the page."
+    "Could not find a notification preference switch on the page.",
   );
 }
 
 async function executeDismissNotification(
   runtime: LinkedInNotificationsExecutorRuntime,
   actionId: string,
-  target: Record<string, unknown>
+  target: Record<string, unknown>,
 ): Promise<{ result: Record<string, unknown>; artifacts: string[] }> {
   const profileName = String(target.profile_name ?? "default");
   const notificationId = String(target.notification_id ?? "");
@@ -1222,7 +1266,7 @@ async function executeDismissNotification(
     {
       cdpUrl: runtime.cdpUrl,
       profileName,
-      headless: true
+      headless: true,
     },
     async (context) => {
       const page = await getOrCreatePage(context);
@@ -1235,16 +1279,16 @@ async function executeDismissNotification(
         profileName,
         targetUrl: LINKEDIN_NOTIFICATIONS_URL,
         metadata: {
-          notification_id: notificationId
+          notification_id: notificationId,
         },
         errorDetails: {
-          notification_id: notificationId
+          notification_id: notificationId,
         },
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
             "UNKNOWN",
-            "Failed to execute LinkedIn notification dismiss action."
+            "Failed to execute LinkedIn notification dismiss action.",
           ),
         execute: async () => {
           await openNotificationsPage(page);
@@ -1254,25 +1298,25 @@ async function executeDismissNotification(
               "TARGET_NOT_FOUND",
               `Could not find LinkedIn notification ${notificationId}.`,
               {
-                notification_id: notificationId
-              }
+                notification_id: notificationId,
+              },
             );
           }
 
           const settingsMenuKey = await openNotificationSettingsMenu(
             match.locator,
-            runtime.selectorLocale
+            runtime.selectorLocale,
           );
           const dismissSelectorKey = await clickNotificationDismissAction(
             page,
-            runtime.selectorLocale
+            runtime.selectorLocale,
           );
 
           const removed = await waitForNotificationState(
             page,
             notificationId,
             (notification) => notification === null,
-            75
+            75,
           );
           if (!removed) {
             throw new LinkedInBuddyError(
@@ -1281,8 +1325,8 @@ async function executeDismissNotification(
               {
                 notification_id: notificationId,
                 settings_menu_key: settingsMenuKey,
-                dismiss_selector_key: dismissSelectorKey
-              }
+                dismiss_selector_key: dismissSelectorKey,
+              },
             );
           }
 
@@ -1292,13 +1336,13 @@ async function executeDismissNotification(
               status: "notification_dismissed",
               notification_id: notificationId,
               settings_menu_key: settingsMenuKey,
-              dismiss_selector_key: dismissSelectorKey
+              dismiss_selector_key: dismissSelectorKey,
             },
-            artifacts: []
+            artifacts: [],
           };
-        }
+        },
       });
-    }
+    },
   );
 }
 
@@ -1306,11 +1350,11 @@ async function executeUpdateNotificationPreference(
   runtime: LinkedInNotificationsExecutorRuntime,
   actionId: string,
   target: Record<string, unknown>,
-  payload: Record<string, unknown>
+  payload: Record<string, unknown>,
 ): Promise<{ result: Record<string, unknown>; artifacts: string[] }> {
   const profileName = String(target.profile_name ?? "default");
   const preferenceUrl = resolveLinkedInNotificationPreferenceUrl(
-    String(target.preference_url ?? payload.preference_url ?? "")
+    String(target.preference_url ?? payload.preference_url ?? ""),
   );
   const enabled = Boolean(payload.enabled);
   const channelRaw = normalizeText(String(payload.channel ?? ""));
@@ -1322,7 +1366,7 @@ async function executeUpdateNotificationPreference(
     {
       cdpUrl: runtime.cdpUrl,
       profileName,
-      headless: true
+      headless: true,
     },
     async (context) => {
       const page = await getOrCreatePage(context);
@@ -1337,18 +1381,18 @@ async function executeUpdateNotificationPreference(
         metadata: {
           preference_url: preferenceUrl,
           channel: channel ?? null,
-          enabled
+          enabled,
         },
         errorDetails: {
           preference_url: preferenceUrl,
           channel: channel ?? null,
-          enabled
+          enabled,
         },
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
             "UNKNOWN",
-            "Failed to execute LinkedIn notification preference update."
+            "Failed to execute LinkedIn notification preference update.",
           ),
         execute: async () => {
           await openNotificationPreferencesPage(page, preferenceUrl);
@@ -1357,14 +1401,14 @@ async function executeUpdateNotificationPreference(
           if (initialState.page.view_type === "overview") {
             throw new LinkedInBuddyError(
               "ACTION_PRECONDITION_FAILED",
-              "Notification preference updates require a category or subcategory page, not the overview."
+              "Notification preference updates require a category or subcategory page, not the overview.",
             );
           }
 
           if (initialState.page.view_type === "subcategory" && !channel) {
             throw new LinkedInBuddyError(
               "ACTION_PRECONDITION_FAILED",
-              "channel is required when updating a notification preference subcategory."
+              "channel is required when updating a notification preference subcategory.",
             );
           }
 
@@ -1375,18 +1419,21 @@ async function executeUpdateNotificationPreference(
               `${targetSwitch.label || "The selected notification preference"} is already ${enabled ? "enabled" : "disabled"}.`,
               {
                 preference_url: preferenceUrl,
-                channel: targetSwitch.channelKey ?? null
-              }
+                channel: targetSwitch.channelKey ?? null,
+              },
             );
           }
 
           await targetSwitch.toggleLocator.click({
-            timeout: 5_000
+            timeout: 5_000,
           });
           await page.waitForTimeout(750);
           await openNotificationPreferencesPage(page, preferenceUrl);
 
-          const refreshedSwitch = await findPreferenceSwitchLocator(page, channel);
+          const refreshedSwitch = await findPreferenceSwitchLocator(
+            page,
+            channel,
+          );
           if (refreshedSwitch.enabled !== enabled) {
             throw new LinkedInBuddyError(
               "UNKNOWN",
@@ -1394,8 +1441,8 @@ async function executeUpdateNotificationPreference(
               {
                 preference_url: preferenceUrl,
                 channel: refreshedSwitch.channelKey ?? channel ?? null,
-                selector_key: refreshedSwitch.selectorKey
-              }
+                selector_key: refreshedSwitch.selectorKey,
+              },
             );
           }
 
@@ -1409,51 +1456,47 @@ async function executeUpdateNotificationPreference(
               channel: refreshedSwitch.channelKey ?? null,
               previous_enabled: targetSwitch.enabled,
               enabled,
-              selector_key: refreshedSwitch.selectorKey
+              selector_key: refreshedSwitch.selectorKey,
             },
-            artifacts: []
+            artifacts: [],
           };
-        }
+        },
       });
-    }
+    },
   );
 }
 
-export class DismissNotificationActionExecutor
-  implements ActionExecutor<LinkedInNotificationsExecutorRuntime>
-{
+export class DismissNotificationActionExecutor implements ActionExecutor<LinkedInNotificationsExecutorRuntime> {
   async execute(
-    input: ActionExecutorInput<LinkedInNotificationsExecutorRuntime>
+    input: ActionExecutorInput<LinkedInNotificationsExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
     const { result, artifacts } = await executeDismissNotification(
       input.runtime,
       input.action.id,
-      input.action.target
+      input.action.target,
     );
     return {
       ok: true,
       result,
-      artifacts
+      artifacts,
     };
   }
 }
 
-export class UpdateNotificationPreferenceActionExecutor
-  implements ActionExecutor<LinkedInNotificationsExecutorRuntime>
-{
+export class UpdateNotificationPreferenceActionExecutor implements ActionExecutor<LinkedInNotificationsExecutorRuntime> {
   async execute(
-    input: ActionExecutorInput<LinkedInNotificationsExecutorRuntime>
+    input: ActionExecutorInput<LinkedInNotificationsExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
     const { result, artifacts } = await executeUpdateNotificationPreference(
       input.runtime,
       input.action.id,
       input.action.target,
-      input.action.payload
+      input.action.payload,
     );
     return {
       ok: true,
       result,
-      artifacts
+      artifacts,
     };
   }
 }
@@ -1465,7 +1508,7 @@ export function createNotificationActionExecutors(): Record<
   return {
     [DISMISS_NOTIFICATION_ACTION_TYPE]: new DismissNotificationActionExecutor(),
     [UPDATE_NOTIFICATION_PREFERENCE_ACTION_TYPE]:
-      new UpdateNotificationPreferenceActionExecutor()
+      new UpdateNotificationPreferenceActionExecutor(),
   };
 }
 
@@ -1473,14 +1516,14 @@ export class LinkedInNotificationsService {
   constructor(private readonly runtime: LinkedInNotificationsRuntime) {}
 
   async listNotifications(
-    input: ListNotificationsInput = {}
+    input: ListNotificationsInput = {},
   ): Promise<LinkedInNotification[]> {
     const profileName = input.profileName ?? "default";
     const limit = readNotificationsLimit(input.limit);
 
     await this.runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: this.runtime.cdpUrl
+      cdpUrl: this.runtime.cdpUrl,
     });
 
     try {
@@ -1488,7 +1531,7 @@ export class LinkedInNotificationsService {
         {
           cdpUrl: this.runtime.cdpUrl,
           profileName,
-          headless: true
+          headless: true,
         },
         async (context) => {
           const page = await getOrCreatePage(context);
@@ -1501,10 +1544,10 @@ export class LinkedInNotificationsService {
               message: notification.message,
               timestamp: notification.timestamp,
               link: notification.link,
-              is_read: notification.is_read
+              is_read: notification.is_read,
             };
           });
-        }
+        },
       );
     } catch (error) {
       if (error instanceof LinkedInBuddyError) {
@@ -1513,26 +1556,26 @@ export class LinkedInNotificationsService {
       throw asLinkedInBuddyError(
         error,
         "UNKNOWN",
-        "Failed to list LinkedIn notifications."
+        "Failed to list LinkedIn notifications.",
       );
     }
   }
 
   async markRead(
-    input: MarkNotificationReadInput
+    input: MarkNotificationReadInput,
   ): Promise<MarkNotificationReadResult> {
     const profileName = input.profileName ?? "default";
     const notificationId = normalizeText(input.notificationId);
     if (!notificationId) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "notificationId is required."
+        "notificationId is required.",
       );
     }
 
     await this.runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: this.runtime.cdpUrl
+      cdpUrl: this.runtime.cdpUrl,
     });
 
     try {
@@ -1540,7 +1583,7 @@ export class LinkedInNotificationsService {
         {
           cdpUrl: this.runtime.cdpUrl,
           profileName,
-          headless: true
+          headless: true,
         },
         async (context) => {
           const page = await getOrCreatePage(context);
@@ -1551,8 +1594,8 @@ export class LinkedInNotificationsService {
               "TARGET_NOT_FOUND",
               `Could not find LinkedIn notification ${notificationId}.`,
               {
-                notification_id: notificationId
-              }
+                notification_id: notificationId,
+              },
             );
           }
 
@@ -1562,16 +1605,18 @@ export class LinkedInNotificationsService {
               was_already_read: true,
               notification_id: notificationId,
               link: match.snapshot.link,
-              selector_key: null
+              selector_key: null,
             };
           }
 
-          const selectorKey = await clickNotificationPrimaryAction(match.locator);
+          const selectorKey = await clickNotificationPrimaryAction(
+            match.locator,
+          );
           const verified = await waitForNotificationState(
             page,
             notificationId,
             (notification) => notification?.is_read === true,
-            75
+            75,
           );
           if (!verified) {
             throw new LinkedInBuddyError(
@@ -1579,8 +1624,8 @@ export class LinkedInNotificationsService {
               "LinkedIn notification mark_read action could not be verified after opening the notification.",
               {
                 notification_id: notificationId,
-                selector_key: selectorKey
-              }
+                selector_key: selectorKey,
+              },
             );
           }
 
@@ -1589,9 +1634,9 @@ export class LinkedInNotificationsService {
             was_already_read: false,
             notification_id: notificationId,
             link: match.snapshot.link,
-            selector_key: selectorKey
+            selector_key: selectorKey,
           };
-        }
+        },
       );
     } catch (error) {
       if (error instanceof LinkedInBuddyError) {
@@ -1600,28 +1645,30 @@ export class LinkedInNotificationsService {
       throw asLinkedInBuddyError(
         error,
         "UNKNOWN",
-        "Failed to mark the LinkedIn notification as read."
+        "Failed to mark the LinkedIn notification as read.",
       );
     }
   }
 
   async prepareDismissNotification(
-    input: PrepareDismissLinkedInNotificationInput
-  ): Promise<ReturnType<LinkedInNotificationsRuntime["twoPhaseCommit"]["prepare"]>> {
+    input: PrepareDismissLinkedInNotificationInput,
+  ): Promise<
+    ReturnType<LinkedInNotificationsRuntime["twoPhaseCommit"]["prepare"]>
+  > {
     const profileName = input.profileName ?? "default";
     const notificationId = normalizeText(input.notificationId);
     if (!notificationId) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "notificationId is required."
+        "notificationId is required.",
       );
     }
 
     const notification = await this.listNotifications({
       profileName,
-      limit: 75
+      limit: 75,
     }).then((notifications) =>
-      notifications.find((candidate) => candidate.id === notificationId)
+      notifications.find((candidate) => candidate.id === notificationId),
     );
 
     if (!notification) {
@@ -1629,8 +1676,8 @@ export class LinkedInNotificationsService {
         "TARGET_NOT_FOUND",
         `Could not find LinkedIn notification ${notificationId}.`,
         {
-          notification_id: notificationId
-        }
+          notification_id: notificationId,
+        },
       );
     }
 
@@ -1638,38 +1685,40 @@ export class LinkedInNotificationsService {
       profile_name: profileName,
       notification_id: notification.id,
       notification_link: notification.link,
-      notification_type: notification.type
+      notification_type: notification.type,
     } satisfies Record<string, unknown>;
     const preview = {
       summary: `Dismiss LinkedIn notification "${notification.message || notification.id}"`,
       target,
-      notification
+      notification,
     } satisfies Record<string, unknown>;
 
     return this.runtime.twoPhaseCommit.prepare({
       actionType: DISMISS_NOTIFICATION_ACTION_TYPE,
       target,
       payload: {
-        notification_id: notification.id
+        notification_id: notification.id,
       },
       preview,
       ...(input.operatorNote
         ? {
-            operatorNote: input.operatorNote
+            operatorNote: input.operatorNote,
           }
-        : {})
+        : {}),
     });
   }
 
   async getPreferences(
-    input: GetLinkedInNotificationPreferencesInput = {}
+    input: GetLinkedInNotificationPreferencesInput = {},
   ): Promise<LinkedInNotificationPreferencePage> {
     const profileName = input.profileName ?? "default";
-    const preferenceUrl = resolveLinkedInNotificationPreferenceUrl(input.preferenceUrl);
+    const preferenceUrl = resolveLinkedInNotificationPreferenceUrl(
+      input.preferenceUrl,
+    );
 
     await this.runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: this.runtime.cdpUrl
+      cdpUrl: this.runtime.cdpUrl,
     });
 
     try {
@@ -1677,7 +1726,7 @@ export class LinkedInNotificationsService {
         {
           cdpUrl: this.runtime.cdpUrl,
           profileName,
-          headless: true
+          headless: true,
         },
         async (context) => {
           const page = await getOrCreatePage(context);
@@ -1691,8 +1740,8 @@ export class LinkedInNotificationsService {
                 ...category,
                 title: normalizeText(category.title),
                 slug: normalizeText(category.slug),
-                preference_url: normalizeText(category.preference_url)
-              }))
+                preference_url: normalizeText(category.preference_url),
+              })),
             };
           }
 
@@ -1705,9 +1754,9 @@ export class LinkedInNotificationsService {
                   title: split.title || normalizeText(subcategory.title),
                   slug: normalizeText(subcategory.slug),
                   summary: subcategory.summary ?? split.summary,
-                  preference_url: normalizeText(subcategory.preference_url)
+                  preference_url: normalizeText(subcategory.preference_url),
                 };
-              })
+              }),
             };
           }
 
@@ -1715,10 +1764,10 @@ export class LinkedInNotificationsService {
             ...state.page,
             channels: state.page.channels.map((channel) => ({
               ...channel,
-              label: normalizeText(channel.label)
-            }))
+              label: normalizeText(channel.label),
+            })),
           };
-        }
+        },
       );
     } catch (error) {
       if (error instanceof LinkedInBuddyError) {
@@ -1727,28 +1776,32 @@ export class LinkedInNotificationsService {
       throw asLinkedInBuddyError(
         error,
         "UNKNOWN",
-        "Failed to read LinkedIn notification preferences."
+        "Failed to read LinkedIn notification preferences.",
       );
     }
   }
 
   async prepareUpdatePreference(
-    input: PrepareUpdateLinkedInNotificationPreferenceInput
-  ): Promise<ReturnType<LinkedInNotificationsRuntime["twoPhaseCommit"]["prepare"]>> {
+    input: PrepareUpdateLinkedInNotificationPreferenceInput,
+  ): Promise<
+    ReturnType<LinkedInNotificationsRuntime["twoPhaseCommit"]["prepare"]>
+  > {
     const profileName = input.profileName ?? "default";
-    const preferenceUrl = resolveLinkedInNotificationPreferenceUrl(input.preferenceUrl);
+    const preferenceUrl = resolveLinkedInNotificationPreferenceUrl(
+      input.preferenceUrl,
+    );
     const channel = input.channel
       ? normalizeLinkedInNotificationPreferenceChannel(String(input.channel))
       : undefined;
     const page = await this.getPreferences({
       profileName,
-      preferenceUrl
+      preferenceUrl,
     });
 
     if (page.view_type === "overview") {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "Notification preference updates require a category or subcategory page, not the overview."
+        "Notification preference updates require a category or subcategory page, not the overview.",
       );
     }
 
@@ -1756,18 +1809,18 @@ export class LinkedInNotificationsService {
       page.view_type === "category"
         ? {
             currentEnabled: page.master_toggle?.enabled ?? null,
-            label: page.master_toggle?.label ?? page.title
+            label: page.master_toggle?.label ?? page.title,
           }
         : (() => {
             if (!channel) {
               throw new LinkedInBuddyError(
                 "ACTION_PRECONDITION_FAILED",
-                "channel is required when updating a notification preference subcategory."
+                "channel is required when updating a notification preference subcategory.",
               );
             }
 
             const targetChannel = page.channels.find(
-              (candidate) => candidate.channel_key === channel
+              (candidate) => candidate.channel_key === channel,
             );
             if (!targetChannel) {
               throw new LinkedInBuddyError(
@@ -1775,14 +1828,14 @@ export class LinkedInNotificationsService {
                 `Could not find the ${channel} notification preference switch on ${page.title}.`,
                 {
                   preference_url: preferenceUrl,
-                  channel
-                }
+                  channel,
+                },
               );
             }
 
             return {
               currentEnabled: targetChannel.enabled,
-              label: targetChannel.label || page.title
+              label: targetChannel.label || page.title,
             };
           })();
 
@@ -1792,8 +1845,8 @@ export class LinkedInNotificationsService {
         `${targetState.label} is already ${input.enabled ? "enabled" : "disabled"}.`,
         {
           preference_url: preferenceUrl,
-          channel: channel ?? null
-        }
+          channel: channel ?? null,
+        },
       );
     }
 
@@ -1802,7 +1855,7 @@ export class LinkedInNotificationsService {
       preference_url: preferenceUrl,
       view_type: page.view_type,
       preference_title: page.title,
-      channel: channel ?? null
+      channel: channel ?? null,
     } satisfies Record<string, unknown>;
     const preview = {
       summary:
@@ -1811,7 +1864,7 @@ export class LinkedInNotificationsService {
           : `Set LinkedIn notification preference "${page.title}" (${channel}) to ${input.enabled ? "on" : "off"}`,
       target,
       current_enabled: targetState.currentEnabled,
-      enabled: input.enabled
+      enabled: input.enabled,
     } satisfies Record<string, unknown>;
 
     return this.runtime.twoPhaseCommit.prepare({
@@ -1820,14 +1873,14 @@ export class LinkedInNotificationsService {
       payload: {
         preference_url: preferenceUrl,
         enabled: input.enabled,
-        ...(channel ? { channel } : {})
+        ...(channel ? { channel } : {}),
       },
       preview,
       ...(input.operatorNote
         ? {
-            operatorNote: input.operatorNote
+            operatorNote: input.operatorNote,
           }
-        : {})
+        : {}),
     });
   }
 }


### PR DESCRIPTION
## Summary

Quality pass on the **Notifications** feature (#240, originally implemented in PR #308). Covers phases 3–8 from issue #356.

## Changes

### Phase 3 — Simplify + Refactor
- Audited code — no dead code, duplicate logic, or unnecessary complexity found. The notifications module is well-structured.

### Phase 5 — Harden
- Added 2 exported max-limit constants to `linkedinNotifications.ts`:
  - `NOTIFICATION_LIST_MAX_LIMIT` (100) — caps the maximum notifications returned by `listNotifications`
  - `NOTIFICATION_SCAN_MAX_LIMIT` (200) — caps the maximum cards scanned when locating a notification by ID
- Applied upper-bound caps in `readNotificationsLimit()` and `readNotificationScanLimit()`

### Phase 4 — Test
- Expanded `linkedinNotifications.test.ts` from 7 to 47 test cases
- Covers: action type constants, limit constants, `normalizeLinkedInNotificationPreferenceChannel` edge cases (casing, whitespace, aliases, invalid), `createNotificationActionExecutors` structure, `prepareDismissNotification` error paths (empty ID, not found, profile forwarding, operator note), `prepareUpdatePreference` error paths (overview page, already-at-state, channel required, channel not found, unsupported channel)

### Phase 6 — UX/QoL
- Added 4 `run*` functions to CLI: `runNotificationsMarkRead`, `runNotificationsDismiss`, `runNotificationsPreferencesGet`, `runNotificationsPreferencesPrepareUpdate`
- Added 4 CLI command registrations: `notifications mark-read`, `notifications dismiss`, `notifications preferences get`, `notifications preferences prepare-update`

### Phase 8 — Docs
- Created `docs/notifications.md` covering CLI, MCP, TypeScript API usage, limits, error codes, and artifacts
- Added entry to README docs map

## Verification
- `npm run lint` — passes
- `npm test -- --run` — 1104 tests pass (104 files)
- Pre-existing build errors confirmed identical on base branch

Closes #356
