### PR TITLE
feat: quality pass for agent feedback loop (#306)

### DIFF
--- a/docs/agent-feedback.md
+++ b/docs/agent-feedback.md
@@ -1,0 +1,75 @@
+# Agent feedback
+
+The feedback module lets operators and AI agents file bug reports, feature requests, and improvement suggestions as GitHub issues directly from the CLI or MCP server. PII is scrubbed automatically before submission.
+
+## Quickstart
+
+Use the interactive mode to file feedback:
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin feedback
+```
+
+File feedback directly with flags:
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin feedback \
+  --type bug \
+  --title "Connection request failure" \
+  --description "The agent failed to send a connection request to URN 12345"
+```
+
+Flush saved feedback files:
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin feedback --submit-pending
+```
+
+## MCP tool
+
+The `submit_feedback` tool allows agents to report issues or suggest improvements. It requires three parameters:
+
+- `type`: Must be one of `bug`, `feature`, or `improvement`.
+- `title`: A short summary of the feedback.
+- `description`: Detailed information about the report or suggestion.
+
+## Privacy scrubbing
+
+The system automatically redacts sensitive information before submission. Redacted content is replaced with `[REDACTED]`. Scrubbed data includes:
+
+- emails and IP addresses
+- LinkedIn URLs and URNs
+- JWT tokens, Bearer tokens, and cookies
+- auth headers and secret assignments
+- user-home file paths
+- long base64 blobs
+
+## Pending feedback
+
+When `gh auth status` fails, feedback is saved as `.md` files under `~/.linkedin-buddy/pending-feedback/`. You can submit these later with `linkedin-buddy feedback --submit-pending` after running `gh auth login`. The system maintains a 50-file limit for pending feedback.
+
+## Feedback hints
+
+Hints appear on the first session use, every 20th invocation, and after errors. You can configure the frequency with the `LINKEDIN_BUDDY_FEEDBACK_HINT_EVERY_N` environment variable. Hints are context-aware, providing different messages for errors versus regular usage. The session idle timeout defaults to 30 minutes and is configurable via `LINKEDIN_BUDDY_FEEDBACK_SESSION_IDLE_MS`.
+
+## GitHub issue labels
+
+| Type        | Labels                          |
+| :---------- | :------------------------------ |
+| bug         | `bug`, `agent-feedback`         |
+| feature     | `enhancement`, `agent-feedback` |
+| improvement | `improvement`, `agent-feedback` |
+
+## Configuration
+
+| Variable                                  | Default | Description                            |
+| :---------------------------------------- | :------ | :------------------------------------- |
+| `LINKEDIN_BUDDY_FEEDBACK_HINT_EVERY_N`    | 20      | Show hint every N invocations          |
+| `LINKEDIN_BUDDY_FEEDBACK_SESSION_IDLE_MS` | 1800000 | Reset session after this idle duration |
+
+## Hardening limits
+
+- 30s `gh` command timeout
+- 50 maximum pending files
+- 512KB maximum pending file size
+- 12KB maximum error stack in technical context

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -1472,7 +1472,7 @@ async function maybeEmitCliFeedbackHint(error?: unknown): Promise<void> {
     });
 
     if (decision.showHint) {
-      writeCliNotice(buildFeedbackHintMessage());
+      writeCliNotice(buildFeedbackHintMessage(decision.reason));
     }
   } catch (trackingError) {
     writeCliWarning(

--- a/packages/cli/test/feedbackCli.test.ts
+++ b/packages/cli/test/feedbackCli.test.ts
@@ -8,14 +8,14 @@ const feedbackCliMocks = vi.hoisted(() => ({
   readFeedbackStateSnapshot: vi.fn(),
   recordFeedbackInvocation: vi.fn(),
   submitFeedback: vi.fn(),
-  submitPendingFeedback: vi.fn()
+  submitPendingFeedback: vi.fn(),
 }));
 
 vi.mock("node:readline/promises", () => ({
   createInterface: feedbackCliMocks.createInterface.mockImplementation(() => ({
     close: feedbackCliMocks.close,
-    question: feedbackCliMocks.question
-  }))
+    question: feedbackCliMocks.question,
+  })),
 }));
 
 vi.mock("@linkedin-buddy/core", async () => {
@@ -25,7 +25,7 @@ vi.mock("@linkedin-buddy/core", async () => {
     readFeedbackStateSnapshot: feedbackCliMocks.readFeedbackStateSnapshot,
     recordFeedbackInvocation: feedbackCliMocks.recordFeedbackInvocation,
     submitFeedback: feedbackCliMocks.submitFeedback,
-    submitPendingFeedback: feedbackCliMocks.submitPendingFeedback
+    submitPendingFeedback: feedbackCliMocks.submitPendingFeedback,
   };
 });
 
@@ -34,22 +34,22 @@ import { runCli } from "../src/bin/linkedin.js";
 function setInteractiveMode(inputIsTty: boolean, outputIsTty: boolean): void {
   Object.defineProperty(stdin, "isTTY", {
     configurable: true,
-    value: inputIsTty
+    value: inputIsTty,
   });
   Object.defineProperty(stdout, "isTTY", {
     configurable: true,
-    value: outputIsTty
+    value: outputIsTty,
   });
   Object.defineProperty(process.stderr, "isTTY", {
     configurable: true,
-    value: outputIsTty
+    value: outputIsTty,
   });
 }
 
 describe("linkedin feedback CLI", () => {
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
   let previousAssistantHome: string | undefined;
-  let stderrWriteSpy: ReturnType<typeof vi.spyOn>;
+  let stderrWriteSpy: { mockRestore: () => void };
   let stdoutChunks: string[] = [];
   let stderrChunks: string[] = [];
 
@@ -69,7 +69,7 @@ describe("linkedin feedback CLI", () => {
       lastMcpToolName: null,
       sessionDurationMs: 60_000,
       sessionId: "session-1",
-      sessionStartedAt: "2026-03-11T10:00:00.000Z"
+      sessionStartedAt: "2026-03-11T10:00:00.000Z",
     });
     feedbackCliMocks.recordFeedbackInvocation.mockResolvedValue({
       showHint: false,
@@ -81,8 +81,8 @@ describe("linkedin feedback CLI", () => {
         lastMcpToolName: null,
         sessionDurationMs: 61_000,
         sessionId: "session-1",
-        sessionStartedAt: "2026-03-11T10:00:00.000Z"
-      }
+        sessionStartedAt: "2026-03-11T10:00:00.000Z",
+      },
     });
     feedbackCliMocks.submitFeedback.mockResolvedValue({
       body: "body",
@@ -92,7 +92,7 @@ describe("linkedin feedback CLI", () => {
       status: "submitted",
       title: "[Agent Feedback] Prompted title",
       type: "bug",
-      url: "https://github.com/sigvardt/linkedin-buddy/issues/321"
+      url: "https://github.com/sigvardt/linkedin-buddy/issues/321",
     });
     feedbackCliMocks.submitPendingFeedback.mockResolvedValue({
       failureCount: 0,
@@ -100,24 +100,29 @@ describe("linkedin feedback CLI", () => {
       repository: "sigvardt/linkedin-buddy",
       submitted: [
         {
-          filePath: "/tmp/assistant-home/.linkedin-buddy/pending-feedback/2026-03-11-bug.md",
+          filePath:
+            "/tmp/assistant-home/.linkedin-buddy/pending-feedback/2026-03-11-bug.md",
           title: "[Agent Feedback] Saved item",
           type: "bug",
-          url: "https://github.com/sigvardt/linkedin-buddy/issues/322"
-        }
+          url: "https://github.com/sigvardt/linkedin-buddy/issues/322",
+        },
       ],
-      submittedCount: 1
+      submittedCount: 1,
     });
 
-    consoleLogSpy = vi.spyOn(console, "log").mockImplementation((value?: unknown) => {
-      stdoutChunks.push(String(value ?? ""));
-    });
+    consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation((value?: unknown) => {
+        stdoutChunks.push(String(value ?? ""));
+      });
     stderrWriteSpy = vi
       .spyOn(process.stderr, "write")
-      .mockImplementation((...args: Parameters<typeof process.stderr.write>) => {
-        stderrChunks.push(String(args[0]));
-        return true;
-      });
+      .mockImplementation(
+        (...args: Parameters<typeof process.stderr.write>) => {
+          stderrChunks.push(String(args[0]));
+          return true;
+        },
+      );
   });
 
   afterEach(() => {
@@ -143,23 +148,72 @@ describe("linkedin feedback CLI", () => {
       expect.objectContaining({
         type: "bug",
         title: "Prompted title",
-        description: "It failed after reconnect."
-      })
+        description: "It failed after reconnect.",
+      }),
     );
     expect(stdoutChunks.join("\n")).toContain("Feedback filed:");
     expect(stderrChunks.join("")).toContain("Detailed explanation.");
   });
 
   it("submits saved pending feedback files", async () => {
+    await runCli(["node", "linkedin-buddy", "feedback", "--submit-pending"]);
+
+    expect(feedbackCliMocks.submitPendingFeedback).toHaveBeenCalledTimes(1);
+    expect(stdoutChunks.join("\n")).toContain(
+      "Submitted 1 pending feedback file",
+    );
+    expect(stdoutChunks.join("\n")).toContain(
+      ".linkedin-buddy/pending-feedback/",
+    );
+  });
+
+  it("refuses interactive prompts in non-interactive mode", async () => {
+    setInteractiveMode(false, true);
+
+    await expect(
+      runCli(["node", "linkedin-buddy", "feedback"]),
+    ).rejects.toThrow("non-interactive mode");
+    expect(feedbackCliMocks.submitFeedback).not.toHaveBeenCalled();
+  });
+
+  it("prints feedback result as json when requested", async () => {
     await runCli([
       "node",
       "linkedin-buddy",
       "feedback",
-      "--submit-pending"
+      "--type",
+      "bug",
+      "--title",
+      "json title",
+      "--description",
+      "json description",
+      "--json",
     ]);
 
-    expect(feedbackCliMocks.submitPendingFeedback).toHaveBeenCalledTimes(1);
-    expect(stdoutChunks.join("\n")).toContain("Submitted 1 pending feedback file");
-    expect(stdoutChunks.join("\n")).toContain(".linkedin-buddy/pending-feedback/");
+    const output = stdoutChunks.join("\n");
+    const parsed = JSON.parse(output) as Record<string, unknown>;
+
+    expect(parsed.status).toBe("submitted");
+    expect(parsed.type).toBe("bug");
+    expect(parsed.title).toBe("[Agent Feedback] Prompted title");
+    expect(parsed.url).toBe(
+      "https://github.com/sigvardt/linkedin-buddy/issues/321",
+    );
+  });
+
+  it("throws for invalid feedback type argument", async () => {
+    await expect(
+      runCli([
+        "node",
+        "linkedin-buddy",
+        "feedback",
+        "--type",
+        "invalid",
+        "--title",
+        "bad type",
+        "--description",
+        "bad",
+      ]),
+    ).rejects.toThrow("feedback type must be one of");
   });
 });

--- a/packages/core/src/feedback.ts
+++ b/packages/core/src/feedback.ts
@@ -1,6 +1,13 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { mkdir, readFile, readdir, unlink, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  readFile,
+  readdir,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { LinkedInBuddyError, asLinkedInBuddyError } from "./errors.js";
@@ -12,10 +19,6 @@ export const LINKEDIN_BUDDY_FEEDBACK_HINT_EVERY_N_ENV =
   "LINKEDIN_BUDDY_FEEDBACK_HINT_EVERY_N";
 export const LINKEDIN_BUDDY_FEEDBACK_SESSION_IDLE_MS_ENV =
   "LINKEDIN_BUDDY_FEEDBACK_SESSION_IDLE_MS";
-export const LINKEDIN_ASSISTANT_FEEDBACK_HINT_EVERY_N_ENV =
-  LINKEDIN_BUDDY_FEEDBACK_HINT_EVERY_N_ENV;
-export const LINKEDIN_ASSISTANT_FEEDBACK_SESSION_IDLE_MS_ENV =
-  LINKEDIN_BUDDY_FEEDBACK_SESSION_IDLE_MS_ENV;
 
 export const DEFAULT_FEEDBACK_HINT_EVERY_N = 20;
 export const DEFAULT_FEEDBACK_SESSION_IDLE_MS = 30 * 60 * 1000;
@@ -29,6 +32,9 @@ const FEEDBACK_PENDING_FILE_EXTENSION = ".md";
 const FEEDBACK_METADATA_HEADER = "<!-- linkedin-buddy-feedback-metadata";
 const FEEDBACK_METADATA_FOOTER = "-->";
 const MAX_STORED_ERROR_STACK_CHARS = 12_000;
+export const GH_COMMAND_TIMEOUT_MS = 30_000;
+export const MAX_PENDING_FEEDBACK_FILES = 50;
+export const MAX_PENDING_FEEDBACK_FILE_BYTES = 512 * 1024;
 
 const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/giu;
 const LINKEDIN_URL_PATTERN =
@@ -46,8 +52,7 @@ const LINKEDIN_MEMBER_ID_PATTERN =
   /\b(?:member[_-]?id|memberId|fs_miniProfile|miniProfileUrn)\b\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,;]+)/giu;
 const IPV4_PATTERN = /\b(?:\d{1,3}\.){3}\d{1,3}\b/gu;
 const UNIX_USER_PATH_PATTERN = /\/(?:Users|home)\/[^/\s]+(?:\/[^\s]*)?/gu;
-const WINDOWS_USER_PATH_PATTERN =
-  /[A-Za-z]:\\Users\\[^\\\s]+(?:\\[^\s]*)?/gu;
+const WINDOWS_USER_PATH_PATTERN = /[A-Za-z]:\\Users\\[^\\\s]+(?:\\[^\s]*)?/gu;
 const LONG_SECRET_BLOB_PATTERN = /\b[A-Za-z0-9+/_=-]{50,}\b/gu;
 const REPEATED_REDACTION_PATTERN =
   /\[REDACTED\](?:[\s,;:|/\\-]*\[REDACTED\])+/gu;
@@ -55,7 +60,7 @@ const REPEATED_REDACTION_PATTERN =
 const FEEDBACK_LABELS: Record<FeedbackType, string[]> = {
   bug: ["bug", "agent-feedback"],
   feature: ["enhancement", "agent-feedback"],
-  improvement: ["improvement", "agent-feedback"]
+  improvement: ["improvement", "agent-feedback"],
 };
 
 export interface FeedbackPaths {
@@ -165,7 +170,7 @@ export interface CommandResult {
 
 export type CommandRunner = (
   command: string,
-  args: string[]
+  args: string[],
 ) => Promise<CommandResult>;
 
 interface FeedbackStateFile {
@@ -192,19 +197,10 @@ function isFeedbackType(value: string): value is FeedbackType {
   return (FEEDBACK_TYPES as readonly string[]).includes(value);
 }
 
-function normalizeFeedbackType(value: string): FeedbackType {
-  const normalized = value.trim().toLowerCase();
-  if (isFeedbackType(normalized)) {
-    return normalized;
-  }
-
-  throw new LinkedInBuddyError(
-    "ACTION_PRECONDITION_FAILED",
-    `feedback type must be one of: ${FEEDBACK_TYPES.join(", ")}.`
-  );
-}
-
-function parsePositiveInteger(value: string | undefined, fallback: number): number {
+function parsePositiveInteger(
+  value: string | undefined,
+  fallback: number,
+): number {
   if (typeof value !== "string" || value.trim().length === 0) {
     return fallback;
   }
@@ -217,7 +213,10 @@ function parsePositiveInteger(value: string | undefined, fallback: number): numb
   return parsed;
 }
 
-function parseNonNegativeInteger(value: string | undefined, fallback: number): number {
+function parseNonNegativeInteger(
+  value: string | undefined,
+  fallback: number,
+): number {
   if (typeof value !== "string" || value.trim().length === 0) {
     return fallback;
   }
@@ -233,14 +232,14 @@ function parseNonNegativeInteger(value: string | undefined, fallback: number): n
 function resolveFeedbackHintEveryN(): number {
   return parsePositiveInteger(
     process.env[LINKEDIN_BUDDY_FEEDBACK_HINT_EVERY_N_ENV],
-    DEFAULT_FEEDBACK_HINT_EVERY_N
+    DEFAULT_FEEDBACK_HINT_EVERY_N,
   );
 }
 
 function resolveFeedbackSessionIdleMs(): number {
   return parseNonNegativeInteger(
     process.env[LINKEDIN_BUDDY_FEEDBACK_SESSION_IDLE_MS_ENV],
-    DEFAULT_FEEDBACK_SESSION_IDLE_MS
+    DEFAULT_FEEDBACK_SESSION_IDLE_MS,
   );
 }
 
@@ -253,7 +252,7 @@ export function resolveFeedbackPaths(baseDir?: string): FeedbackPaths {
   return {
     feedbackRootDir,
     pendingDir: path.join(feedbackRootDir, FEEDBACK_PENDING_DIRNAME),
-    statePath: path.join(feedbackRootDir, FEEDBACK_STATE_FILENAME)
+    statePath: path.join(feedbackRootDir, FEEDBACK_STATE_FILENAME),
   };
 }
 
@@ -281,7 +280,10 @@ function redactPattern(value: string, pattern: RegExp): [string, boolean] {
   return [redacted, redacted !== value];
 }
 
-function redactKeyValuePattern(value: string, pattern: RegExp): [string, boolean] {
+function redactKeyValuePattern(
+  value: string,
+  pattern: RegExp,
+): [string, boolean] {
   const redacted = value.replace(pattern, (match, ...rest: unknown[]) => {
     const offset = rest.at(-2);
     void offset;
@@ -316,7 +318,7 @@ export function scrubFeedbackText(value: string): {
     IPV4_PATTERN,
     UNIX_USER_PATH_PATTERN,
     WINDOWS_USER_PATH_PATTERN,
-    LONG_SECRET_BLOB_PATTERN
+    LONG_SECRET_BLOB_PATTERN,
   ];
 
   for (const pattern of patternReplacements) {
@@ -327,7 +329,7 @@ export function scrubFeedbackText(value: string): {
 
   const [secretRedacted, secretChanged] = redactKeyValuePattern(
     current,
-    SECRET_ASSIGNMENT_PATTERN
+    SECRET_ASSIGNMENT_PATTERN,
   );
   current = secretRedacted;
   redacted = redacted || secretChanged;
@@ -338,13 +340,14 @@ export function scrubFeedbackText(value: string): {
 
   return {
     redacted,
-    value: current
+    value: current,
   };
 }
 
-function scrubOptionalText(
-  value: string | null | undefined
-): { redacted: boolean; value?: string } {
+function scrubOptionalText(value: string | null | undefined): {
+  redacted: boolean;
+  value?: string;
+} {
   const normalized = trimOrUndefined(value);
   if (!normalized) {
     return { redacted: false };
@@ -353,7 +356,7 @@ function scrubOptionalText(
   const scrubbed = scrubFeedbackText(normalized);
   return {
     redacted: scrubbed.redacted,
-    value: scrubbed.value
+    value: scrubbed.value,
   };
 }
 
@@ -388,17 +391,19 @@ function normalizeWhitespace(value: string): string {
 }
 
 function buildTechnicalContextLines(
-  context: FeedbackTechnicalContext
+  context: FeedbackTechnicalContext,
 ): string[] {
   const lines = [
     `- Source: ${context.source}`,
     `- CLI version: ${context.cliVersion}`,
     `- Node.js version: ${context.nodeVersion}`,
     `- OS / architecture: ${context.os} / ${context.architecture}`,
-    `- Session duration: ${formatDuration(context.sessionDurationMs)}`
+    `- Session duration: ${formatDuration(context.sessionDurationMs)}`,
   ];
 
-  const lastInvocationName = trimOrUndefined(context.lastInvocationName ?? undefined);
+  const lastInvocationName = trimOrUndefined(
+    context.lastInvocationName ?? undefined,
+  );
   if (lastInvocationName) {
     lines.push(`- Last command/tool: ${lastInvocationName}`);
   }
@@ -409,7 +414,7 @@ function buildTechnicalContextLines(
   }
 
   const activeProfileName = trimOrUndefined(
-    context.activeProfileName ?? undefined
+    context.activeProfileName ?? undefined,
   );
   if (activeProfileName) {
     lines.push(`- Active profile name: ${activeProfileName}`);
@@ -429,7 +434,7 @@ function buildTechnicalContextLines(
 function buildFeedbackIssueBody(
   description: string,
   context: FeedbackTechnicalContext,
-  type: FeedbackType
+  type: FeedbackType,
 ): string {
   return [
     "## Feedback Type",
@@ -445,42 +450,47 @@ function buildFeedbackIssueBody(
     "",
     ...buildTechnicalContextLines(context),
     "",
-    "</details>"
+    "</details>",
   ].join("\n");
 }
 
 function buildFeedbackTitle(title: string): string {
   const normalizedTitle = title.trim();
-  const fallbackTitle = normalizedTitle.length > 0
-    ? normalizedTitle
-    : "Untitled feedback";
+  const fallbackTitle =
+    normalizedTitle.length > 0 ? normalizedTitle : "Untitled feedback";
   return `[Agent Feedback] ${fallbackTitle}`;
 }
 
 function normalizeFeedbackDraft(
-  input: FeedbackSubmissionInput
+  input: FeedbackSubmissionInput,
 ): NormalizedFeedbackDraft {
   const scrubbedTitle = scrubFeedbackText(normalizeWhitespace(input.title));
   const scrubbedDescription = scrubFeedbackText(
-    normalizeWhitespace(input.description)
+    normalizeWhitespace(input.description),
   );
   const scrubbedLastInvocation = scrubOptionalText(
-    input.technicalContext.lastInvocationName
+    input.technicalContext.lastInvocationName,
   );
-  const scrubbedErrorStack = scrubOptionalText(input.technicalContext.errorStack);
+  const scrubbedErrorStack = scrubOptionalText(
+    input.technicalContext.errorStack,
+  );
   const scrubbedProfileName = scrubOptionalText(
-    input.technicalContext.activeProfileName
+    input.technicalContext.activeProfileName,
   );
-  const scrubbedMcpToolName = scrubOptionalText(input.technicalContext.mcpToolName);
+  const scrubbedMcpToolName = scrubOptionalText(
+    input.technicalContext.mcpToolName,
+  );
   const scrubbedCliVersion = scrubFeedbackText(
-    normalizeWhitespace(input.technicalContext.cliVersion)
+    normalizeWhitespace(input.technicalContext.cliVersion),
   );
   const scrubbedNodeVersion = scrubFeedbackText(
-    normalizeWhitespace(input.technicalContext.nodeVersion)
+    normalizeWhitespace(input.technicalContext.nodeVersion),
   );
-  const scrubbedOs = scrubFeedbackText(normalizeWhitespace(input.technicalContext.os));
+  const scrubbedOs = scrubFeedbackText(
+    normalizeWhitespace(input.technicalContext.os),
+  );
   const scrubbedArchitecture = scrubFeedbackText(
-    normalizeWhitespace(input.technicalContext.architecture)
+    normalizeWhitespace(input.technicalContext.architecture),
   );
 
   const redactionApplied =
@@ -501,19 +511,27 @@ function normalizeFeedbackDraft(
     nodeVersion: scrubbedNodeVersion.value,
     os: scrubbedOs.value,
     architecture: scrubbedArchitecture.value,
-    sessionDurationMs: Math.max(0, Math.floor(input.technicalContext.sessionDurationMs)),
+    sessionDurationMs: Math.max(
+      0,
+      Math.floor(input.technicalContext.sessionDurationMs),
+    ),
     ...(scrubbedLastInvocation.value
       ? { lastInvocationName: scrubbedLastInvocation.value }
       : {}),
     ...(scrubbedErrorStack.value
-      ? { errorStack: clipText(scrubbedErrorStack.value, MAX_STORED_ERROR_STACK_CHARS) }
+      ? {
+          errorStack: clipText(
+            scrubbedErrorStack.value,
+            MAX_STORED_ERROR_STACK_CHARS,
+          ),
+        }
       : {}),
     ...(scrubbedProfileName.value
       ? { activeProfileName: scrubbedProfileName.value }
       : {}),
     ...(scrubbedMcpToolName.value
       ? { mcpToolName: scrubbedMcpToolName.value }
-      : {})
+      : {}),
   };
 
   return {
@@ -524,14 +542,14 @@ function normalizeFeedbackDraft(
     body: buildFeedbackIssueBody(
       scrubbedDescription.value,
       technicalContext,
-      input.type
-    )
+      input.type,
+    ),
   };
 }
 
 function serializePendingFeedbackFile(
   metadata: PendingFeedbackMetadata,
-  body: string
+  body: string,
 ): string {
   return [
     FEEDBACK_METADATA_HEADER,
@@ -539,11 +557,13 @@ function serializePendingFeedbackFile(
     FEEDBACK_METADATA_FOOTER,
     "",
     body.trim(),
-    ""
+    "",
   ].join("\n");
 }
 
-function parsePendingFeedbackContent(content: string): Omit<PendingFeedbackFile, "filePath"> {
+function parsePendingFeedbackContent(
+  content: string,
+): Omit<PendingFeedbackFile, "filePath"> {
   const trimmed = content.trimStart();
   if (
     !trimmed.startsWith(FEEDBACK_METADATA_HEADER) ||
@@ -551,7 +571,7 @@ function parsePendingFeedbackContent(content: string): Omit<PendingFeedbackFile,
   ) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "Pending feedback file is missing metadata."
+      "Pending feedback file is missing metadata.",
     );
   }
 
@@ -560,37 +580,45 @@ function parsePendingFeedbackContent(content: string): Omit<PendingFeedbackFile,
   if (footerIndex < 0) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "Pending feedback file metadata is malformed."
+      "Pending feedback file metadata is malformed.",
     );
   }
 
   const metadataJson = trimmed.slice(metadataStart, footerIndex).trim();
   const parsedMetadata = JSON.parse(metadataJson) as Record<string, unknown>;
-  const body = trimmed.slice(footerIndex + FEEDBACK_METADATA_FOOTER.length).trim();
+  const body = trimmed
+    .slice(footerIndex + FEEDBACK_METADATA_FOOTER.length)
+    .trim();
 
   const title = trimOrUndefined(
-    typeof parsedMetadata.title === "string" ? parsedMetadata.title : undefined
+    typeof parsedMetadata.title === "string" ? parsedMetadata.title : undefined,
   );
   const createdAt = trimOrUndefined(
     typeof parsedMetadata.createdAt === "string"
       ? parsedMetadata.createdAt
-      : undefined
+      : undefined,
   );
-  const typeValue = typeof parsedMetadata.type === "string"
-    ? parsedMetadata.type
-    : "";
+  const typeValue =
+    typeof parsedMetadata.type === "string" ? parsedMetadata.type : "";
   const labelsValue = Array.isArray(parsedMetadata.labels)
-    ? parsedMetadata.labels.filter((label): label is string => typeof label === "string")
+    ? parsedMetadata.labels.filter(
+        (label): label is string => typeof label === "string",
+      )
     : [];
   const redactionApplied =
     typeof parsedMetadata.redactionApplied === "boolean"
       ? parsedMetadata.redactionApplied
       : false;
 
-  if (!title || !createdAt || !isFeedbackType(typeValue) || labelsValue.length === 0) {
+  if (
+    !title ||
+    !createdAt ||
+    !isFeedbackType(typeValue) ||
+    labelsValue.length === 0
+  ) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "Pending feedback file metadata is incomplete."
+      "Pending feedback file metadata is incomplete.",
     );
   }
 
@@ -601,22 +629,37 @@ function parsePendingFeedbackContent(content: string): Omit<PendingFeedbackFile,
       labels: labelsValue,
       redactionApplied,
       title,
-      type: typeValue
-    }
+      type: typeValue,
+    },
   };
 }
 
 async function defaultCommandRunner(
   command: string,
-  args: string[]
+  args: string[],
 ): Promise<CommandResult> {
   return await new Promise<CommandResult>((resolve, reject) => {
     const child = spawn(command, args, {
-      stdio: ["ignore", "pipe", "pipe"]
+      stdio: ["ignore", "pipe", "pipe"],
     });
 
     let stdout = "";
     let stderr = "";
+    let settled = false;
+
+    const timeout = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      child.kill("SIGTERM");
+      reject(
+        new LinkedInBuddyError(
+          "UNKNOWN",
+          `Command timed out after ${GH_COMMAND_TIMEOUT_MS}ms: ${command} ${args.join(" ")}`,
+        ),
+      );
+    }, GH_COMMAND_TIMEOUT_MS);
 
     child.stdout.on("data", (chunk: Buffer | string) => {
       stdout += chunk.toString();
@@ -625,21 +668,29 @@ async function defaultCommandRunner(
       stderr += chunk.toString();
     });
     child.on("error", (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
       reject(error);
     });
     child.on("close", (code) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
       resolve({
         code: code ?? 1,
         stderr,
-        stdout
+        stdout,
       });
     });
   });
 }
 
-async function isGhAuthenticated(
-  runner: CommandRunner
-): Promise<boolean> {
+async function isGhAuthenticated(runner: CommandRunner): Promise<boolean> {
   try {
     const result = await runner("gh", ["auth", "status"]);
     return result.code === 0;
@@ -653,7 +704,7 @@ async function createGitHubIssue(
   body: string,
   labels: string[],
   repository: string,
-  runner: CommandRunner
+  runner: CommandRunner,
 ): Promise<string> {
   const args = [
     "issue",
@@ -663,7 +714,7 @@ async function createGitHubIssue(
     "--title",
     title,
     "--body",
-    body
+    body,
   ];
 
   for (const label of labels) {
@@ -672,21 +723,18 @@ async function createGitHubIssue(
 
   const result = await runner("gh", args);
   if (result.code !== 0) {
-    throw new LinkedInBuddyError(
-      "UNKNOWN",
-      "GitHub issue creation failed.",
-      {
-        stderr: result.stderr.trim(),
-        stdout: result.stdout.trim()
-      }
-    );
+    throw new LinkedInBuddyError("UNKNOWN", "GitHub issue creation failed.", {
+      stderr: result.stderr.trim(),
+      stdout: result.stdout.trim(),
+    });
   }
 
-  const issueUrl = trimOrUndefined(result.stdout) ?? trimOrUndefined(result.stderr);
+  const issueUrl =
+    trimOrUndefined(result.stdout) ?? trimOrUndefined(result.stderr);
   if (!issueUrl) {
     throw new LinkedInBuddyError(
       "UNKNOWN",
-      "GitHub issue creation did not return an issue URL."
+      "GitHub issue creation did not return an issue URL.",
     );
   }
 
@@ -696,17 +744,17 @@ async function createGitHubIssue(
 function buildPendingFeedbackFilePath(
   pendingDir: string,
   type: FeedbackType,
-  now: Date
+  now: Date,
 ): string {
   return path.join(
     pendingDir,
-    `${buildTimestamp(now)}-${type}${FEEDBACK_PENDING_FILE_EXTENSION}`
+    `${buildTimestamp(now)}-${type}${FEEDBACK_PENDING_FILE_EXTENSION}`,
   );
 }
 
 export function formatFeedbackDisplayPath(
   filePath: string,
-  baseDir?: string
+  baseDir?: string,
 ): string {
   const { feedbackRootDir } = resolveFeedbackPaths(baseDir);
   const relativePath = path.relative(feedbackRootDir, filePath);
@@ -724,25 +772,42 @@ export function formatFeedbackDisplayPath(
 
 export async function savePendingFeedback(
   input: FeedbackSubmissionInput,
-  options: { baseDir?: string; now?: Date; repository?: string } = {}
+  options: { baseDir?: string; now?: Date; repository?: string } = {},
 ): Promise<FeedbackSubmissionResult> {
   const draft = normalizeFeedbackDraft(input);
   const now = options.now ?? new Date();
   const paths = await ensureFeedbackDirs(options.baseDir);
-  const filePath = buildPendingFeedbackFilePath(paths.pendingDir, draft.type, now);
+
+  const existingPendingFiles = await listPendingFeedbackFiles(options.baseDir);
+  if (existingPendingFiles.length >= MAX_PENDING_FEEDBACK_FILES) {
+    throw new LinkedInBuddyError(
+      "ACTION_PRECONDITION_FAILED",
+      `Cannot save more than ${MAX_PENDING_FEEDBACK_FILES} pending feedback files. Run \`linkedin-buddy feedback --submit-pending\` or remove old files from ${paths.pendingDir}.`,
+      {
+        limit: MAX_PENDING_FEEDBACK_FILES,
+        current: existingPendingFiles.length,
+      },
+    );
+  }
+
+  const filePath = buildPendingFeedbackFilePath(
+    paths.pendingDir,
+    draft.type,
+    now,
+  );
 
   const metadata: PendingFeedbackMetadata = {
     createdAt: now.toISOString(),
     labels: draft.labels,
     redactionApplied: draft.redactionApplied,
     title: draft.title,
-    type: draft.type
+    type: draft.type,
   };
 
   await writeFile(
     filePath,
     serializePendingFeedbackFile(metadata, draft.body),
-    "utf8"
+    "utf8",
   );
 
   return {
@@ -753,7 +818,7 @@ export async function savePendingFeedback(
     repository: options.repository ?? FEEDBACK_GITHUB_REPOSITORY,
     status: "saved_pending",
     title: draft.title,
-    type: draft.type
+    type: draft.type,
   };
 }
 
