### PR TITLE
feat: quality pass for hardening (#215) (#358)

### DIFF
--- a/docs/hardening-pass-215.md
+++ b/docs/hardening-pass-215.md
@@ -1,0 +1,94 @@
+# Hardening Pass (#215) — Quality Pass
+
+Date: 2026-03-12
+Parent issue: #215
+Quality pass issue: #358
+Original hardening PR: #313
+
+## Summary
+
+This quality pass ran the remaining phases (3–8) from the hardening pipeline
+defined in #215. The original PR #313 added MCP tool input schema validation
+and a shared tool catalog. This pass extends that foundation with input
+validation helpers, unit tests for previously untested modules, and error
+recovery hints for MCP tool consumers.
+
+## Phase 3 — Simplify / Refactor
+
+No code changes were needed. The 30 previously reported typecheck errors were
+traced to missing workspace symlinks in the worktree environment, not source
+code issues. All quality gates pass clean on the current `main` codebase.
+
+## Phase 4 — Test
+
+Added 36 unit tests across three new test files:
+
+| File                                          | Tests | Coverage                                                                                                                             |
+| --------------------------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `packages/core/src/__tests__/errors.test.ts`  | 13    | `LinkedInBuddyError` construction, error payload conversion, privacy redaction in error payloads, `asLinkedInBuddyError` conversions |
+| `packages/core/src/__tests__/privacy.test.ts` | 15    | `resolvePrivacyConfig`, `redactFreeformText`, `redactStructuredValue` across off/partial/full redaction modes                        |
+| `packages/core/src/__tests__/logging.test.ts` | 8     | Logger creation, JSONL event format, log levels, append semantics, payload redaction, DB emission                                    |
+
+These modules were identified as critical gaps: the error taxonomy and privacy
+redaction are used across every MCP tool handler and CLI command, yet had zero
+dedicated test coverage.
+
+## Phase 5 — Harden
+
+### New MCP validation helpers
+
+Three reusable input validation functions added to the MCP server
+(`packages/mcp/src/bin/linkedin-mcp.ts`):
+
+| Helper                                               | Purpose                                                         | Default     |
+| ---------------------------------------------------- | --------------------------------------------------------------- | ----------- |
+| `readBoundedString(args, key, maxLength, fallback?)` | Enforces max character length on text inputs                    | 5 000 chars |
+| `readValidatedUrl(args, key)`                        | Validates and normalizes URL format via `new URL()`             | —           |
+| `readValidatedFilePath(args, key)`                   | Rejects empty paths and path-traversal patterns (`../`, `..\\`) | —           |
+
+### Application
+
+- **Bounded strings** applied to: `handlePrepareReply` (8 000), `handlePrepareNewThread` (8 000), `handleFeedComment` (3 000), `handlePostPrepareCreate` (3 000), `handlePostPrepareEdit` (3 000)
+- **URL validation** applied to: `handleFeedViewPost`, `handleFeedLike`, `handleFeedComment`, `handleFeedPrepareRepost`, `handleFeedSavePost`
+- **File path validation** applied to: `handleProfilePrepareUploadPhoto`, `handleProfilePrepareUploadBanner`
+
+All validation errors throw `LinkedInBuddyError` with code
+`ACTION_PRECONDITION_FAILED` and include the argument path, actual value
+metadata, and a descriptive message.
+
+## Phase 6 — UX / QoL
+
+Added error recovery hints to MCP tool error responses. Every error response
+now includes a `recovery_hint` field that suggests the next action based on
+the error code:
+
+| Error code                   | Recovery hint summary                                     |
+| ---------------------------- | --------------------------------------------------------- |
+| `AUTH_REQUIRED`              | Run `linkedin.session.open_login` to re-authenticate      |
+| `CAPTCHA_OR_CHALLENGE`       | Complete the challenge in the browser manually            |
+| `RATE_LIMITED`               | Wait for the rate-limit window to reset                   |
+| `UI_CHANGED_SELECTOR_FAILED` | Run `linkedin.session.health` to check browser state      |
+| `NETWORK_ERROR`              | Verify connectivity, then check `linkedin.session.health` |
+| `TIMEOUT`                    | Check session health, retry with simpler query            |
+| `TARGET_NOT_FOUND`           | Verify the URL or identifier is correct                   |
+| `ACTION_PRECONDITION_FAILED` | Check error details for missing prerequisites             |
+
+## Phase 7 — Verify
+
+Deferred. Live E2E verification against the Joi Ascend test account requires
+an authenticated LinkedIn session with browser access, which is not available
+in the automated agent context. This phase should be run manually by a human
+operator following the procedure in `docs/e2e-testing.md`.
+
+## Phase 8 — Docs
+
+This document.
+
+## Quality gates
+
+All gates pass after all phases:
+
+- `npm run typecheck` — 0 errors
+- `npm run lint` — clean
+- `npm test` — 1143+ tests passing (107+ test files)
+- `npm run build` — clean

--- a/packages/core/src/__tests__/errors.test.ts
+++ b/packages/core/src/__tests__/errors.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  LINKEDIN_BUDDY_ERROR_CODES,
+  LinkedInBuddyError,
+  asLinkedInBuddyError,
+  toLinkedInBuddyErrorPayload,
+} from "../errors.js";
+
+describe("errors", () => {
+  it("exports all supported LinkedIn Buddy error codes", () => {
+    expect(LINKEDIN_BUDDY_ERROR_CODES).toEqual([
+      "AUTH_REQUIRED",
+      "CAPTCHA_OR_CHALLENGE",
+      "RATE_LIMITED",
+      "UI_CHANGED_SELECTOR_FAILED",
+      "NETWORK_ERROR",
+      "TIMEOUT",
+      "TARGET_NOT_FOUND",
+      "ACTION_PRECONDITION_FAILED",
+      "UNKNOWN",
+    ]);
+  });
+
+  it("constructs LinkedInBuddyError for every known code", () => {
+    for (const code of LINKEDIN_BUDDY_ERROR_CODES) {
+      const error = new LinkedInBuddyError(code, `message-${code}`, {
+        marker: code,
+      });
+
+      expect(error.name).toBe("LinkedInBuddyError");
+      expect(error.code).toBe(code);
+      expect(error.message).toBe(`message-${code}`);
+      expect(error.details).toEqual({ marker: code });
+    }
+  });
+
+  it("preserves Error cause when provided", () => {
+    const cause = new Error("root cause");
+    const error = new LinkedInBuddyError(
+      "NETWORK_ERROR",
+      "network blew up",
+      {},
+      { cause },
+    );
+
+    expect((error as Error & { cause?: unknown }).cause).toBe(cause);
+  });
+
+  it("uses empty details by default", () => {
+    const error = new LinkedInBuddyError("UNKNOWN", "fallback");
+    expect(error.details).toEqual({});
+  });
+
+  it("converts LinkedInBuddyError payload without redaction in off mode", () => {
+    const error = new LinkedInBuddyError(
+      "AUTH_REQUIRED",
+      "Email me at owner@example.com",
+      {
+        participant_name: "Jane Doe",
+        contact_email: "owner@example.com",
+      },
+    );
+
+    const payload = toLinkedInBuddyErrorPayload(error, {
+      redactionMode: "off",
+      storageMode: "full",
+      hashSalt: "salt",
+      messageExcerptLength: 10,
+    });
+
+    expect(payload).toEqual({
+      code: "AUTH_REQUIRED",
+      message: "Email me at owner@example.com",
+      details: {
+        participant_name: "Jane Doe",
+        contact_email: "owner@example.com",
+      },
+    });
+  });
+
+  it("redacts LinkedInBuddyError payload in partial mode", () => {
+    const error = new LinkedInBuddyError(
+      "RATE_LIMITED",
+      "Reach me at owner@example.com and /in/jane-doe",
+      {
+        participant_name: "Jane Doe",
+        body: "Hello Jane Doe from message body",
+      },
+    );
+
+    const payload = toLinkedInBuddyErrorPayload(error, {
+      redactionMode: "partial",
+      storageMode: "full",
+      hashSalt: "salt",
+      messageExcerptLength: 5,
+    });
+
+    expect(payload.code).toBe("RATE_LIMITED");
+    expect(payload.message).toContain("email#");
+    expect(payload.message).toContain("profile#");
+    expect(String(payload.details.participant_name)).toMatch(
+      /^person#[A-Za-z0-9_-]{12}$/,
+    );
+    expect(String(payload.details.body)).toContain("… [len=");
+    expect(String(payload.details.body)).toContain("hash=");
+  });
+
+  it("redacts LinkedInBuddyError payload in full mode", () => {
+    const error = new LinkedInBuddyError(
+      "CAPTCHA_OR_CHALLENGE",
+      "owner@example.com",
+      {
+        body: "Very sensitive message content",
+      },
+    );
+
+    const payload = toLinkedInBuddyErrorPayload(error, {
+      redactionMode: "full",
+      storageMode: "full",
+      hashSalt: "salt",
+      messageExcerptLength: 20,
+    });
+
+    expect(payload.message).toContain("email#");
+    expect(String(payload.details.body)).toMatch(
+      /^\[redacted len=\d+ hash=[A-Za-z0-9_-]{12}\]$/,
+    );
+  });
+
+  it("converts native Error payload to UNKNOWN code", () => {
+    const payload = toLinkedInBuddyErrorPayload(
+      new TypeError("Bad email owner@example.com"),
+      {
+        redactionMode: "partial",
+        storageMode: "full",
+        hashSalt: "salt",
+        messageExcerptLength: 20,
+      },
+    );
+
+    expect(payload.code).toBe("UNKNOWN");
+    expect(payload.message).toContain("email#");
+    expect(payload.details).toEqual({
+      cause_name: "TypeError",
+    });
+  });
+
+  it("converts non-Error payloads to UNKNOWN code with raw details", () => {
+    const payload = toLinkedInBuddyErrorPayload(404, {
+      redactionMode: "off",
+      storageMode: "full",
+      hashSalt: "salt",
+      messageExcerptLength: 20,
+    });
+
+    expect(payload).toEqual({
+      code: "UNKNOWN",
+      message: "404",
+      details: {
+        raw: "404",
+      },
+    });
+  });
+
+  it("returns the original LinkedInBuddyError in asLinkedInBuddyError", () => {
+    const original = new LinkedInBuddyError("TIMEOUT", "timed out", {
+      attempt: 2,
+    });
+    expect(asLinkedInBuddyError(original)).toBe(original);
+  });
+
+  it("converts Error into LinkedInBuddyError with fallback code and cause", () => {
+    const source = new Error("network timeout");
+    const converted = asLinkedInBuddyError(source, "NETWORK_ERROR", "fallback");
+
+    expect(converted).toBeInstanceOf(LinkedInBuddyError);
+    expect(converted.code).toBe("NETWORK_ERROR");
+    expect(converted.message).toBe("network timeout");
+    expect(converted.details).toEqual({ cause_name: "Error" });
+    expect((converted as Error & { cause?: unknown }).cause).toBe(source);
+  });
+
+  it("uses fallback message when converting Error with empty message", () => {
+    const source = new Error("");
+    const converted = asLinkedInBuddyError(
+      source,
+      "ACTION_PRECONDITION_FAILED",
+      "fallback message",
+    );
+
+    expect(converted.message).toBe("fallback message");
+  });
+
+  it("converts non-Error values into LinkedInBuddyError", () => {
+    const mapper = vi.fn((value: unknown) =>
+      asLinkedInBuddyError(value, "TARGET_NOT_FOUND", "missing target"),
+    );
+
+    const converted = mapper({ id: 123 });
+
+    expect(converted.code).toBe("TARGET_NOT_FOUND");
+    expect(converted.message).toBe("missing target");
+    expect(converted.details).toEqual({ raw: "[object Object]" });
+    expect(mapper).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/__tests__/logging.test.ts
+++ b/packages/core/src/__tests__/logging.test.ts
@@ -1,0 +1,190 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveConfigPaths } from "../config.js";
+import { JsonEventLogger } from "../logging.js";
+import type { AssistantDatabase } from "../db/database.js";
+import type { PrivacyConfig } from "../privacy.js";
+
+const tempDirs: string[] = [];
+
+function createTempPaths() {
+  const baseDir = mkdtempSync(path.join(tmpdir(), "linkedin-logging-test-"));
+  tempDirs.push(baseDir);
+  return resolveConfigPaths(baseDir);
+}
+
+function parseJsonLines(filePath: string): Array<Record<string, unknown>> {
+  const content = readFileSync(filePath, "utf8").trim();
+  if (!content) {
+    return [];
+  }
+
+  return content
+    .split("\n")
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const tempDir = tempDirs.pop();
+    if (!tempDir) {
+      continue;
+    }
+
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe("logging", () => {
+  it("creates a run-specific events path", () => {
+    const paths = createTempPaths();
+    const logger = new JsonEventLogger(paths, "run-123");
+
+    expect(logger.getEventsPath()).toBe(
+      path.join(paths.artifactsDir, "run-123", "events.jsonl"),
+    );
+    expect(existsSync(path.join(paths.artifactsDir, "run-123"))).toBe(true);
+  });
+
+  it("writes structured JSON event entries", () => {
+    const paths = createTempPaths();
+    const logger = new JsonEventLogger(paths, "run-structured");
+
+    const entry = logger.log("info", "action.started", {
+      action_id: "act-1",
+      duration_ms: 5,
+    });
+
+    expect(entry.run_id).toBe("run-structured");
+    expect(entry.level).toBe("info");
+    expect(entry.event).toBe("action.started");
+    expect(entry.payload).toEqual({
+      action_id: "act-1",
+      duration_ms: 5,
+    });
+    expect(Number.isNaN(Date.parse(entry.ts))).toBe(false);
+
+    const lines = parseJsonLines(logger.getEventsPath());
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({
+      run_id: "run-structured",
+      level: "info",
+      event: "action.started",
+      payload: {
+        action_id: "act-1",
+        duration_ms: 5,
+      },
+    });
+  });
+
+  it("appends multiple events to a jsonl file", () => {
+    const paths = createTempPaths();
+    const logger = new JsonEventLogger(paths, "run-append");
+
+    logger.log("debug", "first", { index: 1 });
+    logger.log("warn", "second", { index: 2 });
+
+    const lines = parseJsonLines(logger.getEventsPath());
+    expect(lines).toHaveLength(2);
+    expect(lines[0]?.event).toBe("first");
+    expect(lines[1]?.event).toBe("second");
+  });
+
+  it("supports all log levels", () => {
+    const paths = createTempPaths();
+    const logger = new JsonEventLogger(paths, "run-levels");
+
+    logger.log("debug", "level.debug");
+    logger.log("info", "level.info");
+    logger.log("warn", "level.warn");
+    logger.log("error", "level.error");
+
+    const levels = parseJsonLines(logger.getEventsPath()).map(
+      (entry) => entry.level,
+    );
+    expect(levels).toEqual(["debug", "info", "warn", "error"]);
+  });
+
+  it("defaults payload to an empty object", () => {
+    const paths = createTempPaths();
+    const logger = new JsonEventLogger(paths, "run-empty-payload");
+
+    const entry = logger.log("info", "no.payload");
+
+    expect(entry.payload).toEqual({});
+    const lines = parseJsonLines(logger.getEventsPath());
+    expect(lines[0]?.payload).toEqual({});
+  });
+
+  it("redacts payload values before writing to disk", () => {
+    const paths = createTempPaths();
+    const privacy: PrivacyConfig = {
+      redactionMode: "partial",
+      storageMode: "full",
+      hashSalt: "salt",
+      messageExcerptLength: 8,
+    };
+    const logger = new JsonEventLogger(
+      paths,
+      "run-redaction",
+      undefined,
+      privacy,
+    );
+
+    logger.log("info", "privacy.check", {
+      email: "owner@example.com",
+      messages: [{ text: "Hello Jane Doe" }],
+    });
+
+    const serialized = readFileSync(logger.getEventsPath(), "utf8");
+    expect(serialized).not.toContain("owner@example.com");
+    expect(serialized).not.toContain("Hello Jane Doe");
+    expect(serialized).toContain("email#");
+    expect(serialized).toContain("[len=");
+  });
+
+  it("sends sanitized log rows to the database when configured", () => {
+    const paths = createTempPaths();
+    const insertRunLog = vi.fn();
+    const db = {
+      insertRunLog,
+    } as unknown as AssistantDatabase;
+    const logger = new JsonEventLogger(paths, "run-db", db, {
+      redactionMode: "partial",
+      storageMode: "full",
+      hashSalt: "salt",
+      messageExcerptLength: 8,
+    });
+
+    logger.log("error", "db.persisted", {
+      email: "owner@example.com",
+    });
+
+    expect(insertRunLog).toHaveBeenCalledOnce();
+    expect(insertRunLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-db",
+        level: "error",
+        eventName: "db.persisted",
+      }),
+    );
+
+    const insertedRow = insertRunLog.mock.calls[0]?.[0] as {
+      payloadJson: string;
+      createdAtMs: number;
+    };
+    expect(insertedRow.payloadJson).toContain("email#");
+    expect(insertedRow.payloadJson).not.toContain("owner@example.com");
+    expect(typeof insertedRow.createdAtMs).toBe("number");
+  });
+
+  it("does not require a database dependency", () => {
+    const paths = createTempPaths();
+    const logger = new JsonEventLogger(paths, "run-no-db");
+
+    expect(() => logger.log("info", "no-db", { ok: true })).not.toThrow();
+    expect(parseJsonLines(logger.getEventsPath())).toHaveLength(1);
+  });
+});

--- a/packages/core/src/__tests__/privacy.test.ts
+++ b/packages/core/src/__tests__/privacy.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  redactFreeformText,
+  redactStructuredValue,
+  resolvePrivacyConfig,
+  type PrivacyConfig,
+} from "../privacy.js";
+
+function config(
+  redactionMode: PrivacyConfig["redactionMode"],
+  storageMode: PrivacyConfig["storageMode"] = "full",
+): PrivacyConfig {
+  return {
+    redactionMode,
+    storageMode,
+    hashSalt: "unit-test-salt",
+    messageExcerptLength: 10,
+  };
+}
+
+describe("privacy", () => {
+  describe("resolvePrivacyConfig", () => {
+    it("uses defaults from env and applies partial overrides", () => {
+      const resolved = resolvePrivacyConfig(
+        {
+          redactionMode: "full",
+        },
+        {
+          LINKEDIN_BUDDY_REDACTION_MODE: "partial",
+          LINKEDIN_BUDDY_STORAGE_MODE: "excerpt",
+          LINKEDIN_BUDDY_REDACTION_HASH_SALT: "env-salt",
+          LINKEDIN_BUDDY_MESSAGE_EXCERPT_LENGTH: "99",
+        },
+      );
+
+      expect(resolved).toEqual({
+        redactionMode: "full",
+        storageMode: "excerpt",
+        hashSalt: "env-salt",
+        messageExcerptLength: 99,
+      });
+    });
+
+    it("falls back to documented defaults for invalid env values", () => {
+      const resolved = resolvePrivacyConfig(
+        {},
+        {
+          LINKEDIN_BUDDY_REDACTION_MODE: "invalid",
+          LINKEDIN_BUDDY_STORAGE_MODE: "archive",
+          LINKEDIN_BUDDY_MESSAGE_EXCERPT_LENGTH: "NaN",
+        },
+      );
+
+      expect(resolved.redactionMode).toBe("off");
+      expect(resolved.storageMode).toBe("full");
+      expect(resolved.messageExcerptLength).toBe(80);
+    });
+
+    it("clamps messageExcerptLength override to allowed bounds", () => {
+      const low = resolvePrivacyConfig({ messageExcerptLength: -5 }, {});
+      const high = resolvePrivacyConfig({ messageExcerptLength: 9_999 }, {});
+
+      expect(low.messageExcerptLength).toBe(8);
+      expect(high.messageExcerptLength).toBe(512);
+    });
+
+    it("normalizes env casing and trims whitespace", () => {
+      const resolved = resolvePrivacyConfig(
+        {},
+        {
+          LINKEDIN_BUDDY_REDACTION_MODE: "  PARTIAL  ",
+          LINKEDIN_BUDDY_STORAGE_MODE: " ExCerPt ",
+        },
+      );
+
+      expect(resolved.redactionMode).toBe("partial");
+      expect(resolved.storageMode).toBe("excerpt");
+    });
+  });
+
+  describe("redactFreeformText", () => {
+    it("redacts emails and LinkedIn profile URLs", () => {
+      const redacted = redactFreeformText(
+        "Contact me at owner@example.com or https://www.linkedin.com/in/jane-doe/",
+        config("partial"),
+      );
+
+      expect(redacted).toContain("email#");
+      expect(redacted).toContain("profile#");
+      expect(redacted).not.toContain("owner@example.com");
+      expect(redacted).not.toContain("jane-doe");
+    });
+
+    it("redacts supported action-summary subjects", () => {
+      const redacted = redactFreeformText(
+        'Send message to "Jane Doe"',
+        config("partial"),
+      );
+      expect(redacted).toMatch(/^Send message to "person#[A-Za-z0-9_-]{12}"$/);
+    });
+
+    it("redacts profile quoted names in generic messages", () => {
+      const redacted = redactFreeformText(
+        'Failed to load profile "Jane Doe"',
+        config("partial"),
+      );
+      expect(redacted).toMatch(
+        /^Failed to load profile "person#[A-Za-z0-9_-]{12}"$/,
+      );
+    });
+
+    it("leaves plain text unchanged when no sensitive patterns are present", () => {
+      const source = "System ready for health check.";
+      expect(redactFreeformText(source, config("partial"))).toBe(source);
+    });
+  });
+
+  describe("redactStructuredValue", () => {
+    it("applies key-specific redaction rules even in off mode", () => {
+      const input = {
+        full_name: "Jane Doe",
+        email: "owner@example.com",
+        messages: [{ text: "Hello Jane Doe" }],
+      };
+
+      const output = redactStructuredValue(input, config("off"), "log");
+
+      expect(output.full_name).toBe("Jane Doe");
+      expect(String(output.email)).toMatch(/^email#[A-Za-z0-9_-]{12}$/);
+      expect(String(output.messages[0]?.text)).toContain("person#");
+    });
+
+    it("hashes explicit name keys in partial mode", () => {
+      const output = redactStructuredValue(
+        {
+          author_name: "Jane Doe",
+          target_profile: "Jane Doe",
+        },
+        config("partial"),
+        "cli",
+      );
+
+      expect(String(output.author_name)).toMatch(/^person#[A-Za-z0-9_-]{12}$/);
+      expect(String(output.target_profile)).toMatch(
+        /^person#[A-Za-z0-9_-]{12}$/,
+      );
+    });
+
+    it("hashes inbox thread title and name contextually", () => {
+      const output = redactStructuredValue(
+        {
+          thread_id: "thread-1",
+          title: "Jane Doe",
+          participant: {
+            profile_url: "https://www.linkedin.com/in/jane-doe/",
+            name: "Jane Doe",
+          },
+        },
+        config("partial"),
+        "artifact",
+      );
+
+      expect(String(output.title)).toMatch(/^person#[A-Za-z0-9_-]{12}$/);
+      expect(String((output.participant as { name: string }).name)).toMatch(
+        /^person#[A-Za-z0-9_-]{12}$/,
+      );
+      expect(
+        String((output.participant as { profile_url: string }).profile_url),
+      ).toContain("profile#");
+    });
+
+    it("redacts notification message text as excerpt in partial mode", () => {
+      const output = redactStructuredValue(
+        {
+          notifications: [
+            {
+              timestamp: "now",
+              is_read: false,
+              link: "https://www.linkedin.com/notifications/1/",
+              message: "Hi Jane Doe, contact jane@example.com",
+            },
+          ],
+        },
+        config("partial"),
+        "error",
+      );
+
+      const message = (output.notifications as Array<{ message: string }>)[0]
+        ?.message;
+      expect(message).toContain("… [len=");
+      expect(message).toContain("hash=");
+      expect(message).not.toContain("jane@example.com");
+    });
+
+    it("fully redacts message body in full mode", () => {
+      const output = redactStructuredValue(
+        {
+          body: "This is very sensitive body text",
+        },
+        config("full"),
+        "storage",
+      );
+
+      expect(String(output.body)).toMatch(
+        /^\[redacted len=\d+ hash=[A-Za-z0-9_-]{12}\]$/,
+      );
+    });
+
+    it("uses excerpt redaction for storage mode excerpt even when redaction mode is off", () => {
+      const output = redactStructuredValue(
+        {
+          body: "Message body still needs excerpting",
+        },
+        config("off", "excerpt"),
+        "storage",
+      );
+
+      expect(String(output.body)).toContain("… [len=");
+      expect(String(output.body)).toContain("hash=");
+    });
+
+    it("redacts nested arrays and keeps non-string values intact", () => {
+      const transform = vi.fn(() =>
+        redactStructuredValue(
+          {
+            outbound: {
+              messages: [
+                {
+                  author: "Jane Doe",
+                  text: "Hello jane@example.com",
+                  attempts: 3,
+                  success: false,
+                },
+              ],
+            },
+          },
+          config("partial"),
+          "cli",
+        ),
+      );
+
+      const output = transform();
+      const firstMessage = (
+        output.outbound as { messages: Array<Record<string, unknown>> }
+      ).messages[0];
+
+      expect(String(firstMessage.author)).toMatch(/^person#[A-Za-z0-9_-]{12}$/);
+      expect(String(firstMessage.text)).toContain("… [len=");
+      expect(firstMessage.attempts).toBe(3);
+      expect(firstMessage.success).toBe(false);
+      expect(transform).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/packages/mcp/src/__tests__/linkedinMcp.validation.test.ts
+++ b/packages/mcp/src/__tests__/linkedinMcp.validation.test.ts
@@ -3,13 +3,16 @@ import { describe, expect, it } from "vitest";
 import {
   LINKEDIN_INBOX_SEARCH_RECIPIENTS_TOOL,
   LINKEDIN_PROFILE_PREPARE_UPSERT_SECTION_ITEM_TOOL,
-  LINKEDIN_SESSION_STATUS_TOOL
+  LINKEDIN_SESSION_STATUS_TOOL,
 } from "../index.js";
 import * as toolConstants from "../index.js";
 import {
   LINKEDIN_MCP_TOOL_DEFINITIONS,
+  readBoundedString,
+  readValidatedFilePath,
+  readValidatedUrl,
   validateToolArguments,
-  type LinkedInMcpInputSchema
+  type LinkedInMcpInputSchema,
 } from "../bin/linkedin-mcp.js";
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -49,7 +52,10 @@ function synthesizeValidValue(schema: LinkedInMcpInputSchema): unknown {
         value[key] = synthesizeValidValue(propertySchema);
       }
 
-      if (required.length === 0 && typeof schema.additionalProperties === "object") {
+      if (
+        required.length === 0 &&
+        typeof schema.additionalProperties === "object"
+      ) {
         value.sample = synthesizeValidValue(schema.additionalProperties);
       }
 
@@ -60,7 +66,9 @@ function synthesizeValidValue(schema: LinkedInMcpInputSchema): unknown {
   }
 }
 
-function synthesizeValidArgs(schema: LinkedInMcpInputSchema): Record<string, unknown> {
+function synthesizeValidArgs(
+  schema: LinkedInMcpInputSchema,
+): Record<string, unknown> {
   const value = synthesizeValidValue(schema);
   if (!isPlainObject(value)) {
     throw new Error("Expected an object-valued tool schema.");
@@ -108,7 +116,9 @@ function captureValidationFailure(action: () => unknown): LinkedInBuddyError {
 describe("MCP tool schema validation", () => {
   it("keeps the exported tool catalog in sync with the MCP definitions", () => {
     const exportedToolNames = [...Object.values(toolConstants)].sort();
-    const definedToolNames = LINKEDIN_MCP_TOOL_DEFINITIONS.map((tool) => tool.name).sort();
+    const definedToolNames = LINKEDIN_MCP_TOOL_DEFINITIONS.map(
+      (tool) => tool.name,
+    ).sort();
 
     expect(definedToolNames).toEqual(exportedToolNames);
   });
@@ -118,13 +128,13 @@ describe("MCP tool schema validation", () => {
       const assistantError = captureValidationFailure(() =>
         validateToolArguments(tool.name, {
           ...synthesizeValidArgs(tool.inputSchema),
-          unexpected: true
-        })
+          unexpected: true,
+        }),
       );
 
       expect(assistantError.message).toBe("unexpected is not allowed.");
       expect(assistantError.details).toMatchObject({
-        path: "unexpected"
+        path: "unexpected",
       });
     }
   });
@@ -138,27 +148,31 @@ describe("MCP tool schema validation", () => {
 
       const propertySchema = tool.inputSchema.properties?.[requiredKey];
       if (!propertySchema) {
-        throw new Error(`Missing property schema for ${tool.name}.${requiredKey}.`);
+        throw new Error(
+          `Missing property schema for ${tool.name}.${requiredKey}.`,
+        );
       }
 
       const args = synthesizeValidArgs(tool.inputSchema);
       args[requiredKey] = synthesizeTypeMismatchValue(propertySchema);
 
       const assistantError = captureValidationFailure(() =>
-        validateToolArguments(tool.name, args)
+        validateToolArguments(tool.name, args),
       );
 
       expect(assistantError.message).toContain(requiredKey);
       expect(assistantError.details).toMatchObject({
-        path: requiredKey
+        path: requiredKey,
       });
     }
   });
 
   it("rejects invalid enum values wherever root properties declare enums", () => {
     for (const tool of LINKEDIN_MCP_TOOL_DEFINITIONS) {
-      const enumProperty = Object.entries(tool.inputSchema.properties ?? {}).find(
-        ([, schema]) => Array.isArray(schema.enum) && schema.enum.length > 0
+      const enumProperty = Object.entries(
+        tool.inputSchema.properties ?? {},
+      ).find(
+        ([, schema]) => Array.isArray(schema.enum) && schema.enum.length > 0,
       );
       if (!enumProperty) {
         continue;
@@ -169,21 +183,24 @@ describe("MCP tool schema validation", () => {
       args[propertyName] = "__invalid_enum_value__";
 
       const assistantError = captureValidationFailure(() =>
-        validateToolArguments(tool.name, args)
+        validateToolArguments(tool.name, args),
       );
 
       expect(assistantError.message).toContain(propertyName);
       expect(assistantError.message).toContain("must be one of");
       expect(assistantError.details).toMatchObject({
-        path: propertyName
+        path: propertyName,
       });
     }
   });
 
   it("rejects mixed-type arrays for every string-array property", () => {
     for (const tool of LINKEDIN_MCP_TOOL_DEFINITIONS) {
-      const arrayProperty = Object.entries(tool.inputSchema.properties ?? {}).find(
-        ([, schema]) => schema.type === "array" && schema.items?.type === "string"
+      const arrayProperty = Object.entries(
+        tool.inputSchema.properties ?? {},
+      ).find(
+        ([, schema]) =>
+          schema.type === "array" && schema.items?.type === "string",
       );
       if (!arrayProperty) {
         continue;
@@ -194,13 +211,15 @@ describe("MCP tool schema validation", () => {
       args[propertyName] = [synthesizeValidValue(propertySchema.items!), 42];
 
       const assistantError = captureValidationFailure(() =>
-        validateToolArguments(tool.name, args)
+        validateToolArguments(tool.name, args),
       );
 
-      expect(assistantError.message).toBe(`${propertyName}[1] must be a string.`);
+      expect(assistantError.message).toBe(
+        `${propertyName}[1] must be a string.`,
+      );
       expect(assistantError.details).toMatchObject({
         path: `${propertyName}[1]`,
-        actual_type: "number"
+        actual_type: "number",
       });
     }
   });
@@ -210,36 +229,97 @@ describe("MCP tool schema validation", () => {
       validateToolArguments(LINKEDIN_PROFILE_PREPARE_UPSERT_SECTION_ITEM_TOOL, {
         section: "experience",
         values: {
-          headline: ["bad"]
-        }
-      })
+          headline: ["bad"],
+        },
+      }),
     );
 
     expect(assistantError.message).toBe(
-      "values.headline must match one of: string, number, boolean."
+      "values.headline must match one of: string, number, boolean.",
     );
     expect(assistantError.details).toMatchObject({
       path: "values.headline",
-      actual_type: "array"
+      actual_type: "array",
     });
   });
 
   it("treats undefined optional values as absent but still rejects undefined required inputs", () => {
     expect(() =>
       validateToolArguments(LINKEDIN_SESSION_STATUS_TOOL, {
-        profileName: undefined
-      })
+        profileName: undefined,
+      }),
     ).not.toThrow();
 
     const assistantError = captureValidationFailure(() =>
       validateToolArguments(LINKEDIN_INBOX_SEARCH_RECIPIENTS_TOOL, {
-        query: undefined
-      })
+        query: undefined,
+      }),
     );
 
     expect(assistantError.message).toBe("query is required.");
     expect(assistantError.details).toMatchObject({
-      path: "query"
+      path: "query",
     });
+  });
+});
+
+describe("MCP validation helpers", () => {
+  it("readBoundedString enforces max length for normal, boundary, and over-limit values", () => {
+    expect(readBoundedString({ text: "hello" }, "text", 10)).toBe("hello");
+
+    const boundaryValue = "x".repeat(8);
+    expect(readBoundedString({ text: boundaryValue }, "text", 8)).toBe(
+      boundaryValue,
+    );
+
+    const assistantError = captureValidationFailure(() =>
+      readBoundedString({ text: "x".repeat(9) }, "text", 8),
+    );
+
+    expect(assistantError.message).toBe("text must be 8 characters or fewer.");
+  });
+
+  it("readValidatedUrl accepts valid URLs and rejects malformed values", () => {
+    expect(
+      readValidatedUrl(
+        { postUrl: "https://www.linkedin.com/feed/" },
+        "postUrl",
+      ),
+    ).toBe("https://www.linkedin.com/feed/");
+    expect(
+      readValidatedUrl(
+        { postUrl: "HTTP://EXAMPLE.COM/some/path?x=1" },
+        "postUrl",
+      ),
+    ).toBe("http://example.com/some/path?x=1");
+
+    expect(() => readValidatedUrl({ postUrl: "not a url" }, "postUrl")).toThrow(
+      /postUrl must be a valid URL\./,
+    );
+    expect(() => readValidatedUrl({ postUrl: "https://" }, "postUrl")).toThrow(
+      /postUrl must be a valid URL\./,
+    );
+  });
+
+  it("readValidatedFilePath rejects traversal patterns and empty strings", () => {
+    expect(
+      readValidatedFilePath({ filePath: "./assets/photo.png" }, "filePath"),
+    ).toBe("./assets/photo.png");
+    expect(
+      readValidatedFilePath(
+        { filePath: "C:\\Users\\me\\banner.jpg" },
+        "filePath",
+      ),
+    ).toBe("C:\\Users\\me\\banner.jpg");
+
+    expect(() =>
+      readValidatedFilePath({ filePath: "../secret.txt" }, "filePath"),
+    ).toThrow(/filePath must not include path traversal segments\./);
+    expect(() =>
+      readValidatedFilePath({ filePath: "..\\secret.txt" }, "filePath"),
+    ).toThrow(/filePath must not include path traversal segments\./);
+    expect(() =>
+      readValidatedFilePath({ filePath: "   " }, "filePath"),
+    ).toThrow(/filePath is required\./);
   });
 });

--- a/packages/mcp/src/__tests__/mcpRecoveryHints.test.ts
+++ b/packages/mcp/src/__tests__/mcpRecoveryHints.test.ts
@@ -1,0 +1,134 @@
+import { LinkedInBuddyError } from "@linkedin-buddy/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LINKEDIN_SESSION_STATUS_TOOL } from "../index.js";
+
+const recoveryHintMocks = vi.hoisted(() => ({
+  createCoreRuntime: vi.fn(),
+  recordFeedbackInvocation: vi.fn(),
+}));
+
+vi.mock("@linkedin-buddy/core", async () => {
+  const actual = await vi.importActual<typeof import("@linkedin-buddy/core")>(
+    "@linkedin-buddy/core",
+  );
+
+  return {
+    ...actual,
+    createCoreRuntime: recoveryHintMocks.createCoreRuntime,
+    recordFeedbackInvocation: recoveryHintMocks.recordFeedbackInvocation,
+  };
+});
+
+interface FakeRuntime {
+  auth: {
+    status: ReturnType<typeof vi.fn>;
+  };
+  close: ReturnType<typeof vi.fn>;
+  logger: {
+    log: ReturnType<typeof vi.fn>;
+  };
+  runId: string;
+}
+
+function createFakeRuntime(): FakeRuntime {
+  return {
+    auth: {
+      status: vi.fn(),
+    },
+    close: vi.fn(),
+    logger: {
+      log: vi.fn(),
+    },
+    runId: "run-mcp-recovery",
+  };
+}
+
+function parsePayload(result: {
+  content: Array<{ text: string; type: "text" }>;
+}): Record<string, unknown> {
+  return JSON.parse(result.content[0]?.text ?? "{}") as Record<string, unknown>;
+}
+
+describe("MCP recovery hints", () => {
+  let fakeRuntime: FakeRuntime;
+  let handleToolCall: typeof import("../bin/linkedin-mcp.js").handleToolCall;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    fakeRuntime = createFakeRuntime();
+    recoveryHintMocks.createCoreRuntime.mockReturnValue(fakeRuntime);
+    recoveryHintMocks.recordFeedbackInvocation.mockResolvedValue({
+      showHint: false,
+    });
+
+    ({ handleToolCall } = await import("../bin/linkedin-mcp.js"));
+  });
+
+  it("includes open_login guidance for AUTH_REQUIRED errors", async () => {
+    fakeRuntime.auth.status.mockRejectedValue(
+      new LinkedInBuddyError("AUTH_REQUIRED", "Authentication required."),
+    );
+
+    const result = await handleToolCall(LINKEDIN_SESSION_STATUS_TOOL, {
+      profileName: "default",
+    });
+
+    expect("isError" in result && result.isError).toBe(true);
+    const payload = parsePayload(result);
+    expect(payload.code).toBe("AUTH_REQUIRED");
+    expect(payload.recovery_hint).toEqual(
+      expect.stringContaining("open_login"),
+    );
+  });
+
+  it("includes rate-limit guidance for RATE_LIMITED errors", async () => {
+    fakeRuntime.auth.status.mockRejectedValue(
+      new LinkedInBuddyError("RATE_LIMITED", "Too many requests."),
+    );
+
+    const result = await handleToolCall(LINKEDIN_SESSION_STATUS_TOOL, {
+      profileName: "default",
+    });
+
+    expect("isError" in result && result.isError).toBe(true);
+    const payload = parsePayload(result);
+    expect(payload.code).toBe("RATE_LIMITED");
+    expect(payload.recovery_hint).toEqual(
+      expect.stringContaining("rate limit"),
+    );
+  });
+
+  it("includes a generic recovery hint for unknown errors", async () => {
+    fakeRuntime.auth.status.mockRejectedValue(new Error("Unexpected failure"));
+
+    const result = await handleToolCall(LINKEDIN_SESSION_STATUS_TOOL, {
+      profileName: "default",
+    });
+
+    expect("isError" in result && result.isError).toBe(true);
+    const payload = parsePayload(result);
+    expect(payload.code).toBe("UNKNOWN");
+    expect(payload.recovery_hint).toEqual(
+      expect.stringContaining("unexpected error occurred"),
+    );
+  });
+
+  it("does not attach recovery hints to successful responses", async () => {
+    fakeRuntime.auth.status.mockResolvedValue({
+      authenticated: true,
+      evasion: {
+        diagnosticsEnabled: false,
+        level: "moderate",
+      },
+    });
+
+    const result = await handleToolCall(LINKEDIN_SESSION_STATUS_TOOL, {
+      profileName: "default",
+    });
+
+    expect("isError" in result && result.isError).toBe(false);
+    const payload = parsePayload(result);
+    expect(payload.recovery_hint).toBeUndefined();
+  });
+});

--- a/packages/mcp/src/bin/linkedin-mcp.ts
+++ b/packages/mcp/src/bin/linkedin-mcp.ts
@@ -45,14 +45,14 @@ import {
   type ActivityWatchStatus,
   type SearchCategory,
   type WebhookDeliveryAttemptStatus,
-  type WebhookSubscriptionStatus
+  type WebhookSubscriptionStatus,
 } from "@linkedin-buddy/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
-  type CallToolRequest
+  type CallToolRequest,
 } from "@modelcontextprotocol/sdk/types.js";
 import {
   SUBMIT_FEEDBACK_TOOL,
@@ -164,7 +164,7 @@ import {
   LINKEDIN_SEARCH_TOOL,
   LINKEDIN_SESSION_HEALTH_TOOL,
   LINKEDIN_SESSION_OPEN_LOGIN_TOOL,
-  LINKEDIN_SESSION_STATUS_TOOL
+  LINKEDIN_SESSION_STATUS_TOOL,
 } from "../index.js";
 
 type ToolArgs = Record<string, unknown>;
@@ -202,8 +202,7 @@ export interface LinkedInMcpToolDefinition {
 
 const mcpPrivacyConfig = resolvePrivacyConfig();
 const SELECTOR_AUDIT_DOC_PATH = "docs/selector-audit.md";
-const SELECTOR_AUDIT_MCP_HINT =
-  `For broader UI-drift diagnostics, run the CLI selector audit ("linkedin audit selectors") and see ${SELECTOR_AUDIT_DOC_PATH}.`;
+const SELECTOR_AUDIT_MCP_HINT = `For broader UI-drift diagnostics, run the CLI selector audit ("linkedin audit selectors") and see ${SELECTOR_AUDIT_DOC_PATH}.`;
 
 function withSelectorAuditHint(description: string): string {
   return `${description} ${SELECTOR_AUDIT_MCP_HINT}`;
@@ -232,14 +231,73 @@ function readRequiredString(args: ToolArgs, key: string): string {
   }
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    `${key} is required.`
+    `${key} is required.`,
   );
+}
+
+export function readBoundedString(
+  args: ToolArgs,
+  key: string,
+  maxLength = 5000,
+  fallback?: string,
+): string {
+  const value =
+    typeof fallback === "string"
+      ? readString(args, key, fallback)
+      : readRequiredString(args, key);
+
+  if (value.length > maxLength) {
+    throw new LinkedInBuddyError(
+      "ACTION_PRECONDITION_FAILED",
+      `${key} must be ${maxLength} characters or fewer.`,
+      {
+        path: `arguments.${key}`,
+        actual_length: value.length,
+        max_length: maxLength,
+      },
+    );
+  }
+
+  return value;
+}
+
+export function readValidatedUrl(args: ToolArgs, key: string): string {
+  const value = readRequiredString(args, key);
+
+  try {
+    return new URL(value).toString();
+  } catch (error) {
+    throw new LinkedInBuddyError(
+      "ACTION_PRECONDITION_FAILED",
+      `${key} must be a valid URL.`,
+      {
+        path: `arguments.${key}`,
+        cause: error instanceof Error ? error.message : String(error),
+      },
+    );
+  }
+}
+
+export function readValidatedFilePath(args: ToolArgs, key: string): string {
+  const value = readRequiredString(args, key);
+
+  if (value.includes("../") || value.includes("..\\")) {
+    throw new LinkedInBuddyError(
+      "ACTION_PRECONDITION_FAILED",
+      `${key} must not include path traversal segments.`,
+      {
+        path: `arguments.${key}`,
+      },
+    );
+  }
+
+  return value;
 }
 
 function readPositiveNumber(
   args: ToolArgs,
   key: string,
-  fallback: number
+  fallback: number,
 ): number {
   const value = args[key];
   if (typeof value !== "number") {
@@ -249,7 +307,7 @@ function readPositiveNumber(
   if (!Number.isFinite(value) || value <= 0) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      `${key} must be a positive number.`
+      `${key} must be a positive number.`,
     );
   }
 
@@ -259,7 +317,7 @@ function readPositiveNumber(
 function readNonNegativeNumber(
   args: ToolArgs,
   key: string,
-  fallback: number
+  fallback: number,
 ): number {
   const value = args[key];
   if (typeof value !== "number") {
@@ -269,7 +327,7 @@ function readNonNegativeNumber(
   if (!Number.isFinite(value) || value < 0) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      `${key} must be zero or a positive number.`
+      `${key} must be zero or a positive number.`,
     );
   }
 
@@ -289,13 +347,13 @@ function readRequiredBoolean(args: ToolArgs, key: string): boolean {
 
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    `${key} is required.`
+    `${key} is required.`,
   );
 }
 
 function readOptionalPositiveNumber(
   args: ToolArgs,
-  key: string
+  key: string,
 ): number | undefined {
   if (!(key in args) || args[key] === undefined) {
     return undefined;
@@ -306,7 +364,7 @@ function readOptionalPositiveNumber(
 
 function readOptionalNonNegativeNumber(
   args: ToolArgs,
-  key: string
+  key: string,
 ): number | undefined {
   if (!(key in args) || args[key] === undefined) {
     return undefined;
@@ -321,7 +379,7 @@ function readOptionalNonNegativeNumber(
   ) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      `${key} must be a non-negative integer.`
+      `${key} must be a non-negative integer.`,
     );
   }
 
@@ -348,7 +406,7 @@ function readStringArray(args: ToolArgs, key: string): string[] | undefined {
 
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    `${key} must be a string or array of strings.`
+    `${key} must be a string or array of strings.`,
   );
 }
 
@@ -360,13 +418,13 @@ function readRequiredStringArray(args: ToolArgs, key: string): string[] {
 
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    `${key} is required.`
+    `${key} is required.`,
   );
 }
 
 function readObject(
   args: ToolArgs,
-  key: string
+  key: string,
 ): Record<string, unknown> | undefined {
   const value = args[key];
   if (value === undefined) {
@@ -379,13 +437,13 @@ function readObject(
 
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    `${key} must be an object.`
+    `${key} must be an object.`,
   );
 }
 
 async function readJsonInputFile(
   filePath: string,
-  label: string
+  label: string,
 ): Promise<unknown> {
   const resolvedPath = path.resolve(filePath);
   let rawValue: string;
@@ -398,8 +456,8 @@ async function readJsonInputFile(
       `Could not read ${label}.`,
       {
         path: resolvedPath,
-        cause: error instanceof Error ? error.message : String(error)
-      }
+        cause: error instanceof Error ? error.message : String(error),
+      },
     );
   }
 
@@ -411,8 +469,8 @@ async function readJsonInputFile(
       `${label} must contain valid JSON.`,
       {
         path: resolvedPath,
-        cause: error instanceof Error ? error.message : String(error)
-      }
+        cause: error instanceof Error ? error.message : String(error),
+      },
     );
   }
 }
@@ -420,7 +478,7 @@ async function readJsonInputFile(
 function coerceEnumValue<T extends string>(
   value: string,
   allowed: readonly T[],
-  label: string
+  label: string,
 ): T {
   if ((allowed as readonly string[]).includes(value)) {
     return value as T;
@@ -428,7 +486,7 @@ function coerceEnumValue<T extends string>(
 
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    `${label} must be one of: ${allowed.join(", ")}.`
+    `${label} must be one of: ${allowed.join(", ")}.`,
   );
 }
 
@@ -436,61 +494,49 @@ function readActivityWatchKind(args: ToolArgs, key: string): ActivityWatchKind {
   return coerceEnumValue(
     readRequiredString(args, key),
     ACTIVITY_WATCH_KINDS,
-    key
+    key,
   );
 }
 
 function readOptionalActivityWatchStatus(
   args: ToolArgs,
-  key: string
+  key: string,
 ): ActivityWatchStatus | undefined {
   const value = args[key];
   if (typeof value !== "string" || value.trim().length === 0) {
     return undefined;
   }
 
-  return coerceEnumValue(
-    value.trim(),
-    ACTIVITY_WATCH_STATUSES,
-    key
-  );
+  return coerceEnumValue(value.trim(), ACTIVITY_WATCH_STATUSES, key);
 }
 
 function readOptionalWebhookSubscriptionStatus(
   args: ToolArgs,
-  key: string
+  key: string,
 ): WebhookSubscriptionStatus | undefined {
   const value = args[key];
   if (typeof value !== "string" || value.trim().length === 0) {
     return undefined;
   }
 
-  return coerceEnumValue(
-    value.trim(),
-    WEBHOOK_SUBSCRIPTION_STATUSES,
-    key
-  );
+  return coerceEnumValue(value.trim(), WEBHOOK_SUBSCRIPTION_STATUSES, key);
 }
 
 function readOptionalWebhookDeliveryStatus(
   args: ToolArgs,
-  key: string
+  key: string,
 ): WebhookDeliveryAttemptStatus | undefined {
   const value = args[key];
   if (typeof value !== "string" || value.trim().length === 0) {
     return undefined;
   }
 
-  return coerceEnumValue(
-    value.trim(),
-    WEBHOOK_DELIVERY_ATTEMPT_STATUSES,
-    key
-  );
+  return coerceEnumValue(value.trim(), WEBHOOK_DELIVERY_ATTEMPT_STATUSES, key);
 }
 
 function readActivityEventTypes(
   args: ToolArgs,
-  key: string
+  key: string,
 ): ActivityEventType[] | undefined {
   const values = readStringArray(args, key);
   if (!values) {
@@ -498,15 +544,14 @@ function readActivityEventTypes(
   }
 
   return values.map((value) =>
-    coerceEnumValue(value, ACTIVITY_EVENT_TYPES, key)
+    coerceEnumValue(value, ACTIVITY_EVENT_TYPES, key),
   );
 }
-
 
 function readSearchCategory(
   args: ToolArgs,
   key: string,
-  fallback: SearchCategory
+  fallback: SearchCategory,
 ): SearchCategory {
   const value = args[key];
   if (typeof value !== "string" || value.trim().length === 0) {
@@ -520,13 +565,13 @@ function readSearchCategory(
 
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    `${key} must be one of: ${SEARCH_CATEGORIES.join(", ")}.`
+    `${key} must be one of: ${SEARCH_CATEGORIES.join(", ")}.`,
   );
 }
 
 function readMemberReportReason(
   args: ToolArgs,
-  key: string
+  key: string,
 ): ReturnType<typeof normalizeLinkedInMemberReportReason> {
   return normalizeLinkedInMemberReportReason(readRequiredString(args, key));
 }
@@ -543,26 +588,53 @@ function toToolResult(payload: unknown): ToolResult {
         text: JSON.stringify(
           redactStructuredValue(payload, mcpPrivacyConfig, "cli"),
           null,
-          2
-        )
-      }
-    ]
+          2,
+        ),
+      },
+    ],
   };
 }
 
+function buildRecoveryHint(error: unknown): string | undefined {
+  if (!(error instanceof LinkedInBuddyError)) {
+    return "An unexpected error occurred. Check linkedin.session.status to verify your session is active.";
+  }
+
+  switch (error.code) {
+    case "AUTH_REQUIRED":
+      return "Your LinkedIn session has expired or is not authenticated. Run linkedin.session.open_login to start a new session, then retry.";
+    case "CAPTCHA_OR_CHALLENGE":
+      return "LinkedIn is showing a security challenge. Open your browser manually, complete the challenge, then retry the operation.";
+    case "RATE_LIMITED":
+      return "You have exceeded the rate limit for this action. Wait for the current rate-limit window to reset before retrying. Check the rate_limit details for timing.";
+    case "UI_CHANGED_SELECTOR_FAILED":
+      return "A LinkedIn page element could not be found — the page layout may have changed. Try running linkedin.session.health to check browser connectivity, then retry.";
+    case "NETWORK_ERROR":
+      return "A network error occurred. Verify your internet connection, then check linkedin.session.health. If the browser process is unresponsive, restart it with linkedin.session.open_login.";
+    case "TIMEOUT":
+      return "The operation timed out. The page may be loading slowly or the browser may be unresponsive. Try running linkedin.session.health, then retry with a simpler query if possible.";
+    case "TARGET_NOT_FOUND":
+      return "The requested target (profile, post, thread, job, etc.) was not found. Verify the URL or identifier is correct and the content still exists on LinkedIn.";
+    case "ACTION_PRECONDITION_FAILED":
+      return "A precondition for this action was not met. Check the error details for specifics — you may need to correct input parameters or complete a prerequisite step first.";
+    default:
+      return undefined;
+  }
+}
+
 function toErrorResult(error: unknown): ToolErrorResult {
+  const payload = toLinkedInBuddyErrorPayload(error, mcpPrivacyConfig);
+  const hint = buildRecoveryHint(error);
+  const enrichedPayload = hint ? { ...payload, recovery_hint: hint } : payload;
+
   return {
     isError: true,
     content: [
       {
         type: "text",
-        text: JSON.stringify(
-          toLinkedInBuddyErrorPayload(error, mcpPrivacyConfig),
-          null,
-          2
-        )
-      }
-    ]
+        text: JSON.stringify(enrichedPayload, null, 2),
+      },
+    ],
   };
 }
 
@@ -571,7 +643,7 @@ function shouldTrackMcpFeedback(toolName: string): boolean {
 }
 
 function addFeedbackHintToResult<T extends ToolResult | ToolErrorResult>(
-  result: T
+  result: T,
 ): T {
   const firstContent = result.content[0];
   if (!firstContent || firstContent.type !== "text") {
@@ -587,16 +659,18 @@ function addFeedbackHintToResult<T extends ToolResult | ToolErrorResult>(
       content: [
         {
           type: "text",
-          text: JSON.stringify(parsed, null, 2)
-        }
-      ]
+          text: JSON.stringify(parsed, null, 2),
+        },
+      ],
     };
   } catch {
     return result;
   }
 }
 
-function readTargetProfileName(target: Record<string, unknown>): string | undefined {
+function readTargetProfileName(
+  target: Record<string, unknown>,
+): string | undefined {
   const value = target.profile_name;
   if (typeof value === "string" && value.trim().length > 0) {
     return value.trim();
@@ -607,23 +681,23 @@ function readTargetProfileName(target: Record<string, unknown>): string | undefi
 const cdpUrlInputSchemaProperty: LinkedInMcpInputSchema = {
   type: "string",
   description:
-    "Connect to an existing browser via CDP endpoint (for example http://127.0.0.1:18800)."
+    "Connect to an existing browser via CDP endpoint (for example http://127.0.0.1:18800).",
 };
 
 const selectorLocaleInputSchemaProperty: LinkedInMcpInputSchema = {
   type: "string",
   description: `Prefer localized LinkedIn UI text first (${LINKEDIN_SELECTOR_LOCALES.join(
-    ", "
-  )}; region tags like da-DK normalize to da). Unsupported values fall back to en.`
+    ", ",
+  )}; region tags like da-DK normalize to da). Unsupported values fall back to en.`,
 };
 
 function withCdpSchemaProperties(
-  properties: Record<string, LinkedInMcpInputSchema>
+  properties: Record<string, LinkedInMcpInputSchema>,
 ): Record<string, LinkedInMcpInputSchema> {
   return {
     ...properties,
     cdpUrl: cdpUrlInputSchemaProperty,
-    selectorLocale: selectorLocaleInputSchemaProperty
+    selectorLocale: selectorLocaleInputSchemaProperty,
   };
 }
 
@@ -665,7 +739,9 @@ function formatToolSchemaPath(path: string): string {
 
 function describeToolSchemaTypes(schema: LinkedInMcpInputSchema): string {
   if (schema.anyOf && schema.anyOf.length > 0) {
-    return schema.anyOf.map((entry) => describeToolSchemaTypes(entry)).join(", ");
+    return schema.anyOf
+      .map((entry) => describeToolSchemaTypes(entry))
+      .join(", ");
   }
 
   if (schema.enum && schema.enum.length > 0) {
@@ -682,31 +758,34 @@ function describeToolSchemaTypes(schema: LinkedInMcpInputSchema): string {
 function throwToolSchemaValidationError(
   path: string,
   message: string,
-  details: Record<string, unknown> = {}
+  details: Record<string, unknown> = {},
 ): never {
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
     `${formatToolSchemaPath(path)} ${message}`,
     {
       path: formatToolSchemaPath(path),
-      ...details
-    }
+      ...details,
+    },
   );
 }
 
 function validateToolArgEnum(
   schema: LinkedInMcpInputSchema,
   value: unknown,
-  path: string
+  path: string,
 ): void {
-  if (schema.enum && !schema.enum.includes(value as LinkedInMcpSchemaEnumValue)) {
+  if (
+    schema.enum &&
+    !schema.enum.includes(value as LinkedInMcpSchemaEnumValue)
+  ) {
     throwToolSchemaValidationError(
       path,
       `must be one of: ${schema.enum.map((entry) => JSON.stringify(entry)).join(", ")}.`,
       {
         actual_type: describeToolArgValue(value),
-        allowed_values: [...schema.enum]
-      }
+        allowed_values: [...schema.enum],
+      },
     );
   }
 }
@@ -714,7 +793,7 @@ function validateToolArgEnum(
 function validateToolArgValueAgainstSchema(
   schema: LinkedInMcpInputSchema,
   value: unknown,
-  path: string
+  path: string,
 ): void {
   if (schema.anyOf && schema.anyOf.length > 0) {
     for (const candidate of schema.anyOf) {
@@ -733,8 +812,8 @@ function validateToolArgValueAgainstSchema(
       `must match one of: ${describeToolSchemaTypes(schema)}.`,
       {
         actual_type: describeToolArgValue(value),
-        expected: describeToolSchemaTypes(schema)
-      }
+        expected: describeToolSchemaTypes(schema),
+      },
     );
   }
 
@@ -742,7 +821,7 @@ function validateToolArgValueAgainstSchema(
     case "string":
       if (typeof value !== "string") {
         throwToolSchemaValidationError(path, "must be a string.", {
-          actual_type: describeToolArgValue(value)
+          actual_type: describeToolArgValue(value),
         });
       }
       validateToolArgEnum(schema, value, path);
@@ -750,7 +829,7 @@ function validateToolArgValueAgainstSchema(
     case "number":
       if (typeof value !== "number" || !Number.isFinite(value)) {
         throwToolSchemaValidationError(path, "must be a finite number.", {
-          actual_type: describeToolArgValue(value)
+          actual_type: describeToolArgValue(value),
         });
       }
       validateToolArgEnum(schema, value, path);
@@ -762,7 +841,7 @@ function validateToolArgValueAgainstSchema(
         !Number.isInteger(value)
       ) {
         throwToolSchemaValidationError(path, "must be an integer.", {
-          actual_type: describeToolArgValue(value)
+          actual_type: describeToolArgValue(value),
         });
       }
       validateToolArgEnum(schema, value, path);
@@ -770,7 +849,7 @@ function validateToolArgValueAgainstSchema(
     case "boolean":
       if (typeof value !== "boolean") {
         throwToolSchemaValidationError(path, "must be a boolean.", {
-          actual_type: describeToolArgValue(value)
+          actual_type: describeToolArgValue(value),
         });
       }
       validateToolArgEnum(schema, value, path);
@@ -778,7 +857,7 @@ function validateToolArgValueAgainstSchema(
     case "array":
       if (!Array.isArray(value)) {
         throwToolSchemaValidationError(path, "must be an array.", {
-          actual_type: describeToolArgValue(value)
+          actual_type: describeToolArgValue(value),
         });
       }
 
@@ -787,7 +866,7 @@ function validateToolArgValueAgainstSchema(
           validateToolArgValueAgainstSchema(
             schema.items!,
             entry,
-            appendToolSchemaPath(path, `[${index}]`)
+            appendToolSchemaPath(path, `[${index}]`),
           );
         });
       }
@@ -795,7 +874,7 @@ function validateToolArgValueAgainstSchema(
     case "object": {
       if (!isPlainObject(value)) {
         throwToolSchemaValidationError(path, "must be an object.", {
-          actual_type: describeToolArgValue(value)
+          actual_type: describeToolArgValue(value),
         });
       }
 
@@ -805,7 +884,7 @@ function validateToolArgValueAgainstSchema(
         if (!(requiredKey in value) || value[requiredKey] === undefined) {
           throwToolSchemaValidationError(
             appendToolSchemaPath(path, requiredKey),
-            "is required."
+            "is required.",
           );
         }
       }
@@ -816,7 +895,11 @@ function validateToolArgValueAgainstSchema(
 
         if (propertySchema) {
           if (entryValue !== undefined) {
-            validateToolArgValueAgainstSchema(propertySchema, entryValue, propertyPath);
+            validateToolArgValueAgainstSchema(
+              propertySchema,
+              entryValue,
+              propertyPath,
+            );
           }
           continue;
         }
@@ -832,7 +915,7 @@ function validateToolArgValueAgainstSchema(
           validateToolArgValueAgainstSchema(
             schema.additionalProperties,
             entryValue,
-            propertyPath
+            propertyPath,
           );
         }
       }
@@ -852,12 +935,12 @@ function createRuntime(args: ToolArgs) {
       ? {
           cdpUrl,
           privacy: mcpPrivacyConfig,
-          ...(selectorLocale ? { selectorLocale } : {})
+          ...(selectorLocale ? { selectorLocale } : {}),
         }
       : {
           privacy: mcpPrivacyConfig,
-          ...(selectorLocale ? { selectorLocale } : {})
-        }
+          ...(selectorLocale ? { selectorLocale } : {}),
+        },
   );
 }
 
@@ -868,24 +951,24 @@ async function handleSessionStatus(args: ToolArgs): Promise<ToolResult> {
     const profileName = readString(args, "profileName", "default");
 
     runtime.logger.log("info", "mcp.session.status.start", {
-      profileName
+      profileName,
     });
 
     const status = await runtime.auth.status({
-      profileName
+      profileName,
     });
 
     runtime.logger.log("info", "mcp.session.status.done", {
       profileName,
       authenticated: status.authenticated,
       evasion_level: status.evasion?.level,
-      evasion_diagnostics_enabled: status.evasion?.diagnosticsEnabled ?? false
+      evasion_diagnostics_enabled: status.evasion?.diagnosticsEnabled ?? false,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      status
+      status,
     });
   } finally {
     runtime.close();
@@ -901,24 +984,24 @@ async function handleSessionOpenLogin(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.session.open_login.start", {
       profileName,
-      timeoutMs
+      timeoutMs,
     });
 
     const status = await runtime.auth.openLogin({
       profileName,
-      timeoutMs
+      timeoutMs,
     });
 
     runtime.logger.log("info", "mcp.session.open_login.done", {
       profileName,
       authenticated: status.authenticated,
-      timedOut: status.timedOut
+      timedOut: status.timedOut,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      status
+      status,
     });
   } finally {
     runtime.close();
@@ -932,11 +1015,11 @@ async function handleSessionHealth(args: ToolArgs): Promise<ToolResult> {
     const profileName = readString(args, "profileName", "default");
 
     runtime.logger.log("info", "mcp.session.health.start", {
-      profileName
+      profileName,
     });
 
     const health = await runtime.healthCheck({
-      profileName
+      profileName,
     });
 
     runtime.logger.log("info", "mcp.session.health.done", {
@@ -944,13 +1027,13 @@ async function handleSessionHealth(args: ToolArgs): Promise<ToolResult> {
       browserHealthy: health.browser.healthy,
       authenticated: health.session.authenticated,
       evasion_level: health.session.evasion.level,
-      evasion_diagnostics_enabled: health.session.evasion.diagnosticsEnabled
+      evasion_diagnostics_enabled: health.session.evasion.diagnosticsEnabled,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...health
+      ...health,
     });
   } finally {
     runtime.close();
@@ -959,7 +1042,9 @@ async function handleSessionHealth(args: ToolArgs): Promise<ToolResult> {
 
 async function handleSubmitFeedback(args: ToolArgs): Promise<ToolResult> {
   const snapshot = await readFeedbackStateSnapshot();
-  const feedbackType = normalizeFeedbackInputType(readRequiredString(args, "type"));
+  const feedbackType = normalizeFeedbackInputType(
+    readRequiredString(args, "type"),
+  );
   const title = readRequiredString(args, "title");
   const description = readRequiredString(args, "description");
 
@@ -971,8 +1056,8 @@ async function handleSubmitFeedback(args: ToolArgs): Promise<ToolResult> {
       cliVersion: packageJson.version,
       mcpToolName: SUBMIT_FEEDBACK_TOOL,
       snapshot,
-      source: "mcp"
-    })
+      source: "mcp",
+    }),
   });
 
   return toToolResult({
@@ -988,10 +1073,10 @@ async function handleSubmitFeedback(args: ToolArgs): Promise<ToolResult> {
           pending_file_path: path.join(
             ".linkedin-buddy",
             "pending-feedback",
-            path.basename(result.pendingFilePath)
-          )
+            path.basename(result.pendingFilePath),
+          ),
         }
-      : {})
+      : {}),
   });
 }
 
@@ -1006,25 +1091,25 @@ async function handleListThreads(args: ToolArgs): Promise<ToolResult> {
     runtime.logger.log("info", "mcp.inbox.list_threads.start", {
       profileName,
       limit,
-      unreadOnly
+      unreadOnly,
     });
 
     const threads = await runtime.inbox.listThreads({
       profileName,
       limit,
-      unreadOnly
+      unreadOnly,
     });
 
     runtime.logger.log("info", "mcp.inbox.list_threads.done", {
       profileName,
-      count: threads.length
+      count: threads.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
       count: threads.length,
-      threads
+      threads,
     });
   } finally {
     runtime.close();
@@ -1042,24 +1127,24 @@ async function handleGetThread(args: ToolArgs): Promise<ToolResult> {
     runtime.logger.log("info", "mcp.inbox.get_thread.start", {
       profileName,
       thread,
-      limit
+      limit,
     });
 
     const detail = await runtime.inbox.getThread({
       profileName,
       thread,
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.inbox.get_thread.done", {
       profileName,
-      threadId: detail.thread_id
+      threadId: detail.thread_id,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      thread: detail
+      thread: detail,
     });
   } finally {
     runtime.close();
@@ -1077,25 +1162,25 @@ async function handleSearchRecipients(args: ToolArgs): Promise<ToolResult> {
     runtime.logger.log("info", "mcp.inbox.search_recipients.start", {
       profileName,
       query,
-      limit
+      limit,
     });
 
     const result = await runtime.inbox.searchRecipients({
       profileName,
       query,
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.inbox.search_recipients.done", {
       profileName,
       query,
-      count: result.count
+      count: result.count,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
@@ -1108,12 +1193,12 @@ async function handlePrepareReply(args: ToolArgs): Promise<ToolResult> {
   try {
     const profileName = readString(args, "profileName", "default");
     const thread = readRequiredString(args, "thread");
-    const text = readRequiredString(args, "text");
+    const text = readBoundedString(args, "text", 8000);
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.inbox.prepare_reply.start", {
       profileName,
-      thread
+      thread,
     });
 
     const prepared = await runtime.inbox.prepareReply({
@@ -1122,20 +1207,20 @@ async function handlePrepareReply(args: ToolArgs): Promise<ToolResult> {
       text,
       ...(operatorNote
         ? {
-            operatorNote
+            operatorNote,
           }
-        : {})
+        : {}),
     });
 
     runtime.logger.log("info", "mcp.inbox.prepare_reply.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1148,12 +1233,12 @@ async function handlePrepareNewThread(args: ToolArgs): Promise<ToolResult> {
   try {
     const profileName = readString(args, "profileName", "default");
     const recipients = readRequiredStringArray(args, "recipients");
-    const text = readRequiredString(args, "text");
+    const text = readBoundedString(args, "text", 8000);
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.inbox.prepare_new_thread.start", {
       profileName,
-      recipientCount: recipients.length
+      recipientCount: recipients.length,
     });
 
     const prepared = await runtime.inbox.prepareNewThread({
@@ -1162,21 +1247,21 @@ async function handlePrepareNewThread(args: ToolArgs): Promise<ToolResult> {
       text,
       ...(operatorNote
         ? {
-            operatorNote
+            operatorNote,
           }
-        : {})
+        : {}),
     });
 
     runtime.logger.log("info", "mcp.inbox.prepare_new_thread.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
-      recipientCount: recipients.length
+      recipientCount: recipients.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1195,7 +1280,7 @@ async function handlePrepareAddRecipients(args: ToolArgs): Promise<ToolResult> {
     runtime.logger.log("info", "mcp.inbox.prepare_add_recipients.start", {
       profileName,
       recipientCount: recipients.length,
-      thread
+      thread,
     });
 
     const prepared = await runtime.inbox.prepareAddRecipients({
@@ -1204,22 +1289,22 @@ async function handlePrepareAddRecipients(args: ToolArgs): Promise<ToolResult> {
       recipients,
       ...(operatorNote
         ? {
-            operatorNote
+            operatorNote,
           }
-        : {})
+        : {}),
     });
 
     runtime.logger.log("info", "mcp.inbox.prepare_add_recipients.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
       recipientCount: recipients.length,
-      thread
+      thread,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1232,7 +1317,9 @@ async function handlePrepareReact(args: ToolArgs): Promise<ToolResult> {
   try {
     const profileName = readString(args, "profileName", "default");
     const thread = readRequiredString(args, "thread");
-    const reaction = normalizeLinkedInInboxReaction(readString(args, "reaction", "like"));
+    const reaction = normalizeLinkedInInboxReaction(
+      readString(args, "reaction", "like"),
+    );
     const messageIndex = readOptionalNonNegativeNumber(args, "messageIndex");
     const operatorNote = readString(args, "operatorNote", "");
 
@@ -1240,7 +1327,7 @@ async function handlePrepareReact(args: ToolArgs): Promise<ToolResult> {
       profileName,
       thread,
       reaction,
-      messageIndex
+      messageIndex,
     });
 
     const prepared = await runtime.inbox.prepareReact({
@@ -1250,22 +1337,22 @@ async function handlePrepareReact(args: ToolArgs): Promise<ToolResult> {
       ...(messageIndex !== undefined ? { messageIndex } : {}),
       ...(operatorNote
         ? {
-            operatorNote
+            operatorNote,
           }
-        : {})
+        : {}),
     });
 
     runtime.logger.log("info", "mcp.inbox.prepare_react.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
       reaction,
-      messageIndex
+      messageIndex,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1281,23 +1368,23 @@ async function handleArchiveThread(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.inbox.archive_thread.start", {
       profileName,
-      thread
+      thread,
     });
 
     const result = await runtime.inbox.archiveThread({
       profileName,
-      thread
+      thread,
     });
 
     runtime.logger.log("info", "mcp.inbox.archive_thread.done", {
       profileName,
-      threadId: result.thread_id
+      threadId: result.thread_id,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
@@ -1313,23 +1400,23 @@ async function handleUnarchiveThread(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.inbox.unarchive_thread.start", {
       profileName,
-      thread
+      thread,
     });
 
     const result = await runtime.inbox.unarchiveThread({
       profileName,
-      thread
+      thread,
     });
 
     runtime.logger.log("info", "mcp.inbox.unarchive_thread.done", {
       profileName,
-      threadId: result.thread_id
+      threadId: result.thread_id,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
@@ -1345,23 +1432,23 @@ async function handleMarkUnread(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.inbox.mark_unread.start", {
       profileName,
-      thread
+      thread,
     });
 
     const result = await runtime.inbox.markUnread({
       profileName,
-      thread
+      thread,
     });
 
     runtime.logger.log("info", "mcp.inbox.mark_unread.done", {
       profileName,
-      threadId: result.thread_id
+      threadId: result.thread_id,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
@@ -1377,23 +1464,23 @@ async function handleMuteThread(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.inbox.mute_thread.start", {
       profileName,
-      thread
+      thread,
     });
 
     const result = await runtime.inbox.muteThread({
       profileName,
-      thread
+      thread,
     });
 
     runtime.logger.log("info", "mcp.inbox.mute_thread.done", {
       profileName,
-      threadId: result.thread_id
+      threadId: result.thread_id,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
@@ -1409,23 +1496,23 @@ async function handleProfileView(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.profile.view.start", {
       profileName,
-      target
+      target,
     });
 
     const profile = await runtime.profile.viewProfile({
       profileName,
-      target
+      target,
     });
 
     runtime.logger.log("info", "mcp.profile.view.done", {
       profileName,
-      fullName: profile.full_name
+      fullName: profile.full_name,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      profile
+      profile,
     });
   } finally {
     runtime.close();
@@ -1441,23 +1528,23 @@ async function handleCompanyView(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.company.view.start", {
       profileName,
-      target
+      target,
     });
 
     const company = await runtime.companyPages.viewCompanyPage({
       profileName,
-      target
+      target,
     });
 
     runtime.logger.log("info", "mcp.company.view.done", {
       profileName,
-      companyName: company.name
+      companyName: company.name,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      company
+      company,
     });
   } finally {
     runtime.close();
@@ -1471,22 +1558,22 @@ async function handleProfileViewEditable(args: ToolArgs): Promise<ToolResult> {
     const profileName = readString(args, "profileName", "default");
 
     runtime.logger.log("info", "mcp.profile.view_editable.start", {
-      profileName
+      profileName,
     });
 
     const profile = await runtime.profile.viewEditableProfile({
-      profileName
+      profileName,
     });
 
     runtime.logger.log("info", "mcp.profile.view_editable.done", {
       profileName,
-      sectionCount: profile.sections.length
+      sectionCount: profile.sections.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      profile
+      profile,
     });
   } finally {
     runtime.close();
@@ -1494,7 +1581,7 @@ async function handleProfileViewEditable(args: ToolArgs): Promise<ToolResult> {
 }
 
 async function handleProfilePrepareUpdateIntro(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1503,7 +1590,7 @@ async function handleProfilePrepareUpdateIntro(
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.profile.prepare_update_intro.start", {
-      profileName
+      profileName,
     });
 
     const prepared = runtime.profile.prepareUpdateIntro({
@@ -1520,18 +1607,18 @@ async function handleProfilePrepareUpdateIntro(
       ...(typeof args.location === "string"
         ? { location: readString(args, "location", "") }
         : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_update_intro.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1539,7 +1626,7 @@ async function handleProfilePrepareUpdateIntro(
 }
 
 async function handleProfilePrepareUpdateSettings(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1549,24 +1636,24 @@ async function handleProfilePrepareUpdateSettings(
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.profile.prepare_update_settings.start", {
-      profileName
+      profileName,
     });
 
     const prepared = runtime.profile.prepareUpdateSettings({
       profileName,
       industry,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_update_settings.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1574,7 +1661,7 @@ async function handleProfilePrepareUpdateSettings(
 }
 
 async function handleProfilePrepareUpdatePublicProfile(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1582,7 +1669,9 @@ async function handleProfilePrepareUpdatePublicProfile(
     const profileName = readString(args, "profileName", "default");
     const operatorNote = readString(args, "operatorNote", "");
     const vanityName =
-      typeof args.vanityName === "string" ? readString(args, "vanityName", "") : "";
+      typeof args.vanityName === "string"
+        ? readString(args, "vanityName", "")
+        : "";
     const customProfileUrl =
       typeof args.customProfileUrl === "string"
         ? readString(args, "customProfileUrl", "")
@@ -1595,7 +1684,7 @@ async function handleProfilePrepareUpdatePublicProfile(
     if (!vanityName && !customProfileUrl && !publicProfileUrl) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "vanityName, customProfileUrl, or publicProfileUrl is required."
+        "vanityName, customProfileUrl, or publicProfileUrl is required.",
       );
     }
 
@@ -1603,8 +1692,8 @@ async function handleProfilePrepareUpdatePublicProfile(
       "info",
       "mcp.profile.prepare_update_public_profile.start",
       {
-        profileName
-      }
+        profileName,
+      },
     );
 
     const prepared = runtime.profile.prepareUpdatePublicProfile({
@@ -1612,18 +1701,22 @@ async function handleProfilePrepareUpdatePublicProfile(
       ...(vanityName ? { vanityName } : {}),
       ...(customProfileUrl ? { customProfileUrl } : {}),
       ...(publicProfileUrl ? { publicProfileUrl } : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
-    runtime.logger.log("info", "mcp.profile.prepare_update_public_profile.done", {
-      profileName,
-      preparedActionId: prepared.preparedActionId
-    });
+    runtime.logger.log(
+      "info",
+      "mcp.profile.prepare_update_public_profile.done",
+      {
+        profileName,
+        preparedActionId: prepared.preparedActionId,
+      },
+    );
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1631,7 +1724,7 @@ async function handleProfilePrepareUpdatePublicProfile(
 }
 
 async function handleProfilePrepareUpsertSectionItem(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1646,15 +1739,19 @@ async function handleProfilePrepareUpsertSectionItem(
     if (!values) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "values is required."
+        "values is required.",
       );
     }
 
-    runtime.logger.log("info", "mcp.profile.prepare_upsert_section_item.start", {
-      profileName,
-      section,
-      hasItemId: itemId.length > 0
-    });
+    runtime.logger.log(
+      "info",
+      "mcp.profile.prepare_upsert_section_item.start",
+      {
+        profileName,
+        section,
+        hasItemId: itemId.length > 0,
+      },
+    );
 
     const prepared = runtime.profile.prepareUpsertSectionItem({
       profileName,
@@ -1662,19 +1759,19 @@ async function handleProfilePrepareUpsertSectionItem(
       values,
       ...(itemId ? { itemId } : {}),
       ...(match ? { match } : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_upsert_section_item.done", {
       profileName,
       section,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1682,7 +1779,7 @@ async function handleProfilePrepareUpsertSectionItem(
 }
 
 async function handleProfilePrepareRemoveSectionItem(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1693,30 +1790,34 @@ async function handleProfilePrepareRemoveSectionItem(
     const itemId = readString(args, "itemId", "");
     const operatorNote = readString(args, "operatorNote", "");
 
-    runtime.logger.log("info", "mcp.profile.prepare_remove_section_item.start", {
-      profileName,
-      section,
-      hasItemId: itemId.length > 0
-    });
+    runtime.logger.log(
+      "info",
+      "mcp.profile.prepare_remove_section_item.start",
+      {
+        profileName,
+        section,
+        hasItemId: itemId.length > 0,
+      },
+    );
 
     const prepared = runtime.profile.prepareRemoveSectionItem({
       profileName,
       section,
       ...(itemId ? { itemId } : {}),
       ...(match ? { match } : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_remove_section_item.done", {
       profileName,
       section,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1724,34 +1825,34 @@ async function handleProfilePrepareRemoveSectionItem(
 }
 
 async function handleProfilePrepareUploadPhoto(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
     const profileName = readString(args, "profileName", "default");
-    const filePath = readRequiredString(args, "filePath");
+    const filePath = readValidatedFilePath(args, "filePath");
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.profile.prepare_upload_photo.start", {
-      profileName
+      profileName,
     });
 
     const prepared = await runtime.profile.prepareUploadPhoto({
       profileName,
       filePath,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_upload_photo.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1759,34 +1860,34 @@ async function handleProfilePrepareUploadPhoto(
 }
 
 async function handleProfilePrepareUploadBanner(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
     const profileName = readString(args, "profileName", "default");
-    const filePath = readRequiredString(args, "filePath");
+    const filePath = readValidatedFilePath(args, "filePath");
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.profile.prepare_upload_banner.start", {
-      profileName
+      profileName,
     });
 
     const prepared = await runtime.profile.prepareUploadBanner({
       profileName,
       filePath,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_upload_banner.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1794,7 +1895,7 @@ async function handleProfilePrepareUploadBanner(
 }
 
 async function handleProfilePrepareFeaturedAdd(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1805,33 +1906,37 @@ async function handleProfilePrepareFeaturedAdd(
 
     runtime.logger.log("info", "mcp.profile.prepare_featured_add.start", {
       profileName,
-      kind
+      kind,
     });
 
     const prepared = await runtime.profile.prepareFeaturedAdd({
       profileName,
       kind,
-      ...(typeof args.url === "string" ? { url: readString(args, "url", "") } : {}),
+      ...(typeof args.url === "string"
+        ? { url: readString(args, "url", "") }
+        : {}),
       ...(typeof args.filePath === "string"
         ? { filePath: readString(args, "filePath", "") }
         : {}),
-      ...(typeof args.title === "string" ? { title: readString(args, "title", "") } : {}),
+      ...(typeof args.title === "string"
+        ? { title: readString(args, "title", "") }
+        : {}),
       ...(typeof args.description === "string"
         ? { description: readString(args, "description", "") }
         : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_featured_add.done", {
       profileName,
       kind,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1839,7 +1944,7 @@ async function handleProfilePrepareFeaturedAdd(
 }
 
 async function handleProfilePrepareFeaturedRemove(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1851,25 +1956,25 @@ async function handleProfilePrepareFeaturedRemove(
 
     runtime.logger.log("info", "mcp.profile.prepare_featured_remove.start", {
       profileName,
-      hasItemId: itemId.length > 0
+      hasItemId: itemId.length > 0,
     });
 
     const prepared = runtime.profile.prepareFeaturedRemove({
       profileName,
       ...(itemId ? { itemId } : {}),
       ...(match ? { match } : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_featured_remove.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1877,7 +1982,7 @@ async function handleProfilePrepareFeaturedRemove(
 }
 
 async function handleProfilePrepareFeaturedReorder(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1889,31 +1994,31 @@ async function handleProfilePrepareFeaturedReorder(
     if (!itemIds || itemIds.length === 0) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "itemIds is required."
+        "itemIds is required.",
       );
     }
 
     runtime.logger.log("info", "mcp.profile.prepare_featured_reorder.start", {
       profileName,
-      itemCount: itemIds.length
+      itemCount: itemIds.length,
     });
 
     const prepared = runtime.profile.prepareFeaturedReorder({
       profileName,
       itemIds,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_featured_reorder.done", {
       profileName,
       itemCount: itemIds.length,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1921,7 +2026,7 @@ async function handleProfilePrepareFeaturedReorder(
 }
 
 async function handleProfilePrepareAddSkill(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1932,24 +2037,24 @@ async function handleProfilePrepareAddSkill(
 
     runtime.logger.log("info", "mcp.profile.prepare_add_skill.start", {
       profileName,
-      skillName
+      skillName,
     });
 
     const prepared = runtime.profile.prepareAddSkill({
       profileName,
       skillName,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_add_skill.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1957,7 +2062,7 @@ async function handleProfilePrepareAddSkill(
 }
 
 async function handleProfilePrepareReorderSkills(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -1968,25 +2073,25 @@ async function handleProfilePrepareReorderSkills(
 
     runtime.logger.log("info", "mcp.profile.prepare_reorder_skills.start", {
       profileName,
-      skillCount: skillNames.length
+      skillCount: skillNames.length,
     });
 
     const prepared = runtime.profile.prepareReorderSkills({
       profileName,
       skillNames,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_reorder_skills.done", {
       profileName,
       skillCount: skillNames.length,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -1994,7 +2099,7 @@ async function handleProfilePrepareReorderSkills(
 }
 
 async function handleProfilePrepareEndorseSkill(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -2006,25 +2111,25 @@ async function handleProfilePrepareEndorseSkill(
 
     runtime.logger.log("info", "mcp.profile.prepare_endorse_skill.start", {
       profileName,
-      target
+      target,
     });
 
     const prepared = runtime.profile.prepareEndorseSkill({
       profileName,
       target,
       skillName,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.profile.prepare_endorse_skill.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2032,7 +2137,7 @@ async function handleProfilePrepareEndorseSkill(
 }
 
 async function handleProfilePrepareRequestRecommendation(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -2046,8 +2151,8 @@ async function handleProfilePrepareRequestRecommendation(
       "mcp.profile.prepare_request_recommendation.start",
       {
         profileName,
-        target
-      }
+        target,
+      },
     );
 
     const prepared = runtime.profile.prepareRequestRecommendation({
@@ -2065,7 +2170,7 @@ async function handleProfilePrepareRequestRecommendation(
       ...(typeof args.message === "string"
         ? { message: readString(args, "message", "") }
         : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log(
@@ -2073,14 +2178,14 @@ async function handleProfilePrepareRequestRecommendation(
       "mcp.profile.prepare_request_recommendation.done",
       {
         profileName,
-        preparedActionId: prepared.preparedActionId
-      }
+        preparedActionId: prepared.preparedActionId,
+      },
     );
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2088,7 +2193,7 @@ async function handleProfilePrepareRequestRecommendation(
 }
 
 async function handleProfilePrepareWriteRecommendation(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -2103,8 +2208,8 @@ async function handleProfilePrepareWriteRecommendation(
       "mcp.profile.prepare_write_recommendation.start",
       {
         profileName,
-        target
-      }
+        target,
+      },
     );
 
     const prepared = runtime.profile.prepareWriteRecommendation({
@@ -2120,7 +2225,7 @@ async function handleProfilePrepareWriteRecommendation(
       ...(typeof args.company === "string"
         ? { company: readString(args, "company", "") }
         : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log(
@@ -2128,14 +2233,14 @@ async function handleProfilePrepareWriteRecommendation(
       "mcp.profile.prepare_write_recommendation.done",
       {
         profileName,
-        preparedActionId: prepared.preparedActionId
-      }
+        preparedActionId: prepared.preparedActionId,
+      },
     );
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2143,7 +2248,7 @@ async function handleProfilePrepareWriteRecommendation(
 }
 
 async function handleAssetsGenerateProfileImages(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -2153,7 +2258,7 @@ async function handleAssetsGenerateProfileImages(
     const postImageCount = readPositiveNumber(
       args,
       "postImageCount",
-      DEFAULT_LINKEDIN_PERSONA_POST_IMAGE_COUNT
+      DEFAULT_LINKEDIN_PERSONA_POST_IMAGE_COUNT,
     );
     const uploadProfileMedia = readBoolean(args, "uploadProfileMedia", false);
     const uploadDelayMs = readNonNegativeNumber(args, "uploadDelayMs", 4_500);
@@ -2161,7 +2266,7 @@ async function handleAssetsGenerateProfileImages(
     const operatorNote = readString(args, "operatorNote", "");
     const resolvedSpecPath = path.resolve(specPath);
     const persona = buildLinkedInImagePersonaFromProfileSeed(
-      await readJsonInputFile(resolvedSpecPath, "image persona spec")
+      await readJsonInputFile(resolvedSpecPath, "image persona spec"),
     );
 
     runtime.logger.log("info", "mcp.assets.generate_profile_images.start", {
@@ -2169,7 +2274,7 @@ async function handleAssetsGenerateProfileImages(
       specPath: resolvedSpecPath,
       postImageCount,
       uploadProfileMedia,
-      model: model || null
+      model: model || null,
     });
 
     const report = await runtime.imageAssets.generatePersonaImageSet({
@@ -2179,22 +2284,23 @@ async function handleAssetsGenerateProfileImages(
       profileName,
       uploadDelayMs,
       operatorNote:
-        operatorNote || `issue-211 persona images: ${path.basename(resolvedSpecPath)}`,
-      ...(model ? { model } : {})
+        operatorNote ||
+        `issue-211 persona images: ${path.basename(resolvedSpecPath)}`,
+      ...(model ? { model } : {}),
     });
 
     runtime.logger.log("info", "mcp.assets.generate_profile_images.done", {
       profileName,
       specPath: resolvedSpecPath,
       postImageCount,
-      uploadProfileMedia
+      uploadProfileMedia,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
       spec_path: resolvedSpecPath,
-      ...report
+      ...report,
     });
   } finally {
     runtime.close();
@@ -2202,7 +2308,7 @@ async function handleAssetsGenerateProfileImages(
 }
 
 async function handleAnalyticsProfileViews(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -2210,23 +2316,23 @@ async function handleAnalyticsProfileViews(
     const profileName = readString(args, "profileName", "default");
 
     runtime.logger.log("info", "mcp.analytics.profile_views.start", {
-      profileName
+      profileName,
     });
 
     const summary = await runtime.analytics.getProfileViews({
-      profileName
+      profileName,
     });
 
     runtime.logger.log("info", "mcp.analytics.profile_views.done", {
       profileName,
       card_count: summary.cards.length,
-      metric_count: summary.metrics.length
+      metric_count: summary.metrics.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...summary
+      ...summary,
     });
   } finally {
     runtime.close();
@@ -2234,7 +2340,7 @@ async function handleAnalyticsProfileViews(
 }
 
 async function handleAnalyticsSearchAppearances(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -2242,23 +2348,23 @@ async function handleAnalyticsSearchAppearances(
     const profileName = readString(args, "profileName", "default");
 
     runtime.logger.log("info", "mcp.analytics.search_appearances.start", {
-      profileName
+      profileName,
     });
 
     const summary = await runtime.analytics.getSearchAppearances({
-      profileName
+      profileName,
     });
 
     runtime.logger.log("info", "mcp.analytics.search_appearances.done", {
       profileName,
       card_count: summary.cards.length,
-      metric_count: summary.metrics.length
+      metric_count: summary.metrics.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...summary
+      ...summary,
     });
   } finally {
     runtime.close();
@@ -2266,7 +2372,7 @@ async function handleAnalyticsSearchAppearances(
 }
 
 async function handleAnalyticsContentMetrics(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -2276,33 +2382,31 @@ async function handleAnalyticsContentMetrics(
 
     runtime.logger.log("info", "mcp.analytics.content_metrics.start", {
       profileName,
-      limit
+      limit,
     });
 
     const summary = await runtime.analytics.getContentMetrics({
       profileName,
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.analytics.content_metrics.done", {
       profileName,
       card_count: summary.cards.length,
-      metric_count: summary.metrics.length
+      metric_count: summary.metrics.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...summary
+      ...summary,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handleAnalyticsPostMetrics(
-  args: ToolArgs
-): Promise<ToolResult> {
+async function handleAnalyticsPostMetrics(args: ToolArgs): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
@@ -2311,24 +2415,24 @@ async function handleAnalyticsPostMetrics(
 
     runtime.logger.log("info", "mcp.analytics.post_metrics.start", {
       profileName,
-      postUrl
+      postUrl,
     });
 
     const summary = await runtime.analytics.getPostMetrics({
       profileName,
-      postUrl
+      postUrl,
     });
 
     runtime.logger.log("info", "mcp.analytics.post_metrics.done", {
       profileName,
       post_url: summary.post.post_url,
-      metric_count: summary.metrics.length
+      metric_count: summary.metrics.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...summary
+      ...summary,
     });
   } finally {
     runtime.close();
@@ -2344,31 +2448,33 @@ async function handleNotificationsList(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.notifications.list.start", {
       profileName,
-      limit
+      limit,
     });
 
     const notifications = await runtime.notifications.listNotifications({
       profileName,
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.notifications.list.done", {
       profileName,
-      count: notifications.length
+      count: notifications.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
       count: notifications.length,
-      notifications
+      notifications,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handleNotificationsMarkRead(args: ToolArgs): Promise<ToolResult> {
+async function handleNotificationsMarkRead(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
@@ -2377,24 +2483,24 @@ async function handleNotificationsMarkRead(args: ToolArgs): Promise<ToolResult> 
 
     runtime.logger.log("info", "mcp.notifications.mark_read.start", {
       profileName,
-      notificationId
+      notificationId,
     });
 
     const result = await runtime.notifications.markRead({
       profileName,
-      notificationId
+      notificationId,
     });
 
     runtime.logger.log("info", "mcp.notifications.mark_read.done", {
       profileName,
       notificationId,
-      wasAlreadyRead: result.was_already_read
+      wasAlreadyRead: result.was_already_read,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
@@ -2411,25 +2517,25 @@ async function handleNotificationsDismiss(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.notifications.dismiss.start", {
       profileName,
-      notificationId
+      notificationId,
     });
 
     const prepared = await runtime.notifications.prepareDismissNotification({
       profileName,
       notificationId,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.notifications.dismiss.done", {
       profileName,
       notificationId,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2437,7 +2543,7 @@ async function handleNotificationsDismiss(args: ToolArgs): Promise<ToolResult> {
 }
 
 async function handleNotificationPreferencesGet(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -2447,24 +2553,24 @@ async function handleNotificationPreferencesGet(
 
     runtime.logger.log("info", "mcp.notifications.preferences.get.start", {
       profileName,
-      preferenceUrl: preferenceUrl || null
+      preferenceUrl: preferenceUrl || null,
     });
 
     const preferences = await runtime.notifications.getPreferences({
       profileName,
-      ...(preferenceUrl ? { preferenceUrl } : {})
+      ...(preferenceUrl ? { preferenceUrl } : {}),
     });
 
     runtime.logger.log("info", "mcp.notifications.preferences.get.done", {
       profileName,
       viewType: preferences.view_type,
-      preferenceUrl: preferences.preference_url
+      preferenceUrl: preferences.preference_url,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      preferences
+      preferences,
     });
   } finally {
     runtime.close();
@@ -2472,7 +2578,7 @@ async function handleNotificationPreferencesGet(
 }
 
 async function handleNotificationPreferencesPrepareUpdate(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -2480,36 +2586,47 @@ async function handleNotificationPreferencesPrepareUpdate(
     const profileName = readString(args, "profileName", "default");
     const preferenceUrl = readRequiredString(args, "preferenceUrl");
     const enabled = readRequiredBoolean(args, "enabled");
-    const channel = typeof args.channel === "string"
-      ? normalizeLinkedInNotificationPreferenceChannel(readRequiredString(args, "channel"))
-      : undefined;
+    const channel =
+      typeof args.channel === "string"
+        ? normalizeLinkedInNotificationPreferenceChannel(
+            readRequiredString(args, "channel"),
+          )
+        : undefined;
     const operatorNote = readString(args, "operatorNote", "");
 
-    runtime.logger.log("info", "mcp.notifications.preferences.prepare_update.start", {
-      profileName,
-      preferenceUrl,
-      enabled,
-      channel: channel ?? null
-    });
+    runtime.logger.log(
+      "info",
+      "mcp.notifications.preferences.prepare_update.start",
+      {
+        profileName,
+        preferenceUrl,
+        enabled,
+        channel: channel ?? null,
+      },
+    );
 
     const prepared = await runtime.notifications.prepareUpdatePreference({
       profileName,
       preferenceUrl,
       enabled,
       ...(channel ? { channel } : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
-    runtime.logger.log("info", "mcp.notifications.preferences.prepare_update.done", {
-      profileName,
-      preferenceUrl,
-      preparedActionId: prepared.preparedActionId
-    });
+    runtime.logger.log(
+      "info",
+      "mcp.notifications.preferences.prepare_update.done",
+      {
+        profileName,
+        preferenceUrl,
+        preparedActionId: prepared.preparedActionId,
+      },
+    );
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2529,25 +2646,25 @@ async function handleJobsSearch(args: ToolArgs): Promise<ToolResult> {
       profileName,
       query,
       location,
-      limit
+      limit,
     });
 
     const result = await runtime.jobs.searchJobs({
       profileName,
       query,
       ...(location ? { location } : {}),
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.jobs.search.done", {
       profileName,
-      count: result.count
+      count: result.count,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
@@ -2563,23 +2680,23 @@ async function handleJobsView(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.jobs.view.start", {
       profileName,
-      jobId
+      jobId,
     });
 
     const job = await runtime.jobs.viewJob({
       profileName,
-      jobId
+      jobId,
     });
 
     runtime.logger.log("info", "mcp.jobs.view.done", {
       profileName,
-      jobId: job.job_id
+      jobId: job.job_id,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      job
+      job,
     });
   } finally {
     runtime.close();
@@ -2596,24 +2713,24 @@ async function handleJobsSave(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.jobs.save.start", {
       profileName,
-      jobId
+      jobId,
     });
 
     const prepared = runtime.jobs.prepareSaveJob({
       profileName,
       jobId,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.jobs.save.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2630,24 +2747,24 @@ async function handleJobsUnsave(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.jobs.unsave.start", {
       profileName,
-      jobId
+      jobId,
     });
 
     const prepared = runtime.jobs.prepareUnsaveJob({
       profileName,
       jobId,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.jobs.unsave.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2663,23 +2780,23 @@ async function handleJobsAlertsList(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.jobs.alerts.list.start", {
       profileName,
-      limit
+      limit,
     });
 
     const result = await runtime.jobs.listJobAlerts({
       profileName,
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.jobs.alerts.list.done", {
       profileName,
-      count: result.count
+      count: result.count,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
@@ -2698,25 +2815,25 @@ async function handleJobsAlertsCreate(args: ToolArgs): Promise<ToolResult> {
     runtime.logger.log("info", "mcp.jobs.alerts.create.start", {
       profileName,
       query,
-      location
+      location,
     });
 
     const prepared = runtime.jobs.prepareCreateJobAlert({
       profileName,
       query,
       ...(location ? { location } : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.jobs.alerts.create.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2738,7 +2855,7 @@ async function handleJobsAlertsRemove(args: ToolArgs): Promise<ToolResult> {
       profileName,
       hasAlertId: alertId.length > 0,
       hasSearchUrl: searchUrl.length > 0,
-      hasQuery: query.length > 0
+      hasQuery: query.length > 0,
     });
 
     const prepared = await runtime.jobs.prepareRemoveJobAlert({
@@ -2747,18 +2864,18 @@ async function handleJobsAlertsRemove(args: ToolArgs): Promise<ToolResult> {
       ...(searchUrl ? { searchUrl } : {}),
       ...(query ? { query } : {}),
       ...(location ? { location } : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.jobs.alerts.remove.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2783,7 +2900,7 @@ async function handleJobsPrepareEasyApply(args: ToolArgs): Promise<ToolResult> {
       profileName,
       jobId,
       hasResumePath: resumePath.length > 0,
-      hasAnswers: Boolean(answers)
+      hasAnswers: Boolean(answers),
     });
 
     const prepared = runtime.jobs.prepareEasyApply({
@@ -2795,18 +2912,18 @@ async function handleJobsPrepareEasyApply(args: ToolArgs): Promise<ToolResult> {
       ...(resumePath ? { resumePath } : {}),
       ...(coverLetter ? { coverLetter } : {}),
       ...(answers ? { answers } : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.jobs.easy_apply.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2824,24 +2941,24 @@ async function handleGroupsSearch(args: ToolArgs): Promise<ToolResult> {
     runtime.logger.log("info", "mcp.groups.search.start", {
       profileName,
       query,
-      limit
+      limit,
     });
 
     const result = await runtime.groups.searchGroups({
       profileName,
       query,
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.groups.search.done", {
       profileName,
-      count: result.count
+      count: result.count,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
@@ -2857,23 +2974,23 @@ async function handleGroupsView(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.groups.view.start", {
       profileName,
-      group
+      group,
     });
 
     const groupDetails = await runtime.groups.viewGroup({
       profileName,
-      group
+      group,
     });
 
     runtime.logger.log("info", "mcp.groups.view.done", {
       profileName,
-      groupId: groupDetails.group_id
+      groupId: groupDetails.group_id,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      group: groupDetails
+      group: groupDetails,
     });
   } finally {
     runtime.close();
@@ -2890,24 +3007,24 @@ async function handleGroupsPrepareJoin(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.groups.prepare_join.start", {
       profileName,
-      group
+      group,
     });
 
     const prepared = runtime.groups.prepareJoinGroup({
       profileName,
       group,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.groups.prepare_join.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2924,24 +3041,24 @@ async function handleGroupsPrepareLeave(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.groups.prepare_leave.start", {
       profileName,
-      group
+      group,
     });
 
     const prepared = runtime.groups.prepareLeaveGroup({
       profileName,
       group,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.groups.prepare_leave.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2959,25 +3076,25 @@ async function handleGroupsPreparePost(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.groups.prepare_post.start", {
       profileName,
-      group
+      group,
     });
 
     const prepared = runtime.groups.preparePostToGroup({
       profileName,
       group,
       text,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.groups.prepare_post.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -2995,24 +3112,24 @@ async function handleEventsSearch(args: ToolArgs): Promise<ToolResult> {
     runtime.logger.log("info", "mcp.events.search.start", {
       profileName,
       query,
-      limit
+      limit,
     });
 
     const result = await runtime.events.searchEvents({
       profileName,
       query,
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.events.search.done", {
       profileName,
-      count: result.count
+      count: result.count,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...result
+      ...result,
     });
   } finally {
     runtime.close();
@@ -3028,23 +3145,23 @@ async function handleEventsView(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.events.view.start", {
       profileName,
-      event
+      event,
     });
 
     const eventDetails = await runtime.events.viewEvent({
       profileName,
-      event
+      event,
     });
 
     runtime.logger.log("info", "mcp.events.view.done", {
       profileName,
-      eventId: eventDetails.event_id
+      eventId: eventDetails.event_id,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      event: eventDetails
+      event: eventDetails,
     });
   } finally {
     runtime.close();
@@ -3061,24 +3178,24 @@ async function handleEventsPrepareRsvp(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.events.prepare_rsvp.start", {
       profileName,
-      event
+      event,
     });
 
     const prepared = runtime.events.prepareRsvp({
       profileName,
       event,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.events.prepare_rsvp.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3098,26 +3215,26 @@ async function handleSearch(args: ToolArgs): Promise<ToolResult> {
       profileName,
       query,
       category,
-      limit
+      limit,
     });
 
     const search = await runtime.search.search({
       profileName,
       query,
       category,
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.search.done", {
       profileName,
       category: search.category,
-      count: search.count
+      count: search.count,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...search
+      ...search,
     });
   } finally {
     runtime.close();
@@ -3133,24 +3250,24 @@ async function handleConnectionsList(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.connections.list.start", {
       profileName,
-      limit
+      limit,
     });
 
     const connections = await runtime.connections.listConnections({
       profileName,
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.connections.list.done", {
       profileName,
-      count: connections.length
+      count: connections.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
       count: connections.length,
-      connections
+      connections,
     });
   } finally {
     runtime.close();
@@ -3163,23 +3280,23 @@ async function handleConnectionsPending(args: ToolArgs): Promise<ToolResult> {
   try {
     const profileName = readString(args, "profileName", "default");
     const filterRaw = readString(args, "filter", "all");
-    const filter = (["sent", "received", "all"].includes(filterRaw)
-      ? filterRaw
-      : "all") as "sent" | "received" | "all";
+    const filter = (
+      ["sent", "received", "all"].includes(filterRaw) ? filterRaw : "all"
+    ) as "sent" | "received" | "all";
 
     runtime.logger.log("info", "mcp.connections.pending.start", {
       profileName,
-      filter
+      filter,
     });
 
     const invitations = await runtime.connections.listPendingInvitations({
       profileName,
-      filter
+      filter,
     });
 
     runtime.logger.log("info", "mcp.connections.pending.done", {
       profileName,
-      count: invitations.length
+      count: invitations.length,
     });
 
     return toToolResult({
@@ -3187,7 +3304,7 @@ async function handleConnectionsPending(args: ToolArgs): Promise<ToolResult> {
       profile_name: profileName,
       filter,
       count: invitations.length,
-      invitations
+      invitations,
     });
   } finally {
     runtime.close();
@@ -3205,25 +3322,25 @@ async function handleConnectionsInvite(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.connections.invite.start", {
       profileName,
-      targetProfile
+      targetProfile,
     });
 
     const prepared = runtime.connections.prepareSendInvitation({
       profileName,
       targetProfile,
       ...(note ? { note } : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.connections.invite.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3240,24 +3357,24 @@ async function handleConnectionsAccept(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.connections.accept.start", {
       profileName,
-      targetProfile
+      targetProfile,
     });
 
     const prepared = runtime.connections.prepareAcceptInvitation({
       profileName,
       targetProfile,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.connections.accept.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3274,24 +3391,24 @@ async function handleConnectionsWithdraw(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.connections.withdraw.start", {
       profileName,
-      targetProfile
+      targetProfile,
     });
 
     const prepared = runtime.connections.prepareWithdrawInvitation({
       profileName,
       targetProfile,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.connections.withdraw.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3299,7 +3416,7 @@ async function handleConnectionsWithdraw(args: ToolArgs): Promise<ToolResult> {
 }
 
 async function handleConnectionsPrepareIgnore(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -3310,24 +3427,24 @@ async function handleConnectionsPrepareIgnore(
 
     runtime.logger.log("info", "mcp.connections.prepare_ignore.start", {
       profileName,
-      targetProfile
+      targetProfile,
     });
 
     const prepared = runtime.connections.prepareIgnoreInvitation({
       profileName,
       targetProfile,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.connections.prepare_ignore.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3335,7 +3452,7 @@ async function handleConnectionsPrepareIgnore(
 }
 
 async function handleConnectionsPrepareRemove(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -3346,24 +3463,24 @@ async function handleConnectionsPrepareRemove(
 
     runtime.logger.log("info", "mcp.connections.prepare_remove.start", {
       profileName,
-      targetProfile
+      targetProfile,
     });
 
     const prepared = runtime.connections.prepareRemoveConnection({
       profileName,
       targetProfile,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.connections.prepare_remove.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3371,7 +3488,7 @@ async function handleConnectionsPrepareRemove(
 }
 
 async function handleConnectionsPrepareFollow(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -3382,24 +3499,24 @@ async function handleConnectionsPrepareFollow(
 
     runtime.logger.log("info", "mcp.connections.prepare_follow.start", {
       profileName,
-      targetProfile
+      targetProfile,
     });
 
     const prepared = runtime.connections.prepareFollowMember({
       profileName,
       targetProfile,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.connections.prepare_follow.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3407,7 +3524,7 @@ async function handleConnectionsPrepareFollow(
 }
 
 async function handleConnectionsPrepareUnfollow(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -3418,24 +3535,24 @@ async function handleConnectionsPrepareUnfollow(
 
     runtime.logger.log("info", "mcp.connections.prepare_unfollow.start", {
       profileName,
-      targetProfile
+      targetProfile,
     });
 
     const prepared = runtime.connections.prepareUnfollowMember({
       profileName,
       targetProfile,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.connections.prepare_unfollow.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3452,24 +3569,24 @@ async function handleCompanyPrepareFollow(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.company.prepare_follow.start", {
       profileName,
-      targetCompany
+      targetCompany,
     });
 
     const prepared = runtime.companyPages.prepareFollowCompanyPage({
       profileName,
       targetCompany,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.company.prepare_follow.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3477,7 +3594,7 @@ async function handleCompanyPrepareFollow(args: ToolArgs): Promise<ToolResult> {
 }
 
 async function handleCompanyPrepareUnfollow(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -3488,24 +3605,24 @@ async function handleCompanyPrepareUnfollow(
 
     runtime.logger.log("info", "mcp.company.prepare_unfollow.start", {
       profileName,
-      targetCompany
+      targetCompany,
     });
 
     const prepared = runtime.companyPages.prepareUnfollowCompanyPage({
       profileName,
       targetCompany,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.company.prepare_unfollow.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3522,31 +3639,33 @@ async function handleMembersPrepareBlock(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.members.prepare_block.start", {
       profileName,
-      targetProfile
+      targetProfile,
     });
 
     const prepared = runtime.members.prepareBlockMember({
       profileName,
       targetProfile,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.members.prepare_block.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handleMembersPrepareUnblock(args: ToolArgs): Promise<ToolResult> {
+async function handleMembersPrepareUnblock(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
@@ -3556,24 +3675,24 @@ async function handleMembersPrepareUnblock(args: ToolArgs): Promise<ToolResult> 
 
     runtime.logger.log("info", "mcp.members.prepare_unblock.start", {
       profileName,
-      targetProfile
+      targetProfile,
     });
 
     const prepared = runtime.members.prepareUnblockMember({
       profileName,
       targetProfile,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.members.prepare_unblock.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3593,7 +3712,7 @@ async function handleMembersPrepareReport(args: ToolArgs): Promise<ToolResult> {
     runtime.logger.log("info", "mcp.members.prepare_report.start", {
       profileName,
       targetProfile,
-      reason
+      reason,
     });
 
     const prepared = runtime.members.prepareReportMember({
@@ -3601,18 +3720,18 @@ async function handleMembersPrepareReport(args: ToolArgs): Promise<ToolResult> {
       targetProfile,
       reason,
       ...(details ? { details } : {}),
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.members.prepare_report.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3626,22 +3745,22 @@ async function handlePrivacyGetSettings(args: ToolArgs): Promise<ToolResult> {
     const profileName = readString(args, "profileName", "default");
 
     runtime.logger.log("info", "mcp.privacy.get_settings.start", {
-      profileName
+      profileName,
     });
 
     const settings = await runtime.privacySettings.getSettings({
-      profileName
+      profileName,
     });
 
     runtime.logger.log("info", "mcp.privacy.get_settings.done", {
       profileName,
-      count: settings.length
+      count: settings.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      settings
+      settings,
     });
   } finally {
     runtime.close();
@@ -3649,7 +3768,7 @@ async function handlePrivacyGetSettings(args: ToolArgs): Promise<ToolResult> {
 }
 
 async function handlePrivacyPrepareUpdateSetting(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -3658,32 +3777,32 @@ async function handlePrivacyPrepareUpdateSetting(
     const settingKey = readPrivacySettingKey(args, "settingKey");
     const value = normalizeLinkedInPrivacySettingValue(
       settingKey,
-      readRequiredString(args, "value")
+      readRequiredString(args, "value"),
     );
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.privacy.prepare_update_setting.start", {
       profileName,
       settingKey,
-      value
+      value,
     });
 
     const prepared = runtime.privacySettings.prepareUpdateSetting({
       profileName,
       settingKey,
       value,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.privacy.prepare_update_setting.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3691,7 +3810,7 @@ async function handlePrivacyPrepareUpdateSetting(
 }
 
 async function handlePrepareFollowupAfterAccept(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -3703,19 +3822,19 @@ async function handlePrepareFollowupAfterAccept(
 
     runtime.logger.log("info", "mcp.followups.prepare.start", {
       profileName,
-      since
+      since,
     });
 
     const result = await runtime.followups.prepareFollowupsAfterAccept({
       profileName,
       since,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.followups.prepare.done", {
       profileName,
       acceptedConnectionCount: result.acceptedConnections.length,
-      preparedCount: result.preparedFollowups.length
+      preparedCount: result.preparedFollowups.length,
     });
 
     return toToolResult({
@@ -3727,7 +3846,7 @@ async function handlePrepareFollowupAfterAccept(
       accepted_connection_count: result.acceptedConnections.length,
       prepared_count: result.preparedFollowups.length,
       accepted_connections: result.acceptedConnections,
-      prepared_followups: result.preparedFollowups
+      prepared_followups: result.preparedFollowups,
     });
   } finally {
     runtime.close();
@@ -3743,24 +3862,24 @@ async function handleFeedList(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.feed.list.start", {
       profileName,
-      limit
+      limit,
     });
 
     const posts = await runtime.feed.viewFeed({
       profileName,
-      limit
+      limit,
     });
 
     runtime.logger.log("info", "mcp.feed.list.done", {
       profileName,
-      count: posts.length
+      count: posts.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
       count: posts.length,
-      posts
+      posts,
     });
   } finally {
     runtime.close();
@@ -3772,27 +3891,27 @@ async function handleFeedViewPost(args: ToolArgs): Promise<ToolResult> {
 
   try {
     const profileName = readString(args, "profileName", "default");
-    const postUrl = readRequiredString(args, "postUrl");
+    const postUrl = readValidatedUrl(args, "postUrl");
 
     runtime.logger.log("info", "mcp.feed.view_post.start", {
       profileName,
-      postUrl
+      postUrl,
     });
 
     const post = await runtime.feed.viewPost({
       profileName,
-      postUrl
+      postUrl,
     });
 
     runtime.logger.log("info", "mcp.feed.view_post.done", {
       profileName,
-      postId: post.post_id
+      postId: post.post_id,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      post
+      post,
     });
   } finally {
     runtime.close();
@@ -3804,33 +3923,35 @@ async function handleFeedLike(args: ToolArgs): Promise<ToolResult> {
 
   try {
     const profileName = readString(args, "profileName", "default");
-    const postUrl = readRequiredString(args, "postUrl");
-    const reaction = normalizeLinkedInFeedReaction(readString(args, "reaction", "like"));
+    const postUrl = readValidatedUrl(args, "postUrl");
+    const reaction = normalizeLinkedInFeedReaction(
+      readString(args, "reaction", "like"),
+    );
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.feed.like.start", {
       profileName,
       postUrl,
-      reaction
+      reaction,
     });
 
     const prepared = runtime.feed.prepareLikePost({
       profileName,
       postUrl,
       reaction,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.feed.like.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
-      reaction
+      reaction,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3842,31 +3963,31 @@ async function handleFeedComment(args: ToolArgs): Promise<ToolResult> {
 
   try {
     const profileName = readString(args, "profileName", "default");
-    const postUrl = readRequiredString(args, "postUrl");
-    const text = readRequiredString(args, "text");
+    const postUrl = readValidatedUrl(args, "postUrl");
+    const text = readBoundedString(args, "text", 3000);
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.feed.comment.start", {
       profileName,
-      postUrl
+      postUrl,
     });
 
     const prepared = runtime.feed.prepareCommentOnPost({
       profileName,
       postUrl,
       text,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.feed.comment.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3878,29 +3999,29 @@ async function handleFeedPrepareRepost(args: ToolArgs): Promise<ToolResult> {
 
   try {
     const profileName = readString(args, "profileName", "default");
-    const postUrl = readRequiredString(args, "postUrl");
+    const postUrl = readValidatedUrl(args, "postUrl");
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.feed.prepare_repost.start", {
       profileName,
-      postUrl
+      postUrl,
     });
 
     const prepared = runtime.feed.prepareRepostPost({
       profileName,
       postUrl,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.feed.prepare_repost.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3918,25 +4039,25 @@ async function handleFeedPrepareShare(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.feed.prepare_share.start", {
       profileName,
-      postUrl
+      postUrl,
     });
 
     const prepared = runtime.feed.prepareSharePost({
       profileName,
       postUrl,
       text,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.feed.prepare_share.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3948,29 +4069,29 @@ async function handleFeedSavePost(args: ToolArgs): Promise<ToolResult> {
 
   try {
     const profileName = readString(args, "profileName", "default");
-    const postUrl = readRequiredString(args, "postUrl");
+    const postUrl = readValidatedUrl(args, "postUrl");
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.feed.save_post.start", {
       profileName,
-      postUrl
+      postUrl,
     });
 
     const prepared = runtime.feed.prepareSavePost({
       profileName,
       postUrl,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.feed.save_post.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -3987,24 +4108,24 @@ async function handleFeedUnsavePost(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.feed.unsave_post.start", {
       profileName,
-      postUrl
+      postUrl,
     });
 
     const prepared = runtime.feed.prepareUnsavePost({
       profileName,
       postUrl,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.feed.unsave_post.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -4012,7 +4133,7 @@ async function handleFeedUnsavePost(args: ToolArgs): Promise<ToolResult> {
 }
 
 async function handleFeedPrepareRemoveReaction(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -4023,24 +4144,24 @@ async function handleFeedPrepareRemoveReaction(
 
     runtime.logger.log("info", "mcp.feed.prepare_remove_reaction.start", {
       profileName,
-      postUrl
+      postUrl,
     });
 
     const prepared = runtime.feed.prepareRemoveReaction({
       profileName,
       postUrl,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.feed.prepare_remove_reaction.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -4052,42 +4173,44 @@ async function handlePostPrepareCreate(args: ToolArgs): Promise<ToolResult> {
 
   try {
     const profileName = readString(args, "profileName", "default");
-    const text = readRequiredString(args, "text");
+    const text = readBoundedString(args, "text", 3000);
     const visibility = normalizeLinkedInPostVisibility(
       readString(args, "visibility", "public"),
-      "public"
+      "public",
     );
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.post.prepare_create.start", {
       profileName,
-      visibility
+      visibility,
     });
 
     const prepared = await runtime.posts.prepareCreate({
       profileName,
       text,
       visibility,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.post.prepare_create.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
-      visibility
+      visibility,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handlePostPrepareCreateMedia(args: ToolArgs): Promise<ToolResult> {
+async function handlePostPrepareCreateMedia(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
@@ -4097,19 +4220,19 @@ async function handlePostPrepareCreateMedia(args: ToolArgs): Promise<ToolResult>
     if (!mediaPaths) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "mediaPaths is required."
+        "mediaPaths is required.",
       );
     }
     const visibility = normalizeLinkedInPostVisibility(
       readString(args, "visibility", "public"),
-      "public"
+      "public",
     );
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.post.prepare_create_media.start", {
       profileName,
       visibility,
-      mediaCount: mediaPaths.length
+      mediaCount: mediaPaths.length,
     });
 
     const prepared = await runtime.posts.prepareCreateMedia({
@@ -4117,27 +4240,29 @@ async function handlePostPrepareCreateMedia(args: ToolArgs): Promise<ToolResult>
       text,
       mediaPaths,
       visibility,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.post.prepare_create_media.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
       visibility,
-      mediaCount: mediaPaths.length
+      mediaCount: mediaPaths.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handlePostPrepareCreatePoll(args: ToolArgs): Promise<ToolResult> {
+async function handlePostPrepareCreatePoll(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
@@ -4147,14 +4272,14 @@ async function handlePostPrepareCreatePoll(args: ToolArgs): Promise<ToolResult> 
     if (!options) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "options is required."
+        "options is required.",
       );
     }
     const text = readString(args, "text", "");
     const durationDays = readOptionalPositiveNumber(args, "durationDays");
     const visibility = normalizeLinkedInPostVisibility(
       readString(args, "visibility", "public"),
-      "public"
+      "public",
     );
     const operatorNote = readString(args, "operatorNote", "");
 
@@ -4162,7 +4287,7 @@ async function handlePostPrepareCreatePoll(args: ToolArgs): Promise<ToolResult> 
       profileName,
       visibility,
       optionCount: options.length,
-      ...(typeof durationDays === "number" ? { durationDays } : {})
+      ...(typeof durationDays === "number" ? { durationDays } : {}),
     });
 
     const prepared = await runtime.posts.prepareCreatePoll({
@@ -4172,7 +4297,7 @@ async function handlePostPrepareCreatePoll(args: ToolArgs): Promise<ToolResult> 
       ...(text ? { text } : {}),
       ...(typeof durationDays === "number" ? { durationDays } : {}),
       visibility,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.post.prepare_create_poll.done", {
@@ -4180,13 +4305,13 @@ async function handlePostPrepareCreatePoll(args: ToolArgs): Promise<ToolResult> 
       preparedActionId: prepared.preparedActionId,
       visibility,
       optionCount: options.length,
-      ...(typeof durationDays === "number" ? { durationDays } : {})
+      ...(typeof durationDays === "number" ? { durationDays } : {}),
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -4199,31 +4324,31 @@ async function handlePostPrepareEdit(args: ToolArgs): Promise<ToolResult> {
   try {
     const profileName = readString(args, "profileName", "default");
     const postUrl = readRequiredString(args, "postUrl");
-    const text = readRequiredString(args, "text");
+    const text = readBoundedString(args, "text", 3000);
     const operatorNote = readString(args, "operatorNote", "");
 
     runtime.logger.log("info", "mcp.post.prepare_edit.start", {
       profileName,
-      postUrl
+      postUrl,
     });
 
     const prepared = await runtime.posts.prepareEdit({
       profileName,
       postUrl,
       text,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.post.prepare_edit.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
-      postUrl
+      postUrl,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -4240,25 +4365,25 @@ async function handlePostPrepareDelete(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.post.prepare_delete.start", {
       profileName,
-      postUrl
+      postUrl,
     });
 
     const prepared = await runtime.posts.prepareDelete({
       profileName,
       postUrl,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.post.prepare_delete.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
-      postUrl
+      postUrl,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -4276,32 +4401,34 @@ async function handleArticlePrepareCreate(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.article.prepare_create.start", {
       profileName,
-      titleLength: title.length
+      titleLength: title.length,
     });
 
     const prepared = await runtime.articles.prepareCreate({
       profileName,
       title,
       body,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.article.prepare_create.done", {
       profileName,
-      preparedActionId: prepared.preparedActionId
+      preparedActionId: prepared.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handleArticlePreparePublish(args: ToolArgs): Promise<ToolResult> {
+async function handleArticlePreparePublish(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
@@ -4311,32 +4438,34 @@ async function handleArticlePreparePublish(args: ToolArgs): Promise<ToolResult> 
 
     runtime.logger.log("info", "mcp.article.prepare_publish.start", {
       profileName,
-      draftUrl
+      draftUrl,
     });
 
     const prepared = await runtime.articles.preparePublish({
       profileName,
       draftUrl,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.article.prepare_publish.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
-      draftUrl
+      draftUrl,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handleNewsletterPrepareCreate(args: ToolArgs): Promise<ToolResult> {
+async function handleNewsletterPrepareCreate(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
@@ -4348,7 +4477,7 @@ async function handleNewsletterPrepareCreate(args: ToolArgs): Promise<ToolResult
 
     runtime.logger.log("info", "mcp.newsletter.prepare_create.start", {
       profileName,
-      cadence
+      cadence,
     });
 
     const prepared = await runtime.newsletters.prepareCreate({
@@ -4356,19 +4485,19 @@ async function handleNewsletterPrepareCreate(args: ToolArgs): Promise<ToolResult
       title,
       description,
       cadence,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.newsletter.prepare_create.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
-      cadence
+      cadence,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -4376,7 +4505,7 @@ async function handleNewsletterPrepareCreate(args: ToolArgs): Promise<ToolResult
 }
 
 async function handleNewsletterPreparePublishIssue(
-  args: ToolArgs
+  args: ToolArgs,
 ): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
@@ -4389,7 +4518,7 @@ async function handleNewsletterPreparePublishIssue(
 
     runtime.logger.log("info", "mcp.newsletter.prepare_publish_issue.start", {
       profileName,
-      newsletter
+      newsletter,
     });
 
     const prepared = await runtime.newsletters.preparePublishIssue({
@@ -4397,19 +4526,19 @@ async function handleNewsletterPreparePublishIssue(
       newsletter,
       title,
       body,
-      ...(operatorNote ? { operatorNote } : {})
+      ...(operatorNote ? { operatorNote } : {}),
     });
 
     runtime.logger.log("info", "mcp.newsletter.prepare_publish_issue.done", {
       profileName,
       preparedActionId: prepared.preparedActionId,
-      newsletter
+      newsletter,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...prepared
+      ...prepared,
     });
   } finally {
     runtime.close();
@@ -4423,22 +4552,22 @@ async function handleNewsletterList(args: ToolArgs): Promise<ToolResult> {
     const profileName = readString(args, "profileName", "default");
 
     runtime.logger.log("info", "mcp.newsletter.list.start", {
-      profileName
+      profileName,
     });
 
     const newsletters = await runtime.newsletters.list({
-      profileName
+      profileName,
     });
 
     runtime.logger.log("info", "mcp.newsletter.list.done", {
       profileName,
-      count: newsletters.count
+      count: newsletters.count,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      ...newsletters
+      ...newsletters,
     });
   } finally {
     runtime.close();
@@ -4457,7 +4586,7 @@ async function handleActivityWatchCreate(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.activity_watch.create.start", {
       profileName,
-      kind
+      kind,
     });
 
     const watch = runtime.activityWatches.createWatch({
@@ -4465,19 +4594,19 @@ async function handleActivityWatchCreate(args: ToolArgs): Promise<ToolResult> {
       kind,
       ...(target ? { target } : {}),
       ...(typeof intervalSeconds === "number" ? { intervalSeconds } : {}),
-      ...(cron ? { cron } : {})
+      ...(cron ? { cron } : {}),
     });
 
     runtime.logger.log("info", "mcp.activity_watch.create.done", {
       profileName,
       watchId: watch.id,
-      kind: watch.kind
+      kind: watch.kind,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      watch
+      watch,
     });
   } finally {
     runtime.close();
@@ -4493,24 +4622,24 @@ async function handleActivityWatchList(args: ToolArgs): Promise<ToolResult> {
 
     runtime.logger.log("info", "mcp.activity_watch.list.start", {
       profileName,
-      status: status ?? null
+      status: status ?? null,
     });
 
     const watches = runtime.activityWatches.listWatches({
       profileName,
-      ...(status ? { status } : {})
+      ...(status ? { status } : {}),
     });
 
     runtime.logger.log("info", "mcp.activity_watch.list.done", {
       profileName,
-      count: watches.length
+      count: watches.length,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
       count: watches.length,
-      watches
+      watches,
     });
   } finally {
     runtime.close();
@@ -4525,7 +4654,7 @@ async function handleActivityWatchPause(args: ToolArgs): Promise<ToolResult> {
     const watch = runtime.activityWatches.pauseWatch(watchId);
     return toToolResult({
       run_id: runtime.runId,
-      watch
+      watch,
     });
   } finally {
     runtime.close();
@@ -4540,7 +4669,7 @@ async function handleActivityWatchResume(args: ToolArgs): Promise<ToolResult> {
     const watch = runtime.activityWatches.resumeWatch(watchId);
     return toToolResult({
       run_id: runtime.runId,
-      watch
+      watch,
     });
   } finally {
     runtime.close();
@@ -4556,14 +4685,16 @@ async function handleActivityWatchRemove(args: ToolArgs): Promise<ToolResult> {
     return toToolResult({
       run_id: runtime.runId,
       watch_id: watchId,
-      removed
+      removed,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handleActivityWebhookCreate(args: ToolArgs): Promise<ToolResult> {
+async function handleActivityWebhookCreate(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
@@ -4575,7 +4706,7 @@ async function handleActivityWebhookCreate(args: ToolArgs): Promise<ToolResult> 
 
     runtime.logger.log("info", "mcp.activity_webhook.create.start", {
       watchId,
-      eventTypeCount: eventTypes?.length ?? 0
+      eventTypeCount: eventTypes?.length ?? 0,
     });
 
     const subscription = runtime.activityWatches.createWebhookSubscription({
@@ -4583,17 +4714,17 @@ async function handleActivityWebhookCreate(args: ToolArgs): Promise<ToolResult> 
       deliveryUrl,
       ...(eventTypes ? { eventTypes } : {}),
       ...(signingSecret ? { signingSecret } : {}),
-      ...(typeof maxAttempts === "number" ? { maxAttempts } : {})
+      ...(typeof maxAttempts === "number" ? { maxAttempts } : {}),
     });
 
     runtime.logger.log("info", "mcp.activity_webhook.create.done", {
       watchId,
-      subscriptionId: subscription.id
+      subscriptionId: subscription.id,
     });
 
     return toToolResult({
       run_id: runtime.runId,
-      subscription
+      subscription,
     });
   } finally {
     runtime.close();
@@ -4611,14 +4742,14 @@ async function handleActivityWebhookList(args: ToolArgs): Promise<ToolResult> {
     const subscriptions = runtime.activityWatches.listWebhookSubscriptions({
       profileName,
       ...(watchId ? { watchId } : {}),
-      ...(status ? { status } : {})
+      ...(status ? { status } : {}),
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
       count: subscriptions.length,
-      subscriptions
+      subscriptions,
     });
   } finally {
     runtime.close();
@@ -4630,47 +4761,48 @@ async function handleActivityWebhookPause(args: ToolArgs): Promise<ToolResult> {
 
   try {
     const subscriptionId = readRequiredString(args, "subscriptionId");
-    const subscription = runtime.activityWatches.pauseWebhookSubscription(
-      subscriptionId
-    );
+    const subscription =
+      runtime.activityWatches.pauseWebhookSubscription(subscriptionId);
     return toToolResult({
       run_id: runtime.runId,
-      subscription
+      subscription,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handleActivityWebhookResume(args: ToolArgs): Promise<ToolResult> {
+async function handleActivityWebhookResume(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
     const subscriptionId = readRequiredString(args, "subscriptionId");
-    const subscription = runtime.activityWatches.resumeWebhookSubscription(
-      subscriptionId
-    );
+    const subscription =
+      runtime.activityWatches.resumeWebhookSubscription(subscriptionId);
     return toToolResult({
       run_id: runtime.runId,
-      subscription
+      subscription,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handleActivityWebhookRemove(args: ToolArgs): Promise<ToolResult> {
+async function handleActivityWebhookRemove(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
     const subscriptionId = readRequiredString(args, "subscriptionId");
-    const removed = runtime.activityWatches.removeWebhookSubscription(
-      subscriptionId
-    );
+    const removed =
+      runtime.activityWatches.removeWebhookSubscription(subscriptionId);
     return toToolResult({
       run_id: runtime.runId,
       subscription_id: subscriptionId,
-      removed
+      removed,
     });
   } finally {
     runtime.close();
@@ -4687,21 +4819,23 @@ async function handleActivityEventsList(args: ToolArgs): Promise<ToolResult> {
     const events = runtime.activityWatches.listEvents({
       profileName,
       ...(watchId ? { watchId } : {}),
-      limit
+      limit,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
       count: events.length,
-      events
+      events,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handleActivityDeliveriesList(args: ToolArgs): Promise<ToolResult> {
+async function handleActivityDeliveriesList(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
@@ -4715,45 +4849,47 @@ async function handleActivityDeliveriesList(args: ToolArgs): Promise<ToolResult>
       ...(watchId ? { watchId } : {}),
       ...(subscriptionId ? { subscriptionId } : {}),
       ...(status ? { status } : {}),
-      limit
+      limit,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
       count: deliveries.length,
-      deliveries
+      deliveries,
     });
   } finally {
     runtime.close();
   }
 }
 
-async function handleActivityPollerRunOnce(args: ToolArgs): Promise<ToolResult> {
+async function handleActivityPollerRunOnce(
+  args: ToolArgs,
+): Promise<ToolResult> {
   const runtime = createRuntime(args);
 
   try {
     const profileName = readString(args, "profileName", "default");
 
     runtime.logger.log("info", "mcp.activity_poller.run_once.start", {
-      profileName
+      profileName,
     });
 
     const result = await runtime.activityPoller.runTick({
       profileName,
-      workerId: `mcp:${runtime.runId}`
+      workerId: `mcp:${runtime.runId}`,
     });
 
     runtime.logger.log("info", "mcp.activity_poller.run_once.done", {
       profileName,
       emittedEvents: result.emittedEvents,
-      deliveredAttempts: result.deliveredAttempts
+      deliveredAttempts: result.deliveredAttempts,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
-      result
+      result,
     });
   } finally {
     runtime.close();
@@ -4768,11 +4904,11 @@ async function handleConfirm(args: ToolArgs): Promise<ToolResult> {
     const token = readRequiredString(args, "token");
 
     runtime.logger.log("info", "mcp.actions.confirm.start", {
-      profileName
+      profileName,
     });
 
     const preview = runtime.twoPhaseCommit.getPreparedActionPreviewByToken({
-      confirmToken: token
+      confirmToken: token,
     });
 
     const preparedProfileName = readTargetProfileName(preview.target);
@@ -4782,25 +4918,25 @@ async function handleConfirm(args: ToolArgs): Promise<ToolResult> {
         `Prepared action belongs to profile "${preparedProfileName}", but "${profileName}" was provided.`,
         {
           expected_profile_name: preparedProfileName,
-          provided_profile_name: profileName
-        }
+          provided_profile_name: profileName,
+        },
       );
     }
 
     const result = await runtime.twoPhaseCommit.confirmByToken({
-      confirmToken: token
+      confirmToken: token,
     });
 
     runtime.logger.log("info", "mcp.actions.confirm.done", {
       profileName,
-      preparedActionId: result.preparedActionId
+      preparedActionId: result.preparedActionId,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
       preview,
-      result
+      result,
     });
   } finally {
     runtime.close();
@@ -4810,2958 +4946,2995 @@ async function handleConfirm(args: ToolArgs): Promise<ToolResult> {
 const server = new Server(
   {
     name: "linkedin-mcp",
-    version: packageJson.version
+    version: packageJson.version,
   },
   {
     capabilities: {
-      tools: {}
-    }
-  }
+      tools: {},
+    },
+  },
 );
 
 export const LINKEDIN_MCP_TOOL_DEFINITIONS: LinkedInMcpToolDefinition[] = [
-      {
-        name: SUBMIT_FEEDBACK_TOOL,
-        description:
-          "File agent feedback as a GitHub issue or save it locally when GitHub CLI authentication is unavailable.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["type", "title", "description"],
-          properties: {
-            type: {
-              type: "string",
-              enum: ["bug", "feature", "improvement"],
-              description: "Feedback classification chosen by the agent."
-            },
-            title: {
-              type: "string",
-              description: "Short summary for the feedback issue."
-            },
-            description: {
-              type: "string",
-              description: "Detailed explanation of the bug, feature request, or improvement."
-            }
-          }
-        }
-      },
-      {
-        name: LINKEDIN_SESSION_STATUS_TOOL,
-        description:
-          "Check LinkedIn session authentication status for a profile, including the resolved anti-bot evasion configuration.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_SESSION_OPEN_LOGIN_TOOL,
-        description: "Open LinkedIn login and wait for authentication in a profile.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            timeoutMs: {
-              type: "number",
-              description: "Maximum time to wait for authentication, in milliseconds."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_SESSION_HEALTH_TOOL,
-        description:
-          "Check browser connectivity and LinkedIn session health for a profile, including the resolved anti-bot evasion configuration.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_SEARCH_RECIPIENTS_TOOL,
-        description: withSelectorAuditHint(
-          "Search LinkedIn people to resolve recipient identities for messaging flows."
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["query"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            query: {
-              type: "string",
-              description: "Recipient keywords to search for."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of recipients to return. Defaults to 10."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_LIST_THREADS_TOOL,
-        description: withSelectorAuditHint(
-          "List LinkedIn inbox threads for a profile."
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of threads to return."
-            },
-            unreadOnly: {
-              type: "boolean",
-              description: "If true, only unread threads are returned."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_GET_THREAD_TOOL,
-        description: withSelectorAuditHint(
-          "Get one LinkedIn thread with recent messages."
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["thread"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            thread: {
-              type: "string",
-              description: "Thread id or LinkedIn thread URL."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of messages to include."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_PREPARE_REPLY_TOOL,
-        description: "Prepare a two-phase send_message action for a thread.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["thread", "text"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            thread: {
-              type: "string",
-              description: "Thread id or LinkedIn thread URL."
-            },
-            text: {
-              type: "string",
-              description: "Message text to prepare for sending."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_PREPARE_NEW_THREAD_TOOL,
-        description:
-          "Prepare a two-phase first-message action for a new LinkedIn thread. Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["recipients", "text"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            recipients: {
-              type: "array",
-              items: {
-                type: "string"
-              },
-              description:
-                "Recipient LinkedIn profile URLs, /in/ paths, or vanity names. Use linkedin.inbox.search_recipients to resolve free-text names first."
-            },
-            text: {
-              type: "string",
-              description: "First message text to prepare."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note stored with the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_PREPARE_ADD_RECIPIENTS_TOOL,
-        description:
-          "Prepare a two-phase add_recipients action for an existing LinkedIn thread. Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["thread", "recipients"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            thread: {
-              type: "string",
-              description: "Thread id or LinkedIn thread URL."
-            },
-            recipients: {
-              type: "array",
-              items: {
-                type: "string"
-              },
-              description:
-                "Recipient LinkedIn profile URLs, /in/ paths, or vanity names to add to the thread."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note stored with the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_PREPARE_REACT_TOOL,
-        description:
-          "Prepare a two-phase reaction for a message in an existing LinkedIn thread. Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["thread"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            thread: {
-              type: "string",
-              description: "Thread id or LinkedIn thread URL."
-            },
-            reaction: {
-              type: "string",
-              description:
-                `Reaction to apply. Accepts canonical or alias values and normalizes to one of: ${LINKEDIN_INBOX_REACTION_TYPES.join(", ")}. Defaults to like.`
-            },
-            messageIndex: {
-              type: "integer",
-              description:
-                "Zero-based thread message index to react to. Defaults to the latest message returned by the thread."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note stored with the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_ARCHIVE_THREAD_TOOL,
-        description: withSelectorAuditHint(
-          "Archive a LinkedIn inbox thread immediately."
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["thread"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            thread: {
-              type: "string",
-              description: "Thread id or LinkedIn thread URL."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_UNARCHIVE_THREAD_TOOL,
-        description: withSelectorAuditHint(
-          "Move an archived LinkedIn inbox thread back to the main inbox immediately."
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["thread"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            thread: {
-              type: "string",
-              description: "Thread id or LinkedIn thread URL."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_MARK_UNREAD_TOOL,
-        description: withSelectorAuditHint(
-          "Mark a LinkedIn inbox thread as unread immediately."
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["thread"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            thread: {
-              type: "string",
-              description: "Thread id or LinkedIn thread URL."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_INBOX_MUTE_THREAD_TOOL,
-        description: withSelectorAuditHint(
-          "Mute a LinkedIn inbox thread immediately."
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["thread"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            thread: {
-              type: "string",
-              description: "Thread id or LinkedIn thread URL."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_COMPANY_VIEW_TOOL,
-        description: withSelectorAuditHint(
-          "View a LinkedIn company page. Returns structured company overview, details, and current follow state."
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["target"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            target: {
-              type: "string",
-              description:
-                "Company slug, /company/ path, or LinkedIn company URL."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_VIEW_TOOL,
-        description:
-          withSelectorAuditHint(
-            "View a LinkedIn profile. Returns structured profile data including name, headline, location, about, experience, and education."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            target: {
-              type: "string",
-              description:
-                "Vanity name (e.g. 'johndoe'), profile URL, or 'me' for own profile. Defaults to 'me'."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_VIEW_EDITABLE_TOOL,
-        description: withSelectorAuditHint(
-          "Inspect the logged-in member's editable LinkedIn profile surface. Returns intro metadata, supported editable fields, stable-ish section item identifiers for structured profile sections, and featured item identifiers for remove/reorder workflows."
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_UPDATE_INTRO_TOOL,
-        description:
-          "Prepare a LinkedIn profile intro update (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            firstName: {
-              type: "string",
-              description: "Optional new first name."
-            },
-            lastName: {
-              type: "string",
-              description: "Optional new last name."
-            },
-            headline: {
-              type: "string",
-              description: "Optional new headline."
-            },
-            location: {
-              type: "string",
-              description: "Optional new location text."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_UPDATE_SETTINGS_TOOL,
-        description:
-          "Prepare a LinkedIn profile settings update (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["industry"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            industry: {
-              type: "string",
-              description: "Primary professional category / industry."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_UPDATE_PUBLIC_PROFILE_TOOL,
-        description:
-          "Prepare a LinkedIn public profile URL / vanity URL update (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            vanityName: {
-              type: "string",
-              description: "Requested public profile vanity name (slug only)."
-            },
-            customProfileUrl: {
-              type: "string",
-              description:
-                "Requested public profile vanity name or full LinkedIn profile URL. Alias for vanityName."
-            },
-            publicProfileUrl: {
-              type: "string",
-              description:
-                "Requested public profile URL. Use this instead of vanityName if you already have a linkedin.com/in/... URL."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_UPSERT_SECTION_ITEM_TOOL,
-        description:
-          "Prepare to create or update an editable LinkedIn profile section item (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["section", "values"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            section: {
-              type: "string",
-              enum: [
-                "about",
-                "experience",
-                "education",
-                "certifications",
-                "languages",
-                "projects",
-                "volunteer_experience",
-                "honors_awards"
-              ],
-              description: "Editable LinkedIn profile section to create or update."
-            },
-            itemId: {
-              type: "string",
-              description:
-                "Stable-ish item identifier returned by linkedin.profile.view_editable. Provide this (or match) to update an existing item. Omit both to create a new item."
-            },
-            match: {
-              type: "object",
-              additionalProperties: {
-                anyOf: [{ type: "string" }]
-              },
-              description:
-                "Optional optimistic matching object for legacy items when itemId is unavailable. Supported keys include sourceId, primaryText, secondaryText, tertiaryText, and rawText."
-            },
-            values: {
-              type: "object",
-              additionalProperties: {
-                anyOf: [{ type: "string" }, { type: "number" }, { type: "boolean" }]
-              },
-              description:
-                "Section field values to create or update. Use linkedin.profile.view_editable.supported_fields as the canonical field list for each section."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_REMOVE_SECTION_ITEM_TOOL,
-        description:
-          "Prepare to remove an editable LinkedIn profile section item (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["section"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            section: {
-              type: "string",
-              enum: [
-                "about",
-                "experience",
-                "education",
-                "certifications",
-                "languages",
-                "projects",
-                "volunteer_experience",
-                "honors_awards"
-              ],
-              description: "Editable LinkedIn profile section to remove from."
-            },
-            itemId: {
-              type: "string",
-              description:
-                "Stable-ish item identifier returned by linkedin.profile.view_editable. Optional for about; otherwise provide this or match."
-            },
-            match: {
-              type: "object",
-              additionalProperties: {
-                anyOf: [{ type: "string" }]
-              },
-              description:
-                "Optional optimistic matching object for legacy items when itemId is unavailable. Supported keys include sourceId, primaryText, secondaryText, tertiaryText, and rawText."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_UPLOAD_PHOTO_TOOL,
-        description:
-          "Prepare a LinkedIn profile photo upload (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["filePath"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            filePath: {
-              type: "string",
-              description: "Local path to a JPG or PNG file that will be staged into artifacts before confirm."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_UPLOAD_BANNER_TOOL,
-        description:
-          "Prepare a LinkedIn profile banner upload (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["filePath"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            filePath: {
-              type: "string",
-              description: "Local path to a JPG or PNG file that will be staged into artifacts before confirm."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_FEATURED_ADD_TOOL,
-        description:
-          "Prepare to add a Featured item (link, media, or post) on the logged-in member's LinkedIn profile. Returns a confirm token; use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["kind"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            kind: {
-              type: "string",
-              enum: ["link", "media", "post"],
-              description: "Featured item type to add."
-            },
-            url: {
-              type: "string",
-              description: "Required for link/post. External absolute URL for links, or a LinkedIn post/article/newsletter URL for post."
-            },
-            filePath: {
-              type: "string",
-              description: "Required for media. Local path to a supported document or image file that will be staged into artifacts before confirm."
-            },
-            title: {
-              type: "string",
-              description: "Optional title override for link/media flows when the dialog exposes it."
-            },
-            description: {
-              type: "string",
-              description: "Optional description override for link/media flows when the dialog exposes it."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_FEATURED_REMOVE_TOOL,
-        description:
-          "Prepare to remove one item from the LinkedIn Featured section (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            itemId: {
-              type: "string",
-              description:
-                "Stable-ish featured item identifier returned by linkedin.profile.view_editable.featured.items. Provide this or match."
-            },
-            match: {
-              type: "object",
-              additionalProperties: {
-                anyOf: [{ type: "string" }]
-              },
-              description:
-                "Optional optimistic matching object when itemId is unavailable. Supported keys include sourceId, url, title, subtitle, and rawText."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_FEATURED_REORDER_TOOL,
-        description:
-          "Prepare to reorder Featured items on the logged-in member's LinkedIn profile (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["itemIds"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            itemIds: {
-              type: "array",
-              items: {
-                type: "string"
-              },
-              description:
-                "Ordered featured item ids from linkedin.profile.view_editable.featured.items. The specified ids are moved to the top in the provided order."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_ADD_SKILL_TOOL,
-        description:
-          "Prepare to add one skill to the logged-in member's LinkedIn profile (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["skillName"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            skillName: {
-              type: "string",
-              description: "Skill name to add to the profile."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_REORDER_SKILLS_TOOL,
-        description:
-          "Prepare to reorder Skills on the logged-in member's LinkedIn profile (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["skillNames"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            skillNames: {
-              type: "array",
-              items: {
-                type: "string"
-              },
-              description:
-                "Ordered skill names to move to the top of the Skills section in the provided order."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_ENDORSE_SKILL_TOOL,
-        description:
-          "Prepare to endorse one visible skill on another member's LinkedIn profile (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["target", "skillName"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            target: {
-              type: "string",
-              description:
-                "Target member vanity name or LinkedIn profile URL. Must refer to another member, not 'me'."
-            },
-            skillName: {
-              type: "string",
-              description: "Skill name to endorse on the target profile."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_REQUEST_RECOMMENDATION_TOOL,
-        description:
-          "Prepare to request a LinkedIn recommendation from another member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["target"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            target: {
-              type: "string",
-              description:
-                "Target member vanity name or LinkedIn profile URL. Must refer to another member, not 'me'."
-            },
-            relationship: {
-              type: "string",
-              description: "Optional relationship selection for LinkedIn's recommendation dialog."
-            },
-            position: {
-              type: "string",
-              description: "Optional role/position selection for LinkedIn's recommendation dialog."
-            },
-            company: {
-              type: "string",
-              description: "Optional company selection for LinkedIn's recommendation dialog."
-            },
-            message: {
-              type: "string",
-              description: "Optional personal message to include with the request."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PROFILE_PREPARE_WRITE_RECOMMENDATION_TOOL,
-        description:
-          "Prepare to write a LinkedIn recommendation for another member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["target", "text"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            target: {
-              type: "string",
-              description:
-                "Target member vanity name or LinkedIn profile URL. Must refer to another member, not 'me'."
-            },
-            text: {
-              type: "string",
-              description: "Recommendation text to submit."
-            },
-            relationship: {
-              type: "string",
-              description: "Optional relationship selection for LinkedIn's recommendation dialog."
-            },
-            position: {
-              type: "string",
-              description: "Optional role/position selection for LinkedIn's recommendation dialog."
-            },
-            company: {
-              type: "string",
-              description: "Optional company selection for LinkedIn's recommendation dialog."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ASSETS_GENERATE_PROFILE_IMAGES_TOOL,
-        description:
-          "Generate a LinkedIn-ready profile photo, banner, and reusable post images from a local persona JSON spec using OpenAI. Optionally uploads the photo and banner through the existing LinkedIn profile upload flow.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["specPath"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            specPath: {
-              type: "string",
-              description: "Local path to the JSON persona/profile seed spec."
-            },
-            postImageCount: {
-              type: "number",
-              description:
-                "Number of post images to generate. Defaults to 6 and must be 10 or fewer."
-            },
-            model: {
-              type: "string",
-              description: "Optional OpenAI image model override."
-            },
-            uploadProfileMedia: {
-              type: "boolean",
-              description:
-                "If true, upload the generated profile photo and banner after generation."
-            },
-            uploadDelayMs: {
-              type: "number",
-              description:
-                "Base delay between the photo and banner uploads when uploadProfileMedia is true. Defaults to 4500."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the upload actions."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ANALYTICS_PROFILE_VIEWS_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Read the logged-in member's LinkedIn profile-view analytics cards with normalized numeric metrics."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ANALYTICS_SEARCH_APPEARANCES_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Read the logged-in member's LinkedIn search-appearance analytics cards with normalized numeric metrics."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ANALYTICS_CONTENT_METRICS_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Read LinkedIn content and impression analytics cards from the logged-in member's profile analytics surface."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            limit: {
-              type: "number",
-              description:
-                "Maximum number of content analytics cards to return. Defaults to 4."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ANALYTICS_POST_METRICS_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Read normalized engagement metrics for one LinkedIn post URL, URN, or activity/share identifier."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_SEARCH_TOOL,
-        description: withSelectorAuditHint(
-          `Search LinkedIn for ${SEARCH_CATEGORIES.join(", ")}.`
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["query"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            query: {
-              type: "string",
-              description: "Search keywords."
-            },
-            category: {
-              type: "string",
-              enum: [...SEARCH_CATEGORIES],
-              description: "Search category. Defaults to people."
-            },
-            limit: {
-              type: "number",
-              description: "Max results. Defaults to 10."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_CONNECTIONS_LIST_TOOL,
-        description:
-          withSelectorAuditHint(
-            "List your LinkedIn connections. Returns connection names, headlines, profile URLs, and when connected."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of connections to return. Defaults to 40."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_CONNECTIONS_PENDING_TOOL,
-        description:
-          withSelectorAuditHint(
-            "List pending LinkedIn connection invitations (sent, received, or both)."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            filter: {
-              type: "string",
-              enum: ["sent", "received", "all"],
-              description:
-                "Filter invitations by direction. Defaults to all."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_CONNECTIONS_INVITE_TOOL,
-        description:
-          "Prepare a connection invitation to a LinkedIn user (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetProfile"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            targetProfile: {
-              type: "string",
-              description:
-                "Vanity name (e.g. 'johndoe') or full profile URL."
-            },
-            note: {
-              type: "string",
-              description: "Optional invitation note (max 300 chars)."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_CONNECTIONS_ACCEPT_TOOL,
-        description:
-          "Prepare to accept a pending connection invitation (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetProfile"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            targetProfile: {
-              type: "string",
-              description:
-                "Vanity name or profile URL of the person who sent the invitation."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_CONNECTIONS_WITHDRAW_TOOL,
-        description:
-          "Prepare to withdraw a sent connection invitation (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetProfile"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            targetProfile: {
-              type: "string",
-              description:
-                "Vanity name or profile URL of the person to withdraw the invitation from."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_CONNECTIONS_PREPARE_IGNORE_TOOL,
-        description:
-          "Prepare to ignore a received connection invitation (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetProfile"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            targetProfile: {
-              type: "string",
-              description:
-                "Vanity name or profile URL of the person whose received invitation should be ignored."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_CONNECTIONS_PREPARE_REMOVE_TOOL,
-        description:
-          "Prepare to remove an existing connection (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetProfile"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            targetProfile: {
-              type: "string",
-              description:
-                "Vanity name or profile URL of the existing connection to remove."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_COMPANY_PREPARE_FOLLOW_TOOL,
-        description:
-          "Prepare to follow a LinkedIn company page (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetCompany"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            targetCompany: {
-              type: "string",
-              description: "Company slug, /company/ path, or company URL."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_COMPANY_PREPARE_UNFOLLOW_TOOL,
-        description:
-          "Prepare to unfollow a LinkedIn company page (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetCompany"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent Playwright profile name. Defaults to default."
-            },
-            targetCompany: {
-              type: "string",
-              description: "Company slug, /company/ path, or company URL."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Optional note attached to the prepared action."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_CONNECTIONS_PREPARE_FOLLOW_TOOL,
-        description:
-          "Prepare to follow a LinkedIn member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetProfile"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            targetProfile: {
-              type: "string",
-              description:
-                "Vanity name or profile URL of the member to follow."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_CONNECTIONS_PREPARE_UNFOLLOW_TOOL,
-        description:
-          "Prepare to unfollow a LinkedIn member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetProfile"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            targetProfile: {
-              type: "string",
-              description:
-                "Vanity name or profile URL of the member to unfollow."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_MEMBERS_PREPARE_BLOCK_TOOL,
-        description:
-          "Prepare to block a LinkedIn member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetProfile"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            targetProfile: {
-              type: "string",
-              description:
-                "Vanity name or profile URL of the LinkedIn member to block."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_MEMBERS_PREPARE_UNBLOCK_TOOL,
-        description:
-          "Prepare to unblock a LinkedIn member from the blocked-members settings page (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetProfile"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            targetProfile: {
-              type: "string",
-              description:
-                "Vanity name or profile URL of the LinkedIn member to unblock."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_MEMBERS_PREPARE_REPORT_TOOL,
-        description:
-          "Prepare to report a LinkedIn member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["targetProfile", "reason"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            targetProfile: {
-              type: "string",
-              description:
-                "Vanity name or profile URL of the LinkedIn member to report."
-            },
-            reason: {
-              type: "string",
-              enum: [...LINKEDIN_MEMBER_REPORT_REASONS],
-              description: "Structured report reason for the dialog flow."
-            },
-            details: {
-              type: "string",
-              description:
-                "Optional free-text details that will be filled when the dialog exposes a text field."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PRIVACY_GET_SETTINGS_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Read the supported LinkedIn privacy settings surfaced by the automation runtime, including profile viewing mode and related visibility controls."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_PRIVACY_PREPARE_UPDATE_SETTING_TOOL,
-        description:
-          "Prepare to update one supported LinkedIn privacy setting (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["settingKey", "value"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            settingKey: {
-              type: "string",
-              enum: [...LINKEDIN_PRIVACY_SETTING_KEYS],
-              description: "Supported LinkedIn privacy setting key."
-            },
-            value: {
-              type: "string",
-              description: "Requested setting value."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_NETWORK_PREPARE_FOLLOWUP_AFTER_ACCEPT_TOOL,
-        description:
-          "Detect newly accepted sent invitations and prepare follow-up messages (two-phase: returns confirm tokens). Use linkedin.actions.confirm to execute each prepared follow-up.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            since: {
-              type: "string",
-              description:
-                "Lookback window such as 30m, 12h, 7d, or 2w. Defaults to 7d."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note attached to each prepared follow-up."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_FEED_LIST_TOOL,
-        description:
-          withSelectorAuditHint(
-            "List posts from your LinkedIn feed with author, text, and engagement counts."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of feed posts to return. Defaults to 10."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_FEED_VIEW_POST_TOOL,
-        description: withSelectorAuditHint(
-          "View one LinkedIn feed post by URL, URN, or activity id."
-        ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_FEED_LIKE_TOOL,
-        description:
-          "Prepare to react to a LinkedIn post (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            },
-            reaction: {
-              type: "string",
-              enum: [...LINKEDIN_FEED_REACTION_TYPES],
-              description: "Reaction type. Defaults to like."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_FEED_COMMENT_TOOL,
-        description:
-          "Prepare to comment on a LinkedIn post (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl", "text"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            },
-            text: {
-              type: "string",
-              description: "Comment text to prepare."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_FEED_PREPARE_REPOST_TOOL,
-        description:
-          "Prepare to repost a LinkedIn post (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_FEED_PREPARE_SHARE_TOOL,
-        description:
-          "Prepare to share a LinkedIn post with your own text (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl", "text"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            },
-            text: {
-              type: "string",
-              description: "Text to publish with the shared post."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_FEED_SAVE_POST_TOOL,
-        description:
-          "Prepare to save a LinkedIn post for later (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_FEED_UNSAVE_POST_TOOL,
-        description:
-          "Prepare to remove a LinkedIn post from your saved items (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_FEED_PREPARE_REMOVE_REACTION_TOOL,
-        description:
-          "Prepare to remove your current reaction from a LinkedIn post (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_POST_PREPARE_CREATE_TOOL,
-        description:
-          "Prepare a new LinkedIn post (two-phase: returns confirm token). Use linkedin.actions.confirm to publish.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["text"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            text: {
-              type: "string",
-              description: "Post text to prepare for publishing."
-            },
-            visibility: {
-              type: "string",
-              enum: [...LINKEDIN_POST_VISIBILITY_TYPES],
-              description: "Post visibility. Defaults to public."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_POST_PREPARE_CREATE_MEDIA_TOOL,
-        description:
-          "Prepare a new LinkedIn media post with attachments (two-phase: returns confirm token). Use linkedin.actions.confirm to publish.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["text", "mediaPaths"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            text: {
-              type: "string",
-              description: "Post text to publish alongside the media attachments."
-            },
-            mediaPaths: {
-              type: "array",
-              items: {
-                type: "string"
-              },
-              description:
-                "One or more local file paths for image/video attachments."
-            },
-            visibility: {
-              type: "string",
-              enum: [...LINKEDIN_POST_VISIBILITY_TYPES],
-              description: "Post visibility. Defaults to public."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_POST_PREPARE_CREATE_POLL_TOOL,
-        description:
-          "Prepare a new LinkedIn poll post (two-phase: returns confirm token). Use linkedin.actions.confirm to publish.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["question", "options"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            text: {
-              type: "string",
-              description: "Optional lead-in text that appears above the poll."
-            },
-            question: {
-              type: "string",
-              description: "Poll question to publish."
-            },
-            options: {
-              type: "array",
-              items: {
-                type: "string"
-              },
-              description: "Two to four poll options."
-            },
-            durationDays: {
-              type: "number",
-              description: "Poll duration in days. Supported values: 1, 3, 7, or 14."
-            },
-            visibility: {
-              type: "string",
-              enum: [...LINKEDIN_POST_VISIBILITY_TYPES],
-              description: "Post visibility. Defaults to public."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_POST_PREPARE_EDIT_TOOL,
-        description:
-          "Prepare to edit one of your LinkedIn posts (two-phase: returns confirm token). Use linkedin.actions.confirm to save the update.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl", "text"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            },
-            text: {
-              type: "string",
-              description: "Replacement post text to save."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_POST_PREPARE_DELETE_TOOL,
-        description:
-          "Prepare to delete one of your LinkedIn posts (two-phase: returns confirm token). Use linkedin.actions.confirm to execute the deletion.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["postUrl"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            postUrl: {
-              type: "string",
-              description: "LinkedIn post URL, URN, or activity/share identifier."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ARTICLE_PREPARE_CREATE_TOOL,
-        description:
-          "Prepare a new LinkedIn long-form article draft (two-phase: returns confirm token). Use linkedin.actions.confirm to create the draft in the publishing editor.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["title", "body"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            title: {
-              type: "string",
-              description: "Article headline to stage in the publishing editor."
-            },
-            body: {
-              type: "string",
-              description:
-                "Plain-text article body. Paragraph breaks are preserved."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ARTICLE_PREPARE_PUBLISH_TOOL,
-        description:
-          "Prepare to publish an existing LinkedIn article draft (two-phase: returns confirm token). Use linkedin.actions.confirm to publish the draft.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["draftUrl"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            draftUrl: {
-              type: "string",
-              description:
-                "Absolute LinkedIn article editor or draft URL returned by linkedin.article.prepare_create."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_NEWSLETTER_PREPARE_CREATE_TOOL,
-        description:
-          "Prepare a new LinkedIn newsletter series (two-phase: returns confirm token). Use linkedin.actions.confirm to create the newsletter shell.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["title", "description", "cadence"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            title: {
-              type: "string",
-              description: "Newsletter title."
-            },
-            description: {
-              type: "string",
-              description: "Short newsletter description."
-            },
-            cadence: {
-              type: "string",
-              enum: [...LINKEDIN_NEWSLETTER_CADENCE_TYPES],
-              description: "Newsletter publish cadence."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_NEWSLETTER_PREPARE_PUBLISH_ISSUE_TOOL,
-        description:
-          "Prepare a new LinkedIn newsletter issue (two-phase: returns confirm token). Use linkedin.actions.confirm to publish the issue.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["newsletter", "title", "body"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            newsletter: {
-              type: "string",
-              description:
-                "Newsletter title as returned by linkedin.newsletter.list."
-            },
-            title: {
-              type: "string",
-              description: "Issue headline."
-            },
-            body: {
-              type: "string",
-              description:
-                "Plain-text issue body. Paragraph breaks are preserved."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_NEWSLETTER_LIST_TOOL,
-        description:
-          withSelectorAuditHint(
-            "List newsletter series currently available in the LinkedIn publishing editor."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_NOTIFICATIONS_LIST_TOOL,
-        description:
-          withSelectorAuditHint(
-            "List your LinkedIn notifications. Returns notification type, message, timestamp, link, and read/unread status."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of notifications to return. Defaults to 20."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_NOTIFICATIONS_MARK_READ_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Mark one LinkedIn notification as read by notification ID."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["notificationId"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            notificationId: {
-              type: "string",
-              description:
-                "Notification ID returned by linkedin.notifications.list."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_NOTIFICATIONS_DISMISS_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Prepare a dismiss action for one LinkedIn notification (two-phase: returns confirm token). Use linkedin.actions.confirm to execute."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["notificationId"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            notificationId: {
-              type: "string",
-              description:
-                "Notification ID returned by linkedin.notifications.list."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_NOTIFICATIONS_PREFERENCES_GET_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Read LinkedIn notification preference categories or one specific notification preference page."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            preferenceUrl: {
-              type: "string",
-              description:
-                "Optional LinkedIn notification preference URL. When omitted, returns the notifications preferences overview."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_NOTIFICATIONS_PREFERENCES_PREPARE_UPDATE_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Prepare a LinkedIn notification preference update (two-phase: returns confirm token). Use linkedin.actions.confirm to execute."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["preferenceUrl", "enabled"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            preferenceUrl: {
-              type: "string",
-              description:
-                "LinkedIn notification category or subcategory URL returned by linkedin.notifications.preferences.get."
-            },
-            enabled: {
-              type: "boolean",
-              description: "Whether the selected preference should be enabled."
-            },
-            channel: {
-              type: "string",
-              description:
-                "Optional channel key for subcategory pages: in_app, push, or email."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_JOBS_SEARCH_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Search for LinkedIn job postings by keyword and optional location."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["query"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            query: {
-              type: "string",
-              description: "Search keywords for jobs."
-            },
-            location: {
-              type: "string",
-              description: "Location filter for jobs."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of results to return. Defaults to 10."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_JOBS_VIEW_TOOL,
-        description:
-          withSelectorAuditHint(
-            "View details of a specific LinkedIn job posting by job ID."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["jobId"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            jobId: {
-              type: "string",
-              description: "LinkedIn job ID."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_JOBS_SAVE_TOOL,
-        description:
-          "Prepare to save a LinkedIn job for later (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["jobId"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            jobId: {
-              type: "string",
-              description: "LinkedIn job ID."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_JOBS_UNSAVE_TOOL,
-        description:
-          "Prepare to unsave a LinkedIn job (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["jobId"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            jobId: {
-              type: "string",
-              description: "LinkedIn job ID."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_JOBS_ALERTS_LIST_TOOL,
-        description:
-          withSelectorAuditHint("List LinkedIn job alerts for the current account."),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of alerts to return. Defaults to 20."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_JOBS_ALERTS_CREATE_TOOL,
-        description:
-          "Prepare to create a LinkedIn job alert from a search query (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["query"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            query: {
-              type: "string",
-              description: "Search keywords for the alert."
-            },
-            location: {
-              type: "string",
-              description: "Optional location filter for the alert."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_JOBS_ALERTS_REMOVE_TOOL,
-        description:
-          "Prepare to remove a LinkedIn job alert (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            alertId: {
-              type: "string",
-              description: "Alert id previously returned by linkedin.jobs.alerts.list."
-            },
-            searchUrl: {
-              type: "string",
-              description: "LinkedIn jobs search URL for the alert."
-            },
-            query: {
-              type: "string",
-              description: "Alert query if alertId or searchUrl are not available."
-            },
-            location: {
-              type: "string",
-              description: "Alert location if query is provided."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_JOBS_PREPARE_EASY_APPLY_TOOL,
-        description:
-          "Prepare a LinkedIn Easy Apply submission (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["jobId"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            jobId: {
-              type: "string",
-              description: "LinkedIn job ID."
-            },
-            phoneNumber: {
-              type: "string",
-              description: "Phone number value for Easy Apply forms."
-            },
-            email: {
-              type: "string",
-              description: "Email value for Easy Apply forms."
-            },
-            city: {
-              type: "string",
-              description: "City value for Easy Apply forms."
-            },
-            resumePath: {
-              type: "string",
-              description: "Absolute or relative path to the resume file to upload."
-            },
-            coverLetter: {
-              type: "string",
-              description: "Cover letter text for Easy Apply forms."
-            },
-            answers: {
-              type: "object",
-              description:
-                "Additional Easy Apply answers keyed by field label. Values may be strings, booleans, numbers, or string arrays."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_GROUPS_SEARCH_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Search LinkedIn groups by keyword and return matching communities."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["query"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            query: {
-              type: "string",
-              description: "Search keywords for LinkedIn groups."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of results to return. Defaults to 10."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_GROUPS_VIEW_TOOL,
-        description:
-          withSelectorAuditHint(
-            "View details of a specific LinkedIn group by URL or numeric group ID."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["group"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            group: {
-              type: "string",
-              description: "LinkedIn group URL or numeric group ID."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_GROUPS_PREPARE_JOIN_TOOL,
-        description:
-          "Prepare to join a LinkedIn group (two-phase: returns confirm token). Use linkedin.actions.confirm to request or complete the join.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["group"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            group: {
-              type: "string",
-              description: "LinkedIn group URL or numeric group ID."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_GROUPS_PREPARE_LEAVE_TOOL,
-        description:
-          "Prepare to leave a LinkedIn group (two-phase: returns confirm token). Use linkedin.actions.confirm to complete the leave flow.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["group"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            group: {
-              type: "string",
-              description: "LinkedIn group URL or numeric group ID."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_GROUPS_PREPARE_POST_TOOL,
-        description:
-          "Prepare a post inside a LinkedIn group (two-phase: returns confirm token). Use linkedin.actions.confirm to publish the post.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["group", "text"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            group: {
-              type: "string",
-              description: "LinkedIn group URL or numeric group ID."
-            },
-            text: {
-              type: "string",
-              description: "Post text to publish inside the group."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_EVENTS_SEARCH_TOOL,
-        description:
-          withSelectorAuditHint(
-            "Search LinkedIn events by keyword and return matching event cards."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["query"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            query: {
-              type: "string",
-              description: "Search keywords for LinkedIn events."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of results to return. Defaults to 10."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_EVENTS_VIEW_TOOL,
-        description:
-          withSelectorAuditHint(
-            "View details of a specific LinkedIn event by URL or numeric event ID."
-          ),
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["event"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            event: {
-              type: "string",
-              description: "LinkedIn event URL or numeric event ID."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_EVENTS_PREPARE_RSVP_TOOL,
-        description:
-          "Prepare to RSVP attend for a LinkedIn event (two-phase: returns confirm token). Use linkedin.actions.confirm to complete the RSVP.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["event"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            event: {
-              type: "string",
-              description: "LinkedIn event URL or numeric event ID."
-            },
-            operatorNote: {
-              type: "string",
-              description: "Internal note for audit."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_WATCH_CREATE_TOOL,
-        description:
-          "Create a durable poll-based LinkedIn activity watch for one profile and activity source.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["kind"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            kind: {
-              type: "string",
-              enum: [...ACTIVITY_WATCH_KINDS],
-              description: "Activity watch kind."
-            },
-            target: {
-              type: "object",
-              description: "Optional watch target object for profile/feed/inbox filters."
-            },
-            intervalSeconds: {
-              type: "number",
-              description: "Optional polling interval in seconds."
-            },
-            cron: {
-              type: "string",
-              description: "Optional cron schedule expression."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_WATCH_LIST_TOOL,
-        description: "List configured LinkedIn activity watches for a profile.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            status: {
-              type: "string",
-              enum: [...ACTIVITY_WATCH_STATUSES],
-              description: "Optional watch status filter."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_WATCH_PAUSE_TOOL,
-        description: "Pause one activity watch by id.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["watchId"],
-          properties: withCdpSchemaProperties({
-            watchId: {
-              type: "string",
-              description: "Activity watch id."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_WATCH_RESUME_TOOL,
-        description: "Resume one activity watch by id and make it due immediately.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["watchId"],
-          properties: withCdpSchemaProperties({
-            watchId: {
-              type: "string",
-              description: "Activity watch id."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_WATCH_REMOVE_TOOL,
-        description: "Remove one activity watch by id.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["watchId"],
-          properties: withCdpSchemaProperties({
-            watchId: {
-              type: "string",
-              description: "Activity watch id."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_WEBHOOK_CREATE_TOOL,
-        description: "Create a webhook subscription for one activity watch.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["watchId", "deliveryUrl"],
-          properties: withCdpSchemaProperties({
-            watchId: {
-              type: "string",
-              description: "Activity watch id."
-            },
-            deliveryUrl: {
-              type: "string",
-              description: "Webhook delivery URL."
-            },
-            eventTypes: {
-              type: "array",
-              items: {
-                type: "string",
-                enum: [...ACTIVITY_EVENT_TYPES]
-              },
-              description: "Optional event filters for this subscription."
-            },
-            signingSecret: {
-              type: "string",
-              description: "Optional pre-shared signing secret."
-            },
-            maxAttempts: {
-              type: "number",
-              description: "Optional maximum delivery attempts."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_WEBHOOK_LIST_TOOL,
-        description: "List webhook subscriptions for activity watches.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            watchId: {
-              type: "string",
-              description: "Optional watch id filter."
-            },
-            status: {
-              type: "string",
-              enum: [...WEBHOOK_SUBSCRIPTION_STATUSES],
-              description: "Optional webhook subscription status filter."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_WEBHOOK_PAUSE_TOOL,
-        description: "Pause one activity webhook subscription by id.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["subscriptionId"],
-          properties: withCdpSchemaProperties({
-            subscriptionId: {
-              type: "string",
-              description: "Webhook subscription id."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_WEBHOOK_RESUME_TOOL,
-        description: "Resume one activity webhook subscription by id.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["subscriptionId"],
-          properties: withCdpSchemaProperties({
-            subscriptionId: {
-              type: "string",
-              description: "Webhook subscription id."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_WEBHOOK_REMOVE_TOOL,
-        description: "Remove one activity webhook subscription by id.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["subscriptionId"],
-          properties: withCdpSchemaProperties({
-            subscriptionId: {
-              type: "string",
-              description: "Webhook subscription id."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_EVENTS_LIST_TOOL,
-        description: "List emitted LinkedIn activity events from local persistent state.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            watchId: {
-              type: "string",
-              description: "Optional watch id filter."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of events to return. Defaults to 20."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_DELIVERIES_LIST_TOOL,
-        description: "List webhook delivery attempts from local persistent state.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            },
-            watchId: {
-              type: "string",
-              description: "Optional watch id filter."
-            },
-            subscriptionId: {
-              type: "string",
-              description: "Optional webhook subscription id filter."
-            },
-            status: {
-              type: "string",
-              enum: [...WEBHOOK_DELIVERY_ATTEMPT_STATUSES],
-              description: "Optional delivery status filter."
-            },
-            limit: {
-              type: "number",
-              description: "Maximum number of delivery attempts to return. Defaults to 20."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIVITY_POLLER_RUN_ONCE_TOOL,
-        description:
-          "Run one local activity polling tick now and return the watch and delivery summary.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description:
-                "Persistent Playwright profile name. Defaults to default."
-            }
-          })
-        }
-      },
-      {
-        name: LINKEDIN_ACTIONS_CONFIRM_TOOL,
-        description: "Confirm and execute a prepared action by confirm token.",
-        inputSchema: {
-          type: "object",
-          additionalProperties: false,
-          required: ["token"],
-          properties: withCdpSchemaProperties({
-            profileName: {
-              type: "string",
-              description: "Persistent profile expected for this action."
-            },
-            token: {
-              type: "string",
-              description: "Confirmation token in ct_... format."
-            }
-          })
-        }
-      }
+  {
+    name: SUBMIT_FEEDBACK_TOOL,
+    description:
+      "File agent feedback as a GitHub issue or save it locally when GitHub CLI authentication is unavailable.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["type", "title", "description"],
+      properties: {
+        type: {
+          type: "string",
+          enum: ["bug", "feature", "improvement"],
+          description: "Feedback classification chosen by the agent.",
+        },
+        title: {
+          type: "string",
+          description: "Short summary for the feedback issue.",
+        },
+        description: {
+          type: "string",
+          description:
+            "Detailed explanation of the bug, feature request, or improvement.",
+        },
+      },
+    },
+  },
+  {
+    name: LINKEDIN_SESSION_STATUS_TOOL,
+    description:
+      "Check LinkedIn session authentication status for a profile, including the resolved anti-bot evasion configuration.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_SESSION_OPEN_LOGIN_TOOL,
+    description:
+      "Open LinkedIn login and wait for authentication in a profile.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        timeoutMs: {
+          type: "number",
+          description:
+            "Maximum time to wait for authentication, in milliseconds.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_SESSION_HEALTH_TOOL,
+    description:
+      "Check browser connectivity and LinkedIn session health for a profile, including the resolved anti-bot evasion configuration.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_SEARCH_RECIPIENTS_TOOL,
+    description: withSelectorAuditHint(
+      "Search LinkedIn people to resolve recipient identities for messaging flows.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["query"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        query: {
+          type: "string",
+          description: "Recipient keywords to search for.",
+        },
+        limit: {
+          type: "number",
+          description:
+            "Maximum number of recipients to return. Defaults to 10.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_LIST_THREADS_TOOL,
+    description: withSelectorAuditHint(
+      "List LinkedIn inbox threads for a profile.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of threads to return.",
+        },
+        unreadOnly: {
+          type: "boolean",
+          description: "If true, only unread threads are returned.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_GET_THREAD_TOOL,
+    description: withSelectorAuditHint(
+      "Get one LinkedIn thread with recent messages.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["thread"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        thread: {
+          type: "string",
+          description: "Thread id or LinkedIn thread URL.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of messages to include.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_PREPARE_REPLY_TOOL,
+    description: "Prepare a two-phase send_message action for a thread.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["thread", "text"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        thread: {
+          type: "string",
+          description: "Thread id or LinkedIn thread URL.",
+        },
+        text: {
+          type: "string",
+          description: "Message text to prepare for sending.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_PREPARE_NEW_THREAD_TOOL,
+    description:
+      "Prepare a two-phase first-message action for a new LinkedIn thread. Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["recipients", "text"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        recipients: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+          description:
+            "Recipient LinkedIn profile URLs, /in/ paths, or vanity names. Use linkedin.inbox.search_recipients to resolve free-text names first.",
+        },
+        text: {
+          type: "string",
+          description: "First message text to prepare.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note stored with the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_PREPARE_ADD_RECIPIENTS_TOOL,
+    description:
+      "Prepare a two-phase add_recipients action for an existing LinkedIn thread. Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["thread", "recipients"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        thread: {
+          type: "string",
+          description: "Thread id or LinkedIn thread URL.",
+        },
+        recipients: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+          description:
+            "Recipient LinkedIn profile URLs, /in/ paths, or vanity names to add to the thread.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note stored with the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_PREPARE_REACT_TOOL,
+    description:
+      "Prepare a two-phase reaction for a message in an existing LinkedIn thread. Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["thread"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        thread: {
+          type: "string",
+          description: "Thread id or LinkedIn thread URL.",
+        },
+        reaction: {
+          type: "string",
+          description: `Reaction to apply. Accepts canonical or alias values and normalizes to one of: ${LINKEDIN_INBOX_REACTION_TYPES.join(", ")}. Defaults to like.`,
+        },
+        messageIndex: {
+          type: "integer",
+          description:
+            "Zero-based thread message index to react to. Defaults to the latest message returned by the thread.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note stored with the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_ARCHIVE_THREAD_TOOL,
+    description: withSelectorAuditHint(
+      "Archive a LinkedIn inbox thread immediately.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["thread"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        thread: {
+          type: "string",
+          description: "Thread id or LinkedIn thread URL.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_UNARCHIVE_THREAD_TOOL,
+    description: withSelectorAuditHint(
+      "Move an archived LinkedIn inbox thread back to the main inbox immediately.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["thread"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        thread: {
+          type: "string",
+          description: "Thread id or LinkedIn thread URL.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_MARK_UNREAD_TOOL,
+    description: withSelectorAuditHint(
+      "Mark a LinkedIn inbox thread as unread immediately.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["thread"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        thread: {
+          type: "string",
+          description: "Thread id or LinkedIn thread URL.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_INBOX_MUTE_THREAD_TOOL,
+    description: withSelectorAuditHint(
+      "Mute a LinkedIn inbox thread immediately.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["thread"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        thread: {
+          type: "string",
+          description: "Thread id or LinkedIn thread URL.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_COMPANY_VIEW_TOOL,
+    description: withSelectorAuditHint(
+      "View a LinkedIn company page. Returns structured company overview, details, and current follow state.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["target"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        target: {
+          type: "string",
+          description: "Company slug, /company/ path, or LinkedIn company URL.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_VIEW_TOOL,
+    description: withSelectorAuditHint(
+      "View a LinkedIn profile. Returns structured profile data including name, headline, location, about, experience, and education.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        target: {
+          type: "string",
+          description:
+            "Vanity name (e.g. 'johndoe'), profile URL, or 'me' for own profile. Defaults to 'me'.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_VIEW_EDITABLE_TOOL,
+    description: withSelectorAuditHint(
+      "Inspect the logged-in member's editable LinkedIn profile surface. Returns intro metadata, supported editable fields, stable-ish section item identifiers for structured profile sections, and featured item identifiers for remove/reorder workflows.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_UPDATE_INTRO_TOOL,
+    description:
+      "Prepare a LinkedIn profile intro update (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        firstName: {
+          type: "string",
+          description: "Optional new first name.",
+        },
+        lastName: {
+          type: "string",
+          description: "Optional new last name.",
+        },
+        headline: {
+          type: "string",
+          description: "Optional new headline.",
+        },
+        location: {
+          type: "string",
+          description: "Optional new location text.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_UPDATE_SETTINGS_TOOL,
+    description:
+      "Prepare a LinkedIn profile settings update (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["industry"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        industry: {
+          type: "string",
+          description: "Primary professional category / industry.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_UPDATE_PUBLIC_PROFILE_TOOL,
+    description:
+      "Prepare a LinkedIn public profile URL / vanity URL update (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        vanityName: {
+          type: "string",
+          description: "Requested public profile vanity name (slug only).",
+        },
+        customProfileUrl: {
+          type: "string",
+          description:
+            "Requested public profile vanity name or full LinkedIn profile URL. Alias for vanityName.",
+        },
+        publicProfileUrl: {
+          type: "string",
+          description:
+            "Requested public profile URL. Use this instead of vanityName if you already have a linkedin.com/in/... URL.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_UPSERT_SECTION_ITEM_TOOL,
+    description:
+      "Prepare to create or update an editable LinkedIn profile section item (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["section", "values"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        section: {
+          type: "string",
+          enum: [
+            "about",
+            "experience",
+            "education",
+            "certifications",
+            "languages",
+            "projects",
+            "volunteer_experience",
+            "honors_awards",
+          ],
+          description: "Editable LinkedIn profile section to create or update.",
+        },
+        itemId: {
+          type: "string",
+          description:
+            "Stable-ish item identifier returned by linkedin.profile.view_editable. Provide this (or match) to update an existing item. Omit both to create a new item.",
+        },
+        match: {
+          type: "object",
+          additionalProperties: {
+            anyOf: [{ type: "string" }],
+          },
+          description:
+            "Optional optimistic matching object for legacy items when itemId is unavailable. Supported keys include sourceId, primaryText, secondaryText, tertiaryText, and rawText.",
+        },
+        values: {
+          type: "object",
+          additionalProperties: {
+            anyOf: [
+              { type: "string" },
+              { type: "number" },
+              { type: "boolean" },
+            ],
+          },
+          description:
+            "Section field values to create or update. Use linkedin.profile.view_editable.supported_fields as the canonical field list for each section.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_REMOVE_SECTION_ITEM_TOOL,
+    description:
+      "Prepare to remove an editable LinkedIn profile section item (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["section"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        section: {
+          type: "string",
+          enum: [
+            "about",
+            "experience",
+            "education",
+            "certifications",
+            "languages",
+            "projects",
+            "volunteer_experience",
+            "honors_awards",
+          ],
+          description: "Editable LinkedIn profile section to remove from.",
+        },
+        itemId: {
+          type: "string",
+          description:
+            "Stable-ish item identifier returned by linkedin.profile.view_editable. Optional for about; otherwise provide this or match.",
+        },
+        match: {
+          type: "object",
+          additionalProperties: {
+            anyOf: [{ type: "string" }],
+          },
+          description:
+            "Optional optimistic matching object for legacy items when itemId is unavailable. Supported keys include sourceId, primaryText, secondaryText, tertiaryText, and rawText.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_UPLOAD_PHOTO_TOOL,
+    description:
+      "Prepare a LinkedIn profile photo upload (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["filePath"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        filePath: {
+          type: "string",
+          description:
+            "Local path to a JPG or PNG file that will be staged into artifacts before confirm.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_UPLOAD_BANNER_TOOL,
+    description:
+      "Prepare a LinkedIn profile banner upload (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["filePath"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        filePath: {
+          type: "string",
+          description:
+            "Local path to a JPG or PNG file that will be staged into artifacts before confirm.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_FEATURED_ADD_TOOL,
+    description:
+      "Prepare to add a Featured item (link, media, or post) on the logged-in member's LinkedIn profile. Returns a confirm token; use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["kind"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        kind: {
+          type: "string",
+          enum: ["link", "media", "post"],
+          description: "Featured item type to add.",
+        },
+        url: {
+          type: "string",
+          description:
+            "Required for link/post. External absolute URL for links, or a LinkedIn post/article/newsletter URL for post.",
+        },
+        filePath: {
+          type: "string",
+          description:
+            "Required for media. Local path to a supported document or image file that will be staged into artifacts before confirm.",
+        },
+        title: {
+          type: "string",
+          description:
+            "Optional title override for link/media flows when the dialog exposes it.",
+        },
+        description: {
+          type: "string",
+          description:
+            "Optional description override for link/media flows when the dialog exposes it.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_FEATURED_REMOVE_TOOL,
+    description:
+      "Prepare to remove one item from the LinkedIn Featured section (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        itemId: {
+          type: "string",
+          description:
+            "Stable-ish featured item identifier returned by linkedin.profile.view_editable.featured.items. Provide this or match.",
+        },
+        match: {
+          type: "object",
+          additionalProperties: {
+            anyOf: [{ type: "string" }],
+          },
+          description:
+            "Optional optimistic matching object when itemId is unavailable. Supported keys include sourceId, url, title, subtitle, and rawText.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_FEATURED_REORDER_TOOL,
+    description:
+      "Prepare to reorder Featured items on the logged-in member's LinkedIn profile (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["itemIds"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        itemIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+          description:
+            "Ordered featured item ids from linkedin.profile.view_editable.featured.items. The specified ids are moved to the top in the provided order.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_ADD_SKILL_TOOL,
+    description:
+      "Prepare to add one skill to the logged-in member's LinkedIn profile (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["skillName"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        skillName: {
+          type: "string",
+          description: "Skill name to add to the profile.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_REORDER_SKILLS_TOOL,
+    description:
+      "Prepare to reorder Skills on the logged-in member's LinkedIn profile (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["skillNames"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        skillNames: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+          description:
+            "Ordered skill names to move to the top of the Skills section in the provided order.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_ENDORSE_SKILL_TOOL,
+    description:
+      "Prepare to endorse one visible skill on another member's LinkedIn profile (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["target", "skillName"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        target: {
+          type: "string",
+          description:
+            "Target member vanity name or LinkedIn profile URL. Must refer to another member, not 'me'.",
+        },
+        skillName: {
+          type: "string",
+          description: "Skill name to endorse on the target profile.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_REQUEST_RECOMMENDATION_TOOL,
+    description:
+      "Prepare to request a LinkedIn recommendation from another member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["target"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        target: {
+          type: "string",
+          description:
+            "Target member vanity name or LinkedIn profile URL. Must refer to another member, not 'me'.",
+        },
+        relationship: {
+          type: "string",
+          description:
+            "Optional relationship selection for LinkedIn's recommendation dialog.",
+        },
+        position: {
+          type: "string",
+          description:
+            "Optional role/position selection for LinkedIn's recommendation dialog.",
+        },
+        company: {
+          type: "string",
+          description:
+            "Optional company selection for LinkedIn's recommendation dialog.",
+        },
+        message: {
+          type: "string",
+          description: "Optional personal message to include with the request.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PROFILE_PREPARE_WRITE_RECOMMENDATION_TOOL,
+    description:
+      "Prepare to write a LinkedIn recommendation for another member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["target", "text"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        target: {
+          type: "string",
+          description:
+            "Target member vanity name or LinkedIn profile URL. Must refer to another member, not 'me'.",
+        },
+        text: {
+          type: "string",
+          description: "Recommendation text to submit.",
+        },
+        relationship: {
+          type: "string",
+          description:
+            "Optional relationship selection for LinkedIn's recommendation dialog.",
+        },
+        position: {
+          type: "string",
+          description:
+            "Optional role/position selection for LinkedIn's recommendation dialog.",
+        },
+        company: {
+          type: "string",
+          description:
+            "Optional company selection for LinkedIn's recommendation dialog.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ASSETS_GENERATE_PROFILE_IMAGES_TOOL,
+    description:
+      "Generate a LinkedIn-ready profile photo, banner, and reusable post images from a local persona JSON spec using OpenAI. Optionally uploads the photo and banner through the existing LinkedIn profile upload flow.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["specPath"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        specPath: {
+          type: "string",
+          description: "Local path to the JSON persona/profile seed spec.",
+        },
+        postImageCount: {
+          type: "number",
+          description:
+            "Number of post images to generate. Defaults to 6 and must be 10 or fewer.",
+        },
+        model: {
+          type: "string",
+          description: "Optional OpenAI image model override.",
+        },
+        uploadProfileMedia: {
+          type: "boolean",
+          description:
+            "If true, upload the generated profile photo and banner after generation.",
+        },
+        uploadDelayMs: {
+          type: "number",
+          description:
+            "Base delay between the photo and banner uploads when uploadProfileMedia is true. Defaults to 4500.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the upload actions.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ANALYTICS_PROFILE_VIEWS_TOOL,
+    description: withSelectorAuditHint(
+      "Read the logged-in member's LinkedIn profile-view analytics cards with normalized numeric metrics.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ANALYTICS_SEARCH_APPEARANCES_TOOL,
+    description: withSelectorAuditHint(
+      "Read the logged-in member's LinkedIn search-appearance analytics cards with normalized numeric metrics.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ANALYTICS_CONTENT_METRICS_TOOL,
+    description: withSelectorAuditHint(
+      "Read LinkedIn content and impression analytics cards from the logged-in member's profile analytics surface.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        limit: {
+          type: "number",
+          description:
+            "Maximum number of content analytics cards to return. Defaults to 4.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ANALYTICS_POST_METRICS_TOOL,
+    description: withSelectorAuditHint(
+      "Read normalized engagement metrics for one LinkedIn post URL, URN, or activity/share identifier.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_SEARCH_TOOL,
+    description: withSelectorAuditHint(
+      `Search LinkedIn for ${SEARCH_CATEGORIES.join(", ")}.`,
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["query"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        query: {
+          type: "string",
+          description: "Search keywords.",
+        },
+        category: {
+          type: "string",
+          enum: [...SEARCH_CATEGORIES],
+          description: "Search category. Defaults to people.",
+        },
+        limit: {
+          type: "number",
+          description: "Max results. Defaults to 10.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_CONNECTIONS_LIST_TOOL,
+    description: withSelectorAuditHint(
+      "List your LinkedIn connections. Returns connection names, headlines, profile URLs, and when connected.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        limit: {
+          type: "number",
+          description:
+            "Maximum number of connections to return. Defaults to 40.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_CONNECTIONS_PENDING_TOOL,
+    description: withSelectorAuditHint(
+      "List pending LinkedIn connection invitations (sent, received, or both).",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        filter: {
+          type: "string",
+          enum: ["sent", "received", "all"],
+          description: "Filter invitations by direction. Defaults to all.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_CONNECTIONS_INVITE_TOOL,
+    description:
+      "Prepare a connection invitation to a LinkedIn user (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetProfile"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetProfile: {
+          type: "string",
+          description: "Vanity name (e.g. 'johndoe') or full profile URL.",
+        },
+        note: {
+          type: "string",
+          description: "Optional invitation note (max 300 chars).",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_CONNECTIONS_ACCEPT_TOOL,
+    description:
+      "Prepare to accept a pending connection invitation (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetProfile"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetProfile: {
+          type: "string",
+          description:
+            "Vanity name or profile URL of the person who sent the invitation.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_CONNECTIONS_WITHDRAW_TOOL,
+    description:
+      "Prepare to withdraw a sent connection invitation (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetProfile"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetProfile: {
+          type: "string",
+          description:
+            "Vanity name or profile URL of the person to withdraw the invitation from.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_CONNECTIONS_PREPARE_IGNORE_TOOL,
+    description:
+      "Prepare to ignore a received connection invitation (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetProfile"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetProfile: {
+          type: "string",
+          description:
+            "Vanity name or profile URL of the person whose received invitation should be ignored.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_CONNECTIONS_PREPARE_REMOVE_TOOL,
+    description:
+      "Prepare to remove an existing connection (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetProfile"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetProfile: {
+          type: "string",
+          description:
+            "Vanity name or profile URL of the existing connection to remove.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_COMPANY_PREPARE_FOLLOW_TOOL,
+    description:
+      "Prepare to follow a LinkedIn company page (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetCompany"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetCompany: {
+          type: "string",
+          description: "Company slug, /company/ path, or company URL.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_COMPANY_PREPARE_UNFOLLOW_TOOL,
+    description:
+      "Prepare to unfollow a LinkedIn company page (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetCompany"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetCompany: {
+          type: "string",
+          description: "Company slug, /company/ path, or company URL.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Optional note attached to the prepared action.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_CONNECTIONS_PREPARE_FOLLOW_TOOL,
+    description:
+      "Prepare to follow a LinkedIn member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetProfile"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetProfile: {
+          type: "string",
+          description: "Vanity name or profile URL of the member to follow.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_CONNECTIONS_PREPARE_UNFOLLOW_TOOL,
+    description:
+      "Prepare to unfollow a LinkedIn member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetProfile"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetProfile: {
+          type: "string",
+          description: "Vanity name or profile URL of the member to unfollow.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_MEMBERS_PREPARE_BLOCK_TOOL,
+    description:
+      "Prepare to block a LinkedIn member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetProfile"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetProfile: {
+          type: "string",
+          description:
+            "Vanity name or profile URL of the LinkedIn member to block.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_MEMBERS_PREPARE_UNBLOCK_TOOL,
+    description:
+      "Prepare to unblock a LinkedIn member from the blocked-members settings page (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetProfile"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetProfile: {
+          type: "string",
+          description:
+            "Vanity name or profile URL of the LinkedIn member to unblock.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_MEMBERS_PREPARE_REPORT_TOOL,
+    description:
+      "Prepare to report a LinkedIn member (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["targetProfile", "reason"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        targetProfile: {
+          type: "string",
+          description:
+            "Vanity name or profile URL of the LinkedIn member to report.",
+        },
+        reason: {
+          type: "string",
+          enum: [...LINKEDIN_MEMBER_REPORT_REASONS],
+          description: "Structured report reason for the dialog flow.",
+        },
+        details: {
+          type: "string",
+          description:
+            "Optional free-text details that will be filled when the dialog exposes a text field.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PRIVACY_GET_SETTINGS_TOOL,
+    description: withSelectorAuditHint(
+      "Read the supported LinkedIn privacy settings surfaced by the automation runtime, including profile viewing mode and related visibility controls.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_PRIVACY_PREPARE_UPDATE_SETTING_TOOL,
+    description:
+      "Prepare to update one supported LinkedIn privacy setting (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["settingKey", "value"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        settingKey: {
+          type: "string",
+          enum: [...LINKEDIN_PRIVACY_SETTING_KEYS],
+          description: "Supported LinkedIn privacy setting key.",
+        },
+        value: {
+          type: "string",
+          description: "Requested setting value.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_NETWORK_PREPARE_FOLLOWUP_AFTER_ACCEPT_TOOL,
+    description:
+      "Detect newly accepted sent invitations and prepare follow-up messages (two-phase: returns confirm tokens). Use linkedin.actions.confirm to execute each prepared follow-up.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        since: {
+          type: "string",
+          description:
+            "Lookback window such as 30m, 12h, 7d, or 2w. Defaults to 7d.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note attached to each prepared follow-up.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_FEED_LIST_TOOL,
+    description: withSelectorAuditHint(
+      "List posts from your LinkedIn feed with author, text, and engagement counts.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        limit: {
+          type: "number",
+          description:
+            "Maximum number of feed posts to return. Defaults to 10.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_FEED_VIEW_POST_TOOL,
+    description: withSelectorAuditHint(
+      "View one LinkedIn feed post by URL, URN, or activity id.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_FEED_LIKE_TOOL,
+    description:
+      "Prepare to react to a LinkedIn post (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+        reaction: {
+          type: "string",
+          enum: [...LINKEDIN_FEED_REACTION_TYPES],
+          description: "Reaction type. Defaults to like.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_FEED_COMMENT_TOOL,
+    description:
+      "Prepare to comment on a LinkedIn post (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl", "text"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+        text: {
+          type: "string",
+          description: "Comment text to prepare.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_FEED_PREPARE_REPOST_TOOL,
+    description:
+      "Prepare to repost a LinkedIn post (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_FEED_PREPARE_SHARE_TOOL,
+    description:
+      "Prepare to share a LinkedIn post with your own text (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl", "text"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+        text: {
+          type: "string",
+          description: "Text to publish with the shared post.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_FEED_SAVE_POST_TOOL,
+    description:
+      "Prepare to save a LinkedIn post for later (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_FEED_UNSAVE_POST_TOOL,
+    description:
+      "Prepare to remove a LinkedIn post from your saved items (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_FEED_PREPARE_REMOVE_REACTION_TOOL,
+    description:
+      "Prepare to remove your current reaction from a LinkedIn post (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_POST_PREPARE_CREATE_TOOL,
+    description:
+      "Prepare a new LinkedIn post (two-phase: returns confirm token). Use linkedin.actions.confirm to publish.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["text"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        text: {
+          type: "string",
+          description: "Post text to prepare for publishing.",
+        },
+        visibility: {
+          type: "string",
+          enum: [...LINKEDIN_POST_VISIBILITY_TYPES],
+          description: "Post visibility. Defaults to public.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_POST_PREPARE_CREATE_MEDIA_TOOL,
+    description:
+      "Prepare a new LinkedIn media post with attachments (two-phase: returns confirm token). Use linkedin.actions.confirm to publish.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["text", "mediaPaths"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        text: {
+          type: "string",
+          description: "Post text to publish alongside the media attachments.",
+        },
+        mediaPaths: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+          description:
+            "One or more local file paths for image/video attachments.",
+        },
+        visibility: {
+          type: "string",
+          enum: [...LINKEDIN_POST_VISIBILITY_TYPES],
+          description: "Post visibility. Defaults to public.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_POST_PREPARE_CREATE_POLL_TOOL,
+    description:
+      "Prepare a new LinkedIn poll post (two-phase: returns confirm token). Use linkedin.actions.confirm to publish.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["question", "options"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        text: {
+          type: "string",
+          description: "Optional lead-in text that appears above the poll.",
+        },
+        question: {
+          type: "string",
+          description: "Poll question to publish.",
+        },
+        options: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+          description: "Two to four poll options.",
+        },
+        durationDays: {
+          type: "number",
+          description:
+            "Poll duration in days. Supported values: 1, 3, 7, or 14.",
+        },
+        visibility: {
+          type: "string",
+          enum: [...LINKEDIN_POST_VISIBILITY_TYPES],
+          description: "Post visibility. Defaults to public.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_POST_PREPARE_EDIT_TOOL,
+    description:
+      "Prepare to edit one of your LinkedIn posts (two-phase: returns confirm token). Use linkedin.actions.confirm to save the update.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl", "text"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+        text: {
+          type: "string",
+          description: "Replacement post text to save.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_POST_PREPARE_DELETE_TOOL,
+    description:
+      "Prepare to delete one of your LinkedIn posts (two-phase: returns confirm token). Use linkedin.actions.confirm to execute the deletion.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["postUrl"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        postUrl: {
+          type: "string",
+          description: "LinkedIn post URL, URN, or activity/share identifier.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ARTICLE_PREPARE_CREATE_TOOL,
+    description:
+      "Prepare a new LinkedIn long-form article draft (two-phase: returns confirm token). Use linkedin.actions.confirm to create the draft in the publishing editor.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["title", "body"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        title: {
+          type: "string",
+          description: "Article headline to stage in the publishing editor.",
+        },
+        body: {
+          type: "string",
+          description:
+            "Plain-text article body. Paragraph breaks are preserved.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ARTICLE_PREPARE_PUBLISH_TOOL,
+    description:
+      "Prepare to publish an existing LinkedIn article draft (two-phase: returns confirm token). Use linkedin.actions.confirm to publish the draft.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["draftUrl"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        draftUrl: {
+          type: "string",
+          description:
+            "Absolute LinkedIn article editor or draft URL returned by linkedin.article.prepare_create.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_NEWSLETTER_PREPARE_CREATE_TOOL,
+    description:
+      "Prepare a new LinkedIn newsletter series (two-phase: returns confirm token). Use linkedin.actions.confirm to create the newsletter shell.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["title", "description", "cadence"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        title: {
+          type: "string",
+          description: "Newsletter title.",
+        },
+        description: {
+          type: "string",
+          description: "Short newsletter description.",
+        },
+        cadence: {
+          type: "string",
+          enum: [...LINKEDIN_NEWSLETTER_CADENCE_TYPES],
+          description: "Newsletter publish cadence.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_NEWSLETTER_PREPARE_PUBLISH_ISSUE_TOOL,
+    description:
+      "Prepare a new LinkedIn newsletter issue (two-phase: returns confirm token). Use linkedin.actions.confirm to publish the issue.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["newsletter", "title", "body"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        newsletter: {
+          type: "string",
+          description:
+            "Newsletter title as returned by linkedin.newsletter.list.",
+        },
+        title: {
+          type: "string",
+          description: "Issue headline.",
+        },
+        body: {
+          type: "string",
+          description: "Plain-text issue body. Paragraph breaks are preserved.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_NEWSLETTER_LIST_TOOL,
+    description: withSelectorAuditHint(
+      "List newsletter series currently available in the LinkedIn publishing editor.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_NOTIFICATIONS_LIST_TOOL,
+    description: withSelectorAuditHint(
+      "List your LinkedIn notifications. Returns notification type, message, timestamp, link, and read/unread status.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        limit: {
+          type: "number",
+          description:
+            "Maximum number of notifications to return. Defaults to 20.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_NOTIFICATIONS_MARK_READ_TOOL,
+    description: withSelectorAuditHint(
+      "Mark one LinkedIn notification as read by notification ID.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["notificationId"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        notificationId: {
+          type: "string",
+          description:
+            "Notification ID returned by linkedin.notifications.list.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_NOTIFICATIONS_DISMISS_TOOL,
+    description: withSelectorAuditHint(
+      "Prepare a dismiss action for one LinkedIn notification (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["notificationId"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        notificationId: {
+          type: "string",
+          description:
+            "Notification ID returned by linkedin.notifications.list.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_NOTIFICATIONS_PREFERENCES_GET_TOOL,
+    description: withSelectorAuditHint(
+      "Read LinkedIn notification preference categories or one specific notification preference page.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        preferenceUrl: {
+          type: "string",
+          description:
+            "Optional LinkedIn notification preference URL. When omitted, returns the notifications preferences overview.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_NOTIFICATIONS_PREFERENCES_PREPARE_UPDATE_TOOL,
+    description: withSelectorAuditHint(
+      "Prepare a LinkedIn notification preference update (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["preferenceUrl", "enabled"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        preferenceUrl: {
+          type: "string",
+          description:
+            "LinkedIn notification category or subcategory URL returned by linkedin.notifications.preferences.get.",
+        },
+        enabled: {
+          type: "boolean",
+          description: "Whether the selected preference should be enabled.",
+        },
+        channel: {
+          type: "string",
+          description:
+            "Optional channel key for subcategory pages: in_app, push, or email.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_JOBS_SEARCH_TOOL,
+    description: withSelectorAuditHint(
+      "Search for LinkedIn job postings by keyword and optional location.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["query"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        query: {
+          type: "string",
+          description: "Search keywords for jobs.",
+        },
+        location: {
+          type: "string",
+          description: "Location filter for jobs.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of results to return. Defaults to 10.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_JOBS_VIEW_TOOL,
+    description: withSelectorAuditHint(
+      "View details of a specific LinkedIn job posting by job ID.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["jobId"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        jobId: {
+          type: "string",
+          description: "LinkedIn job ID.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_JOBS_SAVE_TOOL,
+    description:
+      "Prepare to save a LinkedIn job for later (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["jobId"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        jobId: {
+          type: "string",
+          description: "LinkedIn job ID.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_JOBS_UNSAVE_TOOL,
+    description:
+      "Prepare to unsave a LinkedIn job (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["jobId"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        jobId: {
+          type: "string",
+          description: "LinkedIn job ID.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_JOBS_ALERTS_LIST_TOOL,
+    description: withSelectorAuditHint(
+      "List LinkedIn job alerts for the current account.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of alerts to return. Defaults to 20.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_JOBS_ALERTS_CREATE_TOOL,
+    description:
+      "Prepare to create a LinkedIn job alert from a search query (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["query"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        query: {
+          type: "string",
+          description: "Search keywords for the alert.",
+        },
+        location: {
+          type: "string",
+          description: "Optional location filter for the alert.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_JOBS_ALERTS_REMOVE_TOOL,
+    description:
+      "Prepare to remove a LinkedIn job alert (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        alertId: {
+          type: "string",
+          description:
+            "Alert id previously returned by linkedin.jobs.alerts.list.",
+        },
+        searchUrl: {
+          type: "string",
+          description: "LinkedIn jobs search URL for the alert.",
+        },
+        query: {
+          type: "string",
+          description: "Alert query if alertId or searchUrl are not available.",
+        },
+        location: {
+          type: "string",
+          description: "Alert location if query is provided.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_JOBS_PREPARE_EASY_APPLY_TOOL,
+    description:
+      "Prepare a LinkedIn Easy Apply submission (two-phase: returns confirm token). Use linkedin.actions.confirm to execute.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["jobId"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        jobId: {
+          type: "string",
+          description: "LinkedIn job ID.",
+        },
+        phoneNumber: {
+          type: "string",
+          description: "Phone number value for Easy Apply forms.",
+        },
+        email: {
+          type: "string",
+          description: "Email value for Easy Apply forms.",
+        },
+        city: {
+          type: "string",
+          description: "City value for Easy Apply forms.",
+        },
+        resumePath: {
+          type: "string",
+          description:
+            "Absolute or relative path to the resume file to upload.",
+        },
+        coverLetter: {
+          type: "string",
+          description: "Cover letter text for Easy Apply forms.",
+        },
+        answers: {
+          type: "object",
+          description:
+            "Additional Easy Apply answers keyed by field label. Values may be strings, booleans, numbers, or string arrays.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_GROUPS_SEARCH_TOOL,
+    description: withSelectorAuditHint(
+      "Search LinkedIn groups by keyword and return matching communities.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["query"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        query: {
+          type: "string",
+          description: "Search keywords for LinkedIn groups.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of results to return. Defaults to 10.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_GROUPS_VIEW_TOOL,
+    description: withSelectorAuditHint(
+      "View details of a specific LinkedIn group by URL or numeric group ID.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["group"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        group: {
+          type: "string",
+          description: "LinkedIn group URL or numeric group ID.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_GROUPS_PREPARE_JOIN_TOOL,
+    description:
+      "Prepare to join a LinkedIn group (two-phase: returns confirm token). Use linkedin.actions.confirm to request or complete the join.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["group"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        group: {
+          type: "string",
+          description: "LinkedIn group URL or numeric group ID.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_GROUPS_PREPARE_LEAVE_TOOL,
+    description:
+      "Prepare to leave a LinkedIn group (two-phase: returns confirm token). Use linkedin.actions.confirm to complete the leave flow.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["group"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        group: {
+          type: "string",
+          description: "LinkedIn group URL or numeric group ID.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_GROUPS_PREPARE_POST_TOOL,
+    description:
+      "Prepare a post inside a LinkedIn group (two-phase: returns confirm token). Use linkedin.actions.confirm to publish the post.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["group", "text"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        group: {
+          type: "string",
+          description: "LinkedIn group URL or numeric group ID.",
+        },
+        text: {
+          type: "string",
+          description: "Post text to publish inside the group.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_EVENTS_SEARCH_TOOL,
+    description: withSelectorAuditHint(
+      "Search LinkedIn events by keyword and return matching event cards.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["query"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        query: {
+          type: "string",
+          description: "Search keywords for LinkedIn events.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of results to return. Defaults to 10.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_EVENTS_VIEW_TOOL,
+    description: withSelectorAuditHint(
+      "View details of a specific LinkedIn event by URL or numeric event ID.",
+    ),
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["event"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        event: {
+          type: "string",
+          description: "LinkedIn event URL or numeric event ID.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_EVENTS_PREPARE_RSVP_TOOL,
+    description:
+      "Prepare to RSVP attend for a LinkedIn event (two-phase: returns confirm token). Use linkedin.actions.confirm to complete the RSVP.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["event"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        event: {
+          type: "string",
+          description: "LinkedIn event URL or numeric event ID.",
+        },
+        operatorNote: {
+          type: "string",
+          description: "Internal note for audit.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_WATCH_CREATE_TOOL,
+    description:
+      "Create a durable poll-based LinkedIn activity watch for one profile and activity source.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["kind"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        kind: {
+          type: "string",
+          enum: [...ACTIVITY_WATCH_KINDS],
+          description: "Activity watch kind.",
+        },
+        target: {
+          type: "object",
+          description:
+            "Optional watch target object for profile/feed/inbox filters.",
+        },
+        intervalSeconds: {
+          type: "number",
+          description: "Optional polling interval in seconds.",
+        },
+        cron: {
+          type: "string",
+          description: "Optional cron schedule expression.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_WATCH_LIST_TOOL,
+    description: "List configured LinkedIn activity watches for a profile.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        status: {
+          type: "string",
+          enum: [...ACTIVITY_WATCH_STATUSES],
+          description: "Optional watch status filter.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_WATCH_PAUSE_TOOL,
+    description: "Pause one activity watch by id.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["watchId"],
+      properties: withCdpSchemaProperties({
+        watchId: {
+          type: "string",
+          description: "Activity watch id.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_WATCH_RESUME_TOOL,
+    description: "Resume one activity watch by id and make it due immediately.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["watchId"],
+      properties: withCdpSchemaProperties({
+        watchId: {
+          type: "string",
+          description: "Activity watch id.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_WATCH_REMOVE_TOOL,
+    description: "Remove one activity watch by id.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["watchId"],
+      properties: withCdpSchemaProperties({
+        watchId: {
+          type: "string",
+          description: "Activity watch id.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_WEBHOOK_CREATE_TOOL,
+    description: "Create a webhook subscription for one activity watch.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["watchId", "deliveryUrl"],
+      properties: withCdpSchemaProperties({
+        watchId: {
+          type: "string",
+          description: "Activity watch id.",
+        },
+        deliveryUrl: {
+          type: "string",
+          description: "Webhook delivery URL.",
+        },
+        eventTypes: {
+          type: "array",
+          items: {
+            type: "string",
+            enum: [...ACTIVITY_EVENT_TYPES],
+          },
+          description: "Optional event filters for this subscription.",
+        },
+        signingSecret: {
+          type: "string",
+          description: "Optional pre-shared signing secret.",
+        },
+        maxAttempts: {
+          type: "number",
+          description: "Optional maximum delivery attempts.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_WEBHOOK_LIST_TOOL,
+    description: "List webhook subscriptions for activity watches.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        watchId: {
+          type: "string",
+          description: "Optional watch id filter.",
+        },
+        status: {
+          type: "string",
+          enum: [...WEBHOOK_SUBSCRIPTION_STATUSES],
+          description: "Optional webhook subscription status filter.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_WEBHOOK_PAUSE_TOOL,
+    description: "Pause one activity webhook subscription by id.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["subscriptionId"],
+      properties: withCdpSchemaProperties({
+        subscriptionId: {
+          type: "string",
+          description: "Webhook subscription id.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_WEBHOOK_RESUME_TOOL,
+    description: "Resume one activity webhook subscription by id.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["subscriptionId"],
+      properties: withCdpSchemaProperties({
+        subscriptionId: {
+          type: "string",
+          description: "Webhook subscription id.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_WEBHOOK_REMOVE_TOOL,
+    description: "Remove one activity webhook subscription by id.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["subscriptionId"],
+      properties: withCdpSchemaProperties({
+        subscriptionId: {
+          type: "string",
+          description: "Webhook subscription id.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_EVENTS_LIST_TOOL,
+    description:
+      "List emitted LinkedIn activity events from local persistent state.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        watchId: {
+          type: "string",
+          description: "Optional watch id filter.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of events to return. Defaults to 20.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_DELIVERIES_LIST_TOOL,
+    description: "List webhook delivery attempts from local persistent state.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+        watchId: {
+          type: "string",
+          description: "Optional watch id filter.",
+        },
+        subscriptionId: {
+          type: "string",
+          description: "Optional webhook subscription id filter.",
+        },
+        status: {
+          type: "string",
+          enum: [...WEBHOOK_DELIVERY_ATTEMPT_STATUSES],
+          description: "Optional delivery status filter.",
+        },
+        limit: {
+          type: "number",
+          description:
+            "Maximum number of delivery attempts to return. Defaults to 20.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIVITY_POLLER_RUN_ONCE_TOOL,
+    description:
+      "Run one local activity polling tick now and return the watch and delivery summary.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description:
+            "Persistent Playwright profile name. Defaults to default.",
+        },
+      }),
+    },
+  },
+  {
+    name: LINKEDIN_ACTIONS_CONFIRM_TOOL,
+    description: "Confirm and execute a prepared action by confirm token.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["token"],
+      properties: withCdpSchemaProperties({
+        profileName: {
+          type: "string",
+          description: "Persistent profile expected for this action.",
+        },
+        token: {
+          type: "string",
+          description: "Confirmation token in ct_... format.",
+        },
+      }),
+    },
+  },
 ];
 
 const TOOL_DEFINITION_BY_NAME = new Map(
-  LINKEDIN_MCP_TOOL_DEFINITIONS.map((tool) => [tool.name, tool] as const)
+  LINKEDIN_MCP_TOOL_DEFINITIONS.map((tool) => [tool.name, tool] as const),
 );
 
 export function validateToolArguments(name: string, args: unknown): ToolArgs {
   const definition = TOOL_DEFINITION_BY_NAME.get(name);
   if (!definition) {
     throw new LinkedInBuddyError("TARGET_NOT_FOUND", `Unknown tool: ${name}.`, {
-      tool: name
+      tool: name,
     });
   }
 
@@ -7771,7 +7944,7 @@ export function validateToolArguments(name: string, args: unknown): ToolArgs {
 
 server.setRequestHandler(ListToolsRequestSchema, async () => {
   return {
-    tools: LINKEDIN_MCP_TOOL_DEFINITIONS
+    tools: LINKEDIN_MCP_TOOL_DEFINITIONS,
   };
 });
 
@@ -7804,7 +7977,8 @@ const TOOL_HANDLERS: Record<string, ToolHandler> = {
   [LINKEDIN_PROFILE_PREPARE_REMOVE_SECTION_ITEM_TOOL]:
     handleProfilePrepareRemoveSectionItem,
   [LINKEDIN_PROFILE_PREPARE_UPLOAD_PHOTO_TOOL]: handleProfilePrepareUploadPhoto,
-  [LINKEDIN_PROFILE_PREPARE_UPLOAD_BANNER_TOOL]: handleProfilePrepareUploadBanner,
+  [LINKEDIN_PROFILE_PREPARE_UPLOAD_BANNER_TOOL]:
+    handleProfilePrepareUploadBanner,
   [LINKEDIN_PROFILE_PREPARE_FEATURED_ADD_TOOL]: handleProfilePrepareFeaturedAdd,
   [LINKEDIN_PROFILE_PREPARE_FEATURED_REMOVE_TOOL]:
     handleProfilePrepareFeaturedRemove,
@@ -7837,14 +8011,16 @@ const TOOL_HANDLERS: Record<string, ToolHandler> = {
   [LINKEDIN_COMPANY_PREPARE_FOLLOW_TOOL]: handleCompanyPrepareFollow,
   [LINKEDIN_COMPANY_PREPARE_UNFOLLOW_TOOL]: handleCompanyPrepareUnfollow,
   [LINKEDIN_CONNECTIONS_PREPARE_FOLLOW_TOOL]: handleConnectionsPrepareFollow,
-  [LINKEDIN_CONNECTIONS_PREPARE_UNFOLLOW_TOOL]: handleConnectionsPrepareUnfollow,
+  [LINKEDIN_CONNECTIONS_PREPARE_UNFOLLOW_TOOL]:
+    handleConnectionsPrepareUnfollow,
   [LINKEDIN_MEMBERS_PREPARE_BLOCK_TOOL]: handleMembersPrepareBlock,
   [LINKEDIN_MEMBERS_PREPARE_UNBLOCK_TOOL]: handleMembersPrepareUnblock,
   [LINKEDIN_MEMBERS_PREPARE_REPORT_TOOL]: handleMembersPrepareReport,
   [LINKEDIN_PRIVACY_GET_SETTINGS_TOOL]: handlePrivacyGetSettings,
   [LINKEDIN_PRIVACY_PREPARE_UPDATE_SETTING_TOOL]:
     handlePrivacyPrepareUpdateSetting,
-  [LINKEDIN_NETWORK_PREPARE_FOLLOWUP_AFTER_ACCEPT_TOOL]: handlePrepareFollowupAfterAccept,
+  [LINKEDIN_NETWORK_PREPARE_FOLLOWUP_AFTER_ACCEPT_TOOL]:
+    handlePrepareFollowupAfterAccept,
   [LINKEDIN_FEED_LIST_TOOL]: handleFeedList,
   [LINKEDIN_FEED_VIEW_POST_TOOL]: handleFeedViewPost,
   [LINKEDIN_FEED_LIKE_TOOL]: handleFeedLike,
@@ -7868,7 +8044,8 @@ const TOOL_HANDLERS: Record<string, ToolHandler> = {
   [LINKEDIN_NOTIFICATIONS_LIST_TOOL]: handleNotificationsList,
   [LINKEDIN_NOTIFICATIONS_MARK_READ_TOOL]: handleNotificationsMarkRead,
   [LINKEDIN_NOTIFICATIONS_DISMISS_TOOL]: handleNotificationsDismiss,
-  [LINKEDIN_NOTIFICATIONS_PREFERENCES_GET_TOOL]: handleNotificationPreferencesGet,
+  [LINKEDIN_NOTIFICATIONS_PREFERENCES_GET_TOOL]:
+    handleNotificationPreferencesGet,
   [LINKEDIN_NOTIFICATIONS_PREFERENCES_PREPARE_UPDATE_TOOL]:
     handleNotificationPreferencesPrepareUpdate,
   [LINKEDIN_JOBS_SEARCH_TOOL]: handleJobsSearch,
@@ -7900,13 +8077,13 @@ const TOOL_HANDLERS: Record<string, ToolHandler> = {
   [LINKEDIN_ACTIVITY_EVENTS_LIST_TOOL]: handleActivityEventsList,
   [LINKEDIN_ACTIVITY_DELIVERIES_LIST_TOOL]: handleActivityDeliveriesList,
   [LINKEDIN_ACTIVITY_POLLER_RUN_ONCE_TOOL]: handleActivityPollerRunOnce,
-  [LINKEDIN_ACTIONS_CONFIRM_TOOL]: handleConfirm
+  [LINKEDIN_ACTIONS_CONFIRM_TOOL]: handleConfirm,
 };
 
 /** Dispatches one MCP tool call to the registered LinkedIn tool handlers. */
 export async function handleToolCall(
   name: string,
-  args: ToolArgs = {}
+  args: ToolArgs = {},
 ): Promise<ToolResult | ToolErrorResult> {
   let errorForTracking: unknown;
 
@@ -7915,7 +8092,7 @@ export async function handleToolCall(
     if (handler) {
       const validatedArgs = validateToolArguments(name, args);
       const profileName = trimOrUndefined(
-        readString(validatedArgs, "profileName", "")
+        readString(validatedArgs, "profileName", ""),
       );
       const result = await handler(validatedArgs);
 
@@ -7927,7 +8104,7 @@ export async function handleToolCall(
         source: "mcp",
         invocationName: name,
         mcpToolName: name,
-        ...(profileName ? { activeProfileName: profileName } : {})
+        ...(profileName ? { activeProfileName: profileName } : {}),
       });
 
       return decision.showHint ? addFeedbackHintToResult(result) : result;
@@ -7935,7 +8112,7 @@ export async function handleToolCall(
 
     errorForTracking = new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      `Unknown tool: ${name}`
+      `Unknown tool: ${name}`,
     );
     const unknownToolResult = toErrorResult(errorForTracking);
 
@@ -7947,7 +8124,7 @@ export async function handleToolCall(
       source: "mcp",
       invocationName: name,
       mcpToolName: name,
-      error: errorForTracking
+      error: errorForTracking,
     });
 
     return decision.showHint
@@ -7962,32 +8139,36 @@ export async function handleToolCall(
     }
 
     try {
-      const validatedArgs = name in TOOL_HANDLERS
-        ? validateToolArguments(name, args)
-        : args;
+      const validatedArgs =
+        name in TOOL_HANDLERS ? validateToolArguments(name, args) : args;
       const profileName = trimOrUndefined(
-        readString(validatedArgs, "profileName", "")
+        readString(validatedArgs, "profileName", ""),
       );
       const decision = await recordFeedbackInvocation({
         source: "mcp",
         invocationName: name,
         mcpToolName: name,
         ...(profileName ? { activeProfileName: profileName } : {}),
-        error: errorForTracking
+        error: errorForTracking,
       });
 
-      return decision.showHint ? addFeedbackHintToResult(errorResult) : errorResult;
+      return decision.showHint
+        ? addFeedbackHintToResult(errorResult)
+        : errorResult;
     } catch {
       return errorResult;
     }
   }
 }
 
-server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
-  const name = request.params.name;
-  const args = (request.params.arguments ?? {}) as ToolArgs;
-  return handleToolCall(name, args);
-});
+server.setRequestHandler(
+  CallToolRequestSchema,
+  async (request: CallToolRequest) => {
+    const name = request.params.name;
+    const args = (request.params.arguments ?? {}) as ToolArgs;
+    return handleToolCall(name, args);
+  },
+);
 
 async function startLinkedInMcpServer(): Promise<void> {
   const transport = new StdioServerTransport();
@@ -8006,7 +8187,11 @@ function isDirectExecution(moduleUrl: string): boolean {
 if (isDirectExecution(import.meta.url)) {
   startLinkedInMcpServer().catch((error: unknown) => {
     console.error(
-      JSON.stringify(toLinkedInBuddyErrorPayload(error, mcpPrivacyConfig), null, 2)
+      JSON.stringify(
+        toLinkedInBuddyErrorPayload(error, mcpPrivacyConfig),
+        null,
+        2,
+      ),
     );
     process.exit(1);
   });


### PR DESCRIPTION
## Summary

Quality pass for hardening (#215), running the remaining phases (3-8) from the hardening pipeline. The original PR #313 added MCP tool input schema validation. This pass extends that foundation with input validation helpers, unit tests for previously untested modules, and error recovery hints for MCP tool consumers.

## Changes

### Phase 4 — Test (36 new tests)
- `packages/core/src/__tests__/errors.test.ts` — 13 tests covering LinkedInBuddyError construction, error payload conversion, privacy redaction across all modes
- `packages/core/src/__tests__/privacy.test.ts` — 15 tests covering resolvePrivacyConfig, redactFreeformText, redactStructuredValue across off/partial/full modes
- `packages/core/src/__tests__/logging.test.ts` — 8 tests covering logger creation, JSONL format, log levels, append semantics, DB emission

### Phase 5 — Harden (MCP input validation)
- Added `readBoundedString()` — enforces max character length on text inputs (applied to message/post/comment handlers)
- Added `readValidatedUrl()` — validates and normalizes URLs via `new URL()` (applied to feed URL handlers)
- Added `readValidatedFilePath()` — rejects empty paths and path-traversal patterns (applied to photo/banner upload handlers)
- Added validation tests for all three helpers

### Phase 6 — UX/QoL (error recovery hints)
- Added `buildRecoveryHint()` that maps error codes to actionable recovery suggestions
- All MCP tool error responses now include a `recovery_hint` field guiding the next action
- Added tests for recovery hint generation

### Phase 8 — Docs
- Added `docs/hardening-pass-215.md` documenting all phases and changes

## Testing

- `npm run typecheck` — 0 errors
- `npm run lint` — clean
- `npm test` — **1147 tests passing** (108 files, up from 1104 tests / 104 files)
- `npm run build` — clean

## Notes

- **Phase 3** (Simplify/Refactor): No code changes needed — pre-existing typecheck errors were traced to worktree setup, not source code
- **Phase 7** (Verify): Deferred — requires authenticated LinkedIn session against test account, not feasible in automated context

Closes #358