@@ -764,7 +829,7 @@ export async function submitFeedback(
     now?: Date;
     repository?: string;
     runner?: CommandRunner;
-  } = {}
+  } = {},
 ): Promise<FeedbackSubmissionResult> {
   const repository = options.repository ?? FEEDBACK_GITHUB_REPOSITORY;
   const runner = options.runner ?? defaultCommandRunner;
@@ -774,7 +839,7 @@ export async function submitFeedback(
     return await savePendingFeedback(input, {
       ...(options.baseDir ? { baseDir: options.baseDir } : {}),
       ...(options.now ? { now: options.now } : {}),
-      repository
+      repository,
     });
   }
 
@@ -786,7 +851,7 @@ export async function submitFeedback(
       draft.body,
       draft.labels,
       repository,
-      runner
+      runner,
     );
 
     return {
@@ -797,29 +862,42 @@ export async function submitFeedback(
       status: "submitted",
       title: draft.title,
       type: draft.type,
-      url
+      url,
     };
   } catch {
     return await savePendingFeedback(input, {
       ...(options.baseDir ? { baseDir: options.baseDir } : {}),
       ...(options.now ? { now: options.now } : {}),
-      repository
+      repository,
     });
   }
 }
 
 export async function readPendingFeedbackFile(
-  filePath: string
+  filePath: string,
 ): Promise<PendingFeedbackFile> {
+  const fileStats = await stat(filePath);
+  if (fileStats.size > MAX_PENDING_FEEDBACK_FILE_BYTES) {
+    throw new LinkedInBuddyError(
+      "ACTION_PRECONDITION_FAILED",
+      `Pending feedback file exceeds the ${MAX_PENDING_FEEDBACK_FILE_BYTES} byte limit.`,
+      {
+        path: filePath,
+        size: fileStats.size,
+        limit: MAX_PENDING_FEEDBACK_FILE_BYTES,
+      },
+    );
+  }
+
   const content = await readFile(filePath, "utf8");
   return {
     filePath,
-    ...parsePendingFeedbackContent(content)
+    ...parsePendingFeedbackContent(content),
   };
 }
 
 export async function listPendingFeedbackFiles(
-  baseDir?: string
+  baseDir?: string,
 ): Promise<string[]> {
   const paths = resolveFeedbackPaths(baseDir);
 
@@ -828,16 +906,13 @@ export async function listPendingFeedbackFiles(
     return entries
       .filter(
         (entry) =>
-          entry.isFile() && entry.name.endsWith(FEEDBACK_PENDING_FILE_EXTENSION)
+          entry.isFile() &&
+          entry.name.endsWith(FEEDBACK_PENDING_FILE_EXTENSION),
       )
       .map((entry) => path.join(paths.pendingDir, entry.name))
       .sort((left, right) => left.localeCompare(right));
   } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
       return [];
     }
 
@@ -850,7 +925,7 @@ export async function submitPendingFeedback(
     baseDir?: string;
     repository?: string;
     runner?: CommandRunner;
-  } = {}
+  } = {},
 ): Promise<SubmitPendingFeedbackResult> {
   const repository = options.repository ?? FEEDBACK_GITHUB_REPOSITORY;
   const runner = options.runner ?? defaultCommandRunner;
@@ -862,14 +937,14 @@ export async function submitPendingFeedback(
       failures: [],
       repository,
       submitted: [],
-      submittedCount: 0
+      submittedCount: 0,
     };
   }
 
   if (!(await isGhAuthenticated(runner))) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "GitHub CLI authentication is required before pending feedback can be submitted. Run `gh auth login` first."
+      "GitHub CLI authentication is required before pending feedback can be submitted. Run `gh auth login` first.",
     );
   }
   const submitted: PendingFeedbackSubmissionItem[] = [];
@@ -883,20 +958,20 @@ export async function submitPendingFeedback(
         pendingFeedback.body,
         pendingFeedback.metadata.labels,
         repository,
-        runner
+        runner,
       );
       await unlink(filePath);
       submitted.push({
         filePath,
         title: pendingFeedback.metadata.title,
         type: pendingFeedback.metadata.type,
-        url
+        url,
       });
     } catch (error) {
       const normalizedError = asLinkedInBuddyError(error);
       failures.push({
         error: normalizedError.message,
-        filePath
+        filePath,
       });
     }
   }
@@ -906,7 +981,7 @@ export async function submitPendingFeedback(
     failures,
     repository,
     submitted,
-    submittedCount: submitted.length
+    submittedCount: submitted.length,
   };
 }
 
@@ -921,7 +996,7 @@ function createInitialFeedbackState(now: Date): FeedbackStateFile {
     lastSeenAt: timestamp,
     sessionHintShownAt: null,
     sessionId: randomUUID(),
-    sessionStartedAt: timestamp
+    sessionStartedAt: timestamp,
   };
 }
 
@@ -944,28 +1019,28 @@ async function readFeedbackState(baseDir?: string): Promise<FeedbackStateFile> {
             : null,
         invocationCount: parsed.invocationCount,
         lastErrorStack:
-          typeof parsed.lastErrorStack === "string" ? parsed.lastErrorStack : null,
+          typeof parsed.lastErrorStack === "string"
+            ? parsed.lastErrorStack
+            : null,
         lastInvocationName:
           typeof parsed.lastInvocationName === "string"
             ? parsed.lastInvocationName
             : null,
         lastMcpToolName:
-          typeof parsed.lastMcpToolName === "string" ? parsed.lastMcpToolName : null,
+          typeof parsed.lastMcpToolName === "string"
+            ? parsed.lastMcpToolName
+            : null,
         lastSeenAt: parsed.lastSeenAt,
         sessionHintShownAt:
           typeof parsed.sessionHintShownAt === "string"
             ? parsed.sessionHintShownAt
             : null,
         sessionId: parsed.sessionId,
-        sessionStartedAt: parsed.sessionStartedAt
+        sessionStartedAt: parsed.sessionStartedAt,
       };
     }
   } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
       return createInitialFeedbackState(new Date());
     }
   }
@@ -975,10 +1050,14 @@ async function readFeedbackState(baseDir?: string): Promise<FeedbackStateFile> {
 
 async function writeFeedbackState(
   state: FeedbackStateFile,
-  baseDir?: string
+  baseDir?: string,
 ): Promise<void> {
   const paths = await ensureFeedbackDirs(baseDir);
-  await writeFile(paths.statePath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  await writeFile(
+    paths.statePath,
+    `${JSON.stringify(state, null, 2)}\n`,
+    "utf8",
+  );
 }
 
 function hasSessionExpired(state: FeedbackStateFile, now: Date): boolean {
@@ -993,7 +1072,7 @@ function hasSessionExpired(state: FeedbackStateFile, now: Date): boolean {
 
 function buildSnapshot(
   state: FeedbackStateFile,
-  now: Date
+  now: Date,
 ): FeedbackStateSnapshot {
   const sessionStartedAtMs = Date.parse(state.sessionStartedAt);
   const sessionDurationMs = Number.isFinite(sessionStartedAtMs)
@@ -1008,7 +1087,7 @@ function buildSnapshot(
     lastMcpToolName: state.lastMcpToolName,
     sessionDurationMs,
     sessionId: state.sessionId,
-    sessionStartedAt: state.sessionStartedAt
+    sessionStartedAt: state.sessionStartedAt,
   };
 }
 
@@ -1017,7 +1096,7 @@ function normalizeInvocationName(value: string): string {
   if (normalized.length === 0) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "invocation name must not be empty."
+      "invocation name must not be empty.",
     );
   }
 
@@ -1039,7 +1118,7 @@ function normalizeErrorStack(error: unknown): string | null {
 }
 
 export async function recordFeedbackInvocation(
-  input: RecordFeedbackInvocationInput
+  input: RecordFeedbackInvocationInput,
 ): Promise<FeedbackHintDecision> {
   const now = input.now ?? new Date();
   const currentState = await readFeedbackState(input.baseDir);
@@ -1055,7 +1134,8 @@ export async function recordFeedbackInvocation(
   state.activeProfileName = normalizedProfileName ?? state.activeProfileName;
 
   if (input.source === "mcp") {
-    state.lastMcpToolName = trimOrUndefined(input.mcpToolName) ?? state.lastInvocationName;
+    state.lastMcpToolName =
+      trimOrUndefined(input.mcpToolName) ?? state.lastInvocationName;
   }
 
   const normalizedErrorStack = normalizeErrorStack(input.error);
@@ -1080,20 +1160,29 @@ export async function recordFeedbackInvocation(
   return {
     showHint: typeof reason === "string",
     snapshot: buildSnapshot(state, now),
-    ...(reason ? { reason } : {})
+    ...(reason ? { reason } : {}),
   };
 }
 
 export async function readFeedbackStateSnapshot(
-  options: { baseDir?: string; now?: Date } = {}
+  options: { baseDir?: string; now?: Date } = {},
 ): Promise<FeedbackStateSnapshot> {
   const now = options.now ?? new Date();
   const state = await readFeedbackState(options.baseDir);
   return buildSnapshot(state, now);
 }
 
-export function buildFeedbackHintMessage(): string {
-  return "Found a bug or have an idea? Run `linkedin-buddy feedback` to file it directly.";
+export function buildFeedbackHintMessage(
+  reason?: FeedbackHintDecision["reason"],
+): string {
+  switch (reason) {
+    case "error":
+      return "Ran into an issue? Run `linkedin-buddy feedback` to report it.";
+    case "nth_invocation":
+      return "Enjoying LinkedIn Buddy? Run `linkedin-buddy feedback` to share suggestions.";
+    default:
+      return "Found a bug or have an idea? Run `linkedin-buddy feedback` to file it directly.";
+  }
 }
 
 export function createFeedbackTechnicalContext(input: {
@@ -1105,28 +1194,31 @@ export function createFeedbackTechnicalContext(input: {
   snapshot: FeedbackStateSnapshot;
   source: "cli" | "mcp";
 }): FeedbackTechnicalContext {
+  const { snapshot } = input;
+  const mcpToolName = input.mcpToolName ?? snapshot.lastMcpToolName;
+
   return {
+    activeProfileName: snapshot.activeProfileName,
     architecture: input.architecture ?? os.arch(),
     cliVersion: input.cliVersion,
+    errorStack: snapshot.lastErrorStack,
+    lastInvocationName: snapshot.lastInvocationName,
+    mcpToolName: mcpToolName ?? undefined,
     nodeVersion: input.nodeVersion ?? process.version,
     os: input.os ?? `${os.platform()} ${os.release()}`,
-    sessionDurationMs: input.snapshot.sessionDurationMs,
+    sessionDurationMs: snapshot.sessionDurationMs,
     source: input.source,
-    ...(input.snapshot.activeProfileName !== undefined
-      ? { activeProfileName: input.snapshot.activeProfileName }
-      : {}),
-    ...(input.snapshot.lastErrorStack !== undefined
-      ? { errorStack: input.snapshot.lastErrorStack }
-      : {}),
-    ...(input.snapshot.lastInvocationName !== undefined
-      ? { lastInvocationName: input.snapshot.lastInvocationName }
-      : {}),
-    ...(input.mcpToolName ?? input.snapshot.lastMcpToolName
-      ? { mcpToolName: input.mcpToolName ?? input.snapshot.lastMcpToolName }
-      : {})
   };
 }
 
 export function normalizeFeedbackInputType(value: string): FeedbackType {
-  return normalizeFeedbackType(value);
+  const normalized = value.trim().toLowerCase();
+  if (isFeedbackType(normalized)) {
+    return normalized;
+  }
+
+  throw new LinkedInBuddyError(
+    "ACTION_PRECONDITION_FAILED",
+    `feedback type must be one of: ${FEEDBACK_TYPES.join(", ")}.`,
+  );
 }

--- a/packages/core/test/feedback.test.ts
+++ b/packages/core/test/feedback.test.ts
@@ -1,36 +1,52 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  LINKEDIN_BUDDY_FEEDBACK_SESSION_IDLE_MS_ENV,
+  LinkedInBuddyError,
+  MAX_PENDING_FEEDBACK_FILES,
   buildFeedbackHintMessage,
   createFeedbackTechnicalContext,
   formatFeedbackDisplayPath,
-  LINKEDIN_ASSISTANT_FEEDBACK_HINT_EVERY_N_ENV,
+  LINKEDIN_BUDDY_FEEDBACK_HINT_EVERY_N_ENV,
+  listPendingFeedbackFiles,
+  normalizeFeedbackInputType,
+  readPendingFeedbackFile,
   readFeedbackStateSnapshot,
   recordFeedbackInvocation,
   resolveFeedbackPaths,
+  savePendingFeedback,
   scrubFeedbackText,
   submitFeedback,
-  submitPendingFeedback
+  submitPendingFeedback,
 } from "../src/index.js";
 
 describe("feedback utilities", () => {
   let tempDir = "";
   let previousHintEveryN: string | undefined;
+  let previousSessionIdleMs: string | undefined;
 
   beforeEach(async () => {
     tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-feedback-"));
-    previousHintEveryN =
-      process.env[LINKEDIN_ASSISTANT_FEEDBACK_HINT_EVERY_N_ENV];
-    process.env[LINKEDIN_ASSISTANT_FEEDBACK_HINT_EVERY_N_ENV] = "3";
+    previousHintEveryN = process.env[LINKEDIN_BUDDY_FEEDBACK_HINT_EVERY_N_ENV];
+    previousSessionIdleMs =
+      process.env[LINKEDIN_BUDDY_FEEDBACK_SESSION_IDLE_MS_ENV];
+    process.env[LINKEDIN_BUDDY_FEEDBACK_HINT_EVERY_N_ENV] = "3";
   });
 
   afterEach(async () => {
     if (previousHintEveryN === undefined) {
-      delete process.env[LINKEDIN_ASSISTANT_FEEDBACK_HINT_EVERY_N_ENV];
+      delete process.env[LINKEDIN_BUDDY_FEEDBACK_HINT_EVERY_N_ENV];
     } else {
-      process.env[LINKEDIN_ASSISTANT_FEEDBACK_HINT_EVERY_N_ENV] = previousHintEveryN;
+      process.env[LINKEDIN_BUDDY_FEEDBACK_HINT_EVERY_N_ENV] =
+        previousHintEveryN;
+    }
+    if (previousSessionIdleMs === undefined) {
+      delete process.env[LINKEDIN_BUDDY_FEEDBACK_SESSION_IDLE_MS_ENV];
+    } else {
+      process.env[LINKEDIN_BUDDY_FEEDBACK_SESSION_IDLE_MS_ENV] =
+        previousSessionIdleMs;
     }
 
     await rm(tempDir, { recursive: true, force: true });
@@ -42,13 +58,18 @@ describe("feedback utilities", () => {
       "token",
       "placeholder",
       "for",
-      "redaction"
+      "redaction",
     ].join("-");
     const exampleCookieValue = ["sample", "cookie", "placeholder"].join("-");
     const exampleIpAddress = [198, 51, 100, 24].join(".");
-    const exampleHomePath = ["", "home", "sample-user", "workspace", "project", "file.ts"].join(
-      "/"
-    );
+    const exampleHomePath = [
+      "",
+      "home",
+      "sample-user",
+      "workspace",
+      "project",
+      "file.ts",
+    ].join("/");
     const input = [
       "Email: alice@example.com",
       `Authorization: Bearer ${exampleBearerToken}`,
@@ -56,7 +77,7 @@ describe("feedback utilities", () => {
       "LinkedIn URL: https://www.linkedin.com/in/alice-example/",
       "LinkedIn URN: urn:li:member:123456789",
       `IP: ${exampleIpAddress}`,
-      `Path: ${exampleHomePath}`
+      `Path: ${exampleHomePath}`,
     ].join("\n");
 
     const scrubbed = scrubFeedbackText(input);
@@ -71,29 +92,34 @@ describe("feedback utilities", () => {
   });
 
   it("shows hints on first session use, every nth invocation, and errors", async () => {
-    const exampleHomePath = ["", "home", "sample-user", "project", "src", "linkedin.ts"].join(
-      "/"
-    );
+    const exampleHomePath = [
+      "",
+      "home",
+      "sample-user",
+      "project",
+      "src",
+      "linkedin.ts",
+    ].join("/");
     const first = await recordFeedbackInvocation({
       baseDir: tempDir,
       source: "cli",
       invocationName: "status",
       activeProfileName: "default",
-      now: new Date("2026-03-11T10:00:00.000Z")
+      now: new Date("2026-03-11T10:00:00.000Z"),
     });
     const second = await recordFeedbackInvocation({
       baseDir: tempDir,
       source: "cli",
       invocationName: "health",
       activeProfileName: "default",
-      now: new Date("2026-03-11T10:01:00.000Z")
+      now: new Date("2026-03-11T10:01:00.000Z"),
     });
     const third = await recordFeedbackInvocation({
       baseDir: tempDir,
       source: "cli",
       invocationName: "profile view",
       activeProfileName: "default",
-      now: new Date("2026-03-11T10:02:00.000Z")
+      now: new Date("2026-03-11T10:02:00.000Z"),
     });
     const failed = await recordFeedbackInvocation({
       baseDir: tempDir,
@@ -101,7 +127,7 @@ describe("feedback utilities", () => {
       invocationName: "feed list",
       activeProfileName: "default",
       now: new Date("2026-03-11T10:03:00.000Z"),
-      error: new Error(`Request failed at ${exampleHomePath}`)
+      error: new Error(`Request failed at ${exampleHomePath}`),
     });
 
     expect(first.showHint).toBe(true);
@@ -115,10 +141,26 @@ describe("feedback utilities", () => {
     expect(buildFeedbackHintMessage()).toContain("linkedin-buddy feedback");
   });
 
+  it("returns context-aware hint messages by trigger reason", () => {
+    const errorHint = buildFeedbackHintMessage("error");
+    const nthHint = buildFeedbackHintMessage("nth_invocation");
+    const defaultHint = buildFeedbackHintMessage();
+    const sessionFirstHint = buildFeedbackHintMessage("session_first");
+
+    expect(errorHint).toContain("issue");
+    expect(errorHint).toContain("linkedin-buddy feedback");
+    expect(nthHint).toContain("suggestions");
+    expect(nthHint).toContain("linkedin-buddy feedback");
+    expect(defaultHint).toContain("linkedin-buddy feedback");
+    expect(sessionFirstHint).toContain("linkedin-buddy feedback");
+    expect(errorHint).not.toBe(defaultHint);
+    expect(nthHint).not.toBe(defaultHint);
+  });
+
   it("submits feedback through gh when authenticated", async () => {
     const snapshot = await readFeedbackStateSnapshot({
       baseDir: tempDir,
-      now: new Date("2026-03-11T10:00:00.000Z")
+      now: new Date("2026-03-11T10:00:00.000Z"),
     });
 
     const ghCalls: Array<{ args: string[]; command: string }> = [];
@@ -130,8 +172,8 @@ describe("feedback utilities", () => {
         technicalContext: createFeedbackTechnicalContext({
           cliVersion: "0.1.0",
           snapshot,
-          source: "cli"
-        })
+          source: "cli",
+        }),
       },
       {
         baseDir: tempDir,
@@ -145,15 +187,15 @@ describe("feedback utilities", () => {
           return {
             code: 0,
             stderr: "",
-            stdout: "https://github.com/sigvardt/linkedin-buddy/issues/999\n"
+            stdout: "https://github.com/sigvardt/linkedin-buddy/issues/999\n",
           };
-        }
-      }
+        },
+      },
     );
 
     expect(result.status).toBe("submitted");
     expect(result.url).toBe(
-      "https://github.com/sigvardt/linkedin-buddy/issues/999"
+      "https://github.com/sigvardt/linkedin-buddy/issues/999",
     );
     expect(ghCalls).toHaveLength(2);
     expect(ghCalls[1]?.args).toEqual(
@@ -165,15 +207,15 @@ describe("feedback utilities", () => {
         "--label",
         "bug",
         "--label",
-        "agent-feedback"
-      ])
+        "agent-feedback",
+      ]),
     );
   });
 
   it("saves pending feedback locally and later submits it", async () => {
     const snapshot = await readFeedbackStateSnapshot({
       baseDir: tempDir,
-      now: new Date("2026-03-11T10:00:00.000Z")
+      now: new Date("2026-03-11T10:00:00.000Z"),
     });
 
     const saved = await submitFeedback(
@@ -186,17 +228,17 @@ describe("feedback utilities", () => {
           cliVersion: "0.1.0",
           snapshot,
           source: "mcp",
-          mcpToolName: "submit_feedback"
-        })
+          mcpToolName: "submit_feedback",
+        }),
       },
       {
         baseDir: tempDir,
         runner: async () => ({
           code: 1,
           stderr: "not logged in",
-          stdout: ""
-        })
-      }
+          stdout: "",
+        }),
+      },
     );
 
     expect(saved.status).toBe("saved_pending");
@@ -207,7 +249,7 @@ describe("feedback utilities", () => {
     expect(pendingFile).toContain("[Agent Feedback] Better MCP errors");
     expect(pendingFile).toContain("[REDACTED]");
     expect(formatFeedbackDisplayPath(pendingPath, tempDir)).toMatch(
-      /^\.linkedin-buddy\/pending-feedback\//
+      /^\.linkedin-buddy\/pending-feedback\//,
     );
 
     const submitted = await submitPendingFeedback({
@@ -220,19 +262,419 @@ describe("feedback utilities", () => {
         return {
           code: 0,
           stderr: "",
-          stdout: "https://github.com/sigvardt/linkedin-buddy/issues/1000\n"
+          stdout: "https://github.com/sigvardt/linkedin-buddy/issues/1000\n",
         };
-      }
+      },
     });
 
     expect(submitted.submittedCount).toBe(1);
     expect(submitted.failureCount).toBe(0);
     expect(submitted.submitted[0]?.url).toBe(
-      "https://github.com/sigvardt/linkedin-buddy/issues/1000"
+      "https://github.com/sigvardt/linkedin-buddy/issues/1000",
     );
     await expect(readFile(pendingPath, "utf8")).rejects.toThrow();
 
     const feedbackPaths = resolveFeedbackPaths(tempDir);
     expect(feedbackPaths.pendingDir).toContain(".linkedin-buddy");
+  });
+
+  it("redacts jwt tokens", () => {
+    const jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abc123.def456";
+    const scrubbed = scrubFeedbackText(`token: ${jwt}`);
+
+    expect(scrubbed.redacted).toBe(true);
+    expect(scrubbed.value).not.toContain(jwt);
+    expect(scrubbed.value).toContain("[REDACTED]");
+  });
+
+  it("redacts authorization headers", () => {
+    const input = "Authorization: Bearer super-secret-token";
+    const scrubbed = scrubFeedbackText(input);
+
+    expect(scrubbed.redacted).toBe(true);
+    expect(scrubbed.value).not.toContain("super-secret-token");
+    expect(scrubbed.value).toContain("[REDACTED]");
+  });
+
+  it("redacts cookie headers", () => {
+    const input = [
+      "Cookie: sessionid=abc123",
+      "Set-Cookie: li_at=secret-value; HttpOnly",
+    ].join("\n");
+    const scrubbed = scrubFeedbackText(input);
+
+    expect(scrubbed.redacted).toBe(true);
+    expect(scrubbed.value).not.toContain("sessionid=abc123");
+    expect(scrubbed.value).not.toContain("li_at=secret-value");
+    expect(scrubbed.value).toContain("[REDACTED]");
+  });
+
+  it("redacts secret assignments", () => {
+    const input = 'api_key=xyz123 password: "abc"';
+    const scrubbed = scrubFeedbackText(input);
+
+    expect(scrubbed.redacted).toBe(true);
+    expect(scrubbed.value).not.toContain("xyz123");
+    expect(scrubbed.value).not.toContain("abc");
+    expect(scrubbed.value).toContain("[REDACTED]");
+  });
+
+  it("redacts windows user paths", () => {
+    const windowsPath = "C:\\Users\\alice\\project\\file.ts";
+    const scrubbed = scrubFeedbackText(`path: ${windowsPath}`);
+
+    expect(scrubbed.redacted).toBe(true);
+    expect(scrubbed.value).not.toContain(windowsPath);
+    expect(scrubbed.value).toContain("[REDACTED]");
+  });
+
+  it("redacts long secret blobs", () => {
+    const blob =
+      "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5QUJDREVGR0hJSktMTQ==";
+    const scrubbed = scrubFeedbackText(`blob=${blob}`);
+
+    expect(scrubbed.redacted).toBe(true);
+    expect(scrubbed.value).not.toContain(blob);
+    expect(scrubbed.value).toContain("[REDACTED]");
+  });
+
+  it("collapses repeated redaction tokens", () => {
+    const scrubbed = scrubFeedbackText("[REDACTED] - [REDACTED] / [REDACTED]");
+
+    expect(scrubbed.redacted).toBe(false);
+    expect(scrubbed.value).toBe("[REDACTED]");
+  });
+
+  it("returns false when text has no sensitive content", () => {
+    const input = "status command failed after reconnect without stack trace";
+    const scrubbed = scrubFeedbackText(input);
+
+    expect(scrubbed.redacted).toBe(false);
+    expect(scrubbed.value).toBe(input);
+  });
+
+  it("returns empty string without redaction for empty input", () => {
+    const scrubbed = scrubFeedbackText("");
+
+    expect(scrubbed.redacted).toBe(false);
+    expect(scrubbed.value).toBe("");
+  });
+
+  it("normalizes feedback type case insensitively", () => {
+    expect(normalizeFeedbackInputType("BUG")).toBe("bug");
+  });
+
+  it("normalizes feedback type with trimmed whitespace", () => {
+    expect(normalizeFeedbackInputType("  feature  ")).toBe("feature");
+  });
+
+  it("throws for invalid feedback type", () => {
+    expect(() => normalizeFeedbackInputType("invalid")).toThrow(
+      LinkedInBuddyError,
+    );
+  });
+
+  it("resolves feedback paths under home directory by default", () => {
+    const resolved = resolveFeedbackPaths();
+
+    expect(resolved.feedbackRootDir).toBe(
+      path.join(os.homedir(), ".linkedin-buddy"),
+    );
+    expect(resolved.pendingDir).toBe(
+      path.join(os.homedir(), ".linkedin-buddy", "pending-feedback"),
+    );
+  });
+
+  it("resolves feedback paths under a custom base directory", () => {
+    const resolved = resolveFeedbackPaths("/custom/dir");
+
+    expect(resolved.feedbackRootDir).toBe(
+      path.join(path.resolve("/custom/dir"), ".linkedin-buddy"),
+    );
+    expect(resolved.statePath).toBe(
+      path.join(
+        path.resolve("/custom/dir"),
+        ".linkedin-buddy",
+        "feedback-state.json",
+      ),
+    );
+  });
+
+  it("formats display path as relative when file is inside feedback root", () => {
+    const filePath = path.join(
+      tempDir,
+      ".linkedin-buddy",
+      "pending-feedback",
+      "entry.md",
+    );
+
+    expect(formatFeedbackDisplayPath(filePath, tempDir)).toBe(
+      path.join(".linkedin-buddy", "pending-feedback", "entry.md"),
+    );
+  });
+
+  it("formats display path as absolute when file is outside feedback root", () => {
+    const outsideFilePath = path.join(tempDir, "outside.md");
+
+    expect(
+      formatFeedbackDisplayPath(outsideFilePath, path.join(tempDir, "other")),
+    ).toBe(outsideFilePath);
+  });
+
+  it("includes humanized session duration in feedback body", async () => {
+    const result = await submitFeedback(
+      {
+        type: "bug",
+        title: "duration formatting",
+        description: "checks duration format",
+        technicalContext: createFeedbackTechnicalContext({
+          cliVersion: "0.1.0",
+          snapshot: {
+            activeProfileName: "default",
+            invocationCount: 1,
+            lastErrorStack: null,
+            lastInvocationName: "feedback",
+            lastMcpToolName: null,
+            sessionDurationMs: 3_726_000,
+            sessionId: "session-1",
+            sessionStartedAt: "2026-03-11T10:00:00.000Z",
+          },
+          source: "cli",
+        }),
+      },
+      {
+        baseDir: tempDir,
+        runner: async () => ({ code: 1, stderr: "not logged in", stdout: "" }),
+      },
+    );
+
+    expect(result.body).toContain("- Session duration: 1h 2m 6s");
+  });
+
+  it("expires session state after configured idle threshold", async () => {
+    process.env[LINKEDIN_BUDDY_FEEDBACK_SESSION_IDLE_MS_ENV] = "0";
+
+    const first = await recordFeedbackInvocation({
+      baseDir: tempDir,
+      source: "cli",
+      invocationName: "status",
+      now: new Date("2026-03-11T10:00:00.000Z"),
+    });
+    const second = await recordFeedbackInvocation({
+      baseDir: tempDir,
+      source: "cli",
+      invocationName: "status",
+      now: new Date("2026-03-11T10:00:00.001Z"),
+    });
+
+    expect(first.snapshot.sessionId).not.toBe(second.snapshot.sessionId);
+    expect(second.reason).toBe("session_first");
+  });
+
+  it("returns zero-count snapshot for fresh feedback state", async () => {
+    const snapshot = await readFeedbackStateSnapshot({
+      baseDir: tempDir,
+      now: new Date("2026-03-11T10:00:00.000Z"),
+    });
+
+    expect(snapshot.invocationCount).toBe(0);
+    expect(snapshot.lastInvocationName).toBeNull();
+    expect(snapshot.lastErrorStack).toBeNull();
+    expect(snapshot.sessionDurationMs).toBe(0);
+  });
+
+  it("uses hint cadence from environment override", async () => {
+    process.env[LINKEDIN_BUDDY_FEEDBACK_HINT_EVERY_N_ENV] = "2";
+
+    await recordFeedbackInvocation({
+      baseDir: tempDir,
+      source: "cli",
+      invocationName: "status",
+      now: new Date("2026-03-11T10:00:00.000Z"),
+    });
+    const second = await recordFeedbackInvocation({
+      baseDir: tempDir,
+      source: "cli",
+      invocationName: "health",
+      now: new Date("2026-03-11T10:00:30.000Z"),
+    });
+
+    expect(second.showHint).toBe(true);
+    expect(second.reason).toBe("nth_invocation");
+  });
+
+  it("returns empty pending file list when directory is missing", async () => {
+    const pendingFiles = await listPendingFeedbackFiles(tempDir);
+
+    expect(pendingFiles).toEqual([]);
+  });
+
+  it("throws when pending feedback metadata is malformed", async () => {
+    const malformedFilePath = path.join(tempDir, "malformed.md");
+    await writeFile(
+      malformedFilePath,
+      [
+        "<!-- linkedin-buddy-feedback-metadata",
+        '{"createdAt":"2026-03-11T10:00:00.000Z"}',
+        "-->",
+        "body",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await expect(readPendingFeedbackFile(malformedFilePath)).rejects.toThrow(
+      "metadata is incomplete",
+    );
+  });
+
+  it("throws helpful error when submitting pending feedback without gh auth", async () => {
+    await submitFeedback(
+      {
+        type: "bug",
+        title: "pending auth failure",
+        description: "save pending first",
+        technicalContext: createFeedbackTechnicalContext({
+          cliVersion: "0.1.0",
+          snapshot: {
+            activeProfileName: "default",
+            invocationCount: 0,
+            lastErrorStack: null,
+            lastInvocationName: null,
+            lastMcpToolName: null,
+            sessionDurationMs: 0,
+            sessionId: "session-1",
+            sessionStartedAt: "2026-03-11T10:00:00.000Z",
+          },
+          source: "cli",
+        }),
+      },
+      {
+        baseDir: tempDir,
+        runner: async () => ({ code: 1, stderr: "not logged in", stdout: "" }),
+      },
+    );
+
+    await expect(
+      submitPendingFeedback({
+        baseDir: tempDir,
+        runner: async () => ({ code: 1, stderr: "not logged in", stdout: "" }),
+      }),
+    ).rejects.toThrow("gh auth login");
+  });
+
+  it("falls back to pending file when github issue creation fails", async () => {
+    const result = await submitFeedback(
+      {
+        type: "bug",
+        title: "gh issue create failure",
+        description: "save pending on issue failure",
+        technicalContext: createFeedbackTechnicalContext({
+          cliVersion: "0.1.0",
+          snapshot: {
+            activeProfileName: "default",
+            invocationCount: 0,
+            lastErrorStack: null,
+            lastInvocationName: null,
+            lastMcpToolName: null,
+            sessionDurationMs: 0,
+            sessionId: "session-1",
+            sessionStartedAt: "2026-03-11T10:00:00.000Z",
+          },
+          source: "cli",
+        }),
+      },
+      {
+        baseDir: tempDir,
+        runner: async (_command, args) => {
+          if (args[0] === "auth") {
+            return { code: 0, stderr: "", stdout: "ok" };
+          }
+
+          return { code: 1, stderr: "create failed", stdout: "" };
+        },
+      },
+    );
+
+    expect(result.status).toBe("saved_pending");
+    expect(result.pendingFilePath).toBeDefined();
+  });
+
+  it("throws when invocation name is empty", async () => {
+    await expect(
+      recordFeedbackInvocation({
+        baseDir: tempDir,
+        source: "cli",
+        invocationName: "   ",
+      }),
+    ).rejects.toThrow("invocation name must not be empty");
+  });
+
+  it("rejects saving when pending file count exceeds the limit", async () => {
+    const feedbackPaths = resolveFeedbackPaths(tempDir);
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(feedbackPaths.pendingDir, { recursive: true });
+
+    for (let i = 0; i < MAX_PENDING_FEEDBACK_FILES; i++) {
+      const padded = String(i).padStart(4, "0");
+      await writeFile(
+        path.join(
+          feedbackPaths.pendingDir,
+          `2026-01-01T00-00-00-000Z-bug-${padded}.md`,
+        ),
+        [
+          "<!-- linkedin-buddy-feedback-metadata",
+          JSON.stringify({
+            createdAt: "2026-01-01T00:00:00.000Z",
+            labels: ["bug", "agent-feedback"],
+            redactionApplied: false,
+            title: `[Agent Feedback] placeholder ${padded}`,
+            type: "bug",
+          }),
+          "-->",
+          "",
+          "placeholder body",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+    }
+
+    const snapshot = await readFeedbackStateSnapshot({
+      baseDir: tempDir,
+      now: new Date("2026-03-11T10:00:00.000Z"),
+    });
+
+    await expect(
+      savePendingFeedback(
+        {
+          type: "bug",
+          title: "one more",
+          description: "exceeds limit",
+          technicalContext: createFeedbackTechnicalContext({
+            cliVersion: "0.1.0",
+            snapshot,
+            source: "cli",
+          }),
+        },
+        { baseDir: tempDir },
+      ),
+    ).rejects.toThrow(`Cannot save more than ${MAX_PENDING_FEEDBACK_FILES}`);
+  });
+
+  it("rejects reading an oversized pending feedback file", async () => {
+    const feedbackPaths = resolveFeedbackPaths(tempDir);
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(feedbackPaths.pendingDir, { recursive: true });
+
+    const oversizedPath = path.join(
+      feedbackPaths.pendingDir,
+      "2026-01-01T00-00-00-000Z-bug.md",
+    );
+    const largeContent = "x".repeat(600 * 1024);
+    await writeFile(oversizedPath, largeContent, "utf8");
+
+    await expect(readPendingFeedbackFile(oversizedPath)).rejects.toThrow(
+      "byte limit",
+    );
   });
 });

--- a/packages/mcp/src/__tests__/feedbackMcp.test.ts
+++ b/packages/mcp/src/__tests__/feedbackMcp.test.ts
@@ -1,28 +1,25 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   LINKEDIN_SESSION_STATUS_TOOL,
-  SUBMIT_FEEDBACK_TOOL
+  SUBMIT_FEEDBACK_TOOL,
 } from "../index.js";
 
 const feedbackMcpMocks = vi.hoisted(() => ({
   createCoreRuntime: vi.fn(),
   readFeedbackStateSnapshot: vi.fn(),
   recordFeedbackInvocation: vi.fn(),
-  submitFeedback: vi.fn()
+  submitFeedback: vi.fn(),
 }));
 
 vi.mock("@linkedin-buddy/core", async () => {
-  const actual =
-    await vi.importActual<typeof import("@linkedin-buddy/core")>(
-      "@linkedin-buddy/core"
-    );
+  const actual = await vi.importActual("@linkedin-buddy/core");
 
   return {
     ...actual,
     createCoreRuntime: feedbackMcpMocks.createCoreRuntime,
     readFeedbackStateSnapshot: feedbackMcpMocks.readFeedbackStateSnapshot,
     recordFeedbackInvocation: feedbackMcpMocks.recordFeedbackInvocation,
-    submitFeedback: feedbackMcpMocks.submitFeedback
+    submitFeedback: feedbackMcpMocks.submitFeedback,
   };
 });
 
@@ -38,15 +35,15 @@ describe("feedback MCP tooling", () => {
           authenticated: true,
           evasion: {
             diagnosticsEnabled: false,
-            level: "moderate"
-          }
-        })
+            level: "moderate",
+          },
+        }),
       },
       close: vi.fn(),
       logger: {
-        log: vi.fn()
+        log: vi.fn(),
       },
-      runId: "run-mcp-feedback"
+      runId: "run-mcp-feedback",
     });
     feedbackMcpMocks.readFeedbackStateSnapshot.mockResolvedValue({
       activeProfileName: "default",
@@ -56,7 +53,7 @@ describe("feedback MCP tooling", () => {
       lastMcpToolName: "linkedin.feed.list",
       sessionDurationMs: 120_000,
       sessionId: "session-1",
-      sessionStartedAt: "2026-03-11T10:00:00.000Z"
+      sessionStartedAt: "2026-03-11T10:00:00.000Z",
     });
     feedbackMcpMocks.recordFeedbackInvocation.mockResolvedValue({
       reason: "session_first",
@@ -69,8 +66,8 @@ describe("feedback MCP tooling", () => {
         lastMcpToolName: "linkedin.session.status",
         sessionDurationMs: 180_000,
         sessionId: "session-1",
-        sessionStartedAt: "2026-03-11T10:00:00.000Z"
-      }
+        sessionStartedAt: "2026-03-11T10:00:00.000Z",
+      },
     });
     feedbackMcpMocks.submitFeedback.mockResolvedValue({
       body: "body",
@@ -81,7 +78,7 @@ describe("feedback MCP tooling", () => {
       title: "[Agent Feedback] Add more logs",
       type: "feature",
       pendingFilePath:
-        "/tmp/assistant-home/.linkedin-buddy/pending-feedback/2026-03-11-feature.md"
+        "/tmp/assistant-home/.linkedin-buddy/pending-feedback/2026-03-11-feature.md",
     });
 
     ({ handleToolCall } = await import("../bin/linkedin-mcp.js"));
@@ -91,7 +88,8 @@ describe("feedback MCP tooling", () => {
     const result = await handleToolCall(SUBMIT_FEEDBACK_TOOL, {
       type: "feature",
       title: "Add more logs",
-      description: "The MCP surface should preserve a little more debug context."
+      description:
+        "The MCP surface should preserve a little more debug context.",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -99,32 +97,78 @@ describe("feedback MCP tooling", () => {
       expect.objectContaining({
         type: "feature",
         title: "Add more logs",
-        description: "The MCP surface should preserve a little more debug context."
-      })
+        description:
+          "The MCP surface should preserve a little more debug context.",
+      }),
     );
 
-    const payload = JSON.parse(result.content[0]?.text ?? "{}") as Record<string, unknown>;
+    const payload = JSON.parse(result.content[0]?.text ?? "{}") as Record<
+      string,
+      unknown
+    >;
     expect(payload.status).toBe("saved_pending");
     expect(payload.pending_file_path).toBe(
-      ".linkedin-buddy/pending-feedback/2026-03-11-feature.md"
+      ".linkedin-buddy/pending-feedback/2026-03-11-feature.md",
     );
     expect(payload.feedback_hint).toBeUndefined();
   });
 
   it("adds a feedback hint to ordinary tool results when the tracker says to show one", async () => {
     const result = await handleToolCall(LINKEDIN_SESSION_STATUS_TOOL, {
-      profileName: "default"
+      profileName: "default",
     });
 
     expect("isError" in result && result.isError).toBe(false);
-    const payload = JSON.parse(result.content[0]?.text ?? "{}") as Record<string, unknown>;
+    const payload = JSON.parse(result.content[0]?.text ?? "{}") as Record<
+      string,
+      unknown
+    >;
     expect(payload.feedback_hint).toContain("linkedin-buddy feedback");
     expect(feedbackMcpMocks.recordFeedbackInvocation).toHaveBeenCalledWith(
       expect.objectContaining({
         invocationName: LINKEDIN_SESSION_STATUS_TOOL,
         mcpToolName: LINKEDIN_SESSION_STATUS_TOOL,
-        source: "mcp"
-      })
+        source: "mcp",
+      }),
     );
+  });
+
+  it("returns an error when submit_feedback title is missing", async () => {
+    const result = await handleToolCall(SUBMIT_FEEDBACK_TOOL, {
+      type: "feature",
+      description: "description",
+    });
+
+    expect("isError" in result && result.isError).toBe(true);
+  });
+
+  it("returns an error when submit_feedback description is empty", async () => {
+    const result = await handleToolCall(SUBMIT_FEEDBACK_TOOL, {
+      type: "feature",
+      title: "title",
+      description: "   ",
+    });
+
+    expect("isError" in result && result.isError).toBe(true);
+  });
+
+  it("does not add feedback hint to submit_feedback error results", async () => {
+    feedbackMcpMocks.submitFeedback.mockRejectedValueOnce(
+      new Error("submit failed"),
+    );
+
+    const result = await handleToolCall(SUBMIT_FEEDBACK_TOOL, {
+      type: "feature",
+      title: "title",
+      description: "description",
+    });
+
+    expect("isError" in result && result.isError).toBe(true);
+    const payload = JSON.parse(result.content[0]?.text ?? "{}") as Record<
+      string,
+      unknown
+    >;
+    expect(payload.feedback_hint).toBeUndefined();
+    expect(feedbackMcpMocks.recordFeedbackInvocation).not.toHaveBeenCalled();
   });
 });

--- a/packages/mcp/src/bin/linkedin-mcp.ts
+++ b/packages/mcp/src/bin/linkedin-mcp.ts
@@ -571,7 +571,8 @@ function shouldTrackMcpFeedback(toolName: string): boolean {
 }
 
 function addFeedbackHintToResult<T extends ToolResult | ToolErrorResult>(
-  result: T
+  result: T,
+  reason?: Parameters<typeof buildFeedbackHintMessage>[0],
 ): T {
   const firstContent = result.content[0];
   if (!firstContent || firstContent.type !== "text") {
@@ -580,7 +581,7 @@ function addFeedbackHintToResult<T extends ToolResult | ToolErrorResult>(
 
   try {
     const parsed = JSON.parse(firstContent.text) as Record<string, unknown>;
-    parsed.feedback_hint = buildFeedbackHintMessage();
+    parsed.feedback_hint = buildFeedbackHintMessage(reason);
 
     return {
       ...result,
@@ -7930,7 +7931,7 @@ export async function handleToolCall(
         ...(profileName ? { activeProfileName: profileName } : {})
       });
 
-      return decision.showHint ? addFeedbackHintToResult(result) : result;
+      return decision.showHint ? addFeedbackHintToResult(result, decision.reason) : result;
     }
 
     errorForTracking = new LinkedInBuddyError(
@@ -7951,7 +7952,7 @@ export async function handleToolCall(
     });
 
     return decision.showHint
-      ? addFeedbackHintToResult(unknownToolResult)
+      ? addFeedbackHintToResult(unknownToolResult, decision.reason)
       : unknownToolResult;
   } catch (error) {
     errorForTracking = error;
@@ -7976,7 +7977,7 @@ export async function handleToolCall(
         error: errorForTracking
       });
 
-      return decision.showHint ? addFeedbackHintToResult(errorResult) : errorResult;
+      return decision.showHint ? addFeedbackHintToResult(errorResult, decision.reason) : errorResult;
     } catch {
       return errorResult;
     }


### PR DESCRIPTION
## Summary

Quality pass (phases 3–8) on the agent feedback loop feature from PR #309.

Closes #355

## Changes by Phase

### Phase 3: Simplify + Refactor
- Removed dead `LINKEDIN_ASSISTANT_*` env var aliases
- Consolidated duplicate `normalizeFeedbackType` into single exported `normalizeFeedbackInputType`
- Simplified `createFeedbackTechnicalContext` with direct assignment over conditional spreads

### Phase 4: Test (+34 tests, 983 → 1017)
- PII scrubbing edge cases: JWT, auth headers, cookies, secrets, Windows paths, long blobs, repeated redaction
- Type normalization: case-insensitive, whitespace trim, invalid throws
- Session expiry and fresh snapshot behavior
- Pending file edge cases and error handling
- Submit fallback behavior, empty invocation validation
- CLI: non-interactive refusal, JSON output, invalid type
- MCP: missing required fields, error result hint exclusion

### Phase 5: Harden
- 30s timeout on `gh` CLI child process (`GH_COMMAND_TIMEOUT_MS`)
- 50-file max pending feedback limit (`MAX_PENDING_FEEDBACK_FILES`)
- 512KB file size guard on `readPendingFeedbackFile` (`MAX_PENDING_FEEDBACK_FILE_BYTES`)
- 2 new hardening tests

### Phase 6: UX/QoL
- Context-aware feedback hint messages based on trigger reason:
  - `"error"` → "Ran into an issue? Run `linkedin-buddy feedback` to report it."
  - `"nth_invocation"` → "Enjoying LinkedIn Buddy? Run `linkedin-buddy feedback` to share suggestions."
  - default → "Found a bug or have an idea? Run `linkedin-buddy feedback` to file it directly."
- Updated CLI and MCP callers to pass `decision.reason` through

### Phase 7: Verify — Skipped
Live E2E against LinkedIn restricted by safety rules.

### Phase 8: Docs
- Created `docs/agent-feedback.md` covering quickstart, MCP tool, privacy scrubbing, pending feedback, hints, configuration, and hardening limits

## Quality Gates
- ✅ 1017/1017 tests passing
- ✅ Lint clean (0 errors)
- ⚠️ Typecheck/build have pre-existing errors (not introduced by this PR)