### PR TITLE
feat: quality pass for rate limiting (#311)

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ See [`docs/repository-seo.md`](./docs/repository-seo.md) for the keyword targets
 | README media inventory                   | [`assets/media/README.md`](./assets/media/README.md)                     |
 | Articles and newsletters                 | [`docs/articles-newsletters.md`](./docs/articles-newsletters.md)         |
 | Notifications                            | [`docs/notifications.md`](./docs/notifications.md)                       |
+| Rate limiting                            | [`docs/rate-limiting.md`](./docs/rate-limiting.md)                       |
 
 ## Contributing
 

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -1,0 +1,221 @@
+# Rate limiting
+
+LinkedIn Buddy enforces local rate limits on every write action to stay within
+LinkedIn's usage expectations. Limits are checked at confirm time so agents
+discover quota issues before the browser automation begins.
+
+## Architecture
+
+Two independent layers enforce cooldowns:
+
+### Action-level rate limiting (`rateLimiter.ts`)
+
+A per-action-type sliding window counter backed by the local SQLite database.
+Every write action type (e.g. `feed.like_post`, `connections.send_invitation`)
+has its own counter key, window size, and limit. The counter is stored in the
+`rate_limit_counter` table.
+
+| Phase   | Method                      | Effect                                                                                             |
+| ------- | --------------------------- | -------------------------------------------------------------------------------------------------- |
+| Prepare | `rateLimiter.peek()`        | Reads remaining quota without consuming. Surfaced as `rate_limit` metadata in the prepare preview. |
+| Confirm | `consumeRateLimitOrThrow()` | Increments the counter and throws `RATE_LIMITED` if the limit is exceeded.                         |
+
+Window boundaries are aligned to wall-clock multiples of `windowSizeMs`:
+
+```
+windowStartMs = Math.floor(nowMs / windowSizeMs) * windowSizeMs
+```
+
+### Session-level rate limiting (`auth/rateLimitState.ts`)
+
+Detects when LinkedIn itself returns rate-limit signals for the account
+(HTTP 429, challenge pages). Persists an exponential backoff state to
+`~/.linkedin-buddy/rate-limit-state.json`. Backoff escalation:
+
+| Consecutive hits | Cooldown |
+| ---------------- | -------- |
+| 1                | 2 hours  |
+| 2                | 4 hours  |
+| 3+               | 8 hours  |
+
+The CLI checks this cooldown before every login and outbound operation.
+
+## Default rate-limit policies
+
+### Feed actions (1-hour windows)
+
+| Action type            | Counter key                     | Limit | Window |
+| ---------------------- | ------------------------------- | ----- | ------ |
+| `feed.like_post`       | `linkedin.feed.like_post`       | 30    | 1 h    |
+| `feed.comment_on_post` | `linkedin.feed.comment_on_post` | 15    | 1 h    |
+| `feed.repost_post`     | `linkedin.feed.repost_post`     | 10    | 1 h    |
+| `feed.share_post`      | `linkedin.feed.share_post`      | 10    | 1 h    |
+| `feed.save_post`       | `linkedin.feed.save_post`       | 40    | 1 h    |
+| `feed.unsave_post`     | `linkedin.feed.unsave_post`     | 40    | 1 h    |
+| `feed.remove_reaction` | `linkedin.feed.remove_reaction` | 30    | 1 h    |
+
+### Messaging actions (1-hour windows)
+
+| Action type              | Counter key                           | Limit | Window |
+| ------------------------ | ------------------------------------- | ----- | ------ |
+| `inbox.send_reply`       | `linkedin.messaging.send_message`     | 20    | 1 h    |
+| `inbox.send_new_thread`  | `linkedin.messaging.send_message`     | 20    | 1 h    |
+| `inbox.add_recipients`   | `linkedin.messaging.add_recipients`   | 20    | 1 h    |
+| `inbox.react`            | `linkedin.messaging.react`            | 60    | 1 h    |
+| `inbox.archive_thread`   | `linkedin.messaging.archive_thread`   | 60    | 1 h    |
+| `inbox.unarchive_thread` | `linkedin.messaging.unarchive_thread` | 60    | 1 h    |
+| `inbox.mark_unread`      | `linkedin.messaging.mark_unread`      | 60    | 1 h    |
+| `inbox.mute_thread`      | `linkedin.messaging.mute_thread`      | 60    | 1 h    |
+
+### Connection actions (24-hour windows)
+
+| Action type                       | Counter key                                | Limit | Window |
+| --------------------------------- | ------------------------------------------ | ----- | ------ |
+| `connections.send_invitation`     | `linkedin.connections.send_invitation`     | 20    | 24 h   |
+| `connections.accept_invitation`   | `linkedin.connections.accept_invitation`   | 30    | 24 h   |
+| `connections.withdraw_invitation` | `linkedin.connections.withdraw_invitation` | 20    | 24 h   |
+| `connections.ignore_invitation`   | `linkedin.connections.ignore_invitation`   | 30    | 24 h   |
+| `connections.remove_connection`   | `linkedin.connections.remove_connection`   | 20    | 24 h   |
+| `connections.follow_member`       | `linkedin.connections.follow_member`       | 30    | 24 h   |
+| `connections.unfollow_member`     | `linkedin.connections.unfollow_member`     | 30    | 24 h   |
+
+### Member actions (24-hour windows)
+
+| Action type              | Counter key                       | Limit | Window |
+| ------------------------ | --------------------------------- | ----- | ------ |
+| `members.block_member`   | `linkedin.members.block_member`   | 10    | 24 h   |
+| `members.unblock_member` | `linkedin.members.unblock_member` | 10    | 24 h   |
+| `members.report_member`  | `linkedin.members.report_member`  | 10    | 24 h   |
+
+### Job actions (1-hour windows)
+
+| Action type          | Counter key                   | Limit | Window |
+| -------------------- | ----------------------------- | ----- | ------ |
+| `jobs.save`          | `linkedin.jobs.save`          | 40    | 1 h    |
+| `jobs.unsave`        | `linkedin.jobs.unsave`        | 40    | 1 h    |
+| `jobs.alerts.create` | `linkedin.jobs.alerts.create` | 30    | 1 h    |
+| `jobs.alerts.remove` | `linkedin.jobs.alerts.remove` | 30    | 1 h    |
+| `jobs.easy_apply`    | `linkedin.jobs.easy_apply`    | 6     | 1 h    |
+
+### Post actions (24-hour windows)
+
+| Action type                  | Counter key            | Limit | Window |
+| ---------------------------- | ---------------------- | ----- | ------ |
+| `post.create` (all variants) | `linkedin.post.create` | 1     | 24 h   |
+| `post.edit`                  | `linkedin.post.edit`   | 10    | 24 h   |
+| `post.delete`                | `linkedin.post.delete` | 10    | 24 h   |
+
+### Publishing actions (24-hour windows)
+
+| Action type                | Counter key                         | Limit | Window |
+| -------------------------- | ----------------------------------- | ----- | ------ |
+| `article.create`           | `linkedin.article.create`           | 1     | 24 h   |
+| `article.publish`          | `linkedin.article.publish`          | 1     | 24 h   |
+| `newsletter.create`        | `linkedin.newsletter.create`        | 1     | 24 h   |
+| `newsletter.publish_issue` | `linkedin.newsletter.publish_issue` | 1     | 24 h   |
+
+### Other actions (24-hour windows)
+
+Groups, events, privacy settings, and profile actions also have per-action
+limits. See the `*_RATE_LIMIT_CONFIG` constants in each executor source file
+for exact values.
+
+## Error handling
+
+When a rate limit is exceeded, the confirm call throws a `LinkedInBuddyError`
+with code `RATE_LIMITED`:
+
+```json
+{
+  "code": "RATE_LIMITED",
+  "message": "LinkedIn send_invitation confirm is rate limited for the current window. Try again in 23h 45m.",
+  "details": {
+    "action_id": "pa_abc123",
+    "profile_name": "default",
+    "rate_limit": {
+      "counter_key": "linkedin.connections.send_invitation",
+      "window_start_ms": 1710201600000,
+      "window_size_ms": 86400000,
+      "window_ends_at_ms": 1710288000000,
+      "retry_after_ms": 85500000,
+      "count": 21,
+      "limit": 20,
+      "remaining": 0,
+      "allowed": false
+    }
+  }
+}
+```
+
+Key fields for agents and operators:
+
+- `retry_after_ms` — milliseconds until the current window resets
+- `window_ends_at_ms` — absolute timestamp when the window resets
+- `remaining` — how many actions are left in the current window (0 when blocked)
+
+The error message includes a human-readable retry hint (e.g. "Try again in
+23h 45m") when the window has not yet expired.
+
+## Prepare preview metadata
+
+Every prepare call includes a `rate_limit` block in the returned preview. This
+lets agents show the remaining quota before the operator confirms:
+
+```json
+{
+  "preview": {
+    "summary": "Send connection invitation to ...",
+    "rate_limit": {
+      "counter_key": "linkedin.connections.send_invitation",
+      "count": 5,
+      "limit": 20,
+      "remaining": 15,
+      "allowed": true,
+      "window_ends_at_ms": 1710288000000,
+      "retry_after_ms": 72000000
+    }
+  }
+}
+```
+
+## For developers
+
+### Adding rate limits to a new write action
+
+1. Define a `ConsumeRateLimitInput` constant in the executor file:
+
+   ```ts
+   const MY_ACTION_RATE_LIMIT_CONFIG = {
+     counterKey: "linkedin.my_feature.my_action",
+     windowSizeMs: 24 * 60 * 60 * 1000,
+     limit: 10,
+   } as const;
+   ```
+
+2. In the executor's `execute` callback or `beforeExecute` hook, call:
+
+   ```ts
+   consumeRateLimitOrThrow(runtime.rateLimiter, {
+     config: MY_ACTION_RATE_LIMIT_CONFIG,
+     message: createConfirmRateLimitMessage(MY_ACTION_TYPE),
+     details: { action_id: action.id, profile_name: profileName },
+   });
+   ```
+
+3. In the prepare method, include a rate-limit preview:
+   ```ts
+   rate_limit: peekRateLimitPreview(
+     this.runtime.rateLimiter,
+     MY_ACTION_RATE_LIMIT_CONFIG,
+   );
+   ```
+
+### Helper functions (`rateLimiter.ts`)
+
+| Function                          | Purpose                                                        |
+| --------------------------------- | -------------------------------------------------------------- |
+| `consumeRateLimitOrThrow()`       | Consume quota and throw `RATE_LIMITED` if exceeded             |
+| `peekRateLimitPreview()`          | Peek at quota and return formatted state for previews          |
+| `createConfirmRateLimitMessage()` | Generate standard error message from action type               |
+| `formatRateLimitState()`          | Convert `RateLimiterState` to a snake_case record              |
+| `formatRetryAfter()`              | Format milliseconds as human-readable duration (e.g. "1h 30m") |

--- a/packages/core/src/__tests__/rateLimiterTestUtils.ts
+++ b/packages/core/src/__tests__/rateLimiterTestUtils.ts
@@ -1,22 +1,32 @@
 import { vi } from "vitest";
-import type { ConsumeRateLimitInput, RateLimiterState } from "../rateLimiter.js";
+import type {
+  ConsumeRateLimitInput,
+  RateLimiterState,
+} from "../rateLimiter.js";
 
 export function createRateLimitState(
   input: ConsumeRateLimitInput,
-  overrides: Partial<RateLimiterState> = {}
+  overrides: Partial<RateLimiterState> = {},
 ): RateLimiterState {
   const count = overrides.count ?? 0;
   const limit = overrides.limit ?? input.limit;
   const remaining = overrides.remaining ?? Math.max(0, limit - count);
+  const windowStartMs = overrides.windowStartMs ?? 0;
+  const windowSizeMs = overrides.windowSizeMs ?? input.windowSizeMs;
+  const windowEndsAtMs =
+    overrides.windowEndsAtMs ?? windowStartMs + windowSizeMs;
+  const retryAfterMs = overrides.retryAfterMs ?? windowSizeMs;
 
   return {
     counterKey: overrides.counterKey ?? input.counterKey,
-    windowStartMs: overrides.windowStartMs ?? 0,
-    windowSizeMs: overrides.windowSizeMs ?? input.windowSizeMs,
+    windowStartMs,
+    windowSizeMs,
     count,
     limit,
     remaining,
-    allowed: overrides.allowed ?? count < limit
+    allowed: overrides.allowed ?? count < limit,
+    windowEndsAtMs,
+    retryAfterMs,
   };
 }
 
@@ -27,9 +37,9 @@ export function createAllowedRateLimiterStub() {
       createRateLimitState(input, {
         count: 1,
         remaining: Math.max(0, input.limit - 1),
-        allowed: true
-      })
-    )
+        allowed: true,
+      }),
+    ),
   };
 }
 
@@ -39,15 +49,15 @@ export function createBlockedRateLimiterStub() {
       createRateLimitState(input, {
         count: input.limit,
         remaining: 0,
-        allowed: false
-      })
+        allowed: false,
+      }),
     ),
     consume: vi.fn((input: ConsumeRateLimitInput) =>
       createRateLimitState(input, {
         count: input.limit + 1,
         remaining: 0,
-        allowed: false
-      })
-    )
+        allowed: false,
+      }),
+    ),
   };
 }

--- a/packages/core/src/linkedinFeed.ts
+++ b/packages/core/src/linkedinFeed.ts
@@ -8,27 +8,33 @@ import type { ConfirmFailureArtifactConfig } from "./config.js";
 import { LinkedInBuddyError, asLinkedInBuddyError } from "./errors.js";
 import {
   scrollLinkedInPageToBottom,
-  scrollLinkedInPageToTop
+  scrollLinkedInPageToTop,
 } from "./linkedinPage.js";
 import type { JsonEventLogger } from "./logging.js";
 import { validateLinkedInPostText } from "./linkedinPosts.js";
 import type { ProfileManager } from "./profileManager.js";
-import type { RateLimiter, RateLimiterState } from "./rateLimiter.js";
+import {
+  consumeRateLimitOrThrow,
+  createConfirmRateLimitMessage,
+  formatRateLimitState,
+  type RateLimiter,
+  type RateLimiterState,
+} from "./rateLimiter.js";
 import type {
   LinkedInSelectorLocale,
-  LinkedInSelectorPhraseKey
+  LinkedInSelectorPhraseKey,
 } from "./selectorLocale.js";
 import {
   buildLinkedInAriaLabelContainsSelector,
   buildLinkedInSelectorPhraseRegex,
   formatLinkedInSelectorRegexHint,
-  valueContainsLinkedInSelectorPhrase
+  valueContainsLinkedInSelectorPhrase,
 } from "./selectorLocale.js";
 import type {
   ActionExecutor,
   ActionExecutorInput,
   ActionExecutorResult,
-  TwoPhaseCommitService
+  TwoPhaseCommitService,
 } from "./twoPhaseCommit.js";
 
 export interface LinkedInFeedPost {
@@ -111,7 +117,10 @@ export interface LinkedInFeedExecutorRuntime {
 }
 
 export interface LinkedInFeedRuntime extends LinkedInFeedExecutorRuntime {
-  twoPhaseCommit: Pick<TwoPhaseCommitService<LinkedInFeedExecutorRuntime>, "prepare">;
+  twoPhaseCommit: Pick<
+    TwoPhaseCommitService<LinkedInFeedExecutorRuntime>,
+    "prepare"
+  >;
 }
 
 const LINKEDIN_FEED_URL = "https://www.linkedin.com/feed/";
@@ -129,51 +138,52 @@ export const LINKEDIN_FEED_REACTION_TYPES = [
   "support",
   "love",
   "insightful",
-  "funny"
+  "funny",
 ] as const;
 
-export type LinkedInFeedReaction = (typeof LINKEDIN_FEED_REACTION_TYPES)[number];
+export type LinkedInFeedReaction =
+  (typeof LINKEDIN_FEED_REACTION_TYPES)[number];
 
 const LIKE_RATE_LIMIT_CONFIG = {
   counterKey: "linkedin.feed.like_post",
   windowSizeMs: 60 * 60 * 1000,
-  limit: 30
+  limit: 30,
 } as const;
 
 const COMMENT_RATE_LIMIT_CONFIG = {
   counterKey: "linkedin.feed.comment_on_post",
   windowSizeMs: 60 * 60 * 1000,
-  limit: 15
+  limit: 15,
 } as const;
 
 const REPOST_RATE_LIMIT_CONFIG = {
   counterKey: "linkedin.feed.repost_post",
   windowSizeMs: 60 * 60 * 1000,
-  limit: 10
+  limit: 10,
 } as const;
 
 const SHARE_RATE_LIMIT_CONFIG = {
   counterKey: "linkedin.feed.share_post",
   windowSizeMs: 60 * 60 * 1000,
-  limit: 10
+  limit: 10,
 } as const;
 
 const SAVE_RATE_LIMIT_CONFIG = {
   counterKey: "linkedin.feed.save_post",
   windowSizeMs: 60 * 60 * 1000,
-  limit: 40
+  limit: 40,
 } as const;
 
 const UNSAVE_RATE_LIMIT_CONFIG = {
   counterKey: "linkedin.feed.unsave_post",
   windowSizeMs: 60 * 60 * 1000,
-  limit: 40
+  limit: 40,
 } as const;
 
 const REMOVE_REACTION_RATE_LIMIT_CONFIG = {
   counterKey: "linkedin.feed.remove_reaction",
   windowSizeMs: 60 * 60 * 1000,
-  limit: 30
+  limit: 30,
 } as const;
 
 interface FeedReactionUiConfig {
@@ -189,33 +199,33 @@ export const LINKEDIN_FEED_REACTION_MAP: Record<
   like: {
     label: "Like",
     menuAriaLabel: "React Like",
-    iconType: "LIKE"
+    iconType: "LIKE",
   },
   celebrate: {
     label: "Celebrate",
     menuAriaLabel: "React Celebrate",
-    iconType: "PRAISE"
+    iconType: "PRAISE",
   },
   support: {
     label: "Support",
     menuAriaLabel: "React Support",
-    iconType: "APPRECIATION"
+    iconType: "APPRECIATION",
   },
   love: {
     label: "Love",
     menuAriaLabel: "React Love",
-    iconType: "EMPATHY"
+    iconType: "EMPATHY",
   },
   insightful: {
     label: "Insightful",
     menuAriaLabel: "React Insightful",
-    iconType: "INTEREST"
+    iconType: "INTEREST",
   },
   funny: {
     label: "Funny",
     menuAriaLabel: "React Funny",
-    iconType: "ENTERTAINMENT"
-  }
+    iconType: "ENTERTAINMENT",
+  },
 };
 
 const LINKEDIN_FEED_REACTION_ALIAS_MAP: Record<string, LinkedInFeedReaction> = {
@@ -236,7 +246,7 @@ const LINKEDIN_FEED_REACTION_ALIAS_MAP: Record<string, LinkedInFeedReaction> = {
   funny: "funny",
   laugh: "funny",
   haha: "funny",
-  entertainment: "funny"
+  entertainment: "funny",
 };
 
 interface FeedPostSnapshot {
@@ -288,12 +298,15 @@ function createVerificationSnippet(text: string): string {
 }
 
 function normalizeReactionKey(value: string): string {
-  return value.trim().toLowerCase().replace(/[\s-]+/g, "_");
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
 }
 
 export function normalizeLinkedInFeedReaction(
   value: string | undefined,
-  fallback: LinkedInFeedReaction = "like"
+  fallback: LinkedInFeedReaction = "like",
 ): LinkedInFeedReaction {
   if (!value || normalizeText(value).length === 0) {
     return fallback;
@@ -310,8 +323,8 @@ export function normalizeLinkedInFeedReaction(
     `reaction must be one of: ${LINKEDIN_FEED_REACTION_TYPES.join(", ")}.`,
     {
       provided_reaction: value,
-      supported_reactions: LINKEDIN_FEED_REACTION_TYPES
-    }
+      supported_reactions: LINKEDIN_FEED_REACTION_TYPES,
+    },
   );
 }
 
@@ -324,7 +337,7 @@ function resolvePostUrl(postUrl: string): string {
   if (!trimmedPostUrl) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "postUrl is required."
+      "postUrl is required.",
     );
   }
 
@@ -336,7 +349,7 @@ function resolvePostUrl(postUrl: string): string {
       throw asLinkedInBuddyError(
         error,
         "ACTION_PRECONDITION_FAILED",
-        "Post URL must be a valid URL."
+        "Post URL must be a valid URL.",
       );
     }
 
@@ -439,7 +452,8 @@ function toAbsoluteLinkedInPostUrl(postId: string): string {
 
 function toFeedPost(snapshot: FeedPostSnapshot): LinkedInFeedPost {
   const postId = normalizeText(snapshot.post_id);
-  const postUrl = normalizeText(snapshot.post_url) || toAbsoluteLinkedInPostUrl(postId);
+  const postUrl =
+    normalizeText(snapshot.post_url) || toAbsoluteLinkedInPostUrl(postId);
 
   return {
     post_id: postId,
@@ -451,21 +465,7 @@ function toFeedPost(snapshot: FeedPostSnapshot): LinkedInFeedPost {
     reactions_count: normalizeText(snapshot.reactions_count),
     comments_count: normalizeText(snapshot.comments_count),
     reposts_count: normalizeText(snapshot.reposts_count),
-    post_url: postUrl
-  };
-}
-
-function formatRateLimitState(
-  state: RateLimiterState
-): Record<string, number | boolean | string> {
-  return {
-    counter_key: state.counterKey,
-    window_start_ms: state.windowStartMs,
-    window_size_ms: state.windowSizeMs,
-    count: state.count,
-    limit: state.limit,
-    remaining: state.remaining,
-    allowed: state.allowed
+    post_url: postUrl,
   };
 }
 
@@ -482,7 +482,7 @@ function getRequiredStringField(
   source: Record<string, unknown>,
   key: string,
   actionId: string,
-  location: "target" | "payload"
+  location: "target" | "payload",
 ): string {
   const value = source[key];
   if (typeof value === "string" && value.trim().length > 0) {
@@ -495,8 +495,8 @@ function getRequiredStringField(
     {
       action_id: actionId,
       location,
-      key
-    }
+      key,
+    },
   );
 }
 
@@ -504,7 +504,7 @@ async function captureScreenshotArtifact(
   runtime: LinkedInFeedExecutorRuntime,
   page: Page,
   relativePath: string,
-  metadata: Record<string, unknown> = {}
+  metadata: Record<string, unknown> = {},
 ): Promise<string> {
   const absolutePath = runtime.artifacts.resolve(relativePath);
   mkdirSync(path.dirname(absolutePath), { recursive: true });
@@ -518,14 +518,14 @@ async function waitForFeedSurface(page: Page): Promise<void> {
     "[data-urn]",
     ".feed-shared-update-v2",
     ".occludable-update",
-    "main"
+    "main",
   ];
 
   for (const selector of selectors) {
     try {
       await page.locator(selector).first().waitFor({
         state: "visible",
-        timeout: 5_000
+        timeout: 5_000,
       });
       return;
     } catch {
@@ -538,24 +538,19 @@ async function waitForFeedSurface(page: Page): Promise<void> {
     "Could not locate LinkedIn feed content.",
     {
       current_url: page.url(),
-      attempted_selectors: selectors
-    }
+      attempted_selectors: selectors,
+    },
   );
 }
 
 async function waitForPostSurface(page: Page): Promise<void> {
-  const selectors = [
-    "[data-urn]",
-    ".feed-shared-update-v2",
-    "article",
-    "main"
-  ];
+  const selectors = ["[data-urn]", ".feed-shared-update-v2", "article", "main"];
 
   for (const selector of selectors) {
     try {
       await page.locator(selector).first().waitFor({
         state: "visible",
-        timeout: 5_000
+        timeout: 5_000,
       });
       return;
     } catch {
@@ -568,232 +563,255 @@ async function waitForPostSurface(page: Page): Promise<void> {
     "Could not locate LinkedIn post content.",
     {
       current_url: page.url(),
-      attempted_selectors: selectors
-    }
+      attempted_selectors: selectors,
+    },
   );
 }
 
 /* eslint-disable no-undef -- DOM types are valid inside page.evaluate() */
-async function extractFeedPosts(page: Page, limit: number): Promise<LinkedInFeedPost[]> {
-  const snapshots = await page.evaluate((maxPosts: number) => {
-    const normalize = (value: string | null | undefined): string =>
-      (value ?? "").replace(/\s+/g, " ").trim();
+async function extractFeedPosts(
+  page: Page,
+  limit: number,
+): Promise<LinkedInFeedPost[]> {
+  const snapshots = await page.evaluate(
+    (maxPosts: number) => {
+      const normalize = (value: string | null | undefined): string =>
+        (value ?? "").replace(/\s+/g, " ").trim();
 
-    const toAbsoluteUrl = (href: string | null | undefined): string => {
-      const value = normalize(href);
-      if (!value) {
-        return "";
-      }
+      const toAbsoluteUrl = (href: string | null | undefined): string => {
+        const value = normalize(href);
+        if (!value) {
+          return "";
+        }
 
-      try {
-        return new URL(value, globalThis.window.location.origin).toString();
-      } catch {
-        return value;
-      }
-    };
-
-    const extractPostId = (value: string): string => {
-      const normalized = normalize(value);
-      if (!normalized) {
-        return "";
-      }
-
-      const urnMatch = /(urn:li:[^/?#]+)/i.exec(normalized);
-      if (urnMatch?.[1]) {
-        return urnMatch[1];
-      }
-
-      const updateMatch = /\/feed\/update\/([^/?#]+)/i.exec(normalized);
-      if (updateMatch?.[1]) {
         try {
-          return decodeURIComponent(updateMatch[1]);
+          return new URL(value, globalThis.window.location.origin).toString();
         } catch {
-          return updateMatch[1];
+          return value;
         }
-      }
+      };
 
-      const activityMatch = /activity[-:/](\d+)/i.exec(normalized);
-      if (activityMatch?.[1]) {
-        return activityMatch[1];
-      }
+      const extractPostId = (value: string): string => {
+        const normalized = normalize(value);
+        if (!normalized) {
+          return "";
+        }
 
-      const postMatch = /\/posts\/[^/?#-]+-(\d+)/i.exec(normalized);
-      if (postMatch?.[1]) {
-        return postMatch[1];
-      }
+        const urnMatch = /(urn:li:[^/?#]+)/i.exec(normalized);
+        if (urnMatch?.[1]) {
+          return urnMatch[1];
+        }
 
-      return normalized;
-    };
+        const updateMatch = /\/feed\/update\/([^/?#]+)/i.exec(normalized);
+        if (updateMatch?.[1]) {
+          try {
+            return decodeURIComponent(updateMatch[1]);
+          } catch {
+            return updateMatch[1];
+          }
+        }
 
-    const buildPostUrl = (postId: string): string => {
-      const normalized = normalize(postId);
-      if (!normalized) {
-        return "";
-      }
+        const activityMatch = /activity[-:/](\d+)/i.exec(normalized);
+        if (activityMatch?.[1]) {
+          return activityMatch[1];
+        }
 
-      if (/^urn:li:/i.test(normalized)) {
+        const postMatch = /\/posts\/[^/?#-]+-(\d+)/i.exec(normalized);
+        if (postMatch?.[1]) {
+          return postMatch[1];
+        }
+
+        return normalized;
+      };
+
+      const buildPostUrl = (postId: string): string => {
+        const normalized = normalize(postId);
+        if (!normalized) {
+          return "";
+        }
+
+        if (/^urn:li:/i.test(normalized)) {
+          return `https://www.linkedin.com/feed/update/${normalized}/`;
+        }
+
+        if (/^\d+$/.test(normalized)) {
+          return `https://www.linkedin.com/feed/update/urn:li:activity:${normalized}/`;
+        }
+
         return `https://www.linkedin.com/feed/update/${normalized}/`;
-      }
+      };
 
-      if (/^\d+$/.test(normalized)) {
-        return `https://www.linkedin.com/feed/update/urn:li:activity:${normalized}/`;
-      }
+      const pickText = (selectors: string[], root: ParentNode): string => {
+        for (const selector of selectors) {
+          const text = normalize(root.querySelector(selector)?.textContent);
+          if (text) {
+            return text;
+          }
+        }
+        return "";
+      };
 
-      return `https://www.linkedin.com/feed/update/${normalized}/`;
-    };
+      const pickHref = (selectors: string[], root: ParentNode): string => {
+        for (const selector of selectors) {
+          const href = (
+            root.querySelector(selector) as HTMLAnchorElement | null
+          )?.href;
+          const absolute = toAbsoluteUrl(href);
+          if (absolute) {
+            return absolute;
+          }
+        }
+        return "";
+      };
 
-    const pickText = (selectors: string[], root: ParentNode): string => {
-      for (const selector of selectors) {
-        const text = normalize(root.querySelector(selector)?.textContent);
-        if (text) {
-          return text;
+      const cardCandidates = [
+        ...Array.from(globalThis.document.querySelectorAll("[data-urn]")),
+        ...Array.from(
+          globalThis.document.querySelectorAll("div.feed-shared-update-v2"),
+        ),
+        ...Array.from(
+          globalThis.document.querySelectorAll("div.occludable-update"),
+        ),
+        ...Array.from(
+          globalThis.document.querySelectorAll("article.feed-shared-update-v2"),
+        ),
+      ];
+
+      const uniqueCards: Element[] = [];
+      const seenCards = new Set<Element>();
+      for (const candidate of cardCandidates) {
+        const root =
+          candidate.closest(
+            "div[data-urn], div.feed-shared-update-v2, div.occludable-update, article.feed-shared-update-v2, li",
+          ) ?? candidate;
+        if (seenCards.has(root)) {
+          continue;
+        }
+        seenCards.add(root);
+        uniqueCards.push(root);
+        if (uniqueCards.length >= maxPosts * 4) {
+          break;
         }
       }
-      return "";
-    };
 
-    const pickHref = (selectors: string[], root: ParentNode): string => {
-      for (const selector of selectors) {
-        const href = (root.querySelector(selector) as HTMLAnchorElement | null)?.href;
-        const absolute = toAbsoluteUrl(href);
-        if (absolute) {
-          return absolute;
+      const results: FeedPostSnapshot[] = [];
+      for (const card of uniqueCards) {
+        const actorRoot =
+          card.querySelector(
+            ".update-components-actor, .feed-shared-actor, .feed-shared-actor__container",
+          ) ?? card;
+
+        const urn =
+          normalize(card.getAttribute("data-urn")) ||
+          normalize(card.querySelector("[data-urn]")?.getAttribute("data-urn"));
+
+        const postUrl = pickHref(
+          [
+            "a[href*='/feed/update/']",
+            "a[href*='/posts/']",
+            "a[href*='activity-']",
+          ],
+          card,
+        );
+        const postId = extractPostId(urn || postUrl);
+        if (!postId && !postUrl) {
+          continue;
+        }
+
+        const postedAtText = pickText(
+          [
+            ".update-components-actor__sub-description span[aria-hidden='true']",
+            ".update-components-actor__sub-description",
+            ".feed-shared-actor__sub-description",
+            ".feed-shared-actor__sub-description-link",
+            ".update-components-actor__meta-link",
+          ],
+          actorRoot,
+        );
+
+        const timeElement = card.querySelector("time");
+        const postedAt =
+          normalize(timeElement?.textContent) ||
+          normalize(timeElement?.getAttribute("datetime")) ||
+          postedAtText;
+
+        const text = pickText(
+          [
+            ".feed-shared-update-v2__description-wrapper .break-words",
+            ".feed-shared-update-v2__description",
+            ".update-components-text span[dir='ltr']",
+            ".update-components-text",
+            ".break-words",
+          ],
+          card,
+        );
+
+        const reactions = pickText(
+          [
+            ".social-details-social-counts__reactions-count",
+            ".social-details-social-counts__social-proof-text",
+          ],
+          card,
+        );
+        const comments = pickText(
+          [".social-details-social-counts__comments"],
+          card,
+        );
+        const reposts = pickText(
+          [".social-details-social-counts__reposts"],
+          card,
+        );
+
+        const authorName = pickText(
+          [
+            ".update-components-actor__name",
+            ".feed-shared-actor__name",
+            ".update-components-actor__title span[aria-hidden='true']",
+          ],
+          actorRoot,
+        );
+
+        const authorHeadline = pickText(
+          [
+            ".update-components-actor__description",
+            ".feed-shared-actor__description",
+          ],
+          actorRoot,
+        );
+
+        const authorProfileUrl = pickHref(["a[href*='/in/']"], actorRoot);
+
+        results.push({
+          post_id: postId,
+          author_name: authorName,
+          author_headline: authorHeadline,
+          author_profile_url: authorProfileUrl,
+          posted_at: postedAt,
+          text,
+          reactions_count: reactions,
+          comments_count: comments,
+          reposts_count: reposts,
+          post_url: postUrl || buildPostUrl(postId),
+        });
+
+        if (results.length >= maxPosts) {
+          break;
         }
       }
-      return "";
-    };
 
-    const cardCandidates = [
-      ...Array.from(globalThis.document.querySelectorAll("[data-urn]")),
-      ...Array.from(globalThis.document.querySelectorAll("div.feed-shared-update-v2")),
-      ...Array.from(globalThis.document.querySelectorAll("div.occludable-update")),
-      ...Array.from(globalThis.document.querySelectorAll("article.feed-shared-update-v2"))
-    ];
-
-    const uniqueCards: Element[] = [];
-    const seenCards = new Set<Element>();
-    for (const candidate of cardCandidates) {
-      const root =
-        candidate.closest(
-          "div[data-urn], div.feed-shared-update-v2, div.occludable-update, article.feed-shared-update-v2, li"
-        ) ?? candidate;
-      if (seenCards.has(root)) {
-        continue;
-      }
-      seenCards.add(root);
-      uniqueCards.push(root);
-      if (uniqueCards.length >= maxPosts * 4) {
-        break;
-      }
-    }
-
-    const results: FeedPostSnapshot[] = [];
-    for (const card of uniqueCards) {
-      const actorRoot =
-        card.querySelector(
-          ".update-components-actor, .feed-shared-actor, .feed-shared-actor__container"
-        ) ?? card;
-
-      const urn =
-        normalize(card.getAttribute("data-urn")) ||
-        normalize(card.querySelector("[data-urn]")?.getAttribute("data-urn"));
-
-      const postUrl = pickHref(
-        [
-          "a[href*='/feed/update/']",
-          "a[href*='/posts/']",
-          "a[href*='activity-']"
-        ],
-        card
-      );
-      const postId = extractPostId(urn || postUrl);
-      if (!postId && !postUrl) {
-        continue;
-      }
-
-      const postedAtText = pickText(
-        [
-          ".update-components-actor__sub-description span[aria-hidden='true']",
-          ".update-components-actor__sub-description",
-          ".feed-shared-actor__sub-description",
-          ".feed-shared-actor__sub-description-link",
-          ".update-components-actor__meta-link"
-        ],
-        actorRoot
-      );
-
-      const timeElement = card.querySelector("time");
-      const postedAt =
-        normalize(timeElement?.textContent) ||
-        normalize(timeElement?.getAttribute("datetime")) ||
-        postedAtText;
-
-      const text = pickText(
-        [
-          ".feed-shared-update-v2__description-wrapper .break-words",
-          ".feed-shared-update-v2__description",
-          ".update-components-text span[dir='ltr']",
-          ".update-components-text",
-          ".break-words"
-        ],
-        card
-      );
-
-      const reactions = pickText(
-        [
-          ".social-details-social-counts__reactions-count",
-          ".social-details-social-counts__social-proof-text"
-        ],
-        card
-      );
-      const comments = pickText([".social-details-social-counts__comments"], card);
-      const reposts = pickText([".social-details-social-counts__reposts"], card);
-
-      const authorName = pickText(
-        [
-          ".update-components-actor__name",
-          ".feed-shared-actor__name",
-          ".update-components-actor__title span[aria-hidden='true']"
-        ],
-        actorRoot
-      );
-
-      const authorHeadline = pickText(
-        [
-          ".update-components-actor__description",
-          ".feed-shared-actor__description"
-        ],
-        actorRoot
-      );
-
-      const authorProfileUrl = pickHref(["a[href*='/in/']"], actorRoot);
-
-      results.push({
-        post_id: postId,
-        author_name: authorName,
-        author_headline: authorHeadline,
-        author_profile_url: authorProfileUrl,
-        posted_at: postedAt,
-        text,
-        reactions_count: reactions,
-        comments_count: comments,
-        reposts_count: reposts,
-        post_url: postUrl || buildPostUrl(postId)
-      });
-
-      if (results.length >= maxPosts) {
-        break;
-      }
-    }
-
-    return results;
-  }, Math.max(1, limit));
+      return results;
+    },
+    Math.max(1, limit),
+  );
 
   return snapshots.map(toFeedPost);
 }
 /* eslint-enable no-undef */
 
-async function loadFeedPosts(page: Page, limit: number): Promise<LinkedInFeedPost[]> {
+async function loadFeedPosts(
+  page: Page,
+  limit: number,
+): Promise<LinkedInFeedPost[]> {
   let posts = await extractFeedPosts(page, limit);
 
   for (let i = 0; i < 6 && posts.length < limit; i++) {
@@ -805,7 +823,10 @@ async function loadFeedPosts(page: Page, limit: number): Promise<LinkedInFeedPos
   return posts.slice(0, Math.max(1, limit));
 }
 
-function findMatchingPost(posts: LinkedInFeedPost[], postUrl: string): LinkedInFeedPost | null {
+function findMatchingPost(
+  posts: LinkedInFeedPost[],
+  postUrl: string,
+): LinkedInFeedPost | null {
   const requestedIdentity = extractPostIdentity(postUrl);
   if (!requestedIdentity) {
     return posts[0] ?? null;
@@ -829,7 +850,7 @@ function findMatchingPost(posts: LinkedInFeedPost[], postUrl: string): LinkedInF
 async function findVisibleLocatorOrThrow(
   page: Page,
   candidates: SelectorCandidate[],
-  selectorKey: string
+  selectorKey: string,
 ): Promise<{ locator: Locator; key: string }> {
   for (const candidate of candidates) {
     const locator = candidate.locatorFactory(page).first();
@@ -837,7 +858,7 @@ async function findVisibleLocatorOrThrow(
       await locator.waitFor({ state: "visible", timeout: 2_500 });
       return {
         locator,
-        key: candidate.key
+        key: candidate.key,
       };
     } catch {
       // Try next selector candidate.
@@ -850,21 +871,23 @@ async function findVisibleLocatorOrThrow(
     {
       selector_key: selectorKey,
       current_url: page.url(),
-      attempted_selectors: candidates.map((candidate) => candidate.selectorHint)
-    }
+      attempted_selectors: candidates.map(
+        (candidate) => candidate.selectorHint,
+      ),
+    },
   );
 }
 
 async function findVisibleLocator(
   page: Page,
-  candidates: SelectorCandidate[]
+  candidates: SelectorCandidate[],
 ): Promise<{ locator: Locator; key: string } | null> {
   for (const candidate of candidates) {
     const locator = candidate.locatorFactory(page).first();
     if (await isLocatorVisible(locator)) {
       return {
         locator,
-        key: candidate.key
+        key: candidate.key,
       };
     }
   }
@@ -876,7 +899,7 @@ async function findVisibleScopedLocatorOrThrow(
   root: Locator,
   candidates: ScopedSelectorCandidate[],
   selectorKey: string,
-  currentUrl: string
+  currentUrl: string,
 ): Promise<{ locator: Locator; key: string }> {
   for (const candidate of candidates) {
     const locator = candidate.locatorFactory(root).first();
@@ -884,7 +907,7 @@ async function findVisibleScopedLocatorOrThrow(
       await locator.waitFor({ state: "visible", timeout: 2_500 });
       return {
         locator,
-        key: candidate.key
+        key: candidate.key,
       };
     } catch {
       // Try next selector candidate.
@@ -897,22 +920,26 @@ async function findVisibleScopedLocatorOrThrow(
     {
       selector_key: selectorKey,
       current_url: currentUrl,
-      attempted_selectors: candidates.map((candidate) => candidate.selectorHint)
-    }
+      attempted_selectors: candidates.map(
+        (candidate) => candidate.selectorHint,
+      ),
+    },
   );
 }
 
 async function waitForNetworkIdleBestEffort(
   page: Page,
-  timeoutMs: number = 8_000
+  timeoutMs: number = 8_000,
 ): Promise<void> {
-  await page.waitForLoadState("networkidle", { timeout: timeoutMs }).catch(() => undefined);
+  await page
+    .waitForLoadState("networkidle", { timeout: timeoutMs })
+    .catch(() => undefined);
 }
 
 async function waitForCondition(
   condition: () => Promise<boolean>,
   timeoutMs: number,
-  intervalMs = 250
+  intervalMs = 250,
 ): Promise<boolean> {
   const deadline = Date.now() + Math.max(0, timeoutMs);
   while (Date.now() < deadline) {
@@ -935,7 +962,10 @@ async function isLocatorVisible(locator: Locator): Promise<boolean> {
   }
 }
 
-async function isAnyLocatorVisible(locator: Locator, maxChecks = 3): Promise<boolean> {
+async function isAnyLocatorVisible(
+  locator: Locator,
+  maxChecks = 3,
+): Promise<boolean> {
   const count = await locator.count();
   const checks = Math.min(count, maxChecks);
   for (let index = 0; index < checks; index += 1) {
@@ -963,12 +993,12 @@ const REACTION_SELECTOR_KEYS: Record<
   support: "support",
   love: "love",
   insightful: "insightful",
-  funny: "funny"
+  funny: "funny",
 };
 
 function inferReactionFromText(
   value: string,
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): LinkedInFeedReaction | null {
   const normalized = normalizeText(value).toLowerCase();
   if (!normalized) {
@@ -981,7 +1011,7 @@ function inferReactionFromText(
       valueContainsLinkedInSelectorPhrase(
         normalized,
         REACTION_SELECTOR_KEYS[reaction],
-        selectorLocale
+        selectorLocale,
       )
     ) {
       return reaction;
@@ -996,12 +1026,16 @@ function inferReactionFromText(
 
 async function getReactionButtonState(
   reactButton: Locator,
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): Promise<ReactionButtonState> {
-  const ariaPressed = normalizeText(await reactButton.getAttribute("aria-pressed")).toLowerCase();
+  const ariaPressed = normalizeText(
+    await reactButton.getAttribute("aria-pressed"),
+  ).toLowerCase();
   const className = normalizeText(await reactButton.getAttribute("class"));
   const ariaLabel = normalizeText(await reactButton.getAttribute("aria-label"));
-  const buttonText = normalizeText(await reactButton.innerText().catch(() => ""));
+  const buttonText = normalizeText(
+    await reactButton.innerText().catch(() => ""),
+  );
 
   const reacted =
     ariaPressed === "true" ||
@@ -1016,14 +1050,14 @@ async function getReactionButtonState(
     reaction: reactionFromLabel ?? reactionFromText,
     ariaLabel,
     className,
-    buttonText
+    buttonText,
   };
 }
 
 async function isDesiredReactionActive(
   reactButton: Locator,
   desiredReaction: LinkedInFeedReaction,
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): Promise<boolean> {
   const state = await getReactionButtonState(reactButton, selectorLocale);
   if (!state.reacted) {
@@ -1042,37 +1076,40 @@ async function selectReactionFromMenu(
   page: Page,
   reactButton: Locator,
   reaction: LinkedInFeedReaction,
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): Promise<string> {
   const reactionKey = REACTION_SELECTOR_KEYS[reaction];
   const reactionLabelRegex = buildLinkedInSelectorPhraseRegex(
     reactionKey,
     selectorLocale,
-    { exact: true }
+    { exact: true },
   );
   const reactionLabelRegexHint = formatLinkedInSelectorRegexHint(
     reactionKey,
     selectorLocale,
-    { exact: true }
+    { exact: true },
   );
   const reactionAriaSelector = buildLinkedInAriaLabelContainsSelector(
     "button.reactions-menu__reaction-index",
     reactionKey,
-    selectorLocale
+    selectorLocale,
   );
   const reactionFallbackAriaSelector = buildLinkedInAriaLabelContainsSelector(
     "button",
     reactionKey,
-    selectorLocale
+    selectorLocale,
   );
   await reactButton.hover({ timeout: 5_000 });
 
   const menu = page.locator("span.reactions-menu--active").first();
-  const menuVisible = await waitForCondition(async () => isLocatorVisible(menu), 3_500);
+  const menuVisible = await waitForCondition(
+    async () => isLocatorVisible(menu),
+    3_500,
+  );
   if (!menuVisible) {
     throw new LinkedInBuddyError(
       "UI_CHANGED_SELECTOR_FAILED",
-      "Could not open LinkedIn reaction menu for the selected post."
+      "Could not open LinkedIn reaction menu for the selected post.",
     );
   }
 
@@ -1083,41 +1120,45 @@ async function selectReactionFromMenu(
       locatorFactory: () =>
         menu
           .locator("button.reactions-menu__reaction-index")
-          .filter({ hasText: reactionLabelRegex })
+          .filter({ hasText: reactionLabelRegex }),
     },
     {
       key: "menu-reaction-aria",
       selectorHint: reactionAriaSelector,
-      locatorFactory: () => menu.locator(reactionAriaSelector)
+      locatorFactory: () => menu.locator(reactionAriaSelector),
     },
     {
       key: "menu-reaction-fallback",
       selectorHint: reactionFallbackAriaSelector,
-      locatorFactory: () => menu.locator(reactionFallbackAriaSelector)
-    }
+      locatorFactory: () => menu.locator(reactionFallbackAriaSelector),
+    },
   ];
 
-  const reactionButton = await findVisibleLocatorOrThrow(page, candidateButtons, "reaction_menu_button");
+  const reactionButton = await findVisibleLocatorOrThrow(
+    page,
+    candidateButtons,
+    "reaction_menu_button",
+  );
   await reactionButton.locator.click({ timeout: 5_000 });
   return reactionButton.key;
 }
 
 function createReactionButtonCandidates(
   postRoot: Locator,
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): SelectorCandidate[] {
   const likeOrReactRegex = buildLinkedInSelectorPhraseRegex(
     ["like", "react"],
-    selectorLocale
+    selectorLocale,
   );
   const likeOrReactRegexHint = formatLinkedInSelectorRegexHint(
     ["like", "react"],
-    selectorLocale
+    selectorLocale,
   );
   const likeReactAriaSelector = buildLinkedInAriaLabelContainsSelector(
     "button",
     ["like", "react", "reaction"],
-    selectorLocale
+    selectorLocale,
   );
 
   return [
@@ -1125,62 +1166,64 @@ function createReactionButtonCandidates(
       key: "post-social-action-like",
       selectorHint: "button.social-actions-button.react-button__trigger",
       locatorFactory: () =>
-        postRoot.locator("button.social-actions-button.react-button__trigger")
+        postRoot.locator("button.social-actions-button.react-button__trigger"),
     },
     {
       key: "post-react-button",
       selectorHint: "button.react-button__trigger",
-      locatorFactory: () => postRoot.locator("button.react-button__trigger")
+      locatorFactory: () => postRoot.locator("button.react-button__trigger"),
     },
     {
       key: "post-aria-like-button",
       selectorHint: likeReactAriaSelector,
-      locatorFactory: () => postRoot.locator(likeReactAriaSelector)
+      locatorFactory: () => postRoot.locator(likeReactAriaSelector),
     },
     {
       key: "post-role-button-like",
       selectorHint: `getByRole(button, ${likeOrReactRegexHint})`,
       locatorFactory: () =>
         postRoot.getByRole("button", {
-          name: likeOrReactRegex
-        })
-    }
+          name: likeOrReactRegex,
+        }),
+    },
   ];
 }
 
 async function resolveReactionButton(
   page: Page,
   postRoot: Locator,
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): Promise<{ locator: Locator; key: string }> {
   return findVisibleLocatorOrThrow(
     page,
     createReactionButtonCandidates(postRoot, selectorLocale),
-    "reaction_button"
+    "reaction_button",
   );
 }
 
 function createPostActionButtonCandidates(input: {
   postRoot: Locator;
   selectorLocale: LinkedInSelectorLocale;
-  selectorKeys: LinkedInSelectorPhraseKey | readonly LinkedInSelectorPhraseKey[];
+  selectorKeys:
+    | LinkedInSelectorPhraseKey
+    | readonly LinkedInSelectorPhraseKey[];
   candidateKeyPrefix: string;
   exact?: boolean;
 }): SelectorCandidate[] {
   const labelRegex = buildLinkedInSelectorPhraseRegex(
     input.selectorKeys,
     input.selectorLocale,
-    input.exact ? { exact: true } : {}
+    input.exact ? { exact: true } : {},
   );
   const labelRegexHint = formatLinkedInSelectorRegexHint(
     input.selectorKeys,
     input.selectorLocale,
-    input.exact ? { exact: true } : {}
+    input.exact ? { exact: true } : {},
   );
   const ariaSelector = buildLinkedInAriaLabelContainsSelector(
     ["button", "[role='button']"],
     input.selectorKeys,
-    input.selectorLocale
+    input.selectorLocale,
   );
 
   return [
@@ -1189,13 +1232,13 @@ function createPostActionButtonCandidates(input: {
       selectorHint: `post.getByRole(button, ${labelRegexHint})`,
       locatorFactory: () =>
         input.postRoot.getByRole("button", {
-          name: labelRegex
-        })
+          name: labelRegex,
+        }),
     },
     {
       key: `${input.candidateKeyPrefix}-post-aria`,
       selectorHint: `post ${ariaSelector}`,
-      locatorFactory: () => input.postRoot.locator(ariaSelector)
+      locatorFactory: () => input.postRoot.locator(ariaSelector),
     },
     {
       key: `${input.candidateKeyPrefix}-post-text`,
@@ -1203,14 +1246,16 @@ function createPostActionButtonCandidates(input: {
       locatorFactory: () =>
         input.postRoot
           .locator("button, [role='button']")
-          .filter({ hasText: labelRegex })
-    }
+          .filter({ hasText: labelRegex }),
+    },
   ];
 }
 
 function createPageMenuActionCandidates(input: {
   selectorLocale: LinkedInSelectorLocale;
-  selectorKeys: LinkedInSelectorPhraseKey | readonly LinkedInSelectorPhraseKey[];
+  selectorKeys:
+    | LinkedInSelectorPhraseKey
+    | readonly LinkedInSelectorPhraseKey[];
   candidateKeyPrefix: string;
   exact?: boolean;
 }): SelectorCandidate[] {
@@ -1220,42 +1265,47 @@ function createPageMenuActionCandidates(input: {
   const labelRegex = buildLinkedInSelectorPhraseRegex(
     selectorKeys,
     input.selectorLocale,
-    input.exact ? { exact: true } : {}
+    input.exact ? { exact: true } : {},
   );
   const labelRegexHint = formatLinkedInSelectorRegexHint(
     selectorKeys,
     input.selectorLocale,
-    input.exact ? { exact: true } : {}
+    input.exact ? { exact: true } : {},
   );
   const ariaSelector = buildLinkedInAriaLabelContainsSelector(
     ["[role='menuitem']", "button", "[role='button']", "li"],
     selectorKeys,
-    input.selectorLocale
+    input.selectorLocale,
   );
-  const fixtureMenuActions = [...new Set(
-    selectorKeys.flatMap((selectorKey) => {
-      switch (selectorKey) {
-        case "repost":
-        case "save":
-        case "share":
-        case "unsave":
-          return [selectorKey];
-        default:
-          return [];
-      }
-    })
-  )];
-  const fixtureMenuActionCandidates = fixtureMenuActions.map((menuAction) => ({
-    key: `${input.candidateKeyPrefix}-fixture-action-${menuAction}`,
-    selectorHint:
-      `.feed-post-actions-menu [data-menu-action="${menuAction}"], ` +
-      `.repost-actions-menu [data-menu-action="${menuAction}"]`,
-    locatorFactory: (page: Page) =>
-      page.locator(
-        `.feed-post-actions-menu [data-menu-action="${menuAction}"], ` +
-          `.repost-actions-menu [data-menu-action="${menuAction}"]`
-      )
-  } satisfies SelectorCandidate));
+  const fixtureMenuActions = [
+    ...new Set(
+      selectorKeys.flatMap((selectorKey) => {
+        switch (selectorKey) {
+          case "repost":
+          case "save":
+          case "share":
+          case "unsave":
+            return [selectorKey];
+          default:
+            return [];
+        }
+      }),
+    ),
+  ];
+  const fixtureMenuActionCandidates = fixtureMenuActions.map(
+    (menuAction) =>
+      ({
+        key: `${input.candidateKeyPrefix}-fixture-action-${menuAction}`,
+        selectorHint:
+          `.feed-post-actions-menu [data-menu-action="${menuAction}"], ` +
+          `.repost-actions-menu [data-menu-action="${menuAction}"]`,
+        locatorFactory: (page: Page) =>
+          page.locator(
+            `.feed-post-actions-menu [data-menu-action="${menuAction}"], ` +
+              `.repost-actions-menu [data-menu-action="${menuAction}"]`,
+          ),
+      }) satisfies SelectorCandidate,
+  );
 
   return [
     {
@@ -1263,8 +1313,8 @@ function createPageMenuActionCandidates(input: {
       selectorHint: `page.getByRole(menuitem, ${labelRegexHint})`,
       locatorFactory: (page) =>
         page.getByRole("menuitem", {
-          name: labelRegex
-        })
+          name: labelRegex,
+        }),
     },
     ...fixtureMenuActionCandidates,
     {
@@ -1272,8 +1322,8 @@ function createPageMenuActionCandidates(input: {
       selectorHint: `page.getByRole(button, ${labelRegexHint})`,
       locatorFactory: (page) =>
         page.getByRole("button", {
-          name: labelRegex
-        })
+          name: labelRegex,
+        }),
     },
     {
       key: `${input.candidateKeyPrefix}-dropdown-text`,
@@ -1281,9 +1331,9 @@ function createPageMenuActionCandidates(input: {
       locatorFactory: (page) =>
         page
           .locator(
-            ".artdeco-dropdown__content-inner [role='menuitem'], .artdeco-dropdown__content-inner [role='button'], .artdeco-dropdown__content-inner button, .artdeco-dropdown__content-inner li, [role='dialog'] [role='menuitem'], [role='dialog'] button, .feed-post-actions-menu [role='menuitem'], .feed-post-actions-menu button"
+            ".artdeco-dropdown__content-inner [role='menuitem'], .artdeco-dropdown__content-inner [role='button'], .artdeco-dropdown__content-inner button, .artdeco-dropdown__content-inner li, [role='dialog'] [role='menuitem'], [role='dialog'] button, .feed-post-actions-menu [role='menuitem'], .feed-post-actions-menu button",
           )
-          .filter({ hasText: labelRegex })
+          .filter({ hasText: labelRegex }),
     },
     {
       key: `${input.candidateKeyPrefix}-generic-text`,
@@ -1291,20 +1341,20 @@ function createPageMenuActionCandidates(input: {
       locatorFactory: (page) =>
         page
           .locator("[role='menuitem'], button, [role='button'], li")
-          .filter({ hasText: labelRegex })
+          .filter({ hasText: labelRegex }),
     },
     {
       key: `${input.candidateKeyPrefix}-aria`,
       selectorHint: ariaSelector,
-      locatorFactory: (page) => page.locator(ariaSelector)
-    }
+      locatorFactory: (page) => page.locator(ariaSelector),
+    },
   ];
 }
 
 async function openPostMoreActionsMenu(
   page: Page,
   postRoot: Locator,
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): Promise<{ locator: Locator; key: string }> {
   const moreButton = await findVisibleLocatorOrThrow(
     page,
@@ -1312,16 +1362,17 @@ async function openPostMoreActionsMenu(
       {
         key: "post-more-menu-trigger",
         selectorHint: "button.feed-shared-control-menu__trigger",
-        locatorFactory: () => postRoot.locator("button.feed-shared-control-menu__trigger")
+        locatorFactory: () =>
+          postRoot.locator("button.feed-shared-control-menu__trigger"),
       },
       ...createPostActionButtonCandidates({
         postRoot,
         selectorLocale,
         selectorKeys: ["more_actions", "more"],
-        candidateKeyPrefix: "post-more"
-      })
+        candidateKeyPrefix: "post-more",
+      }),
     ],
-    "feed_post_more_actions_button"
+    "feed_post_more_actions_button",
   );
 
   await moreButton.locator.click({ timeout: 5_000 });
@@ -1333,30 +1384,39 @@ async function clickPostMoreMenuAction(input: {
   page: Page;
   postRoot: Locator;
   selectorLocale: LinkedInSelectorLocale;
-  selectorKeys: LinkedInSelectorPhraseKey | readonly LinkedInSelectorPhraseKey[];
+  selectorKeys:
+    | LinkedInSelectorPhraseKey
+    | readonly LinkedInSelectorPhraseKey[];
   candidateKeyPrefix: string;
   selectorKey: string;
 }): Promise<string> {
   const menuActionCandidates = createPageMenuActionCandidates({
     selectorLocale: input.selectorLocale,
     selectorKeys: input.selectorKeys,
-    candidateKeyPrefix: input.candidateKeyPrefix
+    candidateKeyPrefix: input.candidateKeyPrefix,
   });
-  const existingMenuAction = await findVisibleLocator(input.page, menuActionCandidates);
+  const existingMenuAction = await findVisibleLocator(
+    input.page,
+    menuActionCandidates,
+  );
 
   let triggerKey = "feed-menu-already-open";
   if (!existingMenuAction) {
     const moreButton = await openPostMoreActionsMenu(
       input.page,
       input.postRoot,
-      input.selectorLocale
+      input.selectorLocale,
     );
     triggerKey = moreButton.key;
   }
 
   const menuAction =
     existingMenuAction ??
-    (await findVisibleLocatorOrThrow(input.page, menuActionCandidates, input.selectorKey));
+    (await findVisibleLocatorOrThrow(
+      input.page,
+      menuActionCandidates,
+      input.selectorKey,
+    ));
 
   await menuAction.locator.click({ timeout: 5_000 });
   return `${triggerKey}:${menuAction.key}`;
@@ -1365,7 +1425,7 @@ async function clickPostMoreMenuAction(input: {
 async function readPostSavedState(
   page: Page,
   postRoot: Locator,
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): Promise<boolean | null> {
   await openPostMoreActionsMenu(page, postRoot, selectorLocale);
 
@@ -1374,8 +1434,8 @@ async function readPostSavedState(
     createPageMenuActionCandidates({
       selectorLocale,
       selectorKeys: "unsave",
-      candidateKeyPrefix: "feed-unsave"
-    })
+      candidateKeyPrefix: "feed-unsave",
+    }),
   );
   if (unsaveAction) {
     await page.keyboard.press("Escape").catch(() => undefined);
@@ -1387,8 +1447,8 @@ async function readPostSavedState(
     createPageMenuActionCandidates({
       selectorLocale,
       selectorKeys: "save",
-      candidateKeyPrefix: "feed-save"
-    })
+      candidateKeyPrefix: "feed-save",
+    }),
   );
   if (saveAction) {
     await page.keyboard.press("Escape").catch(() => undefined);
@@ -1401,41 +1461,48 @@ async function readPostSavedState(
 
 function createRepostButtonCandidates(
   postRoot: Locator,
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): SelectorCandidate[] {
   return [
     {
       key: "post-social-action-repost",
       selectorHint: "button.social-actions-button.repost-button",
-      locatorFactory: () => postRoot.locator("button.social-actions-button.repost-button")
+      locatorFactory: () =>
+        postRoot.locator("button.social-actions-button.repost-button"),
     },
     ...createPostActionButtonCandidates({
       postRoot,
       selectorLocale,
       selectorKeys: ["repost", "share"],
-      candidateKeyPrefix: "feed-repost"
-    })
+      candidateKeyPrefix: "feed-repost",
+    }),
   ];
 }
 
 async function resolveRepostButton(
   page: Page,
   postRoot: Locator,
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): Promise<{ locator: Locator; key: string }> {
   return findVisibleLocatorOrThrow(
     page,
     createRepostButtonCandidates(postRoot, selectorLocale),
-    "feed_repost_button"
+    "feed_repost_button",
   );
 }
 
 async function getRepostButtonState(
-  repostButton: Locator
+  repostButton: Locator,
 ): Promise<PostRepostButtonState> {
-  const ariaLabel = normalizeText(await repostButton.getAttribute("aria-label"));
-  const ariaPressed = normalizeText(await repostButton.getAttribute("aria-pressed")).toLowerCase();
-  const buttonText = normalizeText(await repostButton.innerText().catch(() => ""));
+  const ariaLabel = normalizeText(
+    await repostButton.getAttribute("aria-label"),
+  );
+  const ariaPressed = normalizeText(
+    await repostButton.getAttribute("aria-pressed"),
+  ).toLowerCase();
+  const buttonText = normalizeText(
+    await repostButton.innerText().catch(() => ""),
+  );
   const className = normalizeText(await repostButton.getAttribute("class"));
 
   const reposted =
@@ -1448,7 +1515,7 @@ async function getRepostButtonState(
     ariaLabel,
     ariaPressed,
     buttonText,
-    className
+    className,
   };
 }
 
@@ -1461,14 +1528,16 @@ async function selectRepostMenuAction(input: {
   page: Page;
   postRoot: Locator;
   selectorLocale: LinkedInSelectorLocale;
-  selectorKeys: LinkedInSelectorPhraseKey | readonly LinkedInSelectorPhraseKey[];
+  selectorKeys:
+    | LinkedInSelectorPhraseKey
+    | readonly LinkedInSelectorPhraseKey[];
   candidateKeyPrefix: string;
   selectorKey: string;
 }): Promise<string> {
   const repostButton = await resolveRepostButton(
     input.page,
     input.postRoot,
-    input.selectorLocale
+    input.selectorLocale,
   );
   await repostButton.locator.click({ timeout: 5_000 });
   await input.page.waitForTimeout(600);
@@ -1478,9 +1547,9 @@ async function selectRepostMenuAction(input: {
     createPageMenuActionCandidates({
       selectorLocale: input.selectorLocale,
       selectorKeys: input.selectorKeys,
-      candidateKeyPrefix: input.candidateKeyPrefix
+      candidateKeyPrefix: input.candidateKeyPrefix,
     }),
-    input.selectorKey
+    input.selectorKey,
   );
 
   await menuAction.locator.click({ timeout: 5_000 });
@@ -1488,25 +1557,25 @@ async function selectRepostMenuAction(input: {
 }
 
 function createComposerRootCandidates(
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): SelectorCandidate[] {
   const postExactRegex = buildLinkedInSelectorPhraseRegex(
     "post",
     selectorLocale,
-    { exact: true }
+    { exact: true },
   );
   const postExactRegexHint = formatLinkedInSelectorRegexHint(
     "post",
     selectorLocale,
-    { exact: true }
+    { exact: true },
   );
   const composerPromptRegex = buildLinkedInSelectorPhraseRegex(
     "what_do_you_want_to_talk_about",
-    selectorLocale
+    selectorLocale,
   );
   const composerPromptRegexHint = formatLinkedInSelectorRegexHint(
     "what_do_you_want_to_talk_about",
-    selectorLocale
+    selectorLocale,
   );
 
   return [
@@ -1516,7 +1585,7 @@ function createComposerRootCandidates(
       locatorFactory: (page) =>
         page
           .locator("[role='dialog']")
-          .filter({ has: page.locator("[contenteditable='true'], textarea") })
+          .filter({ has: page.locator("[contenteditable='true'], textarea") }),
     },
     {
       key: "dialog-with-post-button",
@@ -1524,7 +1593,7 @@ function createComposerRootCandidates(
       locatorFactory: (page) =>
         page
           .locator("[role='dialog']")
-          .filter({ has: page.getByRole("button", { name: postExactRegex }) })
+          .filter({ has: page.getByRole("button", { name: postExactRegex }) }),
     },
     {
       key: "dialog-with-prompt",
@@ -1532,27 +1601,29 @@ function createComposerRootCandidates(
       locatorFactory: (page) =>
         page
           .locator("[role='dialog']")
-          .filter({ has: page.getByText(composerPromptRegex) })
+          .filter({ has: page.getByText(composerPromptRegex) }),
     },
     {
       key: "share-box-open",
       selectorHint: ".share-box__open, .share-creation-state, .composer-dialog",
       locatorFactory: (page) =>
-        page.locator(".share-box__open, .share-creation-state, .composer-dialog")
-    }
+        page.locator(
+          ".share-box__open, .share-creation-state, .composer-dialog",
+        ),
+    },
   ];
 }
 
 function createComposerInputCandidates(
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): ScopedSelectorCandidate[] {
   const composerInputRegex = buildLinkedInSelectorPhraseRegex(
     ["what_do_you_want_to_talk_about", "start_post"],
-    selectorLocale
+    selectorLocale,
   );
   const composerInputRegexHint = formatLinkedInSelectorRegexHint(
     ["what_do_you_want_to_talk_about", "start_post"],
-    selectorLocale
+    selectorLocale,
   );
 
   return [
@@ -1561,62 +1632,65 @@ function createComposerInputCandidates(
       selectorHint: `getByRole(textbox, ${composerInputRegexHint})`,
       locatorFactory: (root) =>
         root.getByRole("textbox", {
-          name: composerInputRegex
-        })
+          name: composerInputRegex,
+        }),
     },
     {
       key: "ql-editor",
       selectorHint: ".ql-editor[contenteditable='true']",
-      locatorFactory: (root) => root.locator(".ql-editor[contenteditable='true']")
+      locatorFactory: (root) =>
+        root.locator(".ql-editor[contenteditable='true']"),
     },
     {
       key: "contenteditable-role-textbox",
       selectorHint: "[contenteditable='true'][role='textbox']",
-      locatorFactory: (root) => root.locator("[contenteditable='true'][role='textbox']")
+      locatorFactory: (root) =>
+        root.locator("[contenteditable='true'][role='textbox']"),
     },
     {
       key: "contenteditable",
       selectorHint: "[contenteditable='true']",
-      locatorFactory: (root) => root.locator("[contenteditable='true']")
+      locatorFactory: (root) => root.locator("[contenteditable='true']"),
     },
     {
       key: "textarea",
       selectorHint: "textarea",
-      locatorFactory: (root) => root.locator("textarea")
-    }
+      locatorFactory: (root) => root.locator("textarea"),
+    },
   ];
 }
 
 function createPublishButtonCandidates(
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): ScopedSelectorCandidate[] {
   const postExactRegex = buildLinkedInSelectorPhraseRegex(
     "post",
     selectorLocale,
-    { exact: true }
+    { exact: true },
   );
   const postExactRegexHint = formatLinkedInSelectorRegexHint(
     "post",
     selectorLocale,
-    { exact: true }
+    { exact: true },
   );
 
   return [
     {
       key: "role-button-post",
       selectorHint: `getByRole(button, ${postExactRegexHint})`,
-      locatorFactory: (root) => root.getByRole("button", { name: postExactRegex })
+      locatorFactory: (root) =>
+        root.getByRole("button", { name: postExactRegex }),
     },
     {
       key: "share-actions-primary",
       selectorHint: ".share-actions__primary-action",
-      locatorFactory: (root) => root.locator(".share-actions__primary-action")
+      locatorFactory: (root) => root.locator(".share-actions__primary-action"),
     },
     {
       key: "submit-button",
       selectorHint: "button[type='submit']",
-      locatorFactory: (root) => root.locator("button[type='submit']")
-    }
+      locatorFactory: (root) => root.locator("button[type='submit']"),
+    },
   ];
 }
 
@@ -1624,13 +1698,13 @@ async function setComposerText(
   page: Page,
   composerRoot: Locator,
   selectorLocale: LinkedInSelectorLocale,
-  text: string
+  text: string,
 ): Promise<string> {
   const composerInput = await findVisibleScopedLocatorOrThrow(
     composerRoot,
     createComposerInputCandidates(selectorLocale),
     "feed_share_composer_input",
-    page.url()
+    page.url(),
   );
 
   await composerInput.locator.click({ timeout: 5_000 });
@@ -1649,7 +1723,7 @@ async function setComposerText(
 
 async function findVisiblePostBySnippet(
   page: Page,
-  snippet: string
+  snippet: string,
 ): Promise<Locator | null> {
   const postCandidates = [
     page
@@ -1658,8 +1732,8 @@ async function findVisiblePostBySnippet(
     page
       .getByText(snippet)
       .locator(
-        "xpath=ancestor-or-self::*[self::article or contains(@class, 'feed-shared-update-v2') or contains(@class, 'occludable-update')]"
-      )
+        "xpath=ancestor-or-self::*[self::article or contains(@class, 'feed-shared-update-v2') or contains(@class, 'occludable-update')]",
+      ),
   ];
 
   for (const candidate of postCandidates) {
@@ -1673,14 +1747,16 @@ async function findVisiblePostBySnippet(
 
 async function extractPublishedPostUrl(
   page: Page,
-  postRoot: Locator | null
+  postRoot: Locator | null,
 ): Promise<string | null> {
   if (!postRoot) {
     return null;
   }
 
   const href = await postRoot
-    .locator("a[href*='/feed/update/'], a[href*='/posts/'], a[href*='/activity/']")
+    .locator(
+      "a[href*='/feed/update/'], a[href*='/posts/'], a[href*='/activity/']",
+    )
     .first()
     .getAttribute("href")
     .catch(() => null);
@@ -1698,13 +1774,13 @@ async function extractPublishedPostUrl(
 
 async function verifySharedPost(
   page: Page,
-  text: string
+  text: string,
 ): Promise<{ verified: true; postUrl: string | null }> {
   const snippet = createVerificationSnippet(text);
   if (!snippet) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "Cannot verify a shared post with empty text content."
+      "Cannot verify a shared post with empty text content.",
     );
   }
 
@@ -1734,36 +1810,40 @@ async function verifySharedPost(
         "Shared LinkedIn post could not be verified on the feed.",
         {
           current_url: page.url(),
-          verification_snippet: snippet
-        }
+          verification_snippet: snippet,
+        },
       );
     }
   }
 
   return {
     verified: true,
-    postUrl: await extractPublishedPostUrl(page, postRoot)
+    postUrl: await extractPublishedPostUrl(page, postRoot),
   };
 }
 
 async function openShareComposerFromPost(
   page: Page,
   postRoot: Locator,
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): Promise<{ composerRoot: Locator; triggerKey: string; rootKey: string }> {
-  const repostButton = await resolveRepostButton(page, postRoot, selectorLocale);
+  const repostButton = await resolveRepostButton(
+    page,
+    postRoot,
+    selectorLocale,
+  );
   await repostButton.locator.click({ timeout: 5_000 });
   await page.waitForTimeout(600);
 
   const directComposer = await findVisibleLocator(
     page,
-    createComposerRootCandidates(selectorLocale)
+    createComposerRootCandidates(selectorLocale),
   );
   if (directComposer) {
     return {
       composerRoot: directComposer.locator,
       triggerKey: repostButton.key,
-      rootKey: directComposer.key
+      rootKey: directComposer.key,
     };
   }
 
@@ -1772,9 +1852,9 @@ async function openShareComposerFromPost(
     createPageMenuActionCandidates({
       selectorLocale,
       selectorKeys: "share",
-      candidateKeyPrefix: "feed-share"
+      candidateKeyPrefix: "feed-share",
     }),
-    "feed_share_menu_action"
+    "feed_share_menu_action",
   );
 
   await shareAction.locator.click({ timeout: 5_000 });
@@ -1782,17 +1862,20 @@ async function openShareComposerFromPost(
   const composerRoot = await findVisibleLocatorOrThrow(
     page,
     createComposerRootCandidates(selectorLocale),
-    "feed_share_composer_root"
+    "feed_share_composer_root",
   );
 
   return {
     composerRoot: composerRoot.locator,
     triggerKey: `${repostButton.key}:${shareAction.key}`,
-    rootKey: composerRoot.key
+    rootKey: composerRoot.key,
   };
 }
 
-async function findTargetPostLocator(page: Page, postUrl: string): Promise<TargetPostLocator> {
+async function findTargetPostLocator(
+  page: Page,
+  postUrl: string,
+): Promise<TargetPostLocator> {
   const postIdentity = extractPostIdentity(postUrl);
   const activityId = extractActivityId(postIdentity || postUrl);
   const candidates: SelectorCandidate[] = [];
@@ -1804,20 +1887,20 @@ async function findTargetPostLocator(page: Page, postUrl: string): Promise<Targe
         key: "post-root-data-urn-exact",
         selectorHint: `[data-urn="${postIdentity}"]`,
         locatorFactory: (targetPage) =>
-          targetPage.locator(`[data-urn="${escapedIdentity}"]`)
+          targetPage.locator(`[data-urn="${escapedIdentity}"]`),
       },
       {
         key: "post-root-data-urn-contains",
         selectorHint: `[data-urn*="${postIdentity}"]`,
         locatorFactory: (targetPage) =>
-          targetPage.locator(`[data-urn*="${escapedIdentity}"]`)
+          targetPage.locator(`[data-urn*="${escapedIdentity}"]`),
       },
       {
         key: "post-root-permalink-identity",
         selectorHint: `article:has(a[href*="${postIdentity}"])`,
         locatorFactory: (targetPage) =>
-          targetPage.locator(`article:has(a[href*="${escapedIdentity}"])`)
-      }
+          targetPage.locator(`article:has(a[href*="${escapedIdentity}"])`),
+      },
     );
   }
 
@@ -1828,14 +1911,14 @@ async function findTargetPostLocator(page: Page, postUrl: string): Promise<Targe
         key: "post-root-data-urn-activity",
         selectorHint: `[data-urn*="${activityId}"]`,
         locatorFactory: (targetPage) =>
-          targetPage.locator(`[data-urn*="${escapedActivityId}"]`)
+          targetPage.locator(`[data-urn*="${escapedActivityId}"]`),
       },
       {
         key: "post-root-permalink-activity",
         selectorHint: `article:has(a[href*="${activityId}"])`,
         locatorFactory: (targetPage) =>
-          targetPage.locator(`article:has(a[href*="${escapedActivityId}"])`)
-      }
+          targetPage.locator(`article:has(a[href*="${escapedActivityId}"])`),
+      },
     );
   }
 
@@ -1843,62 +1926,67 @@ async function findTargetPostLocator(page: Page, postUrl: string): Promise<Targe
     {
       key: "post-root-first-data-urn",
       selectorHint: "[data-urn]",
-      locatorFactory: (targetPage) => targetPage.locator("[data-urn]")
+      locatorFactory: (targetPage) => targetPage.locator("[data-urn]"),
     },
     {
       key: "post-root-first-article",
       selectorHint: "article",
-      locatorFactory: (targetPage) => targetPage.locator("article")
-    }
+      locatorFactory: (targetPage) => targetPage.locator("article"),
+    },
   );
 
-  const resolved = await findVisibleLocatorOrThrow(page, candidates, "post_root");
+  const resolved = await findVisibleLocatorOrThrow(
+    page,
+    candidates,
+    "post_root",
+  );
   return {
     locator: resolved.locator,
     key: resolved.key,
     postIdentity,
-    activityId
+    activityId,
   };
 }
 
 async function expandCommentsForPost(
   page: Page,
   postRoot: Locator,
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): Promise<string | null> {
   const commentRegex = buildLinkedInSelectorPhraseRegex(
     "comment",
-    selectorLocale
+    selectorLocale,
   );
   const commentRegexHint = formatLinkedInSelectorRegexHint(
     "comment",
-    selectorLocale
+    selectorLocale,
   );
   const commentAriaSelector = buildLinkedInAriaLabelContainsSelector(
     "button",
     "comment",
-    selectorLocale
+    selectorLocale,
   );
 
   const candidates: SelectorCandidate[] = [
     {
       key: "post-social-action-comment",
       selectorHint: "button.social-actions-button.comment-button",
-      locatorFactory: () => postRoot.locator("button.social-actions-button.comment-button")
+      locatorFactory: () =>
+        postRoot.locator("button.social-actions-button.comment-button"),
     },
     {
       key: "post-aria-comment-button",
       selectorHint: commentAriaSelector,
-      locatorFactory: () => postRoot.locator(commentAriaSelector)
+      locatorFactory: () => postRoot.locator(commentAriaSelector),
     },
     {
       key: "post-role-button-comment",
       selectorHint: `getByRole(button, ${commentRegexHint})`,
       locatorFactory: () =>
         postRoot.getByRole("button", {
-          name: commentRegex
-        })
-    }
+          name: commentRegex,
+        }),
+    },
   ];
 
   for (const candidate of candidates) {
@@ -1913,7 +2001,10 @@ async function expandCommentsForPost(
   return null;
 }
 
-async function isCommentVisibleInPost(postRoot: Locator, text: string): Promise<boolean> {
+async function isCommentVisibleInPost(
+  postRoot: Locator,
+  text: string,
+): Promise<boolean> {
   const normalized = normalizeText(text);
   if (!normalized) {
     return false;
@@ -1922,10 +2013,10 @@ async function isCommentVisibleInPost(postRoot: Locator, text: string): Promise<
   const candidates = [
     postRoot
       .locator(
-        ".comments-comment-item__main-content, .comments-comment-item-content-body, .comments-post-meta__main-content"
+        ".comments-comment-item__main-content, .comments-comment-item-content-body, .comments-post-meta__main-content",
       )
       .filter({ hasText: normalized }),
-    postRoot.locator(".comments-comment-item").filter({ hasText: normalized })
+    postRoot.locator(".comments-comment-item").filter({ hasText: normalized }),
   ];
 
   for (const candidate of candidates) {
@@ -1937,11 +2028,9 @@ async function isCommentVisibleInPost(postRoot: Locator, text: string): Promise<
   return false;
 }
 
-export class LikePostActionExecutor
-  implements ActionExecutor<LinkedInFeedExecutorRuntime>
-{
+export class LikePostActionExecutor implements ActionExecutor<LinkedInFeedExecutorRuntime> {
   async execute(
-    input: ActionExecutorInput<LinkedInFeedExecutorRuntime>
+    input: ActionExecutorInput<LinkedInFeedExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
     const runtime = input.runtime;
     const action = input.action;
@@ -1950,7 +2039,7 @@ export class LikePostActionExecutor
       action.target,
       "post_url",
       action.id,
-      "target"
+      "target",
     );
     const requestedReaction =
       typeof action.payload.reaction === "string"
@@ -1960,14 +2049,14 @@ export class LikePostActionExecutor
 
     await runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: runtime.cdpUrl
+      cdpUrl: runtime.cdpUrl,
     });
 
     return runtime.profileManager.runWithContext(
       {
         cdpUrl: runtime.cdpUrl,
         profileName,
-        headless: true
+        headless: true,
       },
       async (context) => {
         const page = await getOrCreatePage(context);
@@ -1982,221 +2071,220 @@ export class LikePostActionExecutor
           targetUrl: postUrl,
           metadata: {
             post_url: postUrl,
-            requested_reaction: reaction
+            requested_reaction: reaction,
           },
           errorDetails: {
             post_url: postUrl,
-            requested_reaction: reaction
+            requested_reaction: reaction,
           },
           mapError: (error) =>
             asLinkedInBuddyError(
               error,
               "UNKNOWN",
-              "Failed to execute LinkedIn like_post action."
+              "Failed to execute LinkedIn like_post action.",
             ),
           execute: async () => {
-          const rateLimitState = runtime.rateLimiter.consume(
-            LIKE_RATE_LIMIT_CONFIG
-          );
-          if (!rateLimitState.allowed) {
-            throw new LinkedInBuddyError(
-              "RATE_LIMITED",
-              "LinkedIn like_post confirm is rate limited for the current window.",
+            const rateLimitState = consumeRateLimitOrThrow(
+              runtime.rateLimiter,
               {
-                action_id: action.id,
-                profile_name: profileName,
-                post_url: postUrl,
-                reaction,
-                rate_limit: formatRateLimitState(rateLimitState)
-              }
-            );
-          }
-
-          await page.goto(postUrl, { waitUntil: "domcontentloaded" });
-          await waitForPostSurface(page);
-
-          let targetPost = await findTargetPostLocator(page, postUrl);
-          const likeOrReactRegex = buildLinkedInSelectorPhraseRegex(
-            ["like", "react"],
-            runtime.selectorLocale
-          );
-          const likeOrReactRegexHint = formatLinkedInSelectorRegexHint(
-            ["like", "react"],
-            runtime.selectorLocale
-          );
-          const likeReactAriaSelector = buildLinkedInAriaLabelContainsSelector(
-            "button",
-            ["like", "react", "reaction"],
-            runtime.selectorLocale
-          );
-
-          const resolveReactionButton = async (postRoot: Locator) =>
-            findVisibleLocatorOrThrow(
-              page,
-              [
-                {
-                  key: "post-social-action-like",
-                  selectorHint: "button.social-actions-button.react-button__trigger",
-                  locatorFactory: () =>
-                    postRoot.locator(
-                      "button.social-actions-button.react-button__trigger"
-                    )
+                config: LIKE_RATE_LIMIT_CONFIG,
+                message: createConfirmRateLimitMessage(LIKE_POST_ACTION_TYPE),
+                details: {
+                  action_id: action.id,
+                  profile_name: profileName,
+                  post_url: postUrl,
+                  reaction,
                 },
-                {
-                  key: "post-react-button",
-                  selectorHint: "button.react-button__trigger",
-                  locatorFactory: () => postRoot.locator("button.react-button__trigger")
-                },
-                {
-                  key: "post-aria-like-button",
-                  selectorHint: likeReactAriaSelector,
-                  locatorFactory: () => postRoot.locator(likeReactAriaSelector)
-                },
-                {
-                  key: "post-role-button-like",
-                  selectorHint: `getByRole(button, ${likeOrReactRegexHint})`,
-                  locatorFactory: () =>
-                    postRoot.getByRole("button", {
-                      name: likeOrReactRegex
-                    })
-                }
-              ],
-              "reaction_button"
+              },
             );
 
-          let reactButton = await resolveReactionButton(targetPost.locator);
-          const wasAlreadyReacted = await isDesiredReactionActive(
-            reactButton.locator,
-            reaction,
-            runtime.selectorLocale
-          );
-          let reactionSelectorKey: string | null = null;
+            await page.goto(postUrl, { waitUntil: "domcontentloaded" });
+            await waitForPostSurface(page);
 
-          let verifiedReaction = wasAlreadyReacted;
-          if (!wasAlreadyReacted) {
-            if (reaction === "like") {
-              await reactButton.locator.click({ timeout: 5_000 });
-              verifiedReaction = await waitForCondition(
-                async () =>
-                  isDesiredReactionActive(
-                    reactButton.locator,
-                    reaction,
-                    runtime.selectorLocale
-                  ),
-                6_000
+            let targetPost = await findTargetPostLocator(page, postUrl);
+            const likeOrReactRegex = buildLinkedInSelectorPhraseRegex(
+              ["like", "react"],
+              runtime.selectorLocale,
+            );
+            const likeOrReactRegexHint = formatLinkedInSelectorRegexHint(
+              ["like", "react"],
+              runtime.selectorLocale,
+            );
+            const likeReactAriaSelector =
+              buildLinkedInAriaLabelContainsSelector(
+                "button",
+                ["like", "react", "reaction"],
+                runtime.selectorLocale,
               );
 
-              if (!verifiedReaction) {
-                try {
-                  reactionSelectorKey = await selectReactionFromMenu(
-                    page,
-                    reactButton.locator,
-                    reaction,
-                    runtime.selectorLocale
-                  );
-                  verifiedReaction = await waitForCondition(
-                    async () =>
-                      isDesiredReactionActive(
-                        reactButton.locator,
-                        reaction,
-                        runtime.selectorLocale
-                      ),
-                    6_000
-                  );
-                } catch {
-                  // Ignore and fall through to reload verification.
-                }
-              }
-            } else {
-              reactionSelectorKey = await selectReactionFromMenu(
+            const resolveReactionButton = async (postRoot: Locator) =>
+              findVisibleLocatorOrThrow(
                 page,
+                [
+                  {
+                    key: "post-social-action-like",
+                    selectorHint:
+                      "button.social-actions-button.react-button__trigger",
+                    locatorFactory: () =>
+                      postRoot.locator(
+                        "button.social-actions-button.react-button__trigger",
+                      ),
+                  },
+                  {
+                    key: "post-react-button",
+                    selectorHint: "button.react-button__trigger",
+                    locatorFactory: () =>
+                      postRoot.locator("button.react-button__trigger"),
+                  },
+                  {
+                    key: "post-aria-like-button",
+                    selectorHint: likeReactAriaSelector,
+                    locatorFactory: () =>
+                      postRoot.locator(likeReactAriaSelector),
+                  },
+                  {
+                    key: "post-role-button-like",
+                    selectorHint: `getByRole(button, ${likeOrReactRegexHint})`,
+                    locatorFactory: () =>
+                      postRoot.getByRole("button", {
+                        name: likeOrReactRegex,
+                      }),
+                  },
+                ],
+                "reaction_button",
+              );
+
+            let reactButton = await resolveReactionButton(targetPost.locator);
+            const wasAlreadyReacted = await isDesiredReactionActive(
+              reactButton.locator,
+              reaction,
+              runtime.selectorLocale,
+            );
+            let reactionSelectorKey: string | null = null;
+
+            let verifiedReaction = wasAlreadyReacted;
+            if (!wasAlreadyReacted) {
+              if (reaction === "like") {
+                await reactButton.locator.click({ timeout: 5_000 });
+                verifiedReaction = await waitForCondition(
+                  async () =>
+                    isDesiredReactionActive(
+                      reactButton.locator,
+                      reaction,
+                      runtime.selectorLocale,
+                    ),
+                  6_000,
+                );
+
+                if (!verifiedReaction) {
+                  try {
+                    reactionSelectorKey = await selectReactionFromMenu(
+                      page,
+                      reactButton.locator,
+                      reaction,
+                      runtime.selectorLocale,
+                    );
+                    verifiedReaction = await waitForCondition(
+                      async () =>
+                        isDesiredReactionActive(
+                          reactButton.locator,
+                          reaction,
+                          runtime.selectorLocale,
+                        ),
+                      6_000,
+                    );
+                  } catch {
+                    // Ignore and fall through to reload verification.
+                  }
+                }
+              } else {
+                reactionSelectorKey = await selectReactionFromMenu(
+                  page,
+                  reactButton.locator,
+                  reaction,
+                  runtime.selectorLocale,
+                );
+                verifiedReaction = await waitForCondition(
+                  async () =>
+                    isDesiredReactionActive(
+                      reactButton.locator,
+                      reaction,
+                      runtime.selectorLocale,
+                    ),
+                  8_000,
+                );
+              }
+            }
+
+            if (!verifiedReaction) {
+              await page.reload({ waitUntil: "domcontentloaded" });
+              await waitForPostSurface(page);
+              targetPost = await findTargetPostLocator(page, postUrl);
+              reactButton = await resolveReactionButton(targetPost.locator);
+              verifiedReaction = await isDesiredReactionActive(
                 reactButton.locator,
                 reaction,
-                runtime.selectorLocale
-              );
-              verifiedReaction = await waitForCondition(
-                async () =>
-                  isDesiredReactionActive(
-                    reactButton.locator,
-                    reaction,
-                    runtime.selectorLocale
-                  ),
-                8_000
+                runtime.selectorLocale,
               );
             }
-          }
 
-          if (!verifiedReaction) {
-            await page.reload({ waitUntil: "domcontentloaded" });
-            await waitForPostSurface(page);
-            targetPost = await findTargetPostLocator(page, postUrl);
-            reactButton = await resolveReactionButton(targetPost.locator);
-            verifiedReaction = await isDesiredReactionActive(
-              reactButton.locator,
-              reaction,
-              runtime.selectorLocale
-            );
-          }
+            if (!verifiedReaction) {
+              const currentReactionState = await getReactionButtonState(
+                reactButton.locator,
+                runtime.selectorLocale,
+              );
+              throw new LinkedInBuddyError(
+                "UNKNOWN",
+                "Reaction action could not be verified on the target post.",
+                {
+                  action_id: action.id,
+                  profile_name: profileName,
+                  post_url: postUrl,
+                  requested_reaction: reaction,
+                  current_reaction: currentReactionState.reaction,
+                  current_reacted: currentReactionState.reacted,
+                  current_aria_label: currentReactionState.ariaLabel,
+                  post_identity: targetPost.postIdentity,
+                  activity_id: targetPost.activityId,
+                },
+              );
+            }
 
-          if (!verifiedReaction) {
-            const currentReactionState = await getReactionButtonState(
-              reactButton.locator,
-              runtime.selectorLocale
-            );
-            throw new LinkedInBuddyError(
-              "UNKNOWN",
-              "Reaction action could not be verified on the target post.",
-              {
-                action_id: action.id,
-                profile_name: profileName,
-                post_url: postUrl,
-                requested_reaction: reaction,
-                current_reaction: currentReactionState.reaction,
-                current_reacted: currentReactionState.reacted,
-                current_aria_label: currentReactionState.ariaLabel,
-                post_identity: targetPost.postIdentity,
-                activity_id: targetPost.activityId
-              }
-            );
-          }
-
-          const screenshotPath = `linkedin/screenshot-feed-like-${Date.now()}.png`;
-          await captureScreenshotArtifact(runtime, page, screenshotPath, {
-            action: LIKE_POST_ACTION_TYPE,
-            action_id: action.id,
-            profile_name: profileName,
-            post_url: postUrl,
-            reaction,
-            selector_key: reactButton.key,
-            reaction_selector_key: reactionSelectorKey ?? undefined,
-            post_selector_key: targetPost.key
-          });
-
-          return {
-            ok: true,
-            result: {
-              reacted: true,
-              reaction,
-              already_reacted: wasAlreadyReacted,
-              liked: reaction === "like",
-              already_liked: reaction === "like" ? wasAlreadyReacted : false,
+            const screenshotPath = `linkedin/screenshot-feed-like-${Date.now()}.png`;
+            await captureScreenshotArtifact(runtime, page, screenshotPath, {
+              action: LIKE_POST_ACTION_TYPE,
+              action_id: action.id,
+              profile_name: profileName,
               post_url: postUrl,
-              rate_limit: formatRateLimitState(rateLimitState)
-            },
-            artifacts: [screenshotPath]
-          };
-          }
+              reaction,
+              selector_key: reactButton.key,
+              reaction_selector_key: reactionSelectorKey ?? undefined,
+              post_selector_key: targetPost.key,
+            });
+
+            return {
+              ok: true,
+              result: {
+                reacted: true,
+                reaction,
+                already_reacted: wasAlreadyReacted,
+                liked: reaction === "like",
+                already_liked: reaction === "like" ? wasAlreadyReacted : false,
+                post_url: postUrl,
+                rate_limit: formatRateLimitState(rateLimitState),
+              },
+              artifacts: [screenshotPath],
+            };
+          },
         });
-      }
+      },
     );
   }
 }
 
-export class CommentOnPostActionExecutor
-  implements ActionExecutor<LinkedInFeedExecutorRuntime>
-{
+export class CommentOnPostActionExecutor implements ActionExecutor<LinkedInFeedExecutorRuntime> {
   async execute(
-    input: ActionExecutorInput<LinkedInFeedExecutorRuntime>
+    input: ActionExecutorInput<LinkedInFeedExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
     const runtime = input.runtime;
     const action = input.action;
@@ -2205,20 +2293,25 @@ export class CommentOnPostActionExecutor
       action.target,
       "post_url",
       action.id,
-      "target"
+      "target",
     );
-    const text = getRequiredStringField(action.payload, "text", action.id, "payload");
+    const text = getRequiredStringField(
+      action.payload,
+      "text",
+      action.id,
+      "payload",
+    );
 
     await runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: runtime.cdpUrl
+      cdpUrl: runtime.cdpUrl,
     });
 
     return runtime.profileManager.runWithContext(
       {
         cdpUrl: runtime.cdpUrl,
         profileName,
-        headless: true
+        headless: true,
       },
       async (context) => {
         const page = await getOrCreatePage(context);
@@ -2233,291 +2326,298 @@ export class CommentOnPostActionExecutor
           targetUrl: postUrl,
           metadata: {
             post_url: postUrl,
-            comment_text: text
+            comment_text: text,
           },
           errorDetails: {
             post_url: postUrl,
-            comment_text: text
+            comment_text: text,
           },
           mapError: (error) =>
             asLinkedInBuddyError(
               error,
               "UNKNOWN",
-              "Failed to execute LinkedIn comment_on_post action."
+              "Failed to execute LinkedIn comment_on_post action.",
             ),
           execute: async () => {
-          const rateLimitState = runtime.rateLimiter.consume(
-            COMMENT_RATE_LIMIT_CONFIG
-          );
-          if (!rateLimitState.allowed) {
-            throw new LinkedInBuddyError(
-              "RATE_LIMITED",
-              "LinkedIn comment_on_post confirm is rate limited for the current window.",
+            const rateLimitState = consumeRateLimitOrThrow(
+              runtime.rateLimiter,
               {
-                action_id: action.id,
-                profile_name: profileName,
-                post_url: postUrl,
-                rate_limit: formatRateLimitState(rateLimitState)
-              }
+                config: COMMENT_RATE_LIMIT_CONFIG,
+                message: createConfirmRateLimitMessage(
+                  COMMENT_ON_POST_ACTION_TYPE,
+                ),
+                details: {
+                  action_id: action.id,
+                  profile_name: profileName,
+                  post_url: postUrl,
+                },
+              },
             );
-          }
 
-          await page.goto(postUrl, { waitUntil: "domcontentloaded" });
-          await waitForPostSurface(page);
+            await page.goto(postUrl, { waitUntil: "domcontentloaded" });
+            await waitForPostSurface(page);
 
-          let targetPost = await findTargetPostLocator(page, postUrl);
-          const commentRegex = buildLinkedInSelectorPhraseRegex(
-            "comment",
-            runtime.selectorLocale
-          );
-          const commentRegexHint = formatLinkedInSelectorRegexHint(
-            "comment",
-            runtime.selectorLocale
-          );
-          const commentAriaSelector = buildLinkedInAriaLabelContainsSelector(
-            "button",
-            "comment",
-            runtime.selectorLocale
-          );
-          const commentComposerRegex = buildLinkedInSelectorPhraseRegex(
-            ["add_comment", "comment"],
-            runtime.selectorLocale
-          );
-          const commentComposerRegexHint = formatLinkedInSelectorRegexHint(
-            ["add_comment", "comment"],
-            runtime.selectorLocale
-          );
-          const postRegex = buildLinkedInSelectorPhraseRegex(
-            "post",
-            runtime.selectorLocale,
-            { exact: true }
-          );
-          const postRegexHint = formatLinkedInSelectorRegexHint(
-            "post",
-            runtime.selectorLocale,
-            { exact: true }
-          );
-          const commentSubmitAriaSelector = buildLinkedInAriaLabelContainsSelector(
-            "button",
-            ["post_comment", "post"],
-            runtime.selectorLocale
-          );
+            let targetPost = await findTargetPostLocator(page, postUrl);
+            const commentRegex = buildLinkedInSelectorPhraseRegex(
+              "comment",
+              runtime.selectorLocale,
+            );
+            const commentRegexHint = formatLinkedInSelectorRegexHint(
+              "comment",
+              runtime.selectorLocale,
+            );
+            const commentAriaSelector = buildLinkedInAriaLabelContainsSelector(
+              "button",
+              "comment",
+              runtime.selectorLocale,
+            );
+            const commentComposerRegex = buildLinkedInSelectorPhraseRegex(
+              ["add_comment", "comment"],
+              runtime.selectorLocale,
+            );
+            const commentComposerRegexHint = formatLinkedInSelectorRegexHint(
+              ["add_comment", "comment"],
+              runtime.selectorLocale,
+            );
+            const postRegex = buildLinkedInSelectorPhraseRegex(
+              "post",
+              runtime.selectorLocale,
+              { exact: true },
+            );
+            const postRegexHint = formatLinkedInSelectorRegexHint(
+              "post",
+              runtime.selectorLocale,
+              { exact: true },
+            );
+            const commentSubmitAriaSelector =
+              buildLinkedInAriaLabelContainsSelector(
+                "button",
+                ["post_comment", "post"],
+                runtime.selectorLocale,
+              );
 
-          const commentTrigger = await findVisibleLocatorOrThrow(
-            page,
-            [
-              {
-                key: "post-social-action-comment",
-                selectorHint: "button.social-actions-button.comment-button",
-                locatorFactory: () =>
-                  targetPost.locator.locator("button.social-actions-button.comment-button")
-              },
-              {
-                key: "post-aria-comment-button",
-                selectorHint: commentAriaSelector,
-                locatorFactory: () =>
-                  targetPost.locator.locator(commentAriaSelector)
-              },
-              {
-                key: "post-role-button-comment",
-                selectorHint: `getByRole(button, ${commentRegexHint})`,
-                locatorFactory: () =>
-                  targetPost.locator.getByRole("button", {
-                    name: commentRegex
-                  })
-              },
-              {
-                key: "comment-button-fallback",
-                selectorHint: "button.comments-comment-social-bar__button",
-                locatorFactory: () =>
-                  page.locator("button.comments-comment-social-bar__button")
+            const commentTrigger = await findVisibleLocatorOrThrow(
+              page,
+              [
+                {
+                  key: "post-social-action-comment",
+                  selectorHint: "button.social-actions-button.comment-button",
+                  locatorFactory: () =>
+                    targetPost.locator.locator(
+                      "button.social-actions-button.comment-button",
+                    ),
+                },
+                {
+                  key: "post-aria-comment-button",
+                  selectorHint: commentAriaSelector,
+                  locatorFactory: () =>
+                    targetPost.locator.locator(commentAriaSelector),
+                },
+                {
+                  key: "post-role-button-comment",
+                  selectorHint: `getByRole(button, ${commentRegexHint})`,
+                  locatorFactory: () =>
+                    targetPost.locator.getByRole("button", {
+                      name: commentRegex,
+                    }),
+                },
+                {
+                  key: "comment-button-fallback",
+                  selectorHint: "button.comments-comment-social-bar__button",
+                  locatorFactory: () =>
+                    page.locator("button.comments-comment-social-bar__button"),
+                },
+              ],
+              "comment_trigger",
+            );
+
+            await commentTrigger.locator.click({ timeout: 5_000 });
+
+            const commentInput = await findVisibleLocatorOrThrow(
+              page,
+              [
+                {
+                  key: "post-comment-box-editor",
+                  selectorHint:
+                    "div.comments-comment-box__editor[contenteditable='true']",
+                  locatorFactory: () =>
+                    targetPost.locator.locator(
+                      "div.comments-comment-box__editor[contenteditable='true']",
+                    ),
+                },
+                {
+                  key: "post-contenteditable-textbox",
+                  selectorHint: "div[role='textbox'][contenteditable='true']",
+                  locatorFactory: () =>
+                    targetPost.locator.locator(
+                      "div[role='textbox'][contenteditable='true']",
+                    ),
+                },
+                {
+                  key: "post-role-textbox-comment",
+                  selectorHint: `getByRole(textbox, ${commentComposerRegexHint})`,
+                  locatorFactory: () =>
+                    targetPost.locator.getByRole("textbox", {
+                      name: commentComposerRegex,
+                    }),
+                },
+                {
+                  key: "comment-box-editor-fallback",
+                  selectorHint:
+                    "div.comments-comment-box__editor[contenteditable='true']",
+                  locatorFactory: (targetPage) =>
+                    targetPage.locator(
+                      "div.comments-comment-box__editor[contenteditable='true']",
+                    ),
+                },
+                {
+                  key: "comment-textarea-fallback",
+                  selectorHint: "textarea",
+                  locatorFactory: (targetPage) =>
+                    targetPage.locator("textarea"),
+                },
+              ],
+              "comment_input",
+            );
+
+            await commentInput.locator.click({ timeout: 3_000 });
+            await commentInput.locator.fill(text, { timeout: 5_000 });
+
+            const composerRoot = commentInput.locator.locator(
+              "xpath=ancestor::*[contains(@class,'comments-comment-box')][1]",
+            );
+
+            const submitButton = await findVisibleLocatorOrThrow(
+              page,
+              [
+                {
+                  key: "comment-submit-button",
+                  selectorHint:
+                    "button[class*='comments-comment-box__submit-button']",
+                  locatorFactory: () =>
+                    composerRoot.locator(
+                      "button[class*='comments-comment-box__submit-button']",
+                    ),
+                },
+                {
+                  key: "comment-submit-role-post",
+                  selectorHint: `getByRole(button, ${postRegexHint})`,
+                  locatorFactory: () =>
+                    composerRoot.getByRole("button", {
+                      name: postRegex,
+                    }),
+                },
+                {
+                  key: "comment-submit-role-comment",
+                  selectorHint: `getByRole(button, ${commentRegexHint})`,
+                  locatorFactory: () =>
+                    composerRoot.getByRole("button", {
+                      name: commentRegex,
+                    }),
+                },
+                {
+                  key: "comment-submit-aria",
+                  selectorHint: commentSubmitAriaSelector,
+                  locatorFactory: () =>
+                    composerRoot.locator(commentSubmitAriaSelector),
+                },
+                {
+                  key: "comment-submit-post-root-fallback",
+                  selectorHint:
+                    "button[class*='comments-comment-box__submit-button']",
+                  locatorFactory: () =>
+                    targetPost.locator.locator(
+                      "button[class*='comments-comment-box__submit-button']",
+                    ),
+                },
+              ],
+              "comment_submit",
+            );
+
+            const submitEnabled = await waitForCondition(async () => {
+              try {
+                return await submitButton.locator.isEnabled();
+              } catch {
+                return false;
               }
-            ],
-            "comment_trigger"
-          );
+            }, 4_000);
 
-          await commentTrigger.locator.click({ timeout: 5_000 });
-
-          const commentInput = await findVisibleLocatorOrThrow(
-            page,
-            [
-              {
-                key: "post-comment-box-editor",
-                selectorHint: "div.comments-comment-box__editor[contenteditable='true']",
-                locatorFactory: () =>
-                  targetPost.locator.locator(
-                    "div.comments-comment-box__editor[contenteditable='true']"
-                  )
-              },
-              {
-                key: "post-contenteditable-textbox",
-                selectorHint: "div[role='textbox'][contenteditable='true']",
-                locatorFactory: () =>
-                  targetPost.locator.locator("div[role='textbox'][contenteditable='true']")
-              },
-              {
-                key: "post-role-textbox-comment",
-                selectorHint: `getByRole(textbox, ${commentComposerRegexHint})`,
-                locatorFactory: () =>
-                  targetPost.locator.getByRole("textbox", {
-                    name: commentComposerRegex
-                  })
-              },
-              {
-                key: "comment-box-editor-fallback",
-                selectorHint: "div.comments-comment-box__editor[contenteditable='true']",
-                locatorFactory: (targetPage) =>
-                  targetPage.locator(
-                    "div.comments-comment-box__editor[contenteditable='true']"
-                  )
-              },
-              {
-                key: "comment-textarea-fallback",
-                selectorHint: "textarea",
-                locatorFactory: (targetPage) => targetPage.locator("textarea")
-              }
-            ],
-            "comment_input"
-          );
-
-          await commentInput.locator.click({ timeout: 3_000 });
-          await commentInput.locator.fill(text, { timeout: 5_000 });
-
-          const composerRoot = commentInput.locator.locator(
-            "xpath=ancestor::*[contains(@class,'comments-comment-box')][1]"
-          );
-
-          const submitButton = await findVisibleLocatorOrThrow(
-            page,
-            [
-              {
-                key: "comment-submit-button",
-                selectorHint: "button[class*='comments-comment-box__submit-button']",
-                locatorFactory: () =>
-                  composerRoot.locator(
-                    "button[class*='comments-comment-box__submit-button']"
-                  )
-              },
-              {
-                key: "comment-submit-role-post",
-                selectorHint: `getByRole(button, ${postRegexHint})`,
-                locatorFactory: () =>
-                  composerRoot.getByRole("button", {
-                    name: postRegex
-                  })
-              },
-              {
-                key: "comment-submit-role-comment",
-                selectorHint: `getByRole(button, ${commentRegexHint})`,
-                locatorFactory: () =>
-                  composerRoot.getByRole("button", {
-                    name: commentRegex
-                  })
-              },
-              {
-                key: "comment-submit-aria",
-                selectorHint: commentSubmitAriaSelector,
-                locatorFactory: () =>
-                  composerRoot.locator(commentSubmitAriaSelector)
-              },
-              {
-                key: "comment-submit-post-root-fallback",
-                selectorHint: "button[class*='comments-comment-box__submit-button']",
-                locatorFactory: () =>
-                  targetPost.locator.locator(
-                    "button[class*='comments-comment-box__submit-button']"
-                  )
-              }
-            ],
-            "comment_submit"
-          );
-
-          const submitEnabled = await waitForCondition(async () => {
-            try {
-              return await submitButton.locator.isEnabled();
-            } catch {
-              return false;
+            if (!submitEnabled) {
+              throw new LinkedInBuddyError(
+                "UI_CHANGED_SELECTOR_FAILED",
+                "Comment submit button was not enabled after entering comment text.",
+                {
+                  action_id: action.id,
+                  profile_name: profileName,
+                  post_url: postUrl,
+                  selector_key: submitButton.key,
+                },
+              );
             }
-          }, 4_000);
 
-          if (!submitEnabled) {
-            throw new LinkedInBuddyError(
-              "UI_CHANGED_SELECTOR_FAILED",
-              "Comment submit button was not enabled after entering comment text.",
-              {
-                action_id: action.id,
-                profile_name: profileName,
-                post_url: postUrl,
-                selector_key: submitButton.key
-              }
+            await submitButton.locator.click({ timeout: 5_000 });
+            await page.waitForTimeout(1_200);
+
+            await page.reload({ waitUntil: "domcontentloaded" });
+            await waitForPostSurface(page);
+            targetPost = await findTargetPostLocator(page, postUrl);
+            const reopenCommentKey = await expandCommentsForPost(
+              page,
+              targetPost.locator,
+              runtime.selectorLocale,
             );
-          }
 
-          await submitButton.locator.click({ timeout: 5_000 });
-          await page.waitForTimeout(1_200);
-
-          await page.reload({ waitUntil: "domcontentloaded" });
-          await waitForPostSurface(page);
-          targetPost = await findTargetPostLocator(page, postUrl);
-          const reopenCommentKey = await expandCommentsForPost(
-            page,
-            targetPost.locator,
-            runtime.selectorLocale
-          );
-
-          const commentVerified = await waitForCondition(
-            async () => isCommentVisibleInPost(targetPost.locator, text),
-            12_000
-          );
-
-          if (!commentVerified) {
-            throw new LinkedInBuddyError(
-              "UNKNOWN",
-              "Comment action could not be verified on the target post.",
-              {
-                action_id: action.id,
-                profile_name: profileName,
-                post_url: postUrl,
-                post_identity: targetPost.postIdentity,
-                activity_id: targetPost.activityId,
-                reopen_comment_selector_key: reopenCommentKey ?? null,
-                text
-              }
+            const commentVerified = await waitForCondition(
+              async () => isCommentVisibleInPost(targetPost.locator, text),
+              12_000,
             );
-          }
 
-          const screenshotPath = `linkedin/screenshot-feed-comment-${Date.now()}.png`;
-          await captureScreenshotArtifact(runtime, page, screenshotPath, {
-            action: COMMENT_ON_POST_ACTION_TYPE,
-            action_id: action.id,
-            profile_name: profileName,
-            post_url: postUrl,
-            selector_key: submitButton.key,
-            post_selector_key: targetPost.key
-          });
+            if (!commentVerified) {
+              throw new LinkedInBuddyError(
+                "UNKNOWN",
+                "Comment action could not be verified on the target post.",
+                {
+                  action_id: action.id,
+                  profile_name: profileName,
+                  post_url: postUrl,
+                  post_identity: targetPost.postIdentity,
+                  activity_id: targetPost.activityId,
+                  reopen_comment_selector_key: reopenCommentKey ?? null,
+                  text,
+                },
+              );
+            }
 
-          return {
-            ok: true,
-            result: {
-              commented: true,
+            const screenshotPath = `linkedin/screenshot-feed-comment-${Date.now()}.png`;
+            await captureScreenshotArtifact(runtime, page, screenshotPath, {
+              action: COMMENT_ON_POST_ACTION_TYPE,
+              action_id: action.id,
+              profile_name: profileName,
               post_url: postUrl,
-              text,
-              rate_limit: formatRateLimitState(rateLimitState)
-            },
-            artifacts: [screenshotPath]
-          };
-          }
+              selector_key: submitButton.key,
+              post_selector_key: targetPost.key,
+            });
+
+            return {
+              ok: true,
+              result: {
+                commented: true,
+                post_url: postUrl,
+                text,
+                rate_limit: formatRateLimitState(rateLimitState),
+              },
+              artifacts: [screenshotPath],
+            };
+          },
         });
-      }
+      },
     );
   }
 }
 
-export class RepostPostActionExecutor
-  implements ActionExecutor<LinkedInFeedExecutorRuntime>
-{
+export class RepostPostActionExecutor implements ActionExecutor<LinkedInFeedExecutorRuntime> {
   async execute(
-    input: ActionExecutorInput<LinkedInFeedExecutorRuntime>
+    input: ActionExecutorInput<LinkedInFeedExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
     const runtime = input.runtime;
     const action = input.action;
@@ -2526,19 +2626,19 @@ export class RepostPostActionExecutor
       action.target,
       "post_url",
       action.id,
-      "target"
+      "target",
     );
 
     await runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: runtime.cdpUrl
+      cdpUrl: runtime.cdpUrl,
     });
 
     return runtime.profileManager.runWithContext(
       {
         cdpUrl: runtime.cdpUrl,
         profileName,
-        headless: true
+        headless: true,
       },
       async (context) => {
         const page = await getOrCreatePage(context);
@@ -2552,31 +2652,30 @@ export class RepostPostActionExecutor
           profileName,
           targetUrl: postUrl,
           metadata: {
-            post_url: postUrl
+            post_url: postUrl,
           },
           errorDetails: {
-            post_url: postUrl
+            post_url: postUrl,
           },
           mapError: (error) =>
             asLinkedInBuddyError(
               error,
               "UNKNOWN",
-              "Failed to execute LinkedIn repost_post action."
+              "Failed to execute LinkedIn repost_post action.",
             ),
           execute: async () => {
-            const rateLimitState = runtime.rateLimiter.consume(REPOST_RATE_LIMIT_CONFIG);
-            if (!rateLimitState.allowed) {
-              throw new LinkedInBuddyError(
-                "RATE_LIMITED",
-                "LinkedIn repost_post confirm is rate limited for the current window.",
-                {
+            const rateLimitState = consumeRateLimitOrThrow(
+              runtime.rateLimiter,
+              {
+                config: REPOST_RATE_LIMIT_CONFIG,
+                message: createConfirmRateLimitMessage(REPOST_POST_ACTION_TYPE),
+                details: {
                   action_id: action.id,
                   profile_name: profileName,
                   post_url: postUrl,
-                  rate_limit: formatRateLimitState(rateLimitState)
-                }
-              );
-            }
+                },
+              },
+            );
 
             await page.goto(postUrl, { waitUntil: "domcontentloaded" });
             await waitForPostSurface(page);
@@ -2585,7 +2684,7 @@ export class RepostPostActionExecutor
             let repostButton = await resolveRepostButton(
               page,
               targetPost.locator,
-              runtime.selectorLocale
+              runtime.selectorLocale,
             );
             const alreadyReposted = await isPostReposted(repostButton.locator);
 
@@ -2597,7 +2696,7 @@ export class RepostPostActionExecutor
                 selectorLocale: runtime.selectorLocale,
                 selectorKeys: "repost",
                 candidateKeyPrefix: "feed-repost-menu",
-                selectorKey: "feed_repost_menu_action"
+                selectorKey: "feed_repost_menu_action",
               });
 
               let verified = await waitForCondition(async () => {
@@ -2605,7 +2704,7 @@ export class RepostPostActionExecutor
                   repostButton = await resolveRepostButton(
                     page,
                     targetPost.locator,
-                    runtime.selectorLocale
+                    runtime.selectorLocale,
                   );
                   return await isPostReposted(repostButton.locator);
                 } catch {
@@ -2620,7 +2719,7 @@ export class RepostPostActionExecutor
                 repostButton = await resolveRepostButton(
                   page,
                   targetPost.locator,
-                  runtime.selectorLocale
+                  runtime.selectorLocale,
                 );
                 verified = await isPostReposted(repostButton.locator);
               }
@@ -2635,8 +2734,8 @@ export class RepostPostActionExecutor
                     post_url: postUrl,
                     post_identity: targetPost.postIdentity,
                     activity_id: targetPost.activityId,
-                    selector_key: selectorKey
-                  }
+                    selector_key: selectorKey,
+                  },
                 );
               }
             }
@@ -2648,7 +2747,7 @@ export class RepostPostActionExecutor
               profile_name: profileName,
               post_url: postUrl,
               selector_key: selectorKey,
-              post_selector_key: targetPost.key
+              post_selector_key: targetPost.key,
             });
 
             return {
@@ -2657,22 +2756,20 @@ export class RepostPostActionExecutor
                 reposted: true,
                 already_reposted: alreadyReposted,
                 post_url: postUrl,
-                rate_limit: formatRateLimitState(rateLimitState)
+                rate_limit: formatRateLimitState(rateLimitState),
               },
-              artifacts: [screenshotPath]
+              artifacts: [screenshotPath],
             };
-          }
+          },
         });
-      }
+      },
     );
   }
 }
 
-export class SharePostActionExecutor
-  implements ActionExecutor<LinkedInFeedExecutorRuntime>
-{
+export class SharePostActionExecutor implements ActionExecutor<LinkedInFeedExecutorRuntime> {
   async execute(
-    input: ActionExecutorInput<LinkedInFeedExecutorRuntime>
+    input: ActionExecutorInput<LinkedInFeedExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
     const runtime = input.runtime;
     const action = input.action;
@@ -2681,22 +2778,22 @@ export class SharePostActionExecutor
       action.target,
       "post_url",
       action.id,
-      "target"
+      "target",
     );
     const text = validateLinkedInPostText(
-      getRequiredStringField(action.payload, "text", action.id, "payload")
+      getRequiredStringField(action.payload, "text", action.id, "payload"),
     ).normalizedText;
 
     await runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: runtime.cdpUrl
+      cdpUrl: runtime.cdpUrl,
     });
 
     return runtime.profileManager.runWithContext(
       {
         cdpUrl: runtime.cdpUrl,
         profileName,
-        headless: true
+        headless: true,
       },
       async (context) => {
         const page = await getOrCreatePage(context);
@@ -2711,32 +2808,31 @@ export class SharePostActionExecutor
           targetUrl: postUrl,
           metadata: {
             post_url: postUrl,
-            text
+            text,
           },
           errorDetails: {
             post_url: postUrl,
-            text
+            text,
           },
           mapError: (error) =>
             asLinkedInBuddyError(
               error,
               "UNKNOWN",
-              "Failed to execute LinkedIn share_post action."
+              "Failed to execute LinkedIn share_post action.",
             ),
           execute: async () => {
-            const rateLimitState = runtime.rateLimiter.consume(SHARE_RATE_LIMIT_CONFIG);
-            if (!rateLimitState.allowed) {
-              throw new LinkedInBuddyError(
-                "RATE_LIMITED",
-                "LinkedIn share_post confirm is rate limited for the current window.",
-                {
+            const rateLimitState = consumeRateLimitOrThrow(
+              runtime.rateLimiter,
+              {
+                config: SHARE_RATE_LIMIT_CONFIG,
+                message: createConfirmRateLimitMessage(SHARE_POST_ACTION_TYPE),
+                details: {
                   action_id: action.id,
                   profile_name: profileName,
                   post_url: postUrl,
-                  rate_limit: formatRateLimitState(rateLimitState)
-                }
-              );
-            }
+                },
+              },
+            );
 
             await page.goto(postUrl, { waitUntil: "domcontentloaded" });
             await waitForPostSurface(page);
@@ -2745,20 +2841,20 @@ export class SharePostActionExecutor
             const composer = await openShareComposerFromPost(
               page,
               targetPost.locator,
-              runtime.selectorLocale
+              runtime.selectorLocale,
             );
             const inputKey = await setComposerText(
               page,
               composer.composerRoot,
               runtime.selectorLocale,
-              text
+              text,
             );
 
             const publishButton = await findVisibleScopedLocatorOrThrow(
               composer.composerRoot,
               createPublishButtonCandidates(runtime.selectorLocale),
               "feed_share_publish_button",
-              page.url()
+              page.url(),
             );
 
             const publishEnabled = await waitForCondition(async () => {
@@ -2777,40 +2873,50 @@ export class SharePostActionExecutor
                   action_id: action.id,
                   profile_name: profileName,
                   post_url: postUrl,
-                  selector_key: publishButton.key
-                }
+                  selector_key: publishButton.key,
+                },
               );
             }
 
             const beforeScreenshotPath = `linkedin/screenshot-feed-share-before-${Date.now()}.png`;
-            await captureScreenshotArtifact(runtime, page, beforeScreenshotPath, {
-              action: SHARE_POST_ACTION_TYPE,
-              action_id: action.id,
-              profile_name: profileName,
-              post_url: postUrl,
-              trigger_selector_key: composer.triggerKey,
-              composer_selector_key: composer.rootKey,
-              input_selector_key: inputKey,
-              publish_selector_key: publishButton.key
-            });
+            await captureScreenshotArtifact(
+              runtime,
+              page,
+              beforeScreenshotPath,
+              {
+                action: SHARE_POST_ACTION_TYPE,
+                action_id: action.id,
+                profile_name: profileName,
+                post_url: postUrl,
+                trigger_selector_key: composer.triggerKey,
+                composer_selector_key: composer.rootKey,
+                input_selector_key: inputKey,
+                publish_selector_key: publishButton.key,
+              },
+            );
 
             await publishButton.locator.click({ timeout: 5_000 });
             await waitForCondition(
               async () => !(await isAnyLocatorVisible(composer.composerRoot)),
-              10_000
+              10_000,
             );
             await waitForNetworkIdleBestEffort(page);
 
             const verification = await verifySharedPost(page, text);
 
             const afterScreenshotPath = `linkedin/screenshot-feed-share-after-${Date.now()}.png`;
-            await captureScreenshotArtifact(runtime, page, afterScreenshotPath, {
-              action: SHARE_POST_ACTION_TYPE,
-              action_id: action.id,
-              profile_name: profileName,
-              post_url: postUrl,
-              shared_post_url: verification.postUrl
-            });
+            await captureScreenshotArtifact(
+              runtime,
+              page,
+              afterScreenshotPath,
+              {
+                action: SHARE_POST_ACTION_TYPE,
+                action_id: action.id,
+                profile_name: profileName,
+                post_url: postUrl,
+                shared_post_url: verification.postUrl,
+              },
+            );
 
             return {
               ok: true,
@@ -2820,22 +2926,20 @@ export class SharePostActionExecutor
                 shared_post_url: verification.postUrl,
                 text,
                 verification_snippet: createVerificationSnippet(text),
-                rate_limit: formatRateLimitState(rateLimitState)
+                rate_limit: formatRateLimitState(rateLimitState),
               },
-              artifacts: [beforeScreenshotPath, afterScreenshotPath]
+              artifacts: [beforeScreenshotPath, afterScreenshotPath],
             };
-          }
+          },
         });
-      }
+      },
     );
   }
 }
 
-export class SavePostActionExecutor
-  implements ActionExecutor<LinkedInFeedExecutorRuntime>
-{
+export class SavePostActionExecutor implements ActionExecutor<LinkedInFeedExecutorRuntime> {
   async execute(
-    input: ActionExecutorInput<LinkedInFeedExecutorRuntime>
+    input: ActionExecutorInput<LinkedInFeedExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
     const runtime = input.runtime;
     const action = input.action;
@@ -2844,19 +2948,19 @@ export class SavePostActionExecutor
       action.target,
       "post_url",
       action.id,
-      "target"
+      "target",
     );
 
     await runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: runtime.cdpUrl
+      cdpUrl: runtime.cdpUrl,
     });
 
     return runtime.profileManager.runWithContext(
       {
         cdpUrl: runtime.cdpUrl,
         profileName,
-        headless: true
+        headless: true,
       },
       async (context) => {
         const page = await getOrCreatePage(context);
@@ -2870,31 +2974,30 @@ export class SavePostActionExecutor
           profileName,
           targetUrl: postUrl,
           metadata: {
-            post_url: postUrl
+            post_url: postUrl,
           },
           errorDetails: {
-            post_url: postUrl
+            post_url: postUrl,
           },
           mapError: (error) =>
             asLinkedInBuddyError(
               error,
               "UNKNOWN",
-              "Failed to execute LinkedIn save_post action."
+              "Failed to execute LinkedIn save_post action.",
             ),
           execute: async () => {
-            const rateLimitState = runtime.rateLimiter.consume(SAVE_RATE_LIMIT_CONFIG);
-            if (!rateLimitState.allowed) {
-              throw new LinkedInBuddyError(
-                "RATE_LIMITED",
-                "LinkedIn save_post confirm is rate limited for the current window.",
-                {
+            const rateLimitState = consumeRateLimitOrThrow(
+              runtime.rateLimiter,
+              {
+                config: SAVE_RATE_LIMIT_CONFIG,
+                message: createConfirmRateLimitMessage(SAVE_POST_ACTION_TYPE),
+                details: {
                   action_id: action.id,
                   profile_name: profileName,
                   post_url: postUrl,
-                  rate_limit: formatRateLimitState(rateLimitState)
-                }
-              );
-            }
+                },
+              },
+            );
 
             await page.goto(postUrl, { waitUntil: "domcontentloaded" });
             await waitForPostSurface(page);
@@ -2903,7 +3006,7 @@ export class SavePostActionExecutor
             const initialSavedState = await readPostSavedState(
               page,
               targetPost.locator,
-              runtime.selectorLocale
+              runtime.selectorLocale,
             );
 
             let selectorKey = "feed-save-existing-state";
@@ -2914,7 +3017,7 @@ export class SavePostActionExecutor
                 selectorLocale: runtime.selectorLocale,
                 selectorKeys: "save",
                 candidateKeyPrefix: "feed-save",
-                selectorKey: "feed_save_menu_action"
+                selectorKey: "feed_save_menu_action",
               });
             }
 
@@ -2922,11 +3025,13 @@ export class SavePostActionExecutor
             if (!verified) {
               verified = await waitForCondition(async () => {
                 try {
-                  return (await readPostSavedState(
-                    page,
-                    targetPost.locator,
-                    runtime.selectorLocale
-                  )) === true;
+                  return (
+                    (await readPostSavedState(
+                      page,
+                      targetPost.locator,
+                      runtime.selectorLocale,
+                    )) === true
+                  );
                 } catch {
                   return false;
                 }
@@ -2938,7 +3043,11 @@ export class SavePostActionExecutor
               await waitForPostSurface(page);
               targetPost = await findTargetPostLocator(page, postUrl);
               verified =
-                (await readPostSavedState(page, targetPost.locator, runtime.selectorLocale)) === true;
+                (await readPostSavedState(
+                  page,
+                  targetPost.locator,
+                  runtime.selectorLocale,
+                )) === true;
             }
 
             if (!verified) {
@@ -2951,8 +3060,8 @@ export class SavePostActionExecutor
                   post_url: postUrl,
                   selector_key: selectorKey,
                   post_identity: targetPost.postIdentity,
-                  activity_id: targetPost.activityId
-                }
+                  activity_id: targetPost.activityId,
+                },
               );
             }
 
@@ -2963,7 +3072,7 @@ export class SavePostActionExecutor
               profile_name: profileName,
               post_url: postUrl,
               selector_key: selectorKey,
-              post_selector_key: targetPost.key
+              post_selector_key: targetPost.key,
             });
 
             return {
@@ -2972,22 +3081,20 @@ export class SavePostActionExecutor
                 saved: true,
                 already_saved: initialSavedState === true,
                 post_url: postUrl,
-                rate_limit: formatRateLimitState(rateLimitState)
+                rate_limit: formatRateLimitState(rateLimitState),
               },
-              artifacts: [screenshotPath]
+              artifacts: [screenshotPath],
             };
-          }
+          },
         });
-      }
+      },
     );
   }
 }
 
-export class UnsavePostActionExecutor
-  implements ActionExecutor<LinkedInFeedExecutorRuntime>
-{
+export class UnsavePostActionExecutor implements ActionExecutor<LinkedInFeedExecutorRuntime> {
   async execute(
-    input: ActionExecutorInput<LinkedInFeedExecutorRuntime>
+    input: ActionExecutorInput<LinkedInFeedExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
     const runtime = input.runtime;
     const action = input.action;
@@ -2996,19 +3103,19 @@ export class UnsavePostActionExecutor
       action.target,
       "post_url",
       action.id,
-      "target"
+      "target",
     );
 
     await runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: runtime.cdpUrl
+      cdpUrl: runtime.cdpUrl,
     });
 
     return runtime.profileManager.runWithContext(
       {
         cdpUrl: runtime.cdpUrl,
         profileName,
-        headless: true
+        headless: true,
       },
       async (context) => {
         const page = await getOrCreatePage(context);
@@ -3022,31 +3129,30 @@ export class UnsavePostActionExecutor
           profileName,
           targetUrl: postUrl,
           metadata: {
-            post_url: postUrl
+            post_url: postUrl,
           },
           errorDetails: {
-            post_url: postUrl
+            post_url: postUrl,
           },
           mapError: (error) =>
             asLinkedInBuddyError(
               error,
               "UNKNOWN",
-              "Failed to execute LinkedIn unsave_post action."
+              "Failed to execute LinkedIn unsave_post action.",
             ),
           execute: async () => {
-            const rateLimitState = runtime.rateLimiter.consume(UNSAVE_RATE_LIMIT_CONFIG);
-            if (!rateLimitState.allowed) {
-              throw new LinkedInBuddyError(
-                "RATE_LIMITED",
-                "LinkedIn unsave_post confirm is rate limited for the current window.",
-                {
+            const rateLimitState = consumeRateLimitOrThrow(
+              runtime.rateLimiter,
+              {
+                config: UNSAVE_RATE_LIMIT_CONFIG,
+                message: createConfirmRateLimitMessage(UNSAVE_POST_ACTION_TYPE),
+                details: {
                   action_id: action.id,
                   profile_name: profileName,
                   post_url: postUrl,
-                  rate_limit: formatRateLimitState(rateLimitState)
-                }
-              );
-            }
+                },
+              },
+            );
 
             await page.goto(postUrl, { waitUntil: "domcontentloaded" });
             await waitForPostSurface(page);
@@ -3055,7 +3161,7 @@ export class UnsavePostActionExecutor
             const initialSavedState = await readPostSavedState(
               page,
               targetPost.locator,
-              runtime.selectorLocale
+              runtime.selectorLocale,
             );
 
             let selectorKey = "feed-unsave-existing-state";
@@ -3066,7 +3172,7 @@ export class UnsavePostActionExecutor
                 selectorLocale: runtime.selectorLocale,
                 selectorKeys: "unsave",
                 candidateKeyPrefix: "feed-unsave",
-                selectorKey: "feed_unsave_menu_action"
+                selectorKey: "feed_unsave_menu_action",
               });
             }
 
@@ -3074,11 +3180,13 @@ export class UnsavePostActionExecutor
             if (!verified) {
               verified = await waitForCondition(async () => {
                 try {
-                  return (await readPostSavedState(
-                    page,
-                    targetPost.locator,
-                    runtime.selectorLocale
-                  )) === false;
+                  return (
+                    (await readPostSavedState(
+                      page,
+                      targetPost.locator,
+                      runtime.selectorLocale,
+                    )) === false
+                  );
                 } catch {
                   return false;
                 }
@@ -3090,7 +3198,11 @@ export class UnsavePostActionExecutor
               await waitForPostSurface(page);
               targetPost = await findTargetPostLocator(page, postUrl);
               verified =
-                (await readPostSavedState(page, targetPost.locator, runtime.selectorLocale)) === false;
+                (await readPostSavedState(
+                  page,
+                  targetPost.locator,
+                  runtime.selectorLocale,
+                )) === false;
             }
 
             if (!verified) {
@@ -3103,8 +3215,8 @@ export class UnsavePostActionExecutor
                   post_url: postUrl,
                   selector_key: selectorKey,
                   post_identity: targetPost.postIdentity,
-                  activity_id: targetPost.activityId
-                }
+                  activity_id: targetPost.activityId,
+                },
               );
             }
 
@@ -3115,7 +3227,7 @@ export class UnsavePostActionExecutor
               profile_name: profileName,
               post_url: postUrl,
               selector_key: selectorKey,
-              post_selector_key: targetPost.key
+              post_selector_key: targetPost.key,
             });
 
             return {
@@ -3124,22 +3236,20 @@ export class UnsavePostActionExecutor
                 saved: false,
                 already_unsaved: initialSavedState === false,
                 post_url: postUrl,
-                rate_limit: formatRateLimitState(rateLimitState)
+                rate_limit: formatRateLimitState(rateLimitState),
               },
-              artifacts: [screenshotPath]
+              artifacts: [screenshotPath],
             };
-          }
+          },
         });
-      }
+      },
     );
   }
 }
 
-export class RemoveReactionActionExecutor
-  implements ActionExecutor<LinkedInFeedExecutorRuntime>
-{
+export class RemoveReactionActionExecutor implements ActionExecutor<LinkedInFeedExecutorRuntime> {
   async execute(
-    input: ActionExecutorInput<LinkedInFeedExecutorRuntime>
+    input: ActionExecutorInput<LinkedInFeedExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
     const runtime = input.runtime;
     const action = input.action;
@@ -3148,19 +3258,19 @@ export class RemoveReactionActionExecutor
       action.target,
       "post_url",
       action.id,
-      "target"
+      "target",
     );
 
     await runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: runtime.cdpUrl
+      cdpUrl: runtime.cdpUrl,
     });
 
     return runtime.profileManager.runWithContext(
       {
         cdpUrl: runtime.cdpUrl,
         profileName,
-        headless: true
+        headless: true,
       },
       async (context) => {
         const page = await getOrCreatePage(context);
@@ -3174,33 +3284,32 @@ export class RemoveReactionActionExecutor
           profileName,
           targetUrl: postUrl,
           metadata: {
-            post_url: postUrl
+            post_url: postUrl,
           },
           errorDetails: {
-            post_url: postUrl
+            post_url: postUrl,
           },
           mapError: (error) =>
             asLinkedInBuddyError(
               error,
               "UNKNOWN",
-              "Failed to execute LinkedIn remove_reaction action."
+              "Failed to execute LinkedIn remove_reaction action.",
             ),
           execute: async () => {
-            const rateLimitState = runtime.rateLimiter.consume(
-              REMOVE_REACTION_RATE_LIMIT_CONFIG
-            );
-            if (!rateLimitState.allowed) {
-              throw new LinkedInBuddyError(
-                "RATE_LIMITED",
-                "LinkedIn remove_reaction confirm is rate limited for the current window.",
-                {
+            const rateLimitState = consumeRateLimitOrThrow(
+              runtime.rateLimiter,
+              {
+                config: REMOVE_REACTION_RATE_LIMIT_CONFIG,
+                message: createConfirmRateLimitMessage(
+                  REMOVE_REACTION_ACTION_TYPE,
+                ),
+                details: {
                   action_id: action.id,
                   profile_name: profileName,
                   post_url: postUrl,
-                  rate_limit: formatRateLimitState(rateLimitState)
-                }
-              );
-            }
+                },
+              },
+            );
 
             await page.goto(postUrl, { waitUntil: "domcontentloaded" });
             await waitForPostSurface(page);
@@ -3209,11 +3318,11 @@ export class RemoveReactionActionExecutor
             let reactButton = await resolveReactionButton(
               page,
               targetPost.locator,
-              runtime.selectorLocale
+              runtime.selectorLocale,
             );
             const reactionState = await getReactionButtonState(
               reactButton.locator,
-              runtime.selectorLocale
+              runtime.selectorLocale,
             );
             const previousReaction = reactionState.reaction;
             const alreadyCleared = !reactionState.reacted;
@@ -3225,7 +3334,7 @@ export class RemoveReactionActionExecutor
                 try {
                   const currentState = await getReactionButtonState(
                     reactButton.locator,
-                    runtime.selectorLocale
+                    runtime.selectorLocale,
                   );
                   return !currentState.reacted;
                 } catch {
@@ -3240,12 +3349,14 @@ export class RemoveReactionActionExecutor
                 reactButton = await resolveReactionButton(
                   page,
                   targetPost.locator,
-                  runtime.selectorLocale
+                  runtime.selectorLocale,
                 );
-                verified = !(await getReactionButtonState(
-                  reactButton.locator,
-                  runtime.selectorLocale
-                )).reacted;
+                verified = !(
+                  await getReactionButtonState(
+                    reactButton.locator,
+                    runtime.selectorLocale,
+                  )
+                ).reacted;
               }
 
               if (!verified) {
@@ -3258,8 +3369,8 @@ export class RemoveReactionActionExecutor
                     post_url: postUrl,
                     post_identity: targetPost.postIdentity,
                     activity_id: targetPost.activityId,
-                    previous_reaction: previousReaction
-                  }
+                    previous_reaction: previousReaction,
+                  },
                 );
               }
             }
@@ -3271,7 +3382,7 @@ export class RemoveReactionActionExecutor
               profile_name: profileName,
               post_url: postUrl,
               post_selector_key: targetPost.key,
-              previous_reaction: previousReaction
+              previous_reaction: previousReaction,
             });
 
             return {
@@ -3281,13 +3392,13 @@ export class RemoveReactionActionExecutor
                 already_cleared: alreadyCleared,
                 previous_reaction: previousReaction,
                 post_url: postUrl,
-                rate_limit: formatRateLimitState(rateLimitState)
+                rate_limit: formatRateLimitState(rateLimitState),
               },
-              artifacts: [screenshotPath]
+              artifacts: [screenshotPath],
             };
-          }
+          },
         });
-      }
+      },
     );
   }
 }
@@ -3303,7 +3414,7 @@ export function createFeedActionExecutors(): Record<
     [SHARE_POST_ACTION_TYPE]: new SharePostActionExecutor(),
     [SAVE_POST_ACTION_TYPE]: new SavePostActionExecutor(),
     [UNSAVE_POST_ACTION_TYPE]: new UnsavePostActionExecutor(),
-    [REMOVE_REACTION_ACTION_TYPE]: new RemoveReactionActionExecutor()
+    [REMOVE_REACTION_ACTION_TYPE]: new RemoveReactionActionExecutor(),
   };
 }
 
@@ -3324,7 +3435,7 @@ export class LinkedInFeedService {
 
     await this.runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: this.runtime.cdpUrl
+      cdpUrl: this.runtime.cdpUrl,
     });
 
     try {
@@ -3332,7 +3443,7 @@ export class LinkedInFeedService {
         {
           cdpUrl: this.runtime.cdpUrl,
           profileName,
-          headless: true
+          headless: true,
         },
         async (context) => {
           const page = await getOrCreatePage(context);
@@ -3340,7 +3451,7 @@ export class LinkedInFeedService {
           await waitForFeedSurface(page);
           const posts = await loadFeedPosts(page, limit);
           return posts.slice(0, limit);
-        }
+        },
       );
     } catch (error) {
       if (error instanceof LinkedInBuddyError) {
@@ -3349,7 +3460,7 @@ export class LinkedInFeedService {
       throw asLinkedInBuddyError(
         error,
         "UNKNOWN",
-        "Failed to view LinkedIn feed."
+        "Failed to view LinkedIn feed.",
       );
     }
   }
@@ -3360,7 +3471,7 @@ export class LinkedInFeedService {
 
     await this.runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: this.runtime.cdpUrl
+      cdpUrl: this.runtime.cdpUrl,
     });
 
     try {
@@ -3368,7 +3479,7 @@ export class LinkedInFeedService {
         {
           cdpUrl: this.runtime.cdpUrl,
           profileName,
-          headless: true
+          headless: true,
         },
         async (context) => {
           const page = await getOrCreatePage(context);
@@ -3383,13 +3494,13 @@ export class LinkedInFeedService {
               "Could not extract post details from the requested LinkedIn post URL.",
               {
                 post_url: postUrl,
-                current_url: page.url()
-              }
+                current_url: page.url(),
+              },
             );
           }
 
           return post;
-        }
+        },
       );
     } catch (error) {
       if (error instanceof LinkedInBuddyError) {
@@ -3398,7 +3509,7 @@ export class LinkedInFeedService {
       throw asLinkedInBuddyError(
         error,
         "UNKNOWN",
-        "Failed to view LinkedIn post."
+        "Failed to view LinkedIn post.",
       );
     }
   }
@@ -3412,11 +3523,13 @@ export class LinkedInFeedService {
     const profileName = input.profileName ?? "default";
     const postUrl = resolvePostUrl(input.postUrl);
     const reaction = normalizeLinkedInFeedReaction(input.reaction, "like");
-    const rateLimitState = this.runtime.rateLimiter.peek(LIKE_RATE_LIMIT_CONFIG);
+    const rateLimitState: RateLimiterState = this.runtime.rateLimiter.peek(
+      LIKE_RATE_LIMIT_CONFIG,
+    );
 
     const target = {
       profile_name: profileName,
-      post_url: postUrl
+      post_url: postUrl,
     };
 
     const preview = {
@@ -3424,21 +3537,21 @@ export class LinkedInFeedService {
       target,
       outbound: {
         action: "react",
-        reaction
+        reaction,
       },
       supported_reactions: LINKEDIN_FEED_REACTION_TYPES,
       reaction_map: LINKEDIN_FEED_REACTION_MAP,
-      rate_limit: formatRateLimitState(rateLimitState)
+      rate_limit: formatRateLimitState(rateLimitState),
     } satisfies Record<string, unknown>;
 
     return this.runtime.twoPhaseCommit.prepare({
       actionType: LIKE_POST_ACTION_TYPE,
       target,
       payload: {
-        reaction
+        reaction,
       },
       preview,
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
   }
 
@@ -3455,34 +3568,36 @@ export class LinkedInFeedService {
     if (!text) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "Comment text must not be empty."
+        "Comment text must not be empty.",
       );
     }
 
-    const rateLimitState = this.runtime.rateLimiter.peek(COMMENT_RATE_LIMIT_CONFIG);
+    const rateLimitState = this.runtime.rateLimiter.peek(
+      COMMENT_RATE_LIMIT_CONFIG,
+    );
 
     const target = {
       profile_name: profileName,
-      post_url: postUrl
+      post_url: postUrl,
     };
 
     const preview = {
       summary: `Comment on LinkedIn post ${postUrl}`,
       target,
       outbound: {
-        text
+        text,
       },
-      rate_limit: formatRateLimitState(rateLimitState)
+      rate_limit: formatRateLimitState(rateLimitState),
     } satisfies Record<string, unknown>;
 
     return this.runtime.twoPhaseCommit.prepare({
       actionType: COMMENT_ON_POST_ACTION_TYPE,
       target,
       payload: {
-        text
+        text,
       },
       preview,
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
   }
 
@@ -3494,20 +3609,22 @@ export class LinkedInFeedService {
   } {
     const profileName = input.profileName ?? "default";
     const postUrl = resolvePostUrl(input.postUrl);
-    const rateLimitState = this.runtime.rateLimiter.peek(REPOST_RATE_LIMIT_CONFIG);
+    const rateLimitState = this.runtime.rateLimiter.peek(
+      REPOST_RATE_LIMIT_CONFIG,
+    );
 
     const target = {
       profile_name: profileName,
-      post_url: postUrl
+      post_url: postUrl,
     };
 
     const preview = {
       summary: `Repost LinkedIn post ${postUrl}`,
       target,
       outbound: {
-        action: "repost"
+        action: "repost",
       },
-      rate_limit: formatRateLimitState(rateLimitState)
+      rate_limit: formatRateLimitState(rateLimitState),
     } satisfies Record<string, unknown>;
 
     return this.runtime.twoPhaseCommit.prepare({
@@ -3515,7 +3632,7 @@ export class LinkedInFeedService {
       target,
       payload: {},
       preview,
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
   }
 
@@ -3528,11 +3645,13 @@ export class LinkedInFeedService {
     const profileName = input.profileName ?? "default";
     const postUrl = resolvePostUrl(input.postUrl);
     const text = validateLinkedInPostText(input.text).normalizedText;
-    const rateLimitState = this.runtime.rateLimiter.peek(SHARE_RATE_LIMIT_CONFIG);
+    const rateLimitState = this.runtime.rateLimiter.peek(
+      SHARE_RATE_LIMIT_CONFIG,
+    );
 
     const target = {
       profile_name: profileName,
-      post_url: postUrl
+      post_url: postUrl,
     };
 
     const preview = {
@@ -3540,19 +3659,19 @@ export class LinkedInFeedService {
       target,
       outbound: {
         action: "share",
-        text
+        text,
       },
-      rate_limit: formatRateLimitState(rateLimitState)
+      rate_limit: formatRateLimitState(rateLimitState),
     } satisfies Record<string, unknown>;
 
     return this.runtime.twoPhaseCommit.prepare({
       actionType: SHARE_POST_ACTION_TYPE,
       target,
       payload: {
-        text
+        text,
       },
       preview,
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
   }
 
@@ -3564,20 +3683,22 @@ export class LinkedInFeedService {
   } {
     const profileName = input.profileName ?? "default";
     const postUrl = resolvePostUrl(input.postUrl);
-    const rateLimitState = this.runtime.rateLimiter.peek(SAVE_RATE_LIMIT_CONFIG);
+    const rateLimitState = this.runtime.rateLimiter.peek(
+      SAVE_RATE_LIMIT_CONFIG,
+    );
 
     const target = {
       profile_name: profileName,
-      post_url: postUrl
+      post_url: postUrl,
     };
 
     const preview = {
       summary: `Save LinkedIn post ${postUrl} for later`,
       target,
       outbound: {
-        action: "save"
+        action: "save",
       },
-      rate_limit: formatRateLimitState(rateLimitState)
+      rate_limit: formatRateLimitState(rateLimitState),
     } satisfies Record<string, unknown>;
 
     return this.runtime.twoPhaseCommit.prepare({
@@ -3585,7 +3706,7 @@ export class LinkedInFeedService {
       target,
       payload: {},
       preview,
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
   }
 
@@ -3597,20 +3718,22 @@ export class LinkedInFeedService {
   } {
     const profileName = input.profileName ?? "default";
     const postUrl = resolvePostUrl(input.postUrl);
-    const rateLimitState = this.runtime.rateLimiter.peek(UNSAVE_RATE_LIMIT_CONFIG);
+    const rateLimitState = this.runtime.rateLimiter.peek(
+      UNSAVE_RATE_LIMIT_CONFIG,
+    );
 
     const target = {
       profile_name: profileName,
-      post_url: postUrl
+      post_url: postUrl,
     };
 
     const preview = {
       summary: `Unsave LinkedIn post ${postUrl}`,
       target,
       outbound: {
-        action: "unsave"
+        action: "unsave",
       },
-      rate_limit: formatRateLimitState(rateLimitState)
+      rate_limit: formatRateLimitState(rateLimitState),
     } satisfies Record<string, unknown>;
 
     return this.runtime.twoPhaseCommit.prepare({
@@ -3618,7 +3741,7 @@ export class LinkedInFeedService {
       target,
       payload: {},
       preview,
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
   }
 
@@ -3631,21 +3754,21 @@ export class LinkedInFeedService {
     const profileName = input.profileName ?? "default";
     const postUrl = resolvePostUrl(input.postUrl);
     const rateLimitState = this.runtime.rateLimiter.peek(
-      REMOVE_REACTION_RATE_LIMIT_CONFIG
+      REMOVE_REACTION_RATE_LIMIT_CONFIG,
     );
 
     const target = {
       profile_name: profileName,
-      post_url: postUrl
+      post_url: postUrl,
     };
 
     const preview = {
       summary: `Remove your reaction from LinkedIn post ${postUrl}`,
       target,
       outbound: {
-        action: "remove_reaction"
+        action: "remove_reaction",
       },
-      rate_limit: formatRateLimitState(rateLimitState)
+      rate_limit: formatRateLimitState(rateLimitState),
     } satisfies Record<string, unknown>;
 
     return this.runtime.twoPhaseCommit.prepare({
@@ -3653,7 +3776,7 @@ export class LinkedInFeedService {
       target,
       payload: {},
       preview,
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
   }
 }

--- a/packages/core/src/linkedinFollowups.ts
+++ b/packages/core/src/linkedinFollowups.ts
@@ -2,42 +2,43 @@ import {
   errors as playwrightErrors,
   type BrowserContext,
   type Locator,
-  type Page
+  type Page,
 } from "playwright-core";
 import type { ArtifactHelpers } from "./artifacts.js";
 import type { LinkedInAuthService } from "./auth/session.js";
 import type {
   AssistantDatabase,
   PreparedActionRow,
-  SentInvitationStateRow
+  SentInvitationStateRow,
 } from "./db/database.js";
-import {
-  LinkedInBuddyError,
-  asLinkedInBuddyError
-} from "./errors.js";
+import { LinkedInBuddyError, asLinkedInBuddyError } from "./errors.js";
 import {
   SEND_MESSAGE_RATE_LIMIT_CONFIG,
-  type LinkedInMessagingRuntime
+  type LinkedInMessagingRuntime,
 } from "./linkedinInbox.js";
-import {
-  normalizeLinkedInProfileUrl
-} from "./linkedinProfile.js";
+import { normalizeLinkedInProfileUrl } from "./linkedinProfile.js";
 import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
-import type { RateLimiter, RateLimiterState } from "./rateLimiter.js";
+import {
+  consumeRateLimitOrThrow,
+  createConfirmRateLimitMessage,
+  formatRateLimitState,
+  type RateLimiter,
+  type RateLimiterState,
+} from "./rateLimiter.js";
 import type { LinkedInSelectorLocale } from "./selectorLocale.js";
 import {
   buildLinkedInAriaLabelContainsSelector,
   buildLinkedInSelectorPhraseRegex,
-  formatLinkedInSelectorRegexHint
+  formatLinkedInSelectorRegexHint,
 } from "./selectorLocale.js";
 import type {
   ActionExecutor,
   ActionExecutorInput,
   ActionExecutorResult,
   PreparedAction,
-  TwoPhaseCommitService
+  TwoPhaseCommitService,
 } from "./twoPhaseCommit.js";
 
 export const FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE =
@@ -161,7 +162,10 @@ export interface LinkedInFollowupsRuntime extends LinkedInFollowupsExecutorRunti
       filter?: "sent" | "received" | "all";
     }): Promise<unknown[]>;
   };
-  twoPhaseCommit: Pick<TwoPhaseCommitService<LinkedInMessagingRuntime>, "prepare">;
+  twoPhaseCommit: Pick<
+    TwoPhaseCommitService<LinkedInMessagingRuntime>,
+    "prepare"
+  >;
 }
 
 function normalizeText(value: string | null | undefined): string {
@@ -203,7 +207,7 @@ export function buildDefaultFollowupText(fullName: string): string {
  */
 export function resolveFollowupSinceWindow(
   since: string | undefined,
-  nowMs = Date.now()
+  nowMs = Date.now(),
 ): { since: string; sinceMs: number } {
   const normalized = normalizeText(since) || DEFAULT_FOLLOWUP_SINCE;
   const relativeMatch = /^(\d+)\s*(m|h|d|w)$/i.exec(normalized);
@@ -215,7 +219,7 @@ export function resolveFollowupSinceWindow(
     if (!Number.isFinite(amount) || amount <= 0) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "since must be a positive relative duration like 7d or 24h."
+        "since must be a positive relative duration like 7d or 24h.",
       );
     }
 
@@ -230,7 +234,7 @@ export function resolveFollowupSinceWindow(
 
     return {
       since: `${amount}${unit}`,
-      sinceMs: nowMs - amount * multiplier
+      sinceMs: nowMs - amount * multiplier,
     };
   }
 
@@ -239,19 +243,19 @@ export function resolveFollowupSinceWindow(
     if (absoluteMs > nowMs) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "since must not be in the future."
+        "since must not be in the future.",
       );
     }
 
     return {
       since: normalized,
-      sinceMs: absoluteMs
+      sinceMs: absoluteMs,
     };
   }
 
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    "since must be a relative duration like 7d, 24h, 30m, or an ISO date."
+    "since must be a relative duration like 7d, 24h, 30m, or an ISO date.",
   );
 }
 
@@ -260,7 +264,7 @@ function formatLookbackWindowMs(value: number): string {
     { label: "w", sizeMs: 7 * 24 * 60 * 60 * 1000 },
     { label: "d", sizeMs: 24 * 60 * 60 * 1000 },
     { label: "h", sizeMs: 60 * 60 * 1000 },
-    { label: "m", sizeMs: 60 * 1000 }
+    { label: "m", sizeMs: 60 * 1000 },
   ] as const;
 
   for (const unit of units) {
@@ -283,34 +287,21 @@ function resolveFollowupLookbackWindow(input: {
     if (!Number.isFinite(input.sinceMs) || input.sinceMs <= 0) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "sinceMs must be a positive number of milliseconds."
+        "sinceMs must be a positive number of milliseconds.",
       );
     }
 
     return {
-      since: normalizeText(input.since) || formatLookbackWindowMs(input.sinceMs),
-      cutoffMs: nowMs - input.sinceMs
+      since:
+        normalizeText(input.since) || formatLookbackWindowMs(input.sinceMs),
+      cutoffMs: nowMs - input.sinceMs,
     };
   }
 
   const resolved = resolveFollowupSinceWindow(input.since, nowMs);
   return {
     since: resolved.since,
-    cutoffMs: resolved.sinceMs
-  };
-}
-
-function formatRateLimitState(
-  state: RateLimiterState
-): Record<string, number | boolean | string> {
-  return {
-    counter_key: state.counterKey,
-    window_start_ms: state.windowStartMs,
-    window_size_ms: state.windowSizeMs,
-    count: state.count,
-    limit: state.limit,
-    remaining: state.remaining,
-    allowed: state.allowed
+    cutoffMs: resolved.sinceMs,
   };
 }
 
@@ -327,7 +318,7 @@ function getRequiredStringField(
   source: Record<string, unknown>,
   key: string,
   actionId: string,
-  location: "target" | "payload"
+  location: "target" | "payload",
 ): string {
   const value = source[key];
   if (typeof value === "string" && value.trim().length > 0) {
@@ -340,14 +331,14 @@ function getRequiredStringField(
     {
       action_id: actionId,
       location,
-      key
-    }
+      key,
+    },
   );
 }
 
 function getOptionalStringField(
   source: Record<string, unknown>,
-  key: string
+  key: string,
 ): string | undefined {
   const value = source[key];
   if (typeof value === "string" && value.trim().length > 0) {
@@ -360,14 +351,16 @@ function getOptionalStringField(
 function toAutomationError(
   error: unknown,
   message: string,
-  details: Record<string, unknown>
+  details: Record<string, unknown>,
 ): LinkedInBuddyError {
   if (error instanceof LinkedInBuddyError) {
     return error;
   }
 
   if (error instanceof playwrightErrors.TimeoutError) {
-    return new LinkedInBuddyError("TIMEOUT", message, details, { cause: error });
+    return new LinkedInBuddyError("TIMEOUT", message, details, {
+      cause: error,
+    });
   }
 
   if (
@@ -375,7 +368,7 @@ function toAutomationError(
     /(net::|ERR_|ECONN|ENOTFOUND|EAI_AGAIN|socket hang up)/i.test(error.message)
   ) {
     return new LinkedInBuddyError("NETWORK_ERROR", message, details, {
-      cause: error
+      cause: error,
     });
   }
 
@@ -392,7 +385,7 @@ function deriveFollowupStatus(input: {
     state,
     nowMs,
     preparedActionStatus,
-    preparedActionExpiresAtMs = null
+    preparedActionExpiresAtMs = null,
   } = input;
 
   if (state.followup_confirmed_at !== null) {
@@ -412,7 +405,10 @@ function deriveFollowupStatus(input: {
   }
 
   if (preparedActionStatus === "prepared") {
-    if (preparedActionExpiresAtMs !== null && preparedActionExpiresAtMs <= nowMs) {
+    if (
+      preparedActionExpiresAtMs !== null &&
+      preparedActionExpiresAtMs <= nowMs
+    ) {
       return "expired";
     }
 
@@ -423,9 +419,11 @@ function deriveFollowupStatus(input: {
 }
 
 function shouldPrepareAcceptedConnectionFollowup(
-  status: FollowupPreparationStatus
+  status: FollowupPreparationStatus,
 ): boolean {
-  return status === "not_prepared" || status === "failed" || status === "expired";
+  return (
+    status === "not_prepared" || status === "failed" || status === "expired"
+  );
 }
 
 async function getOrCreatePage(context: BrowserContext): Promise<Page> {
@@ -441,7 +439,7 @@ async function captureScreenshotArtifact(
   runtime: Pick<LinkedInFollowupsExecutorRuntime, "artifacts">,
   page: Page,
   relativePath: string,
-  metadata: Record<string, unknown> = {}
+  metadata: Record<string, unknown> = {},
 ): Promise<string> {
   const absolutePath = runtime.artifacts.resolve(relativePath);
   await page.screenshot({ path: absolutePath, fullPage: true });
@@ -449,7 +447,10 @@ async function captureScreenshotArtifact(
   return relativePath;
 }
 
-async function waitForMessageEcho(page: Page, messageText: string): Promise<void> {
+async function waitForMessageEcho(
+  page: Page,
+  messageText: string,
+): Promise<void> {
   const snippet = messageText.trim().slice(0, 140);
   if (!snippet) {
     return;
@@ -461,8 +462,8 @@ async function waitForMessageEcho(page: Page, messageText: string): Promise<void
       .filter({ hasText: snippet })
       .last(),
     page.locator("[role='dialog'], .msg-overlay-conversation-bubble").filter({
-      hasText: snippet
-    })
+      hasText: snippet,
+    }),
   ];
 
   for (const candidate of candidates) {
@@ -477,7 +478,7 @@ async function waitForMessageEcho(page: Page, messageText: string): Promise<void
 
 async function findVisibleLocator(
   page: Page,
-  candidates: SelectorCandidate[]
+  candidates: SelectorCandidate[],
 ): Promise<{ locator: Locator; key: string } | null> {
   for (const candidate of candidates) {
     const locator = candidate.locatorFactory(page).first();
@@ -496,7 +497,7 @@ async function findVisibleLocatorOrThrow(
   page: Page,
   candidates: SelectorCandidate[],
   selectorKey: string,
-  artifactPaths: string[]
+  artifactPaths: string[],
 ): Promise<{ locator: Locator; key: string }> {
   const result = await findVisibleLocator(page, candidates);
   if (result) {
@@ -509,38 +510,40 @@ async function findVisibleLocatorOrThrow(
     {
       selector_key: selectorKey,
       current_url: page.url(),
-      attempted_selectors: candidates.map((candidate) => candidate.selectorHint),
-      artifact_paths: artifactPaths
-    }
+      attempted_selectors: candidates.map(
+        (candidate) => candidate.selectorHint,
+      ),
+      artifact_paths: artifactPaths,
+    },
   );
 }
 
 function profileMessageButtonCandidates(
   root: Locator,
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): SelectorCandidate[] {
   const messageExactRegex = buildLinkedInSelectorPhraseRegex(
     "message",
     selectorLocale,
-    { exact: true }
+    { exact: true },
   );
   const messageExactRegexHint = formatLinkedInSelectorRegexHint(
     "message",
     selectorLocale,
-    { exact: true }
+    { exact: true },
   );
   const messageTextRegex = buildLinkedInSelectorPhraseRegex(
     "message",
-    selectorLocale
+    selectorLocale,
   );
   const messageTextRegexHint = formatLinkedInSelectorRegexHint(
     "message",
-    selectorLocale
+    selectorLocale,
   );
   const messageAriaSelector = buildLinkedInAriaLabelContainsSelector(
     "button",
     "message",
-    selectorLocale
+    selectorLocale,
   );
 
   return [
@@ -549,38 +552,39 @@ function profileMessageButtonCandidates(
       selectorHint: `topCard.getByRole(button, ${messageExactRegexHint})`,
       locatorFactory: () =>
         root.getByRole("button", {
-          name: messageExactRegex
-        })
+          name: messageExactRegex,
+        }),
     },
     {
       key: "topcard-message-text",
       selectorHint: `topCard button hasText ${messageTextRegexHint}`,
-      locatorFactory: () => root.locator("button").filter({ hasText: messageTextRegex })
+      locatorFactory: () =>
+        root.locator("button").filter({ hasText: messageTextRegex }),
     },
     {
       key: "topcard-message-aria",
       selectorHint: `topCard ${messageAriaSelector}`,
-      locatorFactory: () => root.locator(messageAriaSelector)
+      locatorFactory: () => root.locator(messageAriaSelector),
     },
     {
       key: "page-message-role",
       selectorHint: `page.getByRole(button, ${messageExactRegexHint})`,
       locatorFactory: (page) =>
         page.getByRole("button", {
-          name: messageExactRegex
-        })
-    }
+          name: messageExactRegex,
+        }),
+    },
   ];
 }
 
 async function findProfileMessageTrigger(
   page: Page,
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): Promise<{ locator: Locator; key: string } | null> {
   const topCardRoot = page.locator("main .pv-top-card, main").first();
   const direct = await findVisibleLocator(
     page,
-    profileMessageButtonCandidates(topCardRoot, selectorLocale)
+    profileMessageButtonCandidates(topCardRoot, selectorLocale),
   );
   if (direct) {
     return direct;
@@ -589,35 +593,35 @@ async function findProfileMessageTrigger(
   const moreExactRegex = buildLinkedInSelectorPhraseRegex(
     "more",
     selectorLocale,
-    { exact: true }
+    { exact: true },
   );
   const moreExactRegexHint = formatLinkedInSelectorRegexHint(
     "more",
     selectorLocale,
-    { exact: true }
+    { exact: true },
   );
   const moreActionsAriaSelector = buildLinkedInAriaLabelContainsSelector(
     "button",
     "more_actions",
-    selectorLocale
+    selectorLocale,
   );
   const messageMenuExactRegex = buildLinkedInSelectorPhraseRegex(
     "message",
     selectorLocale,
-    { exact: true }
+    { exact: true },
   );
   const messageMenuExactRegexHint = formatLinkedInSelectorRegexHint(
     "message",
     selectorLocale,
-    { exact: true }
+    { exact: true },
   );
   const messageMenuTextRegex = buildLinkedInSelectorPhraseRegex(
     "message",
-    selectorLocale
+    selectorLocale,
   );
   const messageMenuTextRegexHint = formatLinkedInSelectorRegexHint(
     "message",
-    selectorLocale
+    selectorLocale,
   );
 
   const moreCandidates: SelectorCandidate[] = [
@@ -626,19 +630,19 @@ async function findProfileMessageTrigger(
       selectorHint: `topCard.getByRole(button, ${moreExactRegexHint})`,
       locatorFactory: () =>
         topCardRoot.getByRole("button", {
-          name: moreExactRegex
-        })
+          name: moreExactRegex,
+        }),
     },
     {
       key: "topcard-more-aria",
       selectorHint: `topCard ${moreActionsAriaSelector}`,
-      locatorFactory: () => topCardRoot.locator(moreActionsAriaSelector)
+      locatorFactory: () => topCardRoot.locator(moreActionsAriaSelector),
     },
     {
       key: "page-more-aria",
       selectorHint: `page ${moreActionsAriaSelector}`,
-      locatorFactory: (page) => page.locator(moreActionsAriaSelector)
-    }
+      locatorFactory: (page) => page.locator(moreActionsAriaSelector),
+    },
   ];
 
   const more = await findVisibleLocator(page, moreCandidates);
@@ -655,21 +659,23 @@ async function findProfileMessageTrigger(
       selectorHint: `page.getByRole(menuitem, ${messageMenuExactRegexHint})`,
       locatorFactory: (page) =>
         page.getByRole("menuitem", {
-          name: messageMenuExactRegex
-        })
+          name: messageMenuExactRegex,
+        }),
     },
     {
       key: "menu-message-text",
       selectorHint: `[role='menu'] hasText ${messageMenuTextRegexHint}`,
       locatorFactory: (page) =>
-        page.locator("[role='menu']").filter({ hasText: messageMenuTextRegex })
+        page.locator("[role='menu']").filter({ hasText: messageMenuTextRegex }),
     },
     {
       key: "menu-message-button-fallback",
       selectorHint: `div[role='button'] hasText ${messageMenuTextRegexHint}`,
       locatorFactory: (page) =>
-        page.locator("div[role='button']").filter({ hasText: messageMenuTextRegex })
-    }
+        page
+          .locator("div[role='button']")
+          .filter({ hasText: messageMenuTextRegex }),
+    },
   ];
 
   const message = await findVisibleLocator(page, menuCandidates);
@@ -679,7 +685,7 @@ async function findProfileMessageTrigger(
 
   return {
     locator: message.locator,
-    key: `${more.key}:${message.key}`
+    key: `${more.key}:${message.key}`,
   };
 }
 
@@ -694,23 +700,26 @@ async function extractProfileSummary(page: Page): Promise<{
       (value ?? "").replace(/\s+/g, " ").trim();
 
     const fullName = normalize(
-      globalThis.document.querySelector("h1.text-heading-xlarge")?.textContent ??
-        globalThis.document.querySelector("h1[class*='text-heading']")?.textContent ??
-        globalThis.document.querySelector("h1")?.textContent
+      globalThis.document.querySelector("h1.text-heading-xlarge")
+        ?.textContent ??
+        globalThis.document.querySelector("h1[class*='text-heading']")
+          ?.textContent ??
+        globalThis.document.querySelector("h1")?.textContent,
     );
 
     const headline = normalize(
       globalThis.document.querySelector(".text-body-medium.break-words")
         ?.textContent ??
         globalThis.document.querySelector(
-          ".pv-text-details__left-panel .text-body-medium"
+          ".pv-text-details__left-panel .text-body-medium",
         )?.textContent ??
-        globalThis.document.querySelector("main .text-body-medium")?.textContent
+        globalThis.document.querySelector("main .text-body-medium")
+          ?.textContent,
     );
 
     return {
       fullName,
-      headline
+      headline,
     };
   });
 
@@ -720,14 +729,14 @@ async function extractProfileSummary(page: Page): Promise<{
     profileUrl,
     vanityName: extractVanityName(profileUrl),
     fullName: normalizeText(summary.fullName),
-    headline: normalizeText(summary.headline)
+    headline: normalizeText(summary.headline),
   };
 }
 
 async function probeAcceptedConnection(
   page: Page,
   profileUrl: string,
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): Promise<AcceptanceProbeResult | null> {
   await page.goto(profileUrl, { waitUntil: "domcontentloaded" });
   await waitForNetworkIdleBestEffort(page);
@@ -744,14 +753,14 @@ async function probeAcceptedConnection(
     vanityName: summary.vanityName,
     fullName: summary.fullName,
     headline: summary.headline,
-    acceptedDetection: messageTrigger.key
+    acceptedDetection: messageTrigger.key,
   };
 }
 
 async function validateMessageSurfaceTarget(
   page: Page,
   action: PreparedAction,
-  expectedFullName?: string
+  expectedFullName?: string,
 ): Promise<void> {
   const normalizedExpected = normalizeText(expectedFullName).toLowerCase();
   if (!normalizedExpected) {
@@ -761,7 +770,7 @@ async function validateMessageSurfaceTarget(
   const headerCandidates = [
     page.locator(".msg-overlay-bubble-header__title").first(),
     page.locator("[role='dialog'] h2, [role='dialog'] h3").first(),
-    page.locator(".msg-thread__link-to-profile").first()
+    page.locator(".msg-thread__link-to-profile").first(),
   ];
 
   for (const candidate of headerCandidates) {
@@ -791,8 +800,8 @@ async function validateMessageSurfaceTarget(
         action_id: action.id,
         expected_full_name: expectedFullName,
         actual_header: actual,
-        current_url: page.url()
-      }
+        current_url: page.url(),
+      },
     );
   }
 }
@@ -800,9 +809,8 @@ async function validateMessageSurfaceTarget(
 function mapAcceptedConnection(
   state: SentInvitationStateRow,
   nowMs: number,
-  preparedAction?: Pick<PreparedActionRow, "status" | "expires_at">
+  preparedAction?: Pick<PreparedActionRow, "status" | "expires_at">,
 ): LinkedInAcceptedConnection {
-
   return {
     profile_url_key: state.profile_url_key,
     profile_url: state.profile_url,
@@ -817,31 +825,34 @@ function mapAcceptedConnection(
       state,
       nowMs,
       preparedActionStatus: preparedAction?.status,
-      preparedActionExpiresAtMs: preparedAction?.expires_at ?? null
+      preparedActionExpiresAtMs: preparedAction?.expires_at ?? null,
     }),
     followup_prepared_action_id: state.followup_prepared_action_id,
     followup_prepared_at_ms: state.followup_prepared_at,
     followup_confirmed_at_ms: state.followup_confirmed_at,
-    followup_expires_at_ms: preparedAction?.expires_at ?? null
+    followup_expires_at_ms: preparedAction?.expires_at ?? null,
   };
 }
 
 function mapAcceptedConnections(
   db: Pick<AssistantDatabase, "listPreparedActionsByIds">,
   states: SentInvitationStateRow[],
-  nowMs: number
+  nowMs: number,
 ): LinkedInAcceptedConnection[] {
-  const preparedActionIds = [...new Set(
-    states
-      .map((state) => state.followup_prepared_action_id)
-      .filter((preparedActionId): preparedActionId is string =>
-        typeof preparedActionId === "string" && preparedActionId.length > 0
-      )
-  )];
+  const preparedActionIds = [
+    ...new Set(
+      states
+        .map((state) => state.followup_prepared_action_id)
+        .filter(
+          (preparedActionId): preparedActionId is string =>
+            typeof preparedActionId === "string" && preparedActionId.length > 0,
+        ),
+    ),
+  ];
   const preparedActionsById = new Map(
     db
       .listPreparedActionsByIds(preparedActionIds)
-      .map((preparedAction) => [preparedAction.id, preparedAction])
+      .map((preparedAction) => [preparedAction.id, preparedAction]),
   );
 
   return states.map((state) =>
@@ -850,19 +861,17 @@ function mapAcceptedConnections(
       nowMs,
       state.followup_prepared_action_id
         ? preparedActionsById.get(state.followup_prepared_action_id)
-        : undefined
-    )
+        : undefined,
+    ),
   );
 }
 
 /**
  * Confirm-time executor for accepted-connection follow-up actions.
  */
-export class FollowupAfterAcceptActionExecutor
-  implements ActionExecutor<LinkedInFollowupsExecutorRuntime>
-{
+export class FollowupAfterAcceptActionExecutor implements ActionExecutor<LinkedInFollowupsExecutorRuntime> {
   async execute(
-    input: ActionExecutorInput<LinkedInFollowupsExecutorRuntime>
+    input: ActionExecutorInput<LinkedInFollowupsExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
     const runtime = input.runtime;
     const action = input.action;
@@ -871,29 +880,34 @@ export class FollowupAfterAcceptActionExecutor
       action.target,
       "target_profile_url",
       action.id,
-      "target"
+      "target",
     );
     const profileUrlKey = getRequiredStringField(
       action.target,
       "profile_url_key",
       action.id,
-      "target"
+      "target",
     );
     const fullName = getOptionalStringField(action.target, "full_name");
-    const text = getRequiredStringField(action.payload, "text", action.id, "payload");
+    const text = getRequiredStringField(
+      action.payload,
+      "text",
+      action.id,
+      "payload",
+    );
     const tracePath = `linkedin/trace-followup-confirm-${Date.now()}.zip`;
     const artifactPaths: string[] = [tracePath];
 
     await runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: runtime.cdpUrl
+      cdpUrl: runtime.cdpUrl,
     });
 
     return runtime.profileManager.runWithContext(
       {
         cdpUrl: runtime.cdpUrl,
         profileName,
-        headless: true
+        headless: true,
       },
       async (context) => {
         const page = await getOrCreatePage(context);
@@ -903,7 +917,7 @@ export class FollowupAfterAcceptActionExecutor
           await context.tracing.start({
             screenshots: true,
             snapshots: true,
-            sources: true
+            sources: true,
           });
           tracingStarted = true;
 
@@ -912,7 +926,7 @@ export class FollowupAfterAcceptActionExecutor
 
           const messageTrigger = await findProfileMessageTrigger(
             page,
-            runtime.selectorLocale
+            runtime.selectorLocale,
           );
           if (!messageTrigger) {
             throw new LinkedInBuddyError(
@@ -921,8 +935,8 @@ export class FollowupAfterAcceptActionExecutor
               {
                 action_id: action.id,
                 profile_url: profileUrl,
-                current_url: page.url()
-              }
+                current_url: page.url(),
+              },
             );
           }
 
@@ -930,55 +944,49 @@ export class FollowupAfterAcceptActionExecutor
           await page.waitForTimeout(600);
           await validateMessageSurfaceTarget(page, action, fullName);
 
-          const rateLimitState = runtime.rateLimiter.consume(
-            SEND_MESSAGE_RATE_LIMIT_CONFIG
-          );
-          if (!rateLimitState.allowed) {
-            throw new LinkedInBuddyError(
-              "RATE_LIMITED",
-              "LinkedIn follow-up confirm is rate limited for the current window.",
-              {
-                action_id: action.id,
-                profile_name: profileName,
-                profile_url: profileUrl,
-                rate_limit: formatRateLimitState(rateLimitState)
-              }
-            );
-          }
+          consumeRateLimitOrThrow(runtime.rateLimiter, {
+            config: SEND_MESSAGE_RATE_LIMIT_CONFIG,
+            message: createConfirmRateLimitMessage("followup.send_message"),
+            details: {
+              action_id: action.id,
+              profile_name: profileName,
+              profile_url: profileUrl,
+            },
+          });
 
           const composerNameRegex = buildLinkedInSelectorPhraseRegex(
             ["write_message", "message"],
-            runtime.selectorLocale
+            runtime.selectorLocale,
           );
           const composerNameRegexHint = formatLinkedInSelectorRegexHint(
             ["write_message", "message"],
-            runtime.selectorLocale
+            runtime.selectorLocale,
           );
           const placeholderRegex = buildLinkedInSelectorPhraseRegex(
             "write_message",
-            runtime.selectorLocale
+            runtime.selectorLocale,
           );
           const placeholderRegexHint = formatLinkedInSelectorRegexHint(
             "write_message",
-            runtime.selectorLocale
+            runtime.selectorLocale,
           );
           const sendButtonRegex = buildLinkedInSelectorPhraseRegex(
             "send",
             runtime.selectorLocale,
-            { exact: true }
+            { exact: true },
           );
           const sendButtonRegexHint = formatLinkedInSelectorRegexHint(
             "send",
             runtime.selectorLocale,
-            { exact: true }
+            { exact: true },
           );
           const dialogSendRegex = buildLinkedInSelectorPhraseRegex(
             "send",
-            runtime.selectorLocale
+            runtime.selectorLocale,
           );
           const dialogSendRegexHint = formatLinkedInSelectorRegexHint(
             "send",
-            runtime.selectorLocale
+            runtime.selectorLocale,
           );
 
           const composerSelectors: SelectorCandidate[] = [
@@ -987,33 +995,36 @@ export class FollowupAfterAcceptActionExecutor
               selectorHint: `getByRole(textbox, ${composerNameRegexHint})`,
               locatorFactory: (page) =>
                 page.getByRole("textbox", {
-                  name: composerNameRegex
-                })
+                  name: composerNameRegex,
+                }),
             },
             {
               key: "placeholder-write-message",
               selectorHint: `getByPlaceholder(${placeholderRegexHint})`,
-              locatorFactory: (page) => page.getByPlaceholder(placeholderRegex)
+              locatorFactory: (page) => page.getByPlaceholder(placeholderRegex),
             },
             {
               key: "msg-contenteditable",
-              selectorHint: ".msg-form__contenteditable[contenteditable='true']",
+              selectorHint:
+                ".msg-form__contenteditable[contenteditable='true']",
               locatorFactory: (page) =>
-                page.locator(".msg-form__contenteditable[contenteditable='true']")
+                page.locator(
+                  ".msg-form__contenteditable[contenteditable='true']",
+                ),
             },
             {
               key: "dialog-contenteditable",
               selectorHint: "[role='dialog'] [contenteditable='true']",
               locatorFactory: (page) =>
-                page.locator("[role='dialog'] [contenteditable='true']")
-            }
+                page.locator("[role='dialog'] [contenteditable='true']"),
+            },
           ];
 
           const composer = await findVisibleLocatorOrThrow(
             page,
             composerSelectors,
             "followup_message_composer",
-            artifactPaths
+            artifactPaths,
           );
           await composer.locator.click({ timeout: 3_000 });
           await composer.locator.fill(text, { timeout: 5_000 });
@@ -1023,28 +1034,29 @@ export class FollowupAfterAcceptActionExecutor
               key: "role-button-send",
               selectorHint: `getByRole(button, ${sendButtonRegexHint})`,
               locatorFactory: (page) =>
-                page.getByRole("button", { name: sendButtonRegex })
+                page.getByRole("button", { name: sendButtonRegex }),
             },
             {
               key: "msg-form-send-button",
               selectorHint: "button.msg-form__send-button",
-              locatorFactory: (page) => page.locator("button.msg-form__send-button")
+              locatorFactory: (page) =>
+                page.locator("button.msg-form__send-button"),
             },
             {
               key: "dialog-send-button",
               selectorHint: `[role='dialog'] button hasText ${dialogSendRegexHint}`,
               locatorFactory: (page) =>
                 page.locator("[role='dialog'] button").filter({
-                  hasText: dialogSendRegex
-                })
-            }
+                  hasText: dialogSendRegex,
+                }),
+            },
           ];
 
           const sendButton = await findVisibleLocatorOrThrow(
             page,
             sendButtonSelectors,
             "followup_send_button",
-            artifactPaths
+            artifactPaths,
           );
           await sendButton.locator.click({ timeout: 5_000 });
 
@@ -1053,7 +1065,7 @@ export class FollowupAfterAcceptActionExecutor
           await captureScreenshotArtifact(runtime, page, postSendScreenshot, {
             action: FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE,
             profile_name: profileName,
-            profile_url: profileUrl
+            profile_url: profileUrl,
           });
           artifactPaths.push(postSendScreenshot);
 
@@ -1063,7 +1075,7 @@ export class FollowupAfterAcceptActionExecutor
             profileUrlKey,
             confirmedAtMs,
             preparedActionId: action.id,
-            updatedAtMs: confirmedAtMs
+            updatedAtMs: confirmedAtMs,
           });
           if (!updated) {
             runtime.logger.log(
@@ -1072,8 +1084,8 @@ export class FollowupAfterAcceptActionExecutor
               {
                 action_id: action.id,
                 profile_name: profileName,
-                profile_url_key: profileUrlKey
-              }
+                profile_url_key: profileUrlKey,
+              },
             );
           }
 
@@ -1082,9 +1094,9 @@ export class FollowupAfterAcceptActionExecutor
             result: {
               sent: true,
               status: "followup_sent",
-              profile_url: profileUrl
+              profile_url: profileUrl,
             },
-            artifacts: artifactPaths
+            artifacts: artifactPaths,
           };
         } catch (error) {
           const failureScreenshot = `linkedin/screenshot-followup-confirm-error-${Date.now()}.png`;
@@ -1092,7 +1104,7 @@ export class FollowupAfterAcceptActionExecutor
             await captureScreenshotArtifact(runtime, page, failureScreenshot, {
               action: `${FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE}_error`,
               profile_name: profileName,
-              profile_url: profileUrl
+              profile_url: profileUrl,
             });
             artifactPaths.push(failureScreenshot);
           } catch {
@@ -1106,8 +1118,8 @@ export class FollowupAfterAcceptActionExecutor
               action_id: action.id,
               current_url: page.url(),
               selector_context: FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE,
-              artifact_paths: artifactPaths
-            }
+              artifact_paths: artifactPaths,
+            },
           );
         } finally {
           if (tracingStarted) {
@@ -1116,7 +1128,7 @@ export class FollowupAfterAcceptActionExecutor
               await context.tracing.stop({ path: absoluteTracePath });
               runtime.artifacts.registerArtifact(tracePath, "application/zip", {
                 action: FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE,
-                profile_name: profileName
+                profile_name: profileName,
               });
             } catch (error) {
               runtime.logger.log(
@@ -1124,13 +1136,14 @@ export class FollowupAfterAcceptActionExecutor
                 "linkedin.followups.confirm.trace.stop_failed",
                 {
                   action_id: action.id,
-                  message: error instanceof Error ? error.message : String(error)
-                }
+                  message:
+                    error instanceof Error ? error.message : String(error),
+                },
               );
             }
           }
         }
-      }
+      },
     );
   }
 }
@@ -1144,7 +1157,8 @@ export function createFollowupActionExecutors(): Record<
   ActionExecutor<LinkedInFollowupsExecutorRuntime>
 > {
   return {
-    [FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE]: new FollowupAfterAcceptActionExecutor()
+    [FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE]:
+      new FollowupAfterAcceptActionExecutor(),
   };
 }
 
@@ -1169,17 +1183,17 @@ export class LinkedInFollowupsService {
   } {
     const acceptedStates = this.runtime.db.listAcceptedSentInvitations({
       profileName: input.profileName,
-      sinceMs: input.cutoffMs
+      sinceMs: input.cutoffMs,
     });
     const acceptedConnections = mapAcceptedConnections(
       this.runtime.db,
       acceptedStates,
-      input.nowMs ?? Date.now()
+      input.nowMs ?? Date.now(),
     );
 
     return {
       acceptedStates,
-      acceptedConnections
+      acceptedConnections,
     };
   }
 
@@ -1188,7 +1202,7 @@ export class LinkedInFollowupsService {
    * the requested lookback window.
    */
   async listAcceptedConnections(
-    input: ListAcceptedConnectionsInput = {}
+    input: ListAcceptedConnectionsInput = {},
   ): Promise<LinkedInAcceptedConnection[]> {
     const profileName = input.profileName ?? "default";
     const { cutoffMs } = resolveFollowupLookbackWindow(input);
@@ -1197,7 +1211,7 @@ export class LinkedInFollowupsService {
 
     return this.loadAcceptedConnections({
       profileName,
-      cutoffMs
+      cutoffMs,
     }).acceptedConnections;
   }
 
@@ -1206,23 +1220,24 @@ export class LinkedInFollowupsService {
    * accepted connection that still needs one.
    */
   async prepareFollowupsAfterAccept(
-    input: PrepareFollowupsAfterAcceptInput = {}
+    input: PrepareFollowupsAfterAcceptInput = {},
   ): Promise<PrepareFollowupsAfterAcceptResult> {
     const profileName = input.profileName ?? "default";
     const { since, cutoffMs } = resolveFollowupLookbackWindow(input);
 
     await this.refreshAcceptanceState(profileName);
 
-    const { acceptedStates, acceptedConnections } = this.loadAcceptedConnections({
-      profileName,
-      cutoffMs
-    });
+    const { acceptedStates, acceptedConnections } =
+      this.loadAcceptedConnections({
+        profileName,
+        cutoffMs,
+      });
 
     const stateByKey = new Map(
-      acceptedStates.map((state) => [state.profile_url_key, state])
+      acceptedStates.map((state) => [state.profile_url_key, state]),
     );
     const candidates = acceptedConnections.filter((connection) =>
-      shouldPrepareAcceptedConnectionFollowup(connection.followup_status)
+      shouldPrepareAcceptedConnectionFollowup(connection.followup_status),
     );
 
     const preparedFollowups =
@@ -1231,23 +1246,24 @@ export class LinkedInFollowupsService {
             profileName,
             candidates,
             stateByKey,
-            input.operatorNote
+            input.operatorNote,
           )
         : [];
 
     const preparedByKey = new Map(
       preparedFollowups.map((prepared) => [
         prepared.connection.profile_url_key,
-        prepared.connection
-      ])
+        prepared.connection,
+      ]),
     );
 
     return {
       since,
       acceptedConnections: acceptedConnections.map(
-        (connection) => preparedByKey.get(connection.profile_url_key) ?? connection
+        (connection) =>
+          preparedByKey.get(connection.profile_url_key) ?? connection,
       ),
-      preparedFollowups
+      preparedFollowups,
     };
   }
 
@@ -1259,7 +1275,7 @@ export class LinkedInFollowupsService {
    * otherwise `null`.
    */
   async prepareFollowupForAcceptedConnection(
-    input: PrepareAcceptedConnectionFollowupInput
+    input: PrepareAcceptedConnectionFollowupInput,
   ): Promise<PreparedAcceptedConnectionFollowup | null> {
     const profileName = input.profileName ?? "default";
     if (input.refreshState) {
@@ -1268,13 +1284,17 @@ export class LinkedInFollowupsService {
 
     const state = this.runtime.db.getSentInvitationState({
       profileName,
-      profileUrlKey: input.profileUrlKey
+      profileUrlKey: input.profileUrlKey,
     });
     if (!state || state.closed_at !== null || state.accepted_at === null) {
       return null;
     }
 
-    const connection = mapAcceptedConnections(this.runtime.db, [state], Date.now())[0];
+    const connection = mapAcceptedConnections(
+      this.runtime.db,
+      [state],
+      Date.now(),
+    )[0];
     if (!connection) {
       return null;
     }
@@ -1287,7 +1307,7 @@ export class LinkedInFollowupsService {
       profileName,
       [connection],
       new Map([[state.profile_url_key, state]]),
-      input.operatorNote
+      input.operatorNote,
     );
 
     return prepared[0] ?? null;
@@ -1298,12 +1318,12 @@ export class LinkedInFollowupsService {
 
     await this.runtime.connections.listPendingInvitations({
       profileName,
-      filter: "sent"
+      filter: "sent",
     });
 
     const candidates = this.runtime.db.listSentInvitationAcceptanceCandidates({
       profileName,
-      lastSeenBeforeMs
+      lastSeenBeforeMs,
     });
 
     if (candidates.length === 0) {
@@ -1312,14 +1332,14 @@ export class LinkedInFollowupsService {
 
     await this.runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: this.runtime.cdpUrl
+      cdpUrl: this.runtime.cdpUrl,
     });
 
     const acceptedResults = await this.runtime.profileManager.runWithContext(
       {
         cdpUrl: this.runtime.cdpUrl,
         profileName,
-        headless: true
+        headless: true,
       },
       async (context) => {
         const page = await getOrCreatePage(context);
@@ -1333,7 +1353,7 @@ export class LinkedInFollowupsService {
             const probe = await probeAcceptedConnection(
               page,
               state.profile_url,
-              this.runtime.selectorLocale
+              this.runtime.selectorLocale,
             );
             if (!probe) {
               continue;
@@ -1347,14 +1367,14 @@ export class LinkedInFollowupsService {
               {
                 profile_name: profileName,
                 profile_url: state.profile_url,
-                message: error instanceof Error ? error.message : String(error)
-              }
+                message: error instanceof Error ? error.message : String(error),
+              },
             );
           }
         }
 
         return results;
-      }
+      },
     );
 
     const acceptedAtMs = Date.now();
@@ -1368,7 +1388,7 @@ export class LinkedInFollowupsService {
         profileUrl: accepted.probe.profileUrl,
         acceptedAtMs,
         acceptedDetection: accepted.probe.acceptedDetection,
-        updatedAtMs: acceptedAtMs
+        updatedAtMs: acceptedAtMs,
       });
     }
   }
@@ -1377,18 +1397,18 @@ export class LinkedInFollowupsService {
     profileName: string,
     connections: LinkedInAcceptedConnection[],
     stateByKey: Map<string, SentInvitationStateRow>,
-    operatorNote?: string
+    operatorNote?: string,
   ): Promise<PreparedAcceptedConnectionFollowup[]> {
     await this.runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: this.runtime.cdpUrl
+      cdpUrl: this.runtime.cdpUrl,
     });
 
     return this.runtime.profileManager.runWithContext(
       {
         cdpUrl: this.runtime.cdpUrl,
         profileName,
-        headless: true
+        headless: true,
       },
       async (context) => {
         const page = await getOrCreatePage(context);
@@ -1404,7 +1424,7 @@ export class LinkedInFollowupsService {
             const probe = await probeAcceptedConnection(
               page,
               state.profile_url,
-              this.runtime.selectorLocale
+              this.runtime.selectorLocale,
             );
             if (!probe) {
               this.runtime.logger.log(
@@ -1413,26 +1433,32 @@ export class LinkedInFollowupsService {
                 {
                   profile_name: profileName,
                   profile_url: state.profile_url,
-                  profile_url_key: state.profile_url_key
-                }
+                  profile_url_key: state.profile_url_key,
+                },
               );
               continue;
             }
 
             const relativeProfileUrl = normalizeLinkedInProfileUrl(
-              probe.profileUrl || state.profile_url
+              probe.profileUrl || state.profile_url,
             );
-            const text = buildDefaultFollowupText(probe.fullName || state.full_name);
+            const text = buildDefaultFollowupText(
+              probe.fullName || state.full_name,
+            );
             const screenshotPath = `linkedin/screenshot-followup-prepare-${Date.now()}-${preparedResults.length + 1}.png`;
-            await captureScreenshotArtifact(this.runtime, page, screenshotPath, {
-              action: FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE,
-              profile_name: profileName,
-              profile_url: relativeProfileUrl
-            });
-
-            const rateLimitState = this.runtime.rateLimiter.peek(
-              SEND_MESSAGE_RATE_LIMIT_CONFIG
+            await captureScreenshotArtifact(
+              this.runtime,
+              page,
+              screenshotPath,
+              {
+                action: FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE,
+                profile_name: profileName,
+                profile_url: relativeProfileUrl,
+              },
             );
+
+            const rateLimitState: RateLimiterState =
+              this.runtime.rateLimiter.peek(SEND_MESSAGE_RATE_LIMIT_CONFIG);
 
             const target = {
               profile_name: profileName,
@@ -1440,7 +1466,7 @@ export class LinkedInFollowupsService {
               target_profile_url: relativeProfileUrl,
               vanity_name: probe.vanityName,
               full_name: probe.fullName || state.full_name,
-              headline: probe.headline || state.headline
+              headline: probe.headline || state.headline,
             };
 
             const preview = {
@@ -1452,32 +1478,32 @@ export class LinkedInFollowupsService {
                 accepted_at_ms: connection.accepted_at_ms,
                 detected_via: connection.accepted_detection,
                 first_seen_sent_at_ms: connection.first_seen_sent_at_ms,
-                last_seen_sent_at_ms: connection.last_seen_sent_at_ms
+                last_seen_sent_at_ms: connection.last_seen_sent_at_ms,
               },
               outbound: {
-                text
+                text,
               },
               artifacts: [
                 {
                   type: "screenshot",
-                  path: screenshotPath
-                }
+                  path: screenshotPath,
+                },
               ],
-              rate_limit: formatRateLimitState(rateLimitState)
+              rate_limit: formatRateLimitState(rateLimitState),
             } satisfies Record<string, unknown>;
 
             const prepared = this.runtime.twoPhaseCommit.prepare({
               actionType: FOLLOWUP_AFTER_ACCEPT_ACTION_TYPE,
               target,
               payload: {
-                text
+                text,
               },
               preview,
               ...(operatorNote
                 ? {
-                    operatorNote
+                    operatorNote,
                   }
-                : {})
+                : {}),
             });
 
             const preparedAtMs = Date.now();
@@ -1486,7 +1512,7 @@ export class LinkedInFollowupsService {
               profileUrlKey: state.profile_url_key,
               preparedAtMs,
               preparedActionId: prepared.preparedActionId,
-              updatedAtMs: preparedAtMs
+              updatedAtMs: preparedAtMs,
             });
             if (!updated) {
               throw new LinkedInBuddyError(
@@ -1494,8 +1520,8 @@ export class LinkedInFollowupsService {
                 `Could not persist follow-up preparation state for ${state.profile_url}.`,
                 {
                   profile_name: profileName,
-                  profile_url_key: state.profile_url_key
-                }
+                  profile_url_key: state.profile_url_key,
+                },
               );
             }
 
@@ -1509,12 +1535,12 @@ export class LinkedInFollowupsService {
                 followup_status: "prepared",
                 followup_prepared_action_id: prepared.preparedActionId,
                 followup_prepared_at_ms: preparedAtMs,
-                followup_expires_at_ms: prepared.expiresAtMs
+                followup_expires_at_ms: prepared.expiresAtMs,
               },
               preparedActionId: prepared.preparedActionId,
               confirmToken: prepared.confirmToken,
               expiresAtMs: prepared.expiresAtMs,
-              preview: prepared.preview
+              preview: prepared.preview,
             });
           } catch (error) {
             this.runtime.logger.log(
@@ -1523,14 +1549,14 @@ export class LinkedInFollowupsService {
               {
                 profile_name: profileName,
                 profile_url: state.profile_url,
-                message: error instanceof Error ? error.message : String(error)
-              }
+                message: error instanceof Error ? error.message : String(error),
+              },
             );
           }
         }
 
         return preparedResults;
-      }
+      },
     );
   }
 }

--- a/packages/core/src/linkedinInbox.ts
+++ b/packages/core/src/linkedinInbox.ts
@@ -31,10 +31,14 @@ import {
 } from "./linkedinFeed.js";
 import type { LinkedInSearchResult, LinkedInSearchService } from "./linkedinSearch.js";
 import type { ProfileManager } from "./profileManager.js";
+import {
+  consumeRateLimitOrThrow,
+  createConfirmRateLimitMessage,
+  formatRateLimitState
+} from "./rateLimiter.js";
 import type {
   ConsumeRateLimitInput,
-  RateLimiter,
-  RateLimiterState
+  RateLimiter
 } from "./rateLimiter.js";
 import type {
   LinkedInSelectorLocale,
@@ -1240,20 +1244,6 @@ function toAutomationError(
   }
 
   return asLinkedInBuddyError(error, "UNKNOWN", message);
-}
-
-function formatRateLimitState(
-  state: RateLimiterState
-): Record<string, number | boolean | string> {
-  return {
-    counter_key: state.counterKey,
-    window_start_ms: state.windowStartMs,
-    window_size_ms: state.windowSizeMs,
-    count: state.count,
-    limit: state.limit,
-    remaining: state.remaining,
-    allowed: state.allowed
-  };
 }
 
 async function getOrCreatePage(context: BrowserContext): Promise<Page> {
@@ -3442,18 +3432,14 @@ export class LinkedInInboxService {
         async (context) => {
           const page = await getOrCreatePage(context);
           const artifactPaths: string[] = [];
-          const rateLimitState = this.runtime.rateLimiter.consume(input.rateLimitConfig);
-          if (!rateLimitState.allowed) {
-            throw new LinkedInBuddyError(
-              "RATE_LIMITED",
-              `LinkedIn ${input.actionType} is rate limited for the current window.`,
-              {
-                profile_name: input.profileName,
-                thread_url: threadUrl,
-                rate_limit: formatRateLimitState(rateLimitState)
-              }
-            );
-          }
+          const rateLimitState = consumeRateLimitOrThrow(this.runtime.rateLimiter, {
+            config: input.rateLimitConfig,
+            message: createConfirmRateLimitMessage(input.actionType),
+            details: {
+              profile_name: input.profileName,
+              thread_url: threadUrl
+            }
+          });
 
           const mutation = await executeThreadMenuMutation({
             actionType: input.actionType,
@@ -3648,21 +3634,15 @@ class SendMessageActionExecutor
             const detail = await extractThreadDetailWithNetwork(page, threadUrl, 20);
             validateThreadTarget(action, detail, page.url());
 
-            const rateLimitState = runtime.rateLimiter.consume(
-              SEND_MESSAGE_RATE_LIMIT_CONFIG
-            );
-            if (!rateLimitState.allowed) {
-              throw new LinkedInBuddyError(
-                "RATE_LIMITED",
-                "LinkedIn send_message confirm is rate limited for the current window.",
-                {
-                  action_id: action.id,
-                  profile_name: profileName,
-                  thread_url: threadUrl,
-                  rate_limit: formatRateLimitState(rateLimitState)
-                }
-              );
-            }
+            consumeRateLimitOrThrow(runtime.rateLimiter, {
+              config: SEND_MESSAGE_RATE_LIMIT_CONFIG,
+              message: createConfirmRateLimitMessage(SEND_MESSAGE_ACTION_TYPE),
+              details: {
+                action_id: action.id,
+                profile_name: profileName,
+                thread_url: threadUrl
+              }
+            });
 
             await fillAndSendMessage({
               actionId: action.id,
@@ -3758,21 +3738,15 @@ class SendNewThreadActionExecutor
             ),
           execute: async () => {
             const artifactPaths: string[] = [];
-            const rateLimitState = runtime.rateLimiter.consume(
-              SEND_MESSAGE_RATE_LIMIT_CONFIG
-            );
-            if (!rateLimitState.allowed) {
-              throw new LinkedInBuddyError(
-                "RATE_LIMITED",
-                "LinkedIn new-thread send confirm is rate limited for the current window.",
-                {
-                  action_id: action.id,
-                  profile_name: profileName,
-                  recipient_count: recipients.length,
-                  rate_limit: formatRateLimitState(rateLimitState)
-                }
-              );
-            }
+            consumeRateLimitOrThrow(runtime.rateLimiter, {
+              config: SEND_MESSAGE_RATE_LIMIT_CONFIG,
+              message: createConfirmRateLimitMessage(SEND_NEW_THREAD_ACTION_TYPE),
+              details: {
+                action_id: action.id,
+                profile_name: profileName,
+                recipient_count: recipients.length
+              }
+            });
 
             if (recipients.length === 1 && recipients[0]) {
               await openProfileMessageComposer({
@@ -3892,22 +3866,16 @@ class AddRecipientsActionExecutor
             const detail = await extractThreadDetailWithNetwork(page, threadUrl, 20);
             validateThreadTarget(action, detail, page.url());
 
-            const rateLimitState = runtime.rateLimiter.consume(
-              ADD_RECIPIENTS_RATE_LIMIT_CONFIG
-            );
-            if (!rateLimitState.allowed) {
-              throw new LinkedInBuddyError(
-                "RATE_LIMITED",
-                "LinkedIn add_recipients confirm is rate limited for the current window.",
-                {
-                  action_id: action.id,
-                  profile_name: profileName,
-                  recipient_count: recipients.length,
-                  thread_url: threadUrl,
-                  rate_limit: formatRateLimitState(rateLimitState)
-                }
-              );
-            }
+            consumeRateLimitOrThrow(runtime.rateLimiter, {
+              config: ADD_RECIPIENTS_RATE_LIMIT_CONFIG,
+              message: createConfirmRateLimitMessage(ADD_RECIPIENTS_ACTION_TYPE),
+              details: {
+                action_id: action.id,
+                profile_name: profileName,
+                recipient_count: recipients.length,
+                thread_url: threadUrl
+              }
+            });
 
             await openAddRecipientsFlow({
               artifactPaths,
@@ -4024,21 +3992,15 @@ class ReactMessageActionExecutor
             const detail = await extractThreadDetailWithNetwork(page, threadUrl, 20);
             validateThreadTarget(action, detail, page.url());
 
-            const rateLimitState = runtime.rateLimiter.consume(
-              REACT_MESSAGE_RATE_LIMIT_CONFIG
-            );
-            if (!rateLimitState.allowed) {
-              throw new LinkedInBuddyError(
-                "RATE_LIMITED",
-                "LinkedIn inbox reactions are rate limited for the current window.",
-                {
-                  action_id: action.id,
-                  profile_name: profileName,
-                  thread_url: threadUrl,
-                  rate_limit: formatRateLimitState(rateLimitState)
-                }
-              );
-            }
+            const rateLimitState = consumeRateLimitOrThrow(runtime.rateLimiter, {
+              config: REACT_MESSAGE_RATE_LIMIT_CONFIG,
+              message: createConfirmRateLimitMessage(REACT_MESSAGE_ACTION_TYPE),
+              details: {
+                action_id: action.id,
+                profile_name: profileName,
+                thread_url: threadUrl
+              }
+            });
 
             const artifactPaths: string[] = [];
             const reactionResult = await executeThreadReaction({

--- a/packages/core/src/linkedinJobs.ts
+++ b/packages/core/src/linkedinJobs.ts
@@ -5,20 +5,22 @@ import type { ArtifactHelpers } from "./artifacts.js";
 import type { LinkedInAuthService } from "./auth/session.js";
 import { executeConfirmActionWithArtifacts } from "./confirmArtifacts.js";
 import type { ConfirmFailureArtifactConfig } from "./config.js";
-import {
-  LinkedInBuddyError,
-  asLinkedInBuddyError
-} from "./errors.js";
+import { LinkedInBuddyError, asLinkedInBuddyError } from "./errors.js";
 import { scrollLinkedInPageToBottom } from "./linkedinPage.js";
 import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
+import {
+  consumeRateLimitOrThrow,
+  createConfirmRateLimitMessage,
+  formatRateLimitState,
+} from "./rateLimiter.js";
 import type { RateLimiter, RateLimiterState } from "./rateLimiter.js";
 import type {
   ActionExecutor,
   ActionExecutorInput,
   ActionExecutorResult,
-  TwoPhaseCommitService
+  TwoPhaseCommitService,
 } from "./twoPhaseCommit.js";
 
 export interface LinkedInJobSearchResult {
@@ -139,7 +141,10 @@ export interface LinkedInJobsExecutorRuntime {
 }
 
 export interface LinkedInJobsRuntime extends LinkedInJobsExecutorRuntime {
-  twoPhaseCommit: Pick<TwoPhaseCommitService<LinkedInJobsExecutorRuntime>, "prepare">;
+  twoPhaseCommit: Pick<
+    TwoPhaseCommitService<LinkedInJobsExecutorRuntime>,
+    "prepare"
+  >;
 }
 
 export const SAVE_JOB_ACTION_TYPE = "jobs.save";
@@ -151,31 +156,31 @@ export const EASY_APPLY_JOB_ACTION_TYPE = "jobs.easy_apply";
 const SAVE_JOB_RATE_LIMIT_CONFIG = {
   counterKey: "linkedin.jobs.save",
   windowSizeMs: 60 * 60 * 1000,
-  limit: 40
+  limit: 40,
 } as const;
 
 const UNSAVE_JOB_RATE_LIMIT_CONFIG = {
   counterKey: "linkedin.jobs.unsave",
   windowSizeMs: 60 * 60 * 1000,
-  limit: 40
+  limit: 40,
 } as const;
 
 const CREATE_JOB_ALERT_RATE_LIMIT_CONFIG = {
   counterKey: "linkedin.jobs.alerts.create",
   windowSizeMs: 60 * 60 * 1000,
-  limit: 30
+  limit: 30,
 } as const;
 
 const REMOVE_JOB_ALERT_RATE_LIMIT_CONFIG = {
   counterKey: "linkedin.jobs.alerts.remove",
   windowSizeMs: 60 * 60 * 1000,
-  limit: 30
+  limit: 30,
 } as const;
 
 const EASY_APPLY_RATE_LIMIT_CONFIG = {
   counterKey: "linkedin.jobs.easy_apply",
   windowSizeMs: 60 * 60 * 1000,
-  limit: 6
+  limit: 6,
 } as const;
 
 const JOB_ALERTS_URL = "https://www.linkedin.com/jobs/job-alerts/";
@@ -273,20 +278,6 @@ function normalizeLabelKey(value: string): string {
     .trim();
 }
 
-function formatRateLimitState(
-  state: RateLimiterState
-): Record<string, number | boolean | string> {
-  return {
-    counter_key: state.counterKey,
-    window_start_ms: state.windowStartMs,
-    window_size_ms: state.windowSizeMs,
-    count: state.count,
-    limit: state.limit,
-    remaining: state.remaining,
-    allowed: state.allowed
-  };
-}
-
 function readJobsLimit(value: number | undefined): number {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return 10;
@@ -316,7 +307,7 @@ function getRequiredStringField(
   source: Record<string, unknown>,
   key: string,
   actionId: string,
-  location: "target" | "payload"
+  location: "target" | "payload",
 ): string {
   const value = source[key];
   if (typeof value === "string" && value.trim().length > 0) {
@@ -329,14 +320,14 @@ function getRequiredStringField(
     {
       action_id: actionId,
       location,
-      key
-    }
+      key,
+    },
   );
 }
 
 function getOptionalStringField(
   source: Record<string, unknown>,
-  key: string
+  key: string,
 ): string | undefined {
   const value = source[key];
   return typeof value === "string" && value.trim().length > 0
@@ -348,7 +339,7 @@ function getOptionalAnswersField(
   source: Record<string, unknown>,
   key: string,
   actionId: string,
-  location: "target" | "payload"
+  location: "target" | "payload",
 ): Record<string, LinkedInEasyApplyAnswerValue> {
   const value = source[key];
   if (value === undefined) {
@@ -362,8 +353,8 @@ function getOptionalAnswersField(
       {
         action_id: actionId,
         location,
-        key
-      }
+        key,
+      },
     );
   }
 
@@ -394,8 +385,8 @@ function getOptionalAnswersField(
         action_id: actionId,
         location,
         key,
-        answer_key: answerKey
-      }
+        answer_key: answerKey,
+      },
     );
   }
 
@@ -405,11 +396,13 @@ function getOptionalAnswersField(
 function buildJobAlertIdentifier(
   searchUrl: string,
   query: string,
-  location: string
+  location: string,
 ): string {
   return (
     normalizeText(searchUrl) ||
-    [normalizeText(query), normalizeText(location)].filter(Boolean).join("::") ||
+    [normalizeText(query), normalizeText(location)]
+      .filter(Boolean)
+      .join("::") ||
     "job-alert"
   );
 }
@@ -439,7 +432,7 @@ function parseJobSearchUrl(value: string): {
     return {
       normalizedUrl: "",
       query: "",
-      location: ""
+      location: "",
     };
   }
 
@@ -448,27 +441,27 @@ function parseJobSearchUrl(value: string): {
     return {
       normalizedUrl: parsed.toString(),
       query: normalizeText(parsed.searchParams.get("keywords")),
-      location: normalizeText(parsed.searchParams.get("location"))
+      location: normalizeText(parsed.searchParams.get("location")),
     };
   } catch {
     return {
       normalizedUrl,
       query: "",
-      location: ""
+      location: "",
     };
   }
 }
 
 function normalizeEasyApplyAnswerValue(
   value: unknown,
-  key: string
+  key: string,
 ): LinkedInEasyApplyAnswerValue {
   if (typeof value === "string") {
     const normalized = normalizeText(value);
     if (!normalized) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        `answers.${key} must not be empty when provided.`
+        `answers.${key} must not be empty when provided.`,
       );
     }
     return normalized;
@@ -478,7 +471,7 @@ function normalizeEasyApplyAnswerValue(
     if (typeof value === "number" && !Number.isFinite(value)) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        `answers.${key} must be a finite number.`
+        `answers.${key} must be a finite number.`,
       );
     }
     return value;
@@ -490,10 +483,13 @@ function normalizeEasyApplyAnswerValue(
       .map((item) => normalizeText(item))
       .filter((item) => item.length > 0);
 
-    if (normalizedValues.length === 0 || normalizedValues.length !== value.length) {
+    if (
+      normalizedValues.length === 0 ||
+      normalizedValues.length !== value.length
+    ) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        `answers.${key} must be a non-empty array of strings.`
+        `answers.${key} must be a non-empty array of strings.`,
       );
     }
 
@@ -502,12 +498,12 @@ function normalizeEasyApplyAnswerValue(
 
   throw new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
-    `answers.${key} must be a string, boolean, number, or string array.`
+    `answers.${key} must be a string, boolean, number, or string array.`,
   );
 }
 
 function normalizeEasyApplyAnswers(
-  input: Record<string, unknown> | undefined
+  input: Record<string, unknown> | undefined,
 ): Record<string, LinkedInEasyApplyAnswerValue> {
   if (!input) {
     return {};
@@ -519,11 +515,14 @@ function normalizeEasyApplyAnswers(
     if (!normalizedKey) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "answers contains an empty field name."
+        "answers contains an empty field name.",
       );
     }
 
-    normalized[normalizedKey] = normalizeEasyApplyAnswerValue(value, normalizedKey);
+    normalized[normalizedKey] = normalizeEasyApplyAnswerValue(
+      value,
+      normalizedKey,
+    );
   }
 
   return normalized;
@@ -542,7 +541,7 @@ function validateEmail(value: string | undefined): string | undefined {
   if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/u.test(normalized)) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "email must look like a valid email address."
+      "email must look like a valid email address.",
     );
   }
 
@@ -563,7 +562,7 @@ function validateResumePath(value: string | undefined): string | undefined {
   if (!existsSync(resolvedPath)) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      `resumePath does not exist: ${resolvedPath}`
+      `resumePath does not exist: ${resolvedPath}`,
     );
   }
 
@@ -571,7 +570,7 @@ function validateResumePath(value: string | undefined): string | undefined {
   if (!stats.isFile()) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      `resumePath must point to a file: ${resolvedPath}`
+      `resumePath must point to a file: ${resolvedPath}`,
     );
   }
 
@@ -579,7 +578,7 @@ function validateResumePath(value: string | undefined): string | undefined {
 }
 
 function validateEasyApplyInput(
-  input: PrepareEasyApplyInput
+  input: PrepareEasyApplyInput,
 ): ValidatedEasyApplyInput {
   const profileName = input.profileName ?? "default";
   const jobId = normalizeText(input.jobId);
@@ -587,7 +586,7 @@ function validateEasyApplyInput(
   if (!jobId) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "jobId is required."
+      "jobId is required.",
     );
   }
 
@@ -606,7 +605,7 @@ function validateEasyApplyInput(
     ...(city ? { city } : {}),
     ...(resumePath ? { resumePath } : {}),
     ...(coverLetter ? { coverLetter } : {}),
-    answers: normalizeEasyApplyAnswers(input.answers)
+    answers: normalizeEasyApplyAnswers(input.answers),
   };
 }
 
@@ -619,10 +618,7 @@ async function getOrCreatePage(context: BrowserContext): Promise<Page> {
   return context.newPage();
 }
 
-export function buildJobSearchUrl(
-  query: string,
-  location?: string
-): string {
+export function buildJobSearchUrl(query: string, location?: string): string {
   const encodedQuery = encodeURIComponent(query);
   let url = `https://www.linkedin.com/jobs/search/?keywords=${encodedQuery}`;
   if (location && location.trim().length > 0) {
@@ -643,7 +639,7 @@ async function captureScreenshotArtifact(
   runtime: LinkedInJobsExecutorRuntime,
   page: Page,
   relativePath: string,
-  metadata: Record<string, unknown> = {}
+  metadata: Record<string, unknown> = {},
 ): Promise<string> {
   const absolutePath = runtime.artifacts.resolve(relativePath);
   mkdirSync(path.dirname(absolutePath), { recursive: true });
@@ -655,7 +651,7 @@ async function captureScreenshotArtifact(
 async function waitForCondition(
   condition: () => Promise<boolean>,
   timeoutMs: number,
-  intervalMs = 250
+  intervalMs = 250,
 ): Promise<boolean> {
   const deadline = Date.now() + Math.max(0, timeoutMs);
   while (Date.now() < deadline) {
@@ -676,14 +672,14 @@ async function waitForJobSearchSurface(page: Page): Promise<void> {
     ".job-card-container",
     ".base-search-card",
     ".jobs-search-results-list",
-    "main"
+    "main",
   ];
 
   for (const selector of selectors) {
     try {
       await page.locator(selector).first().waitFor({
         state: "visible",
-        timeout: 5_000
+        timeout: 5_000,
       });
       return;
     } catch {
@@ -696,8 +692,8 @@ async function waitForJobSearchSurface(page: Page): Promise<void> {
     "Could not locate LinkedIn job search content.",
     {
       current_url: page.url(),
-      attempted_selectors: selectors
-    }
+      attempted_selectors: selectors,
+    },
   );
 }
 
@@ -707,14 +703,14 @@ async function waitForJobDetailSurface(page: Page): Promise<void> {
     ".jobs-details",
     ".jobs-unified-top-card",
     ".job-view-layout",
-    "main"
+    "main",
   ];
 
   for (const selector of selectors) {
     try {
       await page.locator(selector).first().waitFor({
         state: "visible",
-        timeout: 5_000
+        timeout: 5_000,
       });
       return;
     } catch {
@@ -727,8 +723,8 @@ async function waitForJobDetailSurface(page: Page): Promise<void> {
     "Could not locate LinkedIn job detail content.",
     {
       current_url: page.url(),
-      attempted_selectors: selectors
-    }
+      attempted_selectors: selectors,
+    },
   );
 }
 
@@ -739,14 +735,14 @@ async function waitForJobAlertsSurface(page: Page): Promise<void> {
     ".jobs-alert-card",
     ".job-alert-card",
     "a[href*='/jobs/search/']",
-    "main"
+    "main",
   ];
 
   for (const selector of selectors) {
     try {
       await page.locator(selector).first().waitFor({
         state: "visible",
-        timeout: 5_000
+        timeout: 5_000,
       });
       return;
     } catch {
@@ -759,149 +755,155 @@ async function waitForJobAlertsSurface(page: Page): Promise<void> {
     "Could not locate LinkedIn job alerts content.",
     {
       current_url: page.url(),
-      attempted_selectors: selectors
-    }
+      attempted_selectors: selectors,
+    },
   );
 }
 
 /* eslint-disable no-undef -- DOM types are valid inside page.evaluate() */
 async function extractJobSearchResults(
   page: Page,
-  limit: number
+  limit: number,
 ): Promise<LinkedInJobSearchResult[]> {
-  const snapshots = await page.evaluate((maxJobs: number) => {
-    const normalize = (value: string | null | undefined): string =>
-      (value ?? "").replace(/\s+/g, " ").trim();
+  const snapshots = await page.evaluate(
+    (maxJobs: number) => {
+      const normalize = (value: string | null | undefined): string =>
+        (value ?? "").replace(/\s+/g, " ").trim();
 
-    const origin = globalThis.window.location.origin;
+      const origin = globalThis.window.location.origin;
 
-    const pickText = (root: ParentNode, selectors: string[]): string => {
-      for (const selector of selectors) {
-        const text = normalize(root.querySelector(selector)?.textContent);
-        if (text) {
-          return text;
+      const pickText = (root: ParentNode, selectors: string[]): string => {
+        for (const selector of selectors) {
+          const text = normalize(root.querySelector(selector)?.textContent);
+          if (text) {
+            return text;
+          }
         }
-      }
-      return "";
-    };
-
-    const toAbsoluteHref = (value: string): string => {
-      if (!value) {
         return "";
-      }
-      if (/^https?:\/\//i.test(value)) {
-        return value;
-      }
-      return value.startsWith("/") ? `${origin}${value}` : `${origin}/${value}`;
-    };
+      };
 
-    const pickHref = (root: ParentNode, selectors: string[]): string => {
-      for (const selector of selectors) {
-        const linkElement = root.querySelector(
-          selector
-        ) as HTMLAnchorElement | null;
-        const href = toAbsoluteHref(
-          normalize(linkElement?.getAttribute("href")) ||
-            normalize(linkElement?.href)
-        );
-        if (href) {
-          return href;
+      const toAbsoluteHref = (value: string): string => {
+        if (!value) {
+          return "";
         }
-      }
-      return "";
-    };
-
-    const extractJobId = (jobUrl: string, root: Element): string => {
-      const urlMatch = /\/jobs\/view\/(\d+)/i.exec(jobUrl);
-      if (urlMatch?.[1]) {
-        return urlMatch[1];
-      }
-
-      const idCandidates = [
-        normalize(root.getAttribute("data-job-id")),
-        normalize(root.getAttribute("data-entity-urn")),
-        normalize(root.getAttribute("data-occludable-job-id")),
-        normalize(root.querySelector("[data-job-id]")?.getAttribute("data-job-id"))
-      ];
-
-      for (const candidate of idCandidates) {
-        if (candidate) {
-          const urnMatch = /(\d+)$/.exec(candidate);
-          return urnMatch?.[1] ?? candidate;
+        if (/^https?:\/\//i.test(value)) {
+          return value;
         }
-      }
+        return value.startsWith("/")
+          ? `${origin}${value}`
+          : `${origin}/${value}`;
+      };
 
-      return "";
-    };
-
-    const pickEmploymentType = (root: ParentNode): string => {
-      const signal = pickText(root, [
-        ".job-card-container__metadata-item",
-        ".job-card-container__job-insight",
-        ".base-search-card__metadata"
-      ]);
-      if (!signal) {
+      const pickHref = (root: ParentNode, selectors: string[]): string => {
+        for (const selector of selectors) {
+          const linkElement = root.querySelector(
+            selector,
+          ) as HTMLAnchorElement | null;
+          const href = toAbsoluteHref(
+            normalize(linkElement?.getAttribute("href")) ||
+              normalize(linkElement?.href),
+          );
+          if (href) {
+            return href;
+          }
+        }
         return "";
-      }
+      };
 
-      const match = /(Full-time|Part-time|Contract|Temporary|Internship)/i.exec(
-        signal
-      );
-      return normalize(match?.[1] ?? "");
-    };
+      const extractJobId = (jobUrl: string, root: Element): string => {
+        const urlMatch = /\/jobs\/view\/(\d+)/i.exec(jobUrl);
+        if (urlMatch?.[1]) {
+          return urlMatch[1];
+        }
 
-    const cards = Array.from(
-      globalThis.document.querySelectorAll(
-        ".job-card-container, .base-search-card, .job-card-list__entity-lockup"
-      )
-    ).slice(0, maxJobs);
+        const idCandidates = [
+          normalize(root.getAttribute("data-job-id")),
+          normalize(root.getAttribute("data-entity-urn")),
+          normalize(root.getAttribute("data-occludable-job-id")),
+          normalize(
+            root.querySelector("[data-job-id]")?.getAttribute("data-job-id"),
+          ),
+        ];
 
-    const results: JobSearchSnapshot[] = [];
-    for (const card of cards) {
-      const jobUrl = pickHref(card, [
-        "a[href*='/jobs/view/']",
-        ".job-card-container__link",
-        ".base-search-card__full-link",
-        "a"
-      ]);
+        for (const candidate of idCandidates) {
+          if (candidate) {
+            const urnMatch = /(\d+)$/.exec(candidate);
+            return urnMatch?.[1] ?? candidate;
+          }
+        }
 
-      results.push({
-        job_id: extractJobId(jobUrl, card),
-        title: pickText(card, [
+        return "";
+      };
+
+      const pickEmploymentType = (root: ParentNode): string => {
+        const signal = pickText(root, [
+          ".job-card-container__metadata-item",
+          ".job-card-container__job-insight",
+          ".base-search-card__metadata",
+        ]);
+        if (!signal) {
+          return "";
+        }
+
+        const match =
+          /(Full-time|Part-time|Contract|Temporary|Internship)/i.exec(signal);
+        return normalize(match?.[1] ?? "");
+      };
+
+      const cards = Array.from(
+        globalThis.document.querySelectorAll(
+          ".job-card-container, .base-search-card, .job-card-list__entity-lockup",
+        ),
+      ).slice(0, maxJobs);
+
+      const results: JobSearchSnapshot[] = [];
+      for (const card of cards) {
+        const jobUrl = pickHref(card, [
+          "a[href*='/jobs/view/']",
           ".job-card-container__link",
-          ".base-search-card__title",
-          ".job-card-list__title"
-        ]),
-        company: pickText(card, [
-          ".job-card-container__company-name",
-          ".base-search-card__subtitle",
-          ".job-card-container__primary-description"
-        ]),
-        location: pickText(card, [
-          ".job-card-container__metadata-wrapper",
-          ".job-search-card__location",
-          ".job-card-container__metadata-item"
-        ]),
-        posted_at: pickText(card, [
-          "time",
-          ".job-card-container__footer",
-          ".job-card-container__listed-time"
-        ]),
-        job_url: jobUrl,
-        salary_range: pickText(card, [
-          ".job-card-container__salary-info",
-          ".salary-main-rail__compensation-text"
-        ]),
-        employment_type: pickEmploymentType(card)
-      });
+          ".base-search-card__full-link",
+          "a",
+        ]);
 
-      if (results.length >= maxJobs) {
-        break;
+        results.push({
+          job_id: extractJobId(jobUrl, card),
+          title: pickText(card, [
+            ".job-card-container__link",
+            ".base-search-card__title",
+            ".job-card-list__title",
+          ]),
+          company: pickText(card, [
+            ".job-card-container__company-name",
+            ".base-search-card__subtitle",
+            ".job-card-container__primary-description",
+          ]),
+          location: pickText(card, [
+            ".job-card-container__metadata-wrapper",
+            ".job-search-card__location",
+            ".job-card-container__metadata-item",
+          ]),
+          posted_at: pickText(card, [
+            "time",
+            ".job-card-container__footer",
+            ".job-card-container__listed-time",
+          ]),
+          job_url: jobUrl,
+          salary_range: pickText(card, [
+            ".job-card-container__salary-info",
+            ".salary-main-rail__compensation-text",
+          ]),
+          employment_type: pickEmploymentType(card),
+        });
+
+        if (results.length >= maxJobs) {
+          break;
+        }
       }
-    }
 
-    return results;
-  }, Math.max(1, limit));
+      return results;
+    },
+    Math.max(1, limit),
+  );
 
   return snapshots
     .map((snapshot) => ({
@@ -912,7 +914,7 @@ async function extractJobSearchResults(
       posted_at: normalizeText(snapshot.posted_at),
       job_url: normalizeText(snapshot.job_url),
       salary_range: normalizeText(snapshot.salary_range),
-      employment_type: normalizeText(snapshot.employment_type)
+      employment_type: normalizeText(snapshot.employment_type),
     }))
     .filter((result) => result.title.length > 0 || result.job_url.length > 0)
     .slice(0, limit);
@@ -920,7 +922,7 @@ async function extractJobSearchResults(
 
 async function extractJobDetail(
   page: Page,
-  jobId: string
+  jobId: string,
 ): Promise<LinkedInJobPosting> {
   const snapshot = await page.evaluate((passedJobId: string) => {
     const normalize = (value: string | null | undefined): string =>
@@ -952,40 +954,40 @@ async function extractJobDetail(
     const main = doc.querySelector("main") ?? doc.body;
 
     const companyLinkElement = main.querySelector(
-      "a[href*='/company/']"
+      "a[href*='/company/']",
     ) as HTMLAnchorElement | null;
 
     const title = pickText(main, [
       ".job-details-jobs-unified-top-card__job-title",
       ".jobs-unified-top-card__job-title",
       ".top-card-layout__title",
-      "h1"
+      "h1",
     ]);
 
     const company = pickText(main, [
       ".job-details-jobs-unified-top-card__company-name",
       ".jobs-unified-top-card__company-name",
       ".top-card-layout__card-link",
-      "a[href*='/company/']"
+      "a[href*='/company/']",
     ]);
 
     const companyUrl = toAbsoluteHref(
       normalize(companyLinkElement?.getAttribute("href")) ||
-        normalize(companyLinkElement?.href)
+        normalize(companyLinkElement?.href),
     );
 
     const location = pickText(main, [
       ".job-details-jobs-unified-top-card__bullet",
       ".jobs-unified-top-card__subtitle-primary-grouping .jobs-unified-top-card__bullet",
       ".top-card-layout__second-subline .topcard__flavor--bullet",
-      ".jobs-unified-top-card__workplace-type"
+      ".jobs-unified-top-card__workplace-type",
     ]);
 
     const postedAt = pickText(main, [
       ".job-details-jobs-unified-top-card__posted-date",
       ".jobs-unified-top-card__posted-date",
       "time",
-      ".posted-time-ago__text"
+      ".posted-time-ago__text",
     ]);
 
     const description = pickText(main, [
@@ -993,13 +995,13 @@ async function extractJobDetail(
       ".jobs-description-content__text",
       ".jobs-box__html-content",
       ".description__text",
-      "#job-details"
+      "#job-details",
     ]);
 
     const insightTexts = Array.from(
       main.querySelectorAll(
-        ".job-details-jobs-unified-top-card__job-insight, .jobs-unified-top-card__job-insight, .description__job-criteria-item, .job-criteria__item"
-      )
+        ".job-details-jobs-unified-top-card__job-insight, .jobs-unified-top-card__job-insight, .description__job-criteria-item, .job-criteria__item",
+      ),
     ).map((el) => normalize(el.textContent));
 
     const allInsights = insightTexts.join(" ");
@@ -1008,12 +1010,12 @@ async function extractJobDetail(
       pickText(main, [
         ".salary-main-rail__compensation-text",
         ".job-details-jobs-unified-top-card__salary-info",
-        ".compensation__salary"
+        ".compensation__salary",
       ]) ||
       (() => {
         const salaryMatch =
           /(\$[\d,]+\s*[-–]\s*\$[\d,]+|€[\d,]+\s*[-–]\s*€[\d,]+|£[\d,]+\s*[-–]\s*£[\d,]+|[\d,]+\s*[-–]\s*[\d,]+\s*(?:kr|DKK|USD|EUR|GBP))/i.exec(
-            allInsights
+            allInsights,
           );
         return normalize(salaryMatch?.[1] ?? "");
       })();
@@ -1024,17 +1026,18 @@ async function extractJobDetail(
 
     const seniorityMatch =
       /(Entry level|Associate|Mid-Senior level|Director|Executive|Internship|Not Applicable)/i.exec(
-        allInsights
+        allInsights,
       );
     const seniorityLevel = normalize(seniorityMatch?.[1] ?? "");
 
     const applicantCount = pickText(main, [
       ".jobs-unified-top-card__applicant-count",
       ".job-details-jobs-unified-top-card__applicant-count",
-      ".num-applicants__caption"
+      ".num-applicants__caption",
     ]);
 
-    const isRemote = /\bremote\b/i.test(location) || /\bremote\b/i.test(allInsights);
+    const isRemote =
+      /\bremote\b/i.test(location) || /\bremote\b/i.test(allInsights);
 
     const jobUrl = globalThis.window.location.href;
 
@@ -1051,7 +1054,7 @@ async function extractJobDetail(
       job_url: jobUrl,
       applicant_count: applicantCount,
       seniority_level: seniorityLevel,
-      is_remote: isRemote
+      is_remote: isRemote,
     };
 
     return result;
@@ -1070,141 +1073,147 @@ async function extractJobDetail(
     job_url: normalizeText(snapshot.job_url),
     applicant_count: normalizeText(snapshot.applicant_count),
     seniority_level: normalizeText(snapshot.seniority_level),
-    is_remote: Boolean(snapshot.is_remote)
+    is_remote: Boolean(snapshot.is_remote),
   };
 }
 
 async function extractJobAlerts(
   page: Page,
-  limit: number
+  limit: number,
 ): Promise<LinkedInJobAlert[]> {
-  const snapshots = await page.evaluate((maxAlerts: number) => {
-    const normalize = (value: string | null | undefined): string =>
-      (value ?? "").replace(/\s+/g, " ").trim();
+  const snapshots = await page.evaluate(
+    (maxAlerts: number) => {
+      const normalize = (value: string | null | undefined): string =>
+        (value ?? "").replace(/\s+/g, " ").trim();
 
-    const origin = globalThis.window.location.origin;
+      const origin = globalThis.window.location.origin;
 
-    const isVisible = (element: Element): boolean => {
-      const htmlElement = element as HTMLElement;
-      const style = globalThis.window.getComputedStyle(htmlElement);
-      const rect = htmlElement.getBoundingClientRect();
-      return (
-        style.visibility !== "hidden" &&
-        style.display !== "none" &&
-        rect.width > 0 &&
-        rect.height > 0
-      );
-    };
+      const isVisible = (element: Element): boolean => {
+        const htmlElement = element as HTMLElement;
+        const style = globalThis.window.getComputedStyle(htmlElement);
+        const rect = htmlElement.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
 
-    const toAbsoluteHref = (value: string): string => {
-      if (!value) {
+      const toAbsoluteHref = (value: string): string => {
+        if (!value) {
+          return "";
+        }
+        if (/^https?:\/\//i.test(value)) {
+          return value;
+        }
+        return value.startsWith("/")
+          ? `${origin}${value}`
+          : `${origin}/${value}`;
+      };
+
+      const parseSearchUrl = (
+        value: string,
+      ): { normalizedUrl: string; query: string; location: string } => {
+        const absolute = toAbsoluteHref(value);
+        if (!absolute) {
+          return { normalizedUrl: "", query: "", location: "" };
+        }
+
+        try {
+          const parsed = new URL(absolute);
+          return {
+            normalizedUrl: parsed.toString(),
+            query: normalize(parsed.searchParams.get("keywords")),
+            location: normalize(parsed.searchParams.get("location")),
+          };
+        } catch {
+          return { normalizedUrl: absolute, query: "", location: "" };
+        }
+      };
+
+      const pickText = (root: ParentNode, selectors: string[]): string => {
+        for (const selector of selectors) {
+          const text = normalize(root.querySelector(selector)?.textContent);
+          if (text) {
+            return text;
+          }
+        }
+
         return "";
-      }
-      if (/^https?:\/\//i.test(value)) {
-        return value;
-      }
-      return value.startsWith("/") ? `${origin}${value}` : `${origin}/${value}`;
-    };
+      };
 
-    const parseSearchUrl = (
-      value: string
-    ): { normalizedUrl: string; query: string; location: string } => {
-      const absolute = toAbsoluteHref(value);
-      if (!absolute) {
-        return { normalizedUrl: "", query: "", location: "" };
-      }
+      const cards = Array.from(
+        globalThis.document.querySelectorAll(
+          "[data-job-alert-id], [data-alert-id], .jobs-alert-card, .job-alert-card, article, li",
+        ),
+      ).filter((element) => isVisible(element));
 
-      try {
-        const parsed = new URL(absolute);
-        return {
-          normalizedUrl: parsed.toString(),
-          query: normalize(parsed.searchParams.get("keywords")),
-          location: normalize(parsed.searchParams.get("location"))
-        };
-      } catch {
-        return { normalizedUrl: absolute, query: "", location: "" };
-      }
-    };
+      const results: JobAlertSnapshot[] = [];
+      const seen = new Set<string>();
+      for (const card of cards) {
+        const text = normalize(card.textContent);
+        const searchAnchor = card.querySelector(
+          "a[href*='/jobs/search/']",
+        ) as HTMLAnchorElement | null;
 
-    const pickText = (root: ParentNode, selectors: string[]): string => {
-      for (const selector of selectors) {
-        const text = normalize(root.querySelector(selector)?.textContent);
-        if (text) {
-          return text;
+        if (!searchAnchor && !/alert/i.test(text)) {
+          continue;
+        }
+
+        const parsedSearch = parseSearchUrl(
+          normalize(searchAnchor?.getAttribute("href")) ||
+            normalize(searchAnchor?.href),
+        );
+        const query =
+          pickText(card, [
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+            ".job-alert-card__title",
+            ".jobs-alert-card__title",
+            "a[href*='/jobs/search/']",
+          ]) || parsedSearch.query;
+        const location =
+          pickText(card, [
+            ".job-alert-card__location",
+            ".jobs-alert-card__location",
+            ".t-14",
+            ".t-12",
+          ]) || parsedSearch.location;
+        const frequencyMatch = /(Daily|Weekly|Instant|Immediate)/i.exec(text);
+        const frequency = normalize(frequencyMatch?.[1] ?? "");
+        const alertId =
+          normalize(card.getAttribute("data-job-alert-id")) ||
+          normalize(card.getAttribute("data-alert-id")) ||
+          normalize(card.getAttribute("id")) ||
+          parsedSearch.normalizedUrl ||
+          `${query}::${location}`;
+
+        if (!alertId || seen.has(alertId)) {
+          continue;
+        }
+
+        seen.add(alertId);
+        results.push({
+          alert_id: alertId,
+          query,
+          location,
+          frequency,
+          search_url: parsedSearch.normalizedUrl,
+          enabled: !/\b(paused|off|disabled|muted)\b/i.test(text),
+        });
+
+        if (results.length >= maxAlerts) {
+          break;
         }
       }
 
-      return "";
-    };
-
-    const cards = Array.from(
-      globalThis.document.querySelectorAll(
-        "[data-job-alert-id], [data-alert-id], .jobs-alert-card, .job-alert-card, article, li"
-      )
-    ).filter((element) => isVisible(element));
-
-    const results: JobAlertSnapshot[] = [];
-    const seen = new Set<string>();
-    for (const card of cards) {
-      const text = normalize(card.textContent);
-      const searchAnchor = card.querySelector(
-        "a[href*='/jobs/search/']"
-      ) as HTMLAnchorElement | null;
-
-      if (!searchAnchor && !/alert/i.test(text)) {
-        continue;
-      }
-
-      const parsedSearch = parseSearchUrl(
-        normalize(searchAnchor?.getAttribute("href")) || normalize(searchAnchor?.href)
-      );
-      const query =
-        pickText(card, [
-          "h1",
-          "h2",
-          "h3",
-          "h4",
-          ".job-alert-card__title",
-          ".jobs-alert-card__title",
-          "a[href*='/jobs/search/']"
-        ]) || parsedSearch.query;
-      const location =
-        pickText(card, [
-          ".job-alert-card__location",
-          ".jobs-alert-card__location",
-          ".t-14",
-          ".t-12"
-        ]) || parsedSearch.location;
-      const frequencyMatch = /(Daily|Weekly|Instant|Immediate)/i.exec(text);
-      const frequency = normalize(frequencyMatch?.[1] ?? "");
-      const alertId =
-        normalize(card.getAttribute("data-job-alert-id")) ||
-        normalize(card.getAttribute("data-alert-id")) ||
-        normalize(card.getAttribute("id")) ||
-        parsedSearch.normalizedUrl ||
-        `${query}::${location}`;
-
-      if (!alertId || seen.has(alertId)) {
-        continue;
-      }
-
-      seen.add(alertId);
-      results.push({
-        alert_id: alertId,
-        query,
-        location,
-        frequency,
-        search_url: parsedSearch.normalizedUrl,
-        enabled: !/\b(paused|off|disabled|muted)\b/i.test(text)
-      });
-
-      if (results.length >= maxAlerts) {
-        break;
-      }
-    }
-
-    return results;
-  }, Math.max(1, limit));
+      return results;
+    },
+    Math.max(1, limit),
+  );
 
   return snapshots.map((snapshot) => ({
     alert_id: normalizeText(snapshot.alert_id),
@@ -1212,13 +1221,13 @@ async function extractJobAlerts(
     location: normalizeText(snapshot.location),
     frequency: normalizeText(snapshot.frequency),
     search_url: normalizeText(snapshot.search_url),
-    enabled: Boolean(snapshot.enabled)
+    enabled: Boolean(snapshot.enabled),
   }));
 }
 
 async function loadJobSearchResults(
   page: Page,
-  limit: number
+  limit: number,
 ): Promise<LinkedInJobSearchResult[]> {
   let results = await extractJobSearchResults(page, limit);
 
@@ -1233,7 +1242,7 @@ async function loadJobSearchResults(
 
 async function markJobsButton(
   page: Page,
-  kind: "save" | "easy-apply" | "alert-toggle"
+  kind: "save" | "easy-apply" | "alert-toggle",
 ): Promise<Locator> {
   const attributeName = `data-linkedin-assistant-jobs-${kind}`;
   const markerValue = `marked-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
@@ -1242,7 +1251,7 @@ async function markJobsButton(
     ({
       attributeName: buttonAttributeName,
       markerValue: buttonMarkerValue,
-      kind: buttonKind
+      kind: buttonKind,
     }) => {
       const normalize = (value: string | null | undefined): string =>
         (value ?? "").replace(/\s+/g, " ").trim().toLowerCase();
@@ -1262,7 +1271,7 @@ async function markJobsButton(
       const buttons = Array.from(
         (
           globalThis.document.querySelector("main") ?? globalThis.document.body
-        ).querySelectorAll("button, a[role='button']")
+        ).querySelectorAll("button, a[role='button']"),
       ).filter((element) => isVisible(element));
 
       const getScore = (element: Element): number => {
@@ -1272,7 +1281,9 @@ async function markJobsButton(
         const ariaLabel = normalize(htmlElement.getAttribute("aria-label"));
         const title = normalize(htmlElement.getAttribute("title"));
         const className = normalize(htmlElement.getAttribute("class"));
-        const controlName = normalize(htmlElement.getAttribute("data-control-name"));
+        const controlName = normalize(
+          htmlElement.getAttribute("data-control-name"),
+        );
         const haystack = [text, ariaLabel, title, className, controlName]
           .filter(Boolean)
           .join(" ");
@@ -1315,14 +1326,16 @@ async function markJobsButton(
         if (
           buttonKind !== "alert-toggle" &&
           htmlElement.closest(
-            ".jobs-unified-top-card, .job-details-jobs-unified-top-card, .top-card-layout"
+            ".jobs-unified-top-card, .job-details-jobs-unified-top-card, .top-card-layout",
           )
         ) {
           score += 40;
         }
         if (
           buttonKind === "alert-toggle" &&
-          htmlElement.closest(".jobs-search-two-pane, .jobs-search-results-list")
+          htmlElement.closest(
+            ".jobs-search-two-pane, .jobs-search-results-list",
+          )
         ) {
           score += 20;
         }
@@ -1333,7 +1346,7 @@ async function markJobsButton(
       const sorted = buttons
         .map((element) => ({
           element,
-          score: getScore(element)
+          score: getScore(element),
         }))
         .filter((candidate) => candidate.score > 0)
         .sort((left, right) => right.score - left.score);
@@ -1349,8 +1362,8 @@ async function markJobsButton(
     {
       attributeName,
       markerValue,
-      kind
-    }
+      kind,
+    },
   );
 
   if (!marked) {
@@ -1363,7 +1376,7 @@ async function markJobsButton(
 
     throw new LinkedInBuddyError("UI_CHANGED_SELECTOR_FAILED", message, {
       current_url: page.url(),
-      button_kind: kind
+      button_kind: kind,
     });
   }
 
@@ -1372,7 +1385,7 @@ async function markJobsButton(
 
 async function readJobsToggleState(
   page: Page,
-  kind: "save" | "alert-toggle"
+  kind: "save" | "alert-toggle",
 ): Promise<boolean | null> {
   const button = await markJobsButton(page, kind);
   const state = await button.evaluate((element, buttonKind) => {
@@ -1404,7 +1417,9 @@ async function readJobsToggleState(
       return null;
     }
 
-    if (/\b(job alert set|remove alert|manage alert|alert on)\b/.test(combined)) {
+    if (
+      /\b(job alert set|remove alert|manage alert|alert on)\b/.test(combined)
+    ) {
       return true;
     }
     if (/\b(set alert|create alert|alert off)\b/.test(combined)) {
@@ -1418,7 +1433,7 @@ async function readJobsToggleState(
 }
 
 function classifyEasyApplyActionLabel(
-  value: string
+  value: string,
 ): "submit" | "review" | "next" | "unknown" {
   const normalized = normalizeLabelKey(value);
   if (!normalized) {
@@ -1449,15 +1464,10 @@ function classifyEasyApplyActionLabel(
 }
 
 async function readEasyApplyDialogSnapshot(
-  page: Page
+  page: Page,
 ): Promise<EasyApplyDialogSnapshot> {
   const snapshot = await page.evaluate(
-    ({
-      dialogSelector,
-      fieldAttribute,
-      groupAttribute,
-      optionAttribute
-    }) => {
+    ({ dialogSelector, fieldAttribute, groupAttribute, optionAttribute }) => {
       const normalize = (value: string | null | undefined): string =>
         (value ?? "").replace(/\s+/g, " ").trim();
       const normalizeKey = (value: string): string =>
@@ -1480,7 +1490,7 @@ async function readEasyApplyDialogSnapshot(
       };
 
       const dialog = Array.from(
-        globalThis.document.querySelectorAll(dialogSelector)
+        globalThis.document.querySelectorAll(dialogSelector),
       ).find((element) => isVisible(element));
 
       if (!dialog || !isVisible(dialog)) {
@@ -1489,36 +1499,42 @@ async function readEasyApplyDialogSnapshot(
           title: "",
           primaryActionLabel: "",
           success: false,
-          fields: []
+          fields: [],
         };
       }
 
       const readAssociatedLabel = (element: HTMLElement): string => {
         const htmlInput = element as HTMLInputElement;
         if (htmlInput.id) {
-          const explicitLabel = dialog.querySelector(`label[for="${htmlInput.id}"]`);
+          const explicitLabel = dialog.querySelector(
+            `label[for="${htmlInput.id}"]`,
+          );
           const explicitLabelText = normalize(explicitLabel?.textContent);
           if (explicitLabelText) {
             return explicitLabelText;
           }
         }
 
-        const wrappedLabelText = normalize(element.closest("label")?.textContent);
+        const wrappedLabelText = normalize(
+          element.closest("label")?.textContent,
+        );
         if (wrappedLabelText) {
           return wrappedLabelText;
         }
 
         const fieldsetText = normalize(
-          element.closest("fieldset")?.querySelector("legend")?.textContent
+          element.closest("fieldset")?.querySelector("legend")?.textContent,
         );
         if (fieldsetText) {
           return fieldsetText;
         }
 
         const formElement = element.closest(
-          ".fb-dash-form-element, .jobs-easy-apply-form-element"
+          ".fb-dash-form-element, .jobs-easy-apply-form-element",
         );
-        const formElementLabel = normalize(formElement?.querySelector("label")?.textContent);
+        const formElementLabel = normalize(
+          formElement?.querySelector("label")?.textContent,
+        );
         if (formElementLabel) {
           return formElementLabel;
         }
@@ -1536,8 +1552,8 @@ async function readEasyApplyDialogSnapshot(
         const ariaRequired = normalize(element.getAttribute("aria-required"));
         return Boolean(
           htmlInput.required ||
-            ariaRequired === "true" ||
-            labelText.includes("*")
+          ariaRequired === "true" ||
+          labelText.includes("*"),
         );
       };
 
@@ -1548,7 +1564,7 @@ async function readEasyApplyDialogSnapshot(
       const createFieldId = (): string => `field-${counter++}`;
 
       const inputs = Array.from(
-        dialog.querySelectorAll("input, textarea, select")
+        dialog.querySelectorAll("input, textarea, select"),
       ).filter((element) => isVisible(element));
 
       for (const element of inputs) {
@@ -1566,7 +1582,10 @@ async function readEasyApplyDialogSnapshot(
           continue;
         }
 
-        if ((inputType === "radio" || inputType === "checkbox") && inputElement.name) {
+        if (
+          (inputType === "radio" || inputType === "checkbox") &&
+          inputElement.name
+        ) {
           const groupKey = `${inputType}:${inputElement.name}`;
           if (handledGroups.has(groupKey)) {
             continue;
@@ -1586,7 +1605,10 @@ async function readEasyApplyDialogSnapshot(
             .map((candidate) => {
               const optionLabel = readAssociatedLabel(candidate);
               candidate.setAttribute(groupAttribute, fieldId);
-              candidate.setAttribute(optionAttribute, normalizeKey(optionLabel));
+              candidate.setAttribute(
+                optionAttribute,
+                normalizeKey(optionLabel),
+              );
               return optionLabel;
             })
             .map((candidate) => normalize(candidate))
@@ -1598,11 +1620,13 @@ async function readEasyApplyDialogSnapshot(
             label,
             labelKey: normalizeKey(label),
             kind: inputType as "radio" | "checkbox",
-            required: groupInputs.some((candidate) => isRequiredElement(candidate)),
+            required: groupInputs.some((candidate) =>
+              isRequiredElement(candidate),
+            ),
             filled: groupInputs.some((candidate) => candidate.checked),
             options,
             multiple: inputType === "checkbox" && groupInputs.length > 1,
-            accept: ""
+            accept: "",
           });
           continue;
         }
@@ -1647,17 +1671,17 @@ async function readEasyApplyDialogSnapshot(
               : tagName === "select"
                 ? (element as HTMLSelectElement).multiple
                 : false,
-          accept: normalize(inputElement.accept)
+          accept: normalize(inputElement.accept),
         });
       }
 
-      const buttons = Array.from(dialog.querySelectorAll("button")).filter((element) =>
-        isVisible(element)
+      const buttons = Array.from(dialog.querySelectorAll("button")).filter(
+        (element) => isVisible(element),
       );
       const primaryButton = buttons
         .map((button) => {
           const label = normalize(
-            button.getAttribute("aria-label") || button.textContent
+            button.getAttribute("aria-label") || button.textContent,
           );
           const key = normalizeKey(label);
           let score = 0;
@@ -1678,7 +1702,7 @@ async function readEasyApplyDialogSnapshot(
           }
           return {
             label,
-            score
+            score,
           };
         })
         .sort((left, right) => right.score - left.score)[0];
@@ -1688,17 +1712,17 @@ async function readEasyApplyDialogSnapshot(
         title: normalize(dialog.querySelector("h1, h2, h3")?.textContent),
         primaryActionLabel: primaryButton?.label ?? "",
         success: /application (submitted|sent)|your application was sent/i.test(
-          normalize(dialog.textContent)
+          normalize(dialog.textContent),
         ),
-        fields
+        fields,
       };
     },
     {
       dialogSelector: EASY_APPLY_DIALOG_SELECTOR,
       fieldAttribute: EASY_APPLY_FIELD_ATTR,
       groupAttribute: EASY_APPLY_GROUP_ATTR,
-      optionAttribute: EASY_APPLY_OPTION_ATTR
-    }
+      optionAttribute: EASY_APPLY_OPTION_ATTR,
+    },
   );
 
   return snapshot;
@@ -1706,7 +1730,7 @@ async function readEasyApplyDialogSnapshot(
 
 function resolveEasyApplyFieldValue(
   field: EasyApplyFieldSnapshot,
-  input: ValidatedEasyApplyInput
+  input: ValidatedEasyApplyInput,
 ): LinkedInEasyApplyAnswerValue | string | undefined {
   const labelKey = field.labelKey;
   const answerEntries = Object.entries(input.answers);
@@ -1744,7 +1768,7 @@ function resolveEasyApplyFieldValue(
 async function applyEasyApplyFieldValue(
   page: Page,
   field: EasyApplyFieldSnapshot,
-  value: LinkedInEasyApplyAnswerValue | string
+  value: LinkedInEasyApplyAnswerValue | string,
 ): Promise<void> {
   if (field.kind === "text" || field.kind === "textarea") {
     await page
@@ -1786,12 +1810,14 @@ async function applyEasyApplyFieldValue(
             .trim();
         const inputs = Array.from(
           globalThis.document.querySelectorAll(
-            `[${groupAttribute}="${groupId}"]`
-          )
+            `[${groupAttribute}="${groupId}"]`,
+          ),
         ) as HTMLInputElement[];
 
         const match = inputs.find(
-          (input) => normalizeKey(input.getAttribute(optionAttribute) ?? "") === desiredOption
+          (input) =>
+            normalizeKey(input.getAttribute(optionAttribute) ?? "") ===
+            desiredOption,
         );
 
         if (!match) {
@@ -1800,13 +1826,13 @@ async function applyEasyApplyFieldValue(
 
         match.click();
         return true;
-    },
+      },
       {
         groupId: field.fieldId,
         desiredOption: optionKey,
         groupAttribute: EASY_APPLY_GROUP_ATTR,
-        optionAttribute: EASY_APPLY_OPTION_ATTR
-      }
+        optionAttribute: EASY_APPLY_OPTION_ATTR,
+      },
     );
 
     if (!clicked) {
@@ -1816,8 +1842,8 @@ async function applyEasyApplyFieldValue(
         {
           field_label: field.label,
           provided_value: String(value),
-          options: field.options
-        }
+          options: field.options,
+        },
       );
     }
     return;
@@ -1837,13 +1863,15 @@ async function applyEasyApplyFieldValue(
           .trim();
       const inputs = Array.from(
         globalThis.document.querySelectorAll(
-          `[${groupAttribute}="${groupId}"]`
-        )
+          `[${groupAttribute}="${groupId}"]`,
+        ),
       ) as HTMLInputElement[];
 
       const matchedOptions: string[] = [];
       for (const input of inputs) {
-        const optionKey = normalizeKey(input.getAttribute(optionAttribute) ?? "");
+        const optionKey = normalizeKey(
+          input.getAttribute(optionAttribute) ?? "",
+        );
         const shouldCheck = desiredOptions.includes(optionKey);
         if (shouldCheck !== input.checked) {
           input.click();
@@ -1859,8 +1887,8 @@ async function applyEasyApplyFieldValue(
       groupId: field.fieldId,
       desiredOptions: selectionKeys,
       groupAttribute: EASY_APPLY_GROUP_ATTR,
-      optionAttribute: EASY_APPLY_OPTION_ATTR
-    }
+      optionAttribute: EASY_APPLY_OPTION_ATTR,
+    },
   );
 
   if (selectionResult.length === 0 && values.length > 0) {
@@ -1870,8 +1898,8 @@ async function applyEasyApplyFieldValue(
       {
         field_label: field.label,
         provided_value: values,
-        options: field.options
-      }
+        options: field.options,
+      },
     );
   }
 }
@@ -1879,7 +1907,7 @@ async function applyEasyApplyFieldValue(
 async function fillEasyApplyStep(
   page: Page,
   snapshot: EasyApplyDialogSnapshot,
-  input: ValidatedEasyApplyInput
+  input: ValidatedEasyApplyInput,
 ): Promise<void> {
   const missingRequiredFields: string[] = [];
 
@@ -1900,15 +1928,15 @@ async function fillEasyApplyStep(
       "ACTION_PRECONDITION_FAILED",
       "Easy Apply requires additional answers before confirmation.",
       {
-        missing_fields: missingRequiredFields
-      }
+        missing_fields: missingRequiredFields,
+      },
     );
   }
 }
 
 async function clickEasyApplyPrimaryAction(page: Page): Promise<string> {
   const dialog = page.locator(EASY_APPLY_DIALOG_SELECTOR).filter({
-    has: page.locator("button")
+    has: page.locator("button"),
   });
 
   const buttons = dialog.locator("button");
@@ -1925,11 +1953,17 @@ async function clickEasyApplyPrimaryAction(page: Page): Promise<string> {
 
     const label = normalizeText(
       (await button.getAttribute("aria-label").catch(() => "")) ??
-        (await button.textContent().catch(() => ""))
+        (await button.textContent().catch(() => "")),
     );
     const actionKind = classifyEasyApplyActionLabel(label);
     const score =
-      actionKind === "submit" ? 300 : actionKind === "review" ? 200 : actionKind === "next" ? 100 : 0;
+      actionKind === "submit"
+        ? 300
+        : actionKind === "review"
+          ? 200
+          : actionKind === "next"
+            ? 100
+            : 0;
 
     if (score > bestScore) {
       bestScore = score;
@@ -1943,8 +1977,8 @@ async function clickEasyApplyPrimaryAction(page: Page): Promise<string> {
       "UI_CHANGED_SELECTOR_FAILED",
       "Could not determine the primary Easy Apply action button.",
       {
-        current_url: page.url()
-      }
+        current_url: page.url(),
+      },
     );
   }
 
@@ -1964,34 +1998,42 @@ async function waitForEasyApplySuccess(page: Page): Promise<boolean> {
       .textContent()
       .catch(() => "");
     return /application (submitted|sent)|your application was sent/i.test(
-      normalizeText(pageText)
+      normalizeText(pageText),
     );
   }, 12_000);
 }
 /* eslint-enable no-undef */
 
-export class SaveJobActionExecutor
-  implements ActionExecutor<LinkedInJobsExecutorRuntime>
-{
+export class SaveJobActionExecutor implements ActionExecutor<LinkedInJobsExecutorRuntime> {
   async execute(
-    input: ActionExecutorInput<LinkedInJobsExecutorRuntime>
+    input: ActionExecutorInput<LinkedInJobsExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
     const runtime = input.runtime;
     const action = input.action;
     const profileName = getProfileName(action.target);
-    const jobId = getRequiredStringField(action.target, "job_id", action.id, "target");
-    const jobUrl = getRequiredStringField(action.target, "job_url", action.id, "target");
+    const jobId = getRequiredStringField(
+      action.target,
+      "job_id",
+      action.id,
+      "target",
+    );
+    const jobUrl = getRequiredStringField(
+      action.target,
+      "job_url",
+      action.id,
+      "target",
+    );
 
     await runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: runtime.cdpUrl
+      cdpUrl: runtime.cdpUrl,
     });
 
     return runtime.profileManager.runWithContext(
       {
         cdpUrl: runtime.cdpUrl,
         profileName,
-        headless: true
+        headless: true,
       },
       async (context) => {
         const page = await getOrCreatePage(context);
@@ -2006,34 +2048,31 @@ export class SaveJobActionExecutor
           targetUrl: jobUrl,
           metadata: {
             job_id: jobId,
-            job_url: jobUrl
+            job_url: jobUrl,
           },
           errorDetails: {
             job_id: jobId,
-            job_url: jobUrl
+            job_url: jobUrl,
           },
           mapError: (error) =>
             asLinkedInBuddyError(
               error,
               "UNKNOWN",
-              "Failed to execute LinkedIn save job action."
+              "Failed to execute LinkedIn save job action.",
             ),
           execute: async () => {
-            const rateLimitState = runtime.rateLimiter.consume(
-              SAVE_JOB_RATE_LIMIT_CONFIG
-            );
-            if (!rateLimitState.allowed) {
-              throw new LinkedInBuddyError(
-                "RATE_LIMITED",
-                "LinkedIn save job confirm is rate limited for the current window.",
-                {
+            const rateLimitState = consumeRateLimitOrThrow(
+              runtime.rateLimiter,
+              {
+                config: SAVE_JOB_RATE_LIMIT_CONFIG,
+                message: createConfirmRateLimitMessage(SAVE_JOB_ACTION_TYPE),
+                details: {
                   action_id: action.id,
                   profile_name: profileName,
                   job_id: jobId,
-                  rate_limit: formatRateLimitState(rateLimitState)
-                }
-              );
-            }
+                },
+              },
+            );
 
             await page.goto(jobUrl, { waitUntil: "domcontentloaded" });
             await waitForNetworkIdleBestEffort(page);
@@ -2057,8 +2096,8 @@ export class SaveJobActionExecutor
                   action_id: action.id,
                   profile_name: profileName,
                   job_id: jobId,
-                  job_url: jobUrl
-                }
+                  job_url: jobUrl,
+                },
               );
             }
 
@@ -2068,7 +2107,7 @@ export class SaveJobActionExecutor
               action_id: action.id,
               profile_name: profileName,
               job_id: jobId,
-              job_url: jobUrl
+              job_url: jobUrl,
             });
 
             return {
@@ -2078,39 +2117,47 @@ export class SaveJobActionExecutor
                 already_saved: initialSavedState === true,
                 job_id: jobId,
                 job_url: jobUrl,
-                rate_limit: formatRateLimitState(rateLimitState)
+                rate_limit: formatRateLimitState(rateLimitState),
               },
-              artifacts: [screenshotPath]
+              artifacts: [screenshotPath],
             };
-          }
+          },
         });
-      }
+      },
     );
   }
 }
 
-export class UnsaveJobActionExecutor
-  implements ActionExecutor<LinkedInJobsExecutorRuntime>
-{
+export class UnsaveJobActionExecutor implements ActionExecutor<LinkedInJobsExecutorRuntime> {
   async execute(
-    input: ActionExecutorInput<LinkedInJobsExecutorRuntime>
+    input: ActionExecutorInput<LinkedInJobsExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
     const runtime = input.runtime;
     const action = input.action;
     const profileName = getProfileName(action.target);
-    const jobId = getRequiredStringField(action.target, "job_id", action.id, "target");
-    const jobUrl = getRequiredStringField(action.target, "job_url", action.id, "target");
+    const jobId = getRequiredStringField(
+      action.target,
+      "job_id",
+      action.id,
+      "target",
+    );
+    const jobUrl = getRequiredStringField(
+      action.target,
+      "job_url",
+      action.id,
+      "target",
+    );
 
     await runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: runtime.cdpUrl
+      cdpUrl: runtime.cdpUrl,
     });
 
     return runtime.profileManager.runWithContext(
       {
         cdpUrl: runtime.cdpUrl,
         profileName,
-        headless: true
+        headless: true,
       },
       async (context) => {
         const page = await getOrCreatePage(context);
@@ -2125,34 +2172,31 @@ export class UnsaveJobActionExecutor
           targetUrl: jobUrl,
           metadata: {
             job_id: jobId,
-            job_url: jobUrl
+            job_url: jobUrl,
           },
           errorDetails: {
             job_id: jobId,
-            job_url: jobUrl
+            job_url: jobUrl,
           },
           mapError: (error) =>
             asLinkedInBuddyError(
               error,
               "UNKNOWN",
-              "Failed to execute LinkedIn unsave job action."
+              "Failed to execute LinkedIn unsave job action.",
             ),
           execute: async () => {
-            const rateLimitState = runtime.rateLimiter.consume(
-              UNSAVE_JOB_RATE_LIMIT_CONFIG
-            );
-            if (!rateLimitState.allowed) {
-              throw new LinkedInBuddyError(
-                "RATE_LIMITED",
-                "LinkedIn unsave job confirm is rate limited for the current window.",
-                {
+            const rateLimitState = consumeRateLimitOrThrow(
+              runtime.rateLimiter,
+              {
+                config: UNSAVE_JOB_RATE_LIMIT_CONFIG,
+                message: createConfirmRateLimitMessage(UNSAVE_JOB_ACTION_TYPE),
+                details: {
                   action_id: action.id,
                   profile_name: profileName,
                   job_id: jobId,
-                  rate_limit: formatRateLimitState(rateLimitState)
-                }
-              );
-            }
+                },
+              },
+            );
 
             await page.goto(jobUrl, { waitUntil: "domcontentloaded" });
             await waitForNetworkIdleBestEffort(page);
@@ -2176,8 +2220,8 @@ export class UnsaveJobActionExecutor
                   action_id: action.id,
                   profile_name: profileName,
                   job_id: jobId,
-                  job_url: jobUrl
-                }
+                  job_url: jobUrl,
+                },
               );
             }
 
@@ -2187,7 +2231,7 @@ export class UnsaveJobActionExecutor
               action_id: action.id,
               profile_name: profileName,
               job_id: jobId,
-              job_url: jobUrl
+              job_url: jobUrl,
             });
 
             return {
@@ -2197,45 +2241,48 @@ export class UnsaveJobActionExecutor
                 already_unsaved: initialSavedState === false,
                 job_id: jobId,
                 job_url: jobUrl,
-                rate_limit: formatRateLimitState(rateLimitState)
+                rate_limit: formatRateLimitState(rateLimitState),
               },
-              artifacts: [screenshotPath]
+              artifacts: [screenshotPath],
             };
-          }
+          },
         });
-      }
+      },
     );
   }
 }
 
-export class CreateJobAlertActionExecutor
-  implements ActionExecutor<LinkedInJobsExecutorRuntime>
-{
+export class CreateJobAlertActionExecutor implements ActionExecutor<LinkedInJobsExecutorRuntime> {
   async execute(
-    input: ActionExecutorInput<LinkedInJobsExecutorRuntime>
+    input: ActionExecutorInput<LinkedInJobsExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
     const runtime = input.runtime;
     const action = input.action;
     const profileName = getProfileName(action.target);
-    const query = getRequiredStringField(action.target, "query", action.id, "target");
+    const query = getRequiredStringField(
+      action.target,
+      "query",
+      action.id,
+      "target",
+    );
     const searchUrl = getRequiredStringField(
       action.target,
       "search_url",
       action.id,
-      "target"
+      "target",
     );
     const location = getOptionalStringField(action.target, "location") ?? "";
 
     await runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: runtime.cdpUrl
+      cdpUrl: runtime.cdpUrl,
     });
 
     return runtime.profileManager.runWithContext(
       {
         cdpUrl: runtime.cdpUrl,
         profileName,
-        headless: true
+        headless: true,
       },
       async (context) => {
         const page = await getOrCreatePage(context);
@@ -2251,41 +2298,43 @@ export class CreateJobAlertActionExecutor
           metadata: {
             query,
             location,
-            search_url: searchUrl
+            search_url: searchUrl,
           },
           errorDetails: {
             query,
             location,
-            search_url: searchUrl
+            search_url: searchUrl,
           },
           mapError: (error) =>
             asLinkedInBuddyError(
               error,
               "UNKNOWN",
-              "Failed to create a LinkedIn job alert."
+              "Failed to create a LinkedIn job alert.",
             ),
           execute: async () => {
-            const rateLimitState = runtime.rateLimiter.consume(
-              CREATE_JOB_ALERT_RATE_LIMIT_CONFIG
-            );
-            if (!rateLimitState.allowed) {
-              throw new LinkedInBuddyError(
-                "RATE_LIMITED",
-                "LinkedIn job-alert creation is rate limited for the current window.",
-                {
+            const rateLimitState = consumeRateLimitOrThrow(
+              runtime.rateLimiter,
+              {
+                config: CREATE_JOB_ALERT_RATE_LIMIT_CONFIG,
+                message: createConfirmRateLimitMessage(
+                  CREATE_JOB_ALERT_ACTION_TYPE,
+                ),
+                details: {
                   action_id: action.id,
                   profile_name: profileName,
                   search_url: searchUrl,
-                  rate_limit: formatRateLimitState(rateLimitState)
-                }
-              );
-            }
+                },
+              },
+            );
 
             await page.goto(searchUrl, { waitUntil: "domcontentloaded" });
             await waitForNetworkIdleBestEffort(page);
             await waitForJobSearchSurface(page);
 
-            const initialAlertState = await readJobsToggleState(page, "alert-toggle");
+            const initialAlertState = await readJobsToggleState(
+              page,
+              "alert-toggle",
+            );
             if (initialAlertState !== true) {
               const button = await markJobsButton(page, "alert-toggle");
               await button.click();
@@ -2304,8 +2353,8 @@ export class CreateJobAlertActionExecutor
                   profile_name: profileName,
                   query,
                   location,
-                  search_url: searchUrl
-                }
+                  search_url: searchUrl,
+                },
               );
             }
 
@@ -2316,7 +2365,7 @@ export class CreateJobAlertActionExecutor
               profile_name: profileName,
               query,
               location,
-              search_url: searchUrl
+              search_url: searchUrl,
             });
 
             return {
@@ -2327,32 +2376,35 @@ export class CreateJobAlertActionExecutor
                 query,
                 location,
                 search_url: searchUrl,
-                rate_limit: formatRateLimitState(rateLimitState)
+                rate_limit: formatRateLimitState(rateLimitState),
               },
-              artifacts: [screenshotPath]
+              artifacts: [screenshotPath],
             };
-          }
+          },
         });
-      }
+      },
     );
   }
 }
 
-export class RemoveJobAlertActionExecutor
-  implements ActionExecutor<LinkedInJobsExecutorRuntime>
-{
+export class RemoveJobAlertActionExecutor implements ActionExecutor<LinkedInJobsExecutorRuntime> {
   async execute(
-    input: ActionExecutorInput<LinkedInJobsExecutorRuntime>
+    input: ActionExecutorInput<LinkedInJobsExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
     const runtime = input.runtime;
     const action = input.action;
     const profileName = getProfileName(action.target);
-    const query = getRequiredStringField(action.target, "query", action.id, "target");
+    const query = getRequiredStringField(
+      action.target,
+      "query",
+      action.id,
+      "target",
+    );
     const searchUrl = getRequiredStringField(
       action.target,
       "search_url",
       action.id,
-      "target"
+      "target",
     );
     const location = getOptionalStringField(action.target, "location") ?? "";
     const alertId =
@@ -2361,14 +2413,14 @@ export class RemoveJobAlertActionExecutor
 
     await runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: runtime.cdpUrl
+      cdpUrl: runtime.cdpUrl,
     });
 
     return runtime.profileManager.runWithContext(
       {
         cdpUrl: runtime.cdpUrl,
         profileName,
-        headless: true
+        headless: true,
       },
       async (context) => {
         const page = await getOrCreatePage(context);
@@ -2385,49 +2437,53 @@ export class RemoveJobAlertActionExecutor
             alert_id: alertId,
             query,
             location,
-            search_url: searchUrl
+            search_url: searchUrl,
           },
           errorDetails: {
             alert_id: alertId,
             query,
             location,
-            search_url: searchUrl
+            search_url: searchUrl,
           },
           mapError: (error) =>
             asLinkedInBuddyError(
               error,
               "UNKNOWN",
-              "Failed to remove a LinkedIn job alert."
+              "Failed to remove a LinkedIn job alert.",
             ),
           execute: async () => {
-            const rateLimitState = runtime.rateLimiter.consume(
-              REMOVE_JOB_ALERT_RATE_LIMIT_CONFIG
-            );
-            if (!rateLimitState.allowed) {
-              throw new LinkedInBuddyError(
-                "RATE_LIMITED",
-                "LinkedIn job-alert removal is rate limited for the current window.",
-                {
+            const rateLimitState = consumeRateLimitOrThrow(
+              runtime.rateLimiter,
+              {
+                config: REMOVE_JOB_ALERT_RATE_LIMIT_CONFIG,
+                message: createConfirmRateLimitMessage(
+                  REMOVE_JOB_ALERT_ACTION_TYPE,
+                ),
+                details: {
                   action_id: action.id,
                   profile_name: profileName,
                   search_url: searchUrl,
-                  rate_limit: formatRateLimitState(rateLimitState)
-                }
-              );
-            }
+                },
+              },
+            );
 
             await page.goto(searchUrl, { waitUntil: "domcontentloaded" });
             await waitForNetworkIdleBestEffort(page);
             await waitForJobSearchSurface(page);
 
-            const initialAlertState = await readJobsToggleState(page, "alert-toggle");
+            const initialAlertState = await readJobsToggleState(
+              page,
+              "alert-toggle",
+            );
             if (initialAlertState !== false) {
               const button = await markJobsButton(page, "alert-toggle");
               await button.click();
             }
 
             const verified = await waitForCondition(async () => {
-              return (await readJobsToggleState(page, "alert-toggle")) === false;
+              return (
+                (await readJobsToggleState(page, "alert-toggle")) === false
+              );
             }, 8_000);
 
             if (!verified) {
@@ -2440,8 +2496,8 @@ export class RemoveJobAlertActionExecutor
                   alert_id: alertId,
                   query,
                   location,
-                  search_url: searchUrl
-                }
+                  search_url: searchUrl,
+                },
               );
             }
 
@@ -2453,7 +2509,7 @@ export class RemoveJobAlertActionExecutor
               alert_id: alertId,
               query,
               location,
-              search_url: searchUrl
+              search_url: searchUrl,
             });
 
             return {
@@ -2465,34 +2521,47 @@ export class RemoveJobAlertActionExecutor
                 query,
                 location,
                 search_url: searchUrl,
-                rate_limit: formatRateLimitState(rateLimitState)
+                rate_limit: formatRateLimitState(rateLimitState),
               },
-              artifacts: [screenshotPath]
+              artifacts: [screenshotPath],
             };
-          }
+          },
         });
-      }
+      },
     );
   }
 }
 
-export class EasyApplyJobActionExecutor
-  implements ActionExecutor<LinkedInJobsExecutorRuntime>
-{
+export class EasyApplyJobActionExecutor implements ActionExecutor<LinkedInJobsExecutorRuntime> {
   async execute(
-    input: ActionExecutorInput<LinkedInJobsExecutorRuntime>
+    input: ActionExecutorInput<LinkedInJobsExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
     const runtime = input.runtime;
     const action = input.action;
     const profileName = getProfileName(action.target);
-    const jobId = getRequiredStringField(action.target, "job_id", action.id, "target");
-    const jobUrl = getRequiredStringField(action.target, "job_url", action.id, "target");
+    const jobId = getRequiredStringField(
+      action.target,
+      "job_id",
+      action.id,
+      "target",
+    );
+    const jobUrl = getRequiredStringField(
+      action.target,
+      "job_url",
+      action.id,
+      "target",
+    );
     const phoneNumber = getOptionalStringField(action.payload, "phone_number");
     const email = getOptionalStringField(action.payload, "email");
     const city = getOptionalStringField(action.payload, "city");
     const resumePath = getOptionalStringField(action.payload, "resume_path");
     const coverLetter = getOptionalStringField(action.payload, "cover_letter");
-    const answers = getOptionalAnswersField(action.payload, "answers", action.id, "payload");
+    const answers = getOptionalAnswersField(
+      action.payload,
+      "answers",
+      action.id,
+      "payload",
+    );
 
     const validatedInput: ValidatedEasyApplyInput = {
       profileName,
@@ -2503,19 +2572,19 @@ export class EasyApplyJobActionExecutor
       ...(city ? { city } : {}),
       ...(resumePath ? { resumePath } : {}),
       ...(coverLetter ? { coverLetter } : {}),
-      answers
+      answers,
     };
 
     await runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: runtime.cdpUrl
+      cdpUrl: runtime.cdpUrl,
     });
 
     return runtime.profileManager.runWithContext(
       {
         cdpUrl: runtime.cdpUrl,
         profileName,
-        headless: true
+        headless: true,
       },
       async (context) => {
         const page = await getOrCreatePage(context);
@@ -2530,32 +2599,33 @@ export class EasyApplyJobActionExecutor
           targetUrl: jobUrl,
           metadata: {
             job_id: jobId,
-            job_url: jobUrl
+            job_url: jobUrl,
           },
           errorDetails: {
             job_id: jobId,
-            job_url: jobUrl
+            job_url: jobUrl,
           },
           mapError: (error) =>
             asLinkedInBuddyError(
               error,
               "UNKNOWN",
-              "Failed to submit a LinkedIn Easy Apply application."
+              "Failed to submit a LinkedIn Easy Apply application.",
             ),
           execute: async () => {
-            const rateLimitState = runtime.rateLimiter.consume(EASY_APPLY_RATE_LIMIT_CONFIG);
-            if (!rateLimitState.allowed) {
-              throw new LinkedInBuddyError(
-                "RATE_LIMITED",
-                "LinkedIn Easy Apply confirm is rate limited for the current window.",
-                {
+            const rateLimitState = consumeRateLimitOrThrow(
+              runtime.rateLimiter,
+              {
+                config: EASY_APPLY_RATE_LIMIT_CONFIG,
+                message: createConfirmRateLimitMessage(
+                  EASY_APPLY_JOB_ACTION_TYPE,
+                ),
+                details: {
                   action_id: action.id,
                   profile_name: profileName,
                   job_id: jobId,
-                  rate_limit: formatRateLimitState(rateLimitState)
-                }
-              );
-            }
+                },
+              },
+            );
 
             await page.goto(jobUrl, { waitUntil: "domcontentloaded" });
             await waitForNetworkIdleBestEffort(page);
@@ -2577,8 +2647,8 @@ export class EasyApplyJobActionExecutor
                   action_id: action.id,
                   profile_name: profileName,
                   job_id: jobId,
-                  job_url: jobUrl
-                }
+                  job_url: jobUrl,
+                },
               );
             }
 
@@ -2604,7 +2674,8 @@ export class EasyApplyJobActionExecutor
               await fillEasyApplyStep(page, snapshot, validatedInput);
 
               currentActionLabel = snapshot.primaryActionLabel;
-              const actionKind = classifyEasyApplyActionLabel(currentActionLabel);
+              const actionKind =
+                classifyEasyApplyActionLabel(currentActionLabel);
               if (actionKind === "unknown") {
                 throw new LinkedInBuddyError(
                   "UI_CHANGED_SELECTOR_FAILED",
@@ -2613,8 +2684,8 @@ export class EasyApplyJobActionExecutor
                     action_id: action.id,
                     profile_name: profileName,
                     job_id: jobId,
-                    primary_action_label: currentActionLabel
-                  }
+                    primary_action_label: currentActionLabel,
+                  },
                 );
               }
 
@@ -2637,8 +2708,8 @@ export class EasyApplyJobActionExecutor
                   profile_name: profileName,
                   job_id: jobId,
                   last_primary_action_label: currentActionLabel,
-                  encountered_fields: [...encounteredFields]
-                }
+                  encountered_fields: [...encounteredFields],
+                },
               );
             }
 
@@ -2648,7 +2719,7 @@ export class EasyApplyJobActionExecutor
               action_id: action.id,
               profile_name: profileName,
               job_id: jobId,
-              job_url: jobUrl
+              job_url: jobUrl,
             });
 
             return {
@@ -2658,13 +2729,13 @@ export class EasyApplyJobActionExecutor
                 job_id: jobId,
                 job_url: jobUrl,
                 answered_fields: [...encounteredFields],
-                rate_limit: formatRateLimitState(rateLimitState)
+                rate_limit: formatRateLimitState(rateLimitState),
               },
-              artifacts: [screenshotPath]
+              artifacts: [screenshotPath],
             };
-          }
+          },
         });
-      }
+      },
     );
   }
 }
@@ -2678,7 +2749,7 @@ export function createJobActionExecutors(): Record<
     [UNSAVE_JOB_ACTION_TYPE]: new UnsaveJobActionExecutor(),
     [CREATE_JOB_ALERT_ACTION_TYPE]: new CreateJobAlertActionExecutor(),
     [REMOVE_JOB_ALERT_ACTION_TYPE]: new RemoveJobAlertActionExecutor(),
-    [EASY_APPLY_JOB_ACTION_TYPE]: new EasyApplyJobActionExecutor()
+    [EASY_APPLY_JOB_ACTION_TYPE]: new EasyApplyJobActionExecutor(),
   };
 }
 
@@ -2709,16 +2780,18 @@ export class LinkedInJobsService {
     if (!jobId) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "jobId is required."
+        "jobId is required.",
       );
     }
 
     const jobUrl = buildJobViewUrl(jobId);
-    const rateLimitState = this.runtime.rateLimiter.peek(input.rateLimitConfig);
+    const rateLimitState: RateLimiterState = this.runtime.rateLimiter.peek(
+      input.rateLimitConfig,
+    );
     const target = {
       profile_name: profileName,
       job_id: jobId,
-      job_url: jobUrl
+      job_url: jobUrl,
     };
 
     return this.runtime.twoPhaseCommit.prepare({
@@ -2729,12 +2802,12 @@ export class LinkedInJobsService {
         summary: input.summary,
         target,
         outbound: {
-          action: input.outboundAction
+          action: input.outboundAction,
         },
         risk_level: "low",
-        rate_limit: formatRateLimitState(rateLimitState)
+        rate_limit: formatRateLimitState(rateLimitState),
       },
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
   }
 
@@ -2747,13 +2820,13 @@ export class LinkedInJobsService {
     if (!query) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "query is required."
+        "query is required.",
       );
     }
 
     await this.runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: this.runtime.cdpUrl
+      cdpUrl: this.runtime.cdpUrl,
     });
 
     try {
@@ -2761,24 +2834,24 @@ export class LinkedInJobsService {
         {
           cdpUrl: this.runtime.cdpUrl,
           profileName,
-          headless: true
+          headless: true,
         },
         async (context) => {
           const page = await getOrCreatePage(context);
           await page.goto(buildJobSearchUrl(query, location || undefined), {
-            waitUntil: "domcontentloaded"
+            waitUntil: "domcontentloaded",
           });
           await waitForNetworkIdleBestEffort(page);
           await waitForJobSearchSurface(page);
           return loadJobSearchResults(page, limit);
-        }
+        },
       );
 
       return {
         query,
         location,
         results,
-        count: results.length
+        count: results.length,
       };
     } catch (error) {
       if (error instanceof LinkedInBuddyError) {
@@ -2787,7 +2860,7 @@ export class LinkedInJobsService {
       throw asLinkedInBuddyError(
         error,
         "UNKNOWN",
-        "Failed to search LinkedIn jobs."
+        "Failed to search LinkedIn jobs.",
       );
     }
   }
@@ -2799,13 +2872,13 @@ export class LinkedInJobsService {
     if (!jobId) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "jobId is required."
+        "jobId is required.",
       );
     }
 
     await this.runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: this.runtime.cdpUrl
+      cdpUrl: this.runtime.cdpUrl,
     });
 
     try {
@@ -2813,17 +2886,17 @@ export class LinkedInJobsService {
         {
           cdpUrl: this.runtime.cdpUrl,
           profileName,
-          headless: true
+          headless: true,
         },
         async (context) => {
           const page = await getOrCreatePage(context);
           await page.goto(buildJobViewUrl(jobId), {
-            waitUntil: "domcontentloaded"
+            waitUntil: "domcontentloaded",
           });
           await waitForNetworkIdleBestEffort(page);
           await waitForJobDetailSurface(page);
           return extractJobDetail(page, jobId);
-        }
+        },
       );
     } catch (error) {
       if (error instanceof LinkedInBuddyError) {
@@ -2832,7 +2905,7 @@ export class LinkedInJobsService {
       throw asLinkedInBuddyError(
         error,
         "UNKNOWN",
-        "Failed to view LinkedIn job posting."
+        "Failed to view LinkedIn job posting.",
       );
     }
   }
@@ -2851,7 +2924,7 @@ export class LinkedInJobsService {
       summary: `Save LinkedIn job ${buildJobViewUrl(jobId)} for later`,
       rateLimitConfig: SAVE_JOB_RATE_LIMIT_CONFIG,
       operatorNote: input.operatorNote,
-      outboundAction: "save"
+      outboundAction: "save",
     });
   }
 
@@ -2869,19 +2942,19 @@ export class LinkedInJobsService {
       summary: `Unsave LinkedIn job ${buildJobViewUrl(jobId)}`,
       rateLimitConfig: UNSAVE_JOB_RATE_LIMIT_CONFIG,
       operatorNote: input.operatorNote,
-      outboundAction: "unsave"
+      outboundAction: "unsave",
     });
   }
 
   async listJobAlerts(
-    input: ListJobAlertsInput = {}
+    input: ListJobAlertsInput = {},
   ): Promise<ListJobAlertsOutput> {
     const profileName = input.profileName ?? "default";
     const limit = readJobAlertsLimit(input.limit);
 
     await this.runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: this.runtime.cdpUrl
+      cdpUrl: this.runtime.cdpUrl,
     });
 
     try {
@@ -2889,22 +2962,22 @@ export class LinkedInJobsService {
         {
           cdpUrl: this.runtime.cdpUrl,
           profileName,
-          headless: true
+          headless: true,
         },
         async (context) => {
           const page = await getOrCreatePage(context);
           await page.goto(buildJobAlertsUrl(), {
-            waitUntil: "domcontentloaded"
+            waitUntil: "domcontentloaded",
           });
           await waitForNetworkIdleBestEffort(page);
           await waitForJobAlertsSurface(page);
           return extractJobAlerts(page, limit);
-        }
+        },
       );
 
       return {
         alerts,
-        count: alerts.length
+        count: alerts.length,
       };
     } catch (error) {
       if (error instanceof LinkedInBuddyError) {
@@ -2913,7 +2986,7 @@ export class LinkedInJobsService {
       throw asLinkedInBuddyError(
         error,
         "UNKNOWN",
-        "Failed to list LinkedIn job alerts."
+        "Failed to list LinkedIn job alerts.",
       );
     }
   }
@@ -2931,19 +3004,19 @@ export class LinkedInJobsService {
     if (!query) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "query is required."
+        "query is required.",
       );
     }
 
     const searchUrl = buildJobSearchUrl(query, location || undefined);
-    const rateLimitState = this.runtime.rateLimiter.peek(
-      CREATE_JOB_ALERT_RATE_LIMIT_CONFIG
+    const rateLimitState: RateLimiterState = this.runtime.rateLimiter.peek(
+      CREATE_JOB_ALERT_RATE_LIMIT_CONFIG,
     );
     const target = {
       profile_name: profileName,
       query,
       location,
-      search_url: searchUrl
+      search_url: searchUrl,
     };
 
     return this.runtime.twoPhaseCommit.prepare({
@@ -2954,18 +3027,16 @@ export class LinkedInJobsService {
         summary: `Create a LinkedIn job alert for "${query}"${location ? ` in ${location}` : ""}`,
         target,
         outbound: {
-          action: "create_alert"
+          action: "create_alert",
         },
         risk_level: "low",
-        rate_limit: formatRateLimitState(rateLimitState)
+        rate_limit: formatRateLimitState(rateLimitState),
       },
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
   }
 
-  async prepareRemoveJobAlert(
-    input: PrepareRemoveJobAlertInput
-  ): Promise<{
+  async prepareRemoveJobAlert(input: PrepareRemoveJobAlertInput): Promise<{
     preparedActionId: string;
     confirmToken: string;
     expiresAtMs: number;
@@ -2986,18 +3057,18 @@ export class LinkedInJobsService {
     if (!searchUrl && providedAlertId) {
       const alerts = await this.listJobAlerts({
         profileName,
-        limit: 100
+        limit: 100,
       });
       const matchedAlert = alerts.alerts.find(
-        (alert) => normalizeText(alert.alert_id) === providedAlertId
+        (alert) => normalizeText(alert.alert_id) === providedAlertId,
       );
       if (!matchedAlert) {
         throw new LinkedInBuddyError(
           "TARGET_NOT_FOUND",
           `Could not find a LinkedIn job alert with id "${providedAlertId}".`,
           {
-            alert_id: providedAlertId
-          }
+            alert_id: providedAlertId,
+          },
         );
       }
 
@@ -3008,7 +3079,7 @@ export class LinkedInJobsService {
     if (!searchUrl) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "Provide alertId, searchUrl, or query to remove a job alert."
+        "Provide alertId, searchUrl, or query to remove a job alert.",
       );
     }
 
@@ -3016,16 +3087,17 @@ export class LinkedInJobsService {
     const resolvedQuery = query || resolvedSearch.query;
     const resolvedLocation = location || resolvedSearch.location;
     const resolvedAlertId =
-      alertId || buildJobAlertIdentifier(searchUrl, resolvedQuery, resolvedLocation);
-    const rateLimitState = this.runtime.rateLimiter.peek(
-      REMOVE_JOB_ALERT_RATE_LIMIT_CONFIG
+      alertId ||
+      buildJobAlertIdentifier(searchUrl, resolvedQuery, resolvedLocation);
+    const rateLimitState: RateLimiterState = this.runtime.rateLimiter.peek(
+      REMOVE_JOB_ALERT_RATE_LIMIT_CONFIG,
     );
     const target = {
       profile_name: profileName,
       alert_id: resolvedAlertId,
       query: resolvedQuery,
       location: resolvedLocation,
-      search_url: resolvedSearch.normalizedUrl || searchUrl
+      search_url: resolvedSearch.normalizedUrl || searchUrl,
     };
 
     return this.runtime.twoPhaseCommit.prepare({
@@ -3036,12 +3108,12 @@ export class LinkedInJobsService {
         summary: `Remove LinkedIn job alert for "${resolvedQuery}"${resolvedLocation ? ` in ${resolvedLocation}` : ""}`,
         target,
         outbound: {
-          action: "remove_alert"
+          action: "remove_alert",
         },
         risk_level: "low",
-        rate_limit: formatRateLimitState(rateLimitState)
+        rate_limit: formatRateLimitState(rateLimitState),
       },
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
   }
 
@@ -3052,12 +3124,14 @@ export class LinkedInJobsService {
     preview: Record<string, unknown>;
   } {
     const validatedInput = validateEasyApplyInput(input);
-    const rateLimitState = this.runtime.rateLimiter.peek(EASY_APPLY_RATE_LIMIT_CONFIG);
+    const rateLimitState: RateLimiterState = this.runtime.rateLimiter.peek(
+      EASY_APPLY_RATE_LIMIT_CONFIG,
+    );
 
     const target = {
       profile_name: validatedInput.profileName,
       job_id: validatedInput.jobId,
-      job_url: validatedInput.jobUrl
+      job_url: validatedInput.jobUrl,
     };
 
     return this.runtime.twoPhaseCommit.prepare({
@@ -3077,7 +3151,7 @@ export class LinkedInJobsService {
           : {}),
         ...(Object.keys(validatedInput.answers).length > 0
           ? { answers: validatedInput.answers }
-          : {})
+          : {}),
       },
       preview: {
         summary: `Submit LinkedIn Easy Apply application for ${validatedInput.jobUrl}`,
@@ -3091,12 +3165,12 @@ export class LinkedInJobsService {
             ? path.basename(validatedInput.resumePath)
             : "",
           cover_letter_supplied: Boolean(validatedInput.coverLetter),
-          answer_keys: Object.keys(validatedInput.answers)
+          answer_keys: Object.keys(validatedInput.answers),
         },
         risk_level: "high",
-        rate_limit: formatRateLimitState(rateLimitState)
+        rate_limit: formatRateLimitState(rateLimitState),
       },
-      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
     });
   }
 }

--- a/packages/core/src/linkedinPosts.ts
+++ b/packages/core/src/linkedinPosts.ts
@@ -5,27 +5,29 @@ import {
   errors as playwrightErrors,
   type BrowserContext,
   type Locator,
-  type Page
+  type Page,
 } from "playwright-core";
 import type { ArtifactHelpers } from "./artifacts.js";
 import type { LinkedInAuthService } from "./auth/session.js";
-import {
-  LinkedInBuddyError,
-  asLinkedInBuddyError
-} from "./errors.js";
+import { LinkedInBuddyError, asLinkedInBuddyError } from "./errors.js";
 import { scrollLinkedInPageToTop } from "./linkedinPage.js";
 import type { JsonEventLogger } from "./logging.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
+import {
+  consumeRateLimitOrThrow,
+  createConfirmRateLimitMessage,
+  formatRateLimitState,
+} from "./rateLimiter.js";
 import type { RateLimiter, RateLimiterState } from "./rateLimiter.js";
 import type {
   LinkedInSelectorLocale,
-  LinkedInSelectorPhraseKey
+  LinkedInSelectorPhraseKey,
 } from "./selectorLocale.js";
 import {
   buildLinkedInAriaLabelContainsSelector,
   buildLinkedInSelectorPhraseRegex,
-  formatLinkedInSelectorRegexHint
+  formatLinkedInSelectorRegexHint,
 } from "./selectorLocale.js";
 import { createFeedPostComposerTriggerCandidates } from "./feedPostComposerTriggerSelectors.js";
 import type {
@@ -34,11 +36,12 @@ import type {
   ActionExecutorResult,
   ActionExecutorRegistry,
   PreparedActionResult,
-  TwoPhaseCommitService
+  TwoPhaseCommitService,
 } from "./twoPhaseCommit.js";
 
 const LINKEDIN_FEED_URL = "https://www.linkedin.com/feed/";
-const LINKEDIN_PROFILE_ACTIVITY_URL = "https://www.linkedin.com/in/me/recent-activity/all/";
+const LINKEDIN_PROFILE_ACTIVITY_URL =
+  "https://www.linkedin.com/in/me/recent-activity/all/";
 const LINKEDIN_BUDDY_CONFIG_FILENAME = "config.json";
 const DEFAULT_LINK_PREVIEW_VALIDATION_TIMEOUT_MS = 5_000;
 const MAX_LINK_PREVIEW_VALIDATION_TIMEOUT_MS = 30_000;
@@ -60,7 +63,7 @@ export const LINKEDIN_POST_FEED_SURFACE_SELECTORS = [
   ".feed-shared-update-v2",
   ".occludable-update",
   ".share-box-feed-entry",
-  "main"
+  "main",
 ] as const;
 export const LINKEDIN_POST_ACTIVITY_SURFACE_SELECTORS = [
   "main[role='main']",
@@ -68,7 +71,7 @@ export const LINKEDIN_POST_ACTIVITY_SURFACE_SELECTORS = [
   "article",
   ".feed-shared-update-v2",
   ".occludable-update",
-  "main"
+  "main",
 ] as const;
 
 type LinkedInPollDurationDays =
@@ -76,12 +79,11 @@ type LinkedInPollDurationDays =
 
 export const LINKEDIN_POST_MEDIA_KINDS = ["image", "video"] as const;
 
-export type LinkedInPostMediaKind =
-  (typeof LINKEDIN_POST_MEDIA_KINDS)[number];
+export type LinkedInPostMediaKind = (typeof LINKEDIN_POST_MEDIA_KINDS)[number];
 
 export const LINKEDIN_POST_VISIBILITY_TYPES = [
   "public",
-  "connections"
+  "connections",
 ] as const;
 
 export type LinkedInPostVisibility =
@@ -98,39 +100,42 @@ export const LINKEDIN_POST_VISIBILITY_MAP: Record<
 > = {
   public: {
     label: "Public",
-    audienceLabel: "Anyone"
+    audienceLabel: "Anyone",
   },
   connections: {
     label: "Connections",
-    audienceLabel: "Connections only"
-  }
+    audienceLabel: "Connections only",
+  },
 };
 
-const LINKEDIN_POST_VISIBILITY_ALIAS_MAP: Record<string, LinkedInPostVisibility> = {
+const LINKEDIN_POST_VISIBILITY_ALIAS_MAP: Record<
+  string,
+  LinkedInPostVisibility
+> = {
   public: "public",
   anyone: "public",
   everyone: "public",
   connections: "connections",
   connection: "connections",
-  connections_only: "connections"
+  connections_only: "connections",
 };
 
 const CREATE_POST_RATE_LIMIT_CONFIG = {
   counterKey: "linkedin.post.create",
   windowSizeMs: 24 * 60 * 60 * 1000,
-  limit: 1
+  limit: 1,
 } as const;
 
 const EDIT_POST_RATE_LIMIT_CONFIG = {
   counterKey: "linkedin.post.edit",
   windowSizeMs: 24 * 60 * 60 * 1000,
-  limit: 10
+  limit: 10,
 } as const;
 
 const DELETE_POST_RATE_LIMIT_CONFIG = {
   counterKey: "linkedin.post.delete",
   windowSizeMs: 24 * 60 * 60 * 1000,
-  limit: 10
+  limit: 10,
 } as const;
 
 const LINKEDIN_POST_IMAGE_EXTENSIONS = new Set([
@@ -139,7 +144,7 @@ const LINKEDIN_POST_IMAGE_EXTENSIONS = new Set([
   ".jpeg",
   ".gif",
   ".webp",
-  ".bmp"
+  ".bmp",
 ]);
 
 const LINKEDIN_POST_VIDEO_EXTENSIONS = new Set([
@@ -147,7 +152,7 @@ const LINKEDIN_POST_VIDEO_EXTENSIONS = new Set([
   ".mov",
   ".m4v",
   ".avi",
-  ".webm"
+  ".webm",
 ]);
 
 export interface PrepareCreatePostInput {
@@ -273,12 +278,13 @@ interface TargetPostLocator {
   activityId: string;
 }
 
-export const DEFAULT_LINKEDIN_POST_SAFETY_LINT_CONFIG: LinkedInPostSafetyLintConfig = {
-  maxLength: LINKEDIN_POST_MAX_LENGTH,
-  bannedPhrases: [],
-  validateLinkPreviews: false,
-  linkPreviewValidationTimeoutMs: DEFAULT_LINK_PREVIEW_VALIDATION_TIMEOUT_MS
-};
+export const DEFAULT_LINKEDIN_POST_SAFETY_LINT_CONFIG: LinkedInPostSafetyLintConfig =
+  {
+    maxLength: LINKEDIN_POST_MAX_LENGTH,
+    bannedPhrases: [],
+    validateLinkPreviews: false,
+    linkPreviewValidationTimeoutMs: DEFAULT_LINK_PREVIEW_VALIDATION_TIMEOUT_MS,
+  };
 
 function normalizeText(value: string | null | undefined): string {
   return (value ?? "").replace(/\s+/g, " ").trim();
@@ -291,7 +297,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function parseOptionalPositiveInteger(
   value: unknown,
   label: string,
-  options: { min?: number; max?: number } = {}
+  options: { min?: number; max?: number } = {},
 ): number | undefined {
   if (value === undefined) {
     return undefined;
@@ -303,8 +309,8 @@ function parseOptionalPositiveInteger(
       `${label} must be an integer.`,
       {
         label,
-        provided_value: value
-      }
+        provided_value: value,
+      },
     );
   }
 
@@ -320,15 +326,18 @@ function parseOptionalPositiveInteger(
         label,
         provided_value: value,
         min,
-        ...(max === undefined ? {} : { max })
-      }
+        ...(max === undefined ? {} : { max }),
+      },
     );
   }
 
   return value;
 }
 
-function parseOptionalBoolean(value: unknown, label: string): boolean | undefined {
+function parseOptionalBoolean(
+  value: unknown,
+  label: string,
+): boolean | undefined {
   if (value === undefined) {
     return undefined;
   }
@@ -339,8 +348,8 @@ function parseOptionalBoolean(value: unknown, label: string): boolean | undefine
       `${label} must be a boolean.`,
       {
         label,
-        provided_value: value
-      }
+        provided_value: value,
+      },
     );
   }
 
@@ -371,27 +380,33 @@ function normalizeConfiguredPhraseList(values: string[]): string[] {
 
 function parseOptionalBannedPhraseList(
   value: unknown,
-  label: string
+  label: string,
 ): string[] | undefined {
   if (value === undefined) {
     return undefined;
   }
 
-  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+  if (
+    !Array.isArray(value) ||
+    value.some((entry) => typeof entry !== "string")
+  ) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
       `${label} must be an array of strings.`,
       {
         label,
-        provided_value: value
-      }
+        provided_value: value,
+      },
     );
   }
 
   return normalizeConfiguredPhraseList(value);
 }
 
-function parseBooleanEnv(value: string | undefined, label: string): boolean | undefined {
+function parseBooleanEnv(
+  value: string | undefined,
+  label: string,
+): boolean | undefined {
   if (value === undefined) {
     return undefined;
   }
@@ -410,15 +425,15 @@ function parseBooleanEnv(value: string | undefined, label: string): boolean | un
     `${label} must be one of: true, false, 1, 0, yes, no, on, off.`,
     {
       label,
-      provided_value: value
-    }
+      provided_value: value,
+    },
   );
 }
 
 function parseIntegerEnv(
   value: string | undefined,
   label: string,
-  options: { min?: number; max?: number } = {}
+  options: { min?: number; max?: number } = {},
 ): number | undefined {
   if (value === undefined || value.trim().length === 0) {
     return undefined;
@@ -431,8 +446,8 @@ function parseIntegerEnv(
       `${label} must be an integer.`,
       {
         label,
-        provided_value: value
-      }
+        provided_value: value,
+      },
     );
   }
 
@@ -441,7 +456,7 @@ function parseIntegerEnv(
 
 function parseBannedPhraseEnv(
   value: string | undefined,
-  label: string
+  label: string,
 ): string[] | undefined {
   if (value === undefined) {
     return undefined;
@@ -464,9 +479,9 @@ function parseBannedPhraseEnv(
         {
           label,
           provided_value: value,
-          message: error instanceof Error ? error.message : String(error)
+          message: error instanceof Error ? error.message : String(error),
         },
-        error instanceof Error ? { cause: error } : undefined
+        error instanceof Error ? { cause: error } : undefined,
       );
     }
 
@@ -476,7 +491,9 @@ function parseBannedPhraseEnv(
   return normalizeConfiguredPhraseList(trimmedValue.split(/\r?\n|,/g));
 }
 
-function readPostSafetyLintConfigShape(baseDir: string): PostSafetyLintConfigShape {
+function readPostSafetyLintConfigShape(
+  baseDir: string,
+): PostSafetyLintConfigShape {
   const configPath = path.join(baseDir, LINKEDIN_BUDDY_CONFIG_FILENAME);
   if (!existsSync(configPath)) {
     return {};
@@ -491,9 +508,9 @@ function readPostSafetyLintConfigShape(baseDir: string): PostSafetyLintConfigSha
       `Failed to parse LinkedIn Buddy config file at ${configPath}.`,
       {
         config_path: configPath,
-        message: error instanceof Error ? error.message : String(error)
+        message: error instanceof Error ? error.message : String(error),
       },
-      error instanceof Error ? { cause: error } : undefined
+      error instanceof Error ? { cause: error } : undefined,
     );
   }
 
@@ -502,8 +519,8 @@ function readPostSafetyLintConfigShape(baseDir: string): PostSafetyLintConfigSha
       "ACTION_PRECONDITION_FAILED",
       `LinkedIn Buddy config file at ${configPath} must contain a JSON object.`,
       {
-        config_path: configPath
-      }
+        config_path: configPath,
+      },
     );
   }
 
@@ -518,8 +535,8 @@ function readPostSafetyLintConfigShape(baseDir: string): PostSafetyLintConfigSha
       `postSafetyLint in ${configPath} must be a JSON object.`,
       {
         config_path: configPath,
-        provided_value: directLintConfig
-      }
+        provided_value: directLintConfig,
+      },
     );
   }
 
@@ -527,7 +544,7 @@ function readPostSafetyLintConfigShape(baseDir: string): PostSafetyLintConfigSha
 }
 
 export function resolveLinkedInPostSafetyLintConfig(
-  baseDir?: string
+  baseDir?: string,
 ): LinkedInPostSafetyLintConfig {
   const fileConfig = baseDir ? readPostSafetyLintConfigShape(baseDir) : {};
   const fileLabel = baseDir
@@ -539,30 +556,37 @@ export function resolveLinkedInPostSafetyLintConfig(
       process.env.LINKEDIN_BUDDY_POST_SAFETY_MAX_LENGTH,
       "LINKEDIN_BUDDY_POST_SAFETY_MAX_LENGTH",
       {
-      max: LINKEDIN_POST_MAX_LENGTH
-      }
+        max: LINKEDIN_POST_MAX_LENGTH,
+      },
     ) ??
-    parseOptionalPositiveInteger(fileConfig.maxLength, `${fileLabel}.maxLength`, {
-      max: LINKEDIN_POST_MAX_LENGTH
-    }) ??
+    parseOptionalPositiveInteger(
+      fileConfig.maxLength,
+      `${fileLabel}.maxLength`,
+      {
+        max: LINKEDIN_POST_MAX_LENGTH,
+      },
+    ) ??
     DEFAULT_LINKEDIN_POST_SAFETY_LINT_CONFIG.maxLength;
 
   const bannedPhrases =
     parseBannedPhraseEnv(
       process.env.LINKEDIN_BUDDY_POST_SAFETY_BANNED_PHRASES,
-      "LINKEDIN_BUDDY_POST_SAFETY_BANNED_PHRASES"
+      "LINKEDIN_BUDDY_POST_SAFETY_BANNED_PHRASES",
     ) ??
-    parseOptionalBannedPhraseList(fileConfig.bannedPhrases, `${fileLabel}.bannedPhrases`) ??
+    parseOptionalBannedPhraseList(
+      fileConfig.bannedPhrases,
+      `${fileLabel}.bannedPhrases`,
+    ) ??
     DEFAULT_LINKEDIN_POST_SAFETY_LINT_CONFIG.bannedPhrases;
 
   const validateLinkPreviews =
     parseBooleanEnv(
       process.env.LINKEDIN_BUDDY_POST_SAFETY_VALIDATE_LINK_PREVIEWS,
-      "LINKEDIN_BUDDY_POST_SAFETY_VALIDATE_LINK_PREVIEWS"
+      "LINKEDIN_BUDDY_POST_SAFETY_VALIDATE_LINK_PREVIEWS",
     ) ??
     parseOptionalBoolean(
       fileConfig.validateLinkPreviews,
-      `${fileLabel}.validateLinkPreviews`
+      `${fileLabel}.validateLinkPreviews`,
     ) ??
     DEFAULT_LINKEDIN_POST_SAFETY_LINT_CONFIG.validateLinkPreviews;
 
@@ -571,15 +595,15 @@ export function resolveLinkedInPostSafetyLintConfig(
       process.env.LINKEDIN_BUDDY_POST_SAFETY_LINK_TIMEOUT_MS,
       "LINKEDIN_BUDDY_POST_SAFETY_LINK_TIMEOUT_MS",
       {
-        max: MAX_LINK_PREVIEW_VALIDATION_TIMEOUT_MS
-      }
+        max: MAX_LINK_PREVIEW_VALIDATION_TIMEOUT_MS,
+      },
     ) ??
     parseOptionalPositiveInteger(
       fileConfig.linkPreviewValidationTimeoutMs,
       `${fileLabel}.linkPreviewValidationTimeoutMs`,
       {
-        max: MAX_LINK_PREVIEW_VALIDATION_TIMEOUT_MS
-      }
+        max: MAX_LINK_PREVIEW_VALIDATION_TIMEOUT_MS,
+      },
     ) ??
     DEFAULT_LINKEDIN_POST_SAFETY_LINT_CONFIG.linkPreviewValidationTimeoutMs;
 
@@ -587,7 +611,7 @@ export function resolveLinkedInPostSafetyLintConfig(
     maxLength,
     bannedPhrases,
     validateLinkPreviews,
-    linkPreviewValidationTimeoutMs
+    linkPreviewValidationTimeoutMs,
   };
 }
 
@@ -626,21 +650,21 @@ function hasUnsupportedControlCharacters(value: string): boolean {
 
 export function validateLinkedInPostText(
   value: string,
-  maxLength: number = LINKEDIN_POST_MAX_LENGTH
+  maxLength: number = LINKEDIN_POST_MAX_LENGTH,
 ): ValidatedPostText {
   const normalizedText = normalizePostText(value);
 
   if (!normalizedText) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "Post text must not be empty."
+      "Post text must not be empty.",
     );
   }
 
   if (hasUnsupportedControlCharacters(normalizedText)) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "Post text contains unsupported control characters."
+      "Post text contains unsupported control characters.",
     );
   }
 
@@ -652,8 +676,8 @@ export function validateLinkedInPostText(
       {
         character_count: characterCount,
         max_length: maxLength,
-        linkedin_max_length: LINKEDIN_POST_MAX_LENGTH
-      }
+        linkedin_max_length: LINKEDIN_POST_MAX_LENGTH,
+      },
     );
   }
 
@@ -666,7 +690,7 @@ export function validateLinkedInPostText(
     paragraphCount: countParagraphs(normalizedText),
     containsUrl: /(https?:\/\/|www\.)/i.test(normalizedText),
     containsMention: /(^|\s)@[\p{L}\p{N}_.-]+/iu.test(normalizedText),
-    containsHashtag: /(^|\s)#[\p{L}\p{N}_-]+/iu.test(normalizedText)
+    containsHashtag: /(^|\s)#[\p{L}\p{N}_-]+/iu.test(normalizedText),
   };
 }
 
@@ -676,7 +700,7 @@ function normalizeBannedPhraseMatcher(value: string): string {
 
 function matchConfiguredBannedPhrases(
   text: string,
-  bannedPhrases: string[]
+  bannedPhrases: string[],
 ): string[] {
   return bannedPhrases.filter((phrase) => {
     const normalizedPhrase = normalizeBannedPhraseMatcher(phrase);
@@ -684,10 +708,13 @@ function matchConfiguredBannedPhrases(
       return false;
     }
 
-    const normalizedPattern = escapeRegExp(normalizedPhrase).replace(/\s+/g, "\\s+");
+    const normalizedPattern = escapeRegExp(normalizedPhrase).replace(
+      /\s+/g,
+      "\\s+",
+    );
     return new RegExp(
       `(^|[^\\p{L}\\p{N}_])${normalizedPattern}($|[^\\p{L}\\p{N}_])`,
-      "iu"
+      "iu",
     ).test(text);
   });
 }
@@ -734,7 +761,7 @@ function extractUrlsFromPostText(text: string): ExtractedPostLinks {
 
   return {
     validUrls,
-    invalidUrls
+    invalidUrls,
   };
 }
 
@@ -751,7 +778,9 @@ function isPrivateHostname(hostname: string): boolean {
 
   const ipVersion = isIP(normalizedHostname);
   if (ipVersion === 4) {
-    const octets = normalizedHostname.split(".").map((segment) => Number.parseInt(segment, 10));
+    const octets = normalizedHostname
+      .split(".")
+      .map((segment) => Number.parseInt(segment, 10));
     const firstOctet = octets[0] ?? -1;
     const secondOctet = octets[1] ?? -1;
 
@@ -786,7 +815,10 @@ function isPrivateHostname(hostname: string): boolean {
   return false;
 }
 
-async function readResponseSnippet(response: Response, maxBytes: number): Promise<string> {
+async function readResponseSnippet(
+  response: Response,
+  maxBytes: number,
+): Promise<string> {
   if (!response.body) {
     return "";
   }
@@ -834,7 +866,10 @@ function looksPreviewableHtml(html: string): boolean {
   );
 }
 
-async function validateLinkPreview(url: string, timeoutMs: number): Promise<string | null> {
+async function validateLinkPreview(
+  url: string,
+  timeoutMs: number,
+): Promise<string | null> {
   const parsedUrl = new URL(url);
   if (isPrivateHostname(parsedUrl.hostname)) {
     return "Private, loopback, or local-network links cannot be preview-validated.";
@@ -849,8 +884,8 @@ async function validateLinkPreview(url: string, timeoutMs: number): Promise<stri
       redirect: "follow",
       signal: controller.signal,
       headers: {
-        accept: "text/html,application/xhtml+xml;q=0.9,*/*;q=0.1"
-      }
+        accept: "text/html,application/xhtml+xml;q=0.9,*/*;q=0.1",
+      },
     });
 
     if (!response.ok) {
@@ -862,7 +897,10 @@ async function validateLinkPreview(url: string, timeoutMs: number): Promise<stri
       return `Expected HTML content but received ${contentType || "unknown content type"}.`;
     }
 
-    const htmlSnippet = await readResponseSnippet(response, LINK_PREVIEW_BODY_BYTE_LIMIT);
+    const htmlSnippet = await readResponseSnippet(
+      response,
+      LINK_PREVIEW_BODY_BYTE_LIMIT,
+    );
     if (!looksPreviewableHtml(htmlSnippet)) {
       return "The page does not expose HTML title or preview metadata near the top of the document.";
     }
@@ -881,7 +919,7 @@ async function validateLinkPreview(url: string, timeoutMs: number): Promise<stri
 
 async function validateConfiguredLinkPreviews(
   urls: string[],
-  timeoutMs: number
+  timeoutMs: number,
 ): Promise<void> {
   const results = await Promise.all(
     urls.map(async (url): Promise<LinkPreviewValidationFailure | null> => {
@@ -892,13 +930,13 @@ async function validateConfiguredLinkPreviews(
 
       return {
         url,
-        reason: failureReason
+        reason: failureReason,
       };
-    })
+    }),
   );
 
   const failedLinks = results.filter(
-    (result): result is LinkPreviewValidationFailure => result !== null
+    (result): result is LinkPreviewValidationFailure => result !== null,
   );
   if (failedLinks.length === 0) {
     return;
@@ -918,20 +956,20 @@ async function validateConfiguredLinkPreviews(
       invalid_links: failedLinks,
       link_preview_validation: {
         enabled: true,
-        timeout_ms: timeoutMs
-      }
-    }
+        timeout_ms: timeoutMs,
+      },
+    },
   );
 }
 
 export async function lintLinkedInPostContent(
   value: string,
-  config: LinkedInPostSafetyLintConfig = DEFAULT_LINKEDIN_POST_SAFETY_LINT_CONFIG
+  config: LinkedInPostSafetyLintConfig = DEFAULT_LINKEDIN_POST_SAFETY_LINT_CONFIG,
 ): Promise<LinkedInPostLintResult> {
   const validatedText = validateLinkedInPostText(value, config.maxLength);
   const matchedBannedPhrases = matchConfiguredBannedPhrases(
     validatedText.normalizedText,
-    config.bannedPhrases
+    config.bannedPhrases,
   );
   if (matchedBannedPhrases.length > 0) {
     throw new LinkedInBuddyError(
@@ -941,8 +979,8 @@ export async function lintLinkedInPostContent(
         : `Post text contains ${matchedBannedPhrases.length} banned phrases.`,
       {
         banned_phrases: matchedBannedPhrases,
-        configured_banned_phrase_count: config.bannedPhrases.length
-      }
+        configured_banned_phrase_count: config.bannedPhrases.length,
+      },
     );
   }
 
@@ -958,37 +996,41 @@ export async function lintLinkedInPostContent(
           invalid_urls: extractedLinks.invalidUrls,
           link_preview_validation: {
             enabled: true,
-            timeout_ms: config.linkPreviewValidationTimeoutMs
-          }
-        }
+            timeout_ms: config.linkPreviewValidationTimeoutMs,
+          },
+        },
       );
     }
 
     await validateConfiguredLinkPreviews(
       extractedLinks.validUrls,
-      config.linkPreviewValidationTimeoutMs
+      config.linkPreviewValidationTimeoutMs,
     );
   }
 
   return {
     validatedText,
-    urls: extractedLinks.validUrls
+    urls: extractedLinks.validUrls,
   };
 }
 
 function normalizeVisibilityKey(value: string): string {
-  return value.trim().toLowerCase().replace(/[\s-]+/g, "_");
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
 }
 
 export function normalizeLinkedInPostVisibility(
   value: string | undefined,
-  fallback: LinkedInPostVisibility = "public"
+  fallback: LinkedInPostVisibility = "public",
 ): LinkedInPostVisibility {
   if (!value || normalizeText(value).length === 0) {
     return fallback;
   }
 
-  const mapped = LINKEDIN_POST_VISIBILITY_ALIAS_MAP[normalizeVisibilityKey(value)];
+  const mapped =
+    LINKEDIN_POST_VISIBILITY_ALIAS_MAP[normalizeVisibilityKey(value)];
   if (mapped) {
     return mapped;
   }
@@ -998,8 +1040,8 @@ export function normalizeLinkedInPostVisibility(
     `visibility must be one of: ${LINKEDIN_POST_VISIBILITY_TYPES.join(", ")}.`,
     {
       provided_visibility: value,
-      supported_visibilities: LINKEDIN_POST_VISIBILITY_TYPES
-    }
+      supported_visibilities: LINKEDIN_POST_VISIBILITY_TYPES,
+    },
   );
 }
 
@@ -1014,7 +1056,7 @@ function normalizeOptionalPostText(value: string | undefined): string | null {
 
 async function lintOptionalLinkedInPostContent(
   value: string | undefined,
-  config: LinkedInPostSafetyLintConfig = DEFAULT_LINKEDIN_POST_SAFETY_LINT_CONFIG
+  config: LinkedInPostSafetyLintConfig = DEFAULT_LINKEDIN_POST_SAFETY_LINT_CONFIG,
 ): Promise<LinkedInPostLintResult | null> {
   const normalizedValue = normalizeOptionalPostText(value);
   if (!normalizedValue) {
@@ -1033,7 +1075,7 @@ function resolvePostUrl(postUrl: string): string {
   if (!trimmedPostUrl) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "postUrl is required."
+      "postUrl is required.",
     );
   }
 
@@ -1045,7 +1087,7 @@ function resolvePostUrl(postUrl: string): string {
       throw asLinkedInBuddyError(
         error,
         "ACTION_PRECONDITION_FAILED",
-        "Post URL must be a valid URL."
+        "Post URL must be a valid URL.",
       );
     }
 
@@ -1126,10 +1168,12 @@ function buildTextRegex(labels: readonly string[], exact = false): RegExp {
     new Set(
       labels
         .map((label) => normalizeText(label))
-        .filter((label) => label.length > 0)
-    )
+        .filter((label) => label.length > 0),
+    ),
   );
-  const pattern = normalizedLabels.map((label) => escapeRegExp(label)).join("|");
+  const pattern = normalizedLabels
+    .map((label) => escapeRegExp(label))
+    .join("|");
   return new RegExp(exact ? `^(?:${pattern})$` : `(?:${pattern})`, "i");
 }
 
@@ -1146,12 +1190,12 @@ function determineMediaKind(extension: string): LinkedInPostMediaKind | null {
 }
 
 function validateLinkedInPostMediaAttachments(
-  mediaPaths: string[]
+  mediaPaths: string[],
 ): ValidatedMediaAttachment[] {
   if (!Array.isArray(mediaPaths) || mediaPaths.length === 0) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "mediaPaths must include at least one attachment."
+      "mediaPaths must include at least one attachment.",
     );
   }
 
@@ -1161,8 +1205,8 @@ function validateLinkedInPostMediaAttachments(
       `mediaPaths may include at most ${LINKEDIN_POST_MAX_MEDIA_ATTACHMENTS} files.`,
       {
         media_count: mediaPaths.length,
-        max_media_attachments: LINKEDIN_POST_MAX_MEDIA_ATTACHMENTS
-      }
+        max_media_attachments: LINKEDIN_POST_MAX_MEDIA_ATTACHMENTS,
+      },
     );
   }
 
@@ -1171,7 +1215,7 @@ function validateLinkedInPostMediaAttachments(
     if (!normalizedPath) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
-        "mediaPaths must not contain empty entries."
+        "mediaPaths must not contain empty entries.",
       );
     }
 
@@ -1182,8 +1226,8 @@ function validateLinkedInPostMediaAttachments(
         `Media file does not exist: ${normalizedPath}.`,
         {
           media_path: normalizedPath,
-          absolute_path: absolutePath
-        }
+          absolute_path: absolutePath,
+        },
       );
     }
 
@@ -1194,8 +1238,8 @@ function validateLinkedInPostMediaAttachments(
         `Media path must point to a file: ${normalizedPath}.`,
         {
           media_path: normalizedPath,
-          absolute_path: absolutePath
-        }
+          absolute_path: absolutePath,
+        },
       );
     }
 
@@ -1205,8 +1249,8 @@ function validateLinkedInPostMediaAttachments(
         `Media file must not be empty: ${normalizedPath}.`,
         {
           media_path: normalizedPath,
-          absolute_path: absolutePath
-        }
+          absolute_path: absolutePath,
+        },
       );
     }
 
@@ -1222,9 +1266,9 @@ function validateLinkedInPostMediaAttachments(
           extension,
           supported_extensions: [
             ...Array.from(LINKEDIN_POST_IMAGE_EXTENSIONS),
-            ...Array.from(LINKEDIN_POST_VIDEO_EXTENSIONS)
-          ]
-        }
+            ...Array.from(LINKEDIN_POST_VIDEO_EXTENSIONS),
+          ],
+        },
       );
     }
 
@@ -1234,7 +1278,7 @@ function validateLinkedInPostMediaAttachments(
       fileName: path.basename(absolutePath),
       extension,
       kind,
-      sizeBytes: stats.size
+      sizeBytes: stats.size,
     } satisfies ValidatedMediaAttachment;
   });
 
@@ -1244,8 +1288,8 @@ function validateLinkedInPostMediaAttachments(
       "ACTION_PRECONDITION_FAILED",
       "mediaPaths must contain only images or only a single video.",
       {
-        media_kinds: Array.from(kinds)
-      }
+        media_kinds: Array.from(kinds),
+      },
     );
   }
 
@@ -1255,8 +1299,8 @@ function validateLinkedInPostMediaAttachments(
       "ACTION_PRECONDITION_FAILED",
       "LinkedIn post composer only supports one video attachment per post.",
       {
-        media_count: attachments.length
-      }
+        media_count: attachments.length,
+      },
     );
   }
 
@@ -1268,7 +1312,7 @@ function normalizePollQuestion(question: string): string {
   if (!normalized) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "question is required."
+      "question is required.",
     );
   }
 
@@ -1279,7 +1323,7 @@ function normalizePollOptions(options: string[]): string[] {
   if (!Array.isArray(options)) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      `options must include ${LINKEDIN_POST_POLL_MIN_OPTIONS}-${LINKEDIN_POST_POLL_MAX_OPTIONS} entries.`
+      `options must include ${LINKEDIN_POST_POLL_MIN_OPTIONS}-${LINKEDIN_POST_POLL_MAX_OPTIONS} entries.`,
     );
   }
 
@@ -1297,19 +1341,21 @@ function normalizePollOptions(options: string[]): string[] {
       {
         option_count: normalizedOptions.length,
         min_options: LINKEDIN_POST_POLL_MIN_OPTIONS,
-        max_options: LINKEDIN_POST_POLL_MAX_OPTIONS
-      }
+        max_options: LINKEDIN_POST_POLL_MAX_OPTIONS,
+      },
     );
   }
 
-  const dedupeSet = new Set(normalizedOptions.map((option) => option.toLowerCase()));
+  const dedupeSet = new Set(
+    normalizedOptions.map((option) => option.toLowerCase()),
+  );
   if (dedupeSet.size !== normalizedOptions.length) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
       "options must be distinct.",
       {
-        options: normalizedOptions
-      }
+        options: normalizedOptions,
+      },
     );
   }
 
@@ -1317,7 +1363,7 @@ function normalizePollOptions(options: string[]): string[] {
 }
 
 function normalizePollDurationDays(
-  durationDays: number | LinkedInPollDurationDays | undefined
+  durationDays: number | LinkedInPollDurationDays | undefined,
 ): LinkedInPollDurationDays {
   if (durationDays === undefined) {
     return 7;
@@ -1325,15 +1371,17 @@ function normalizePollDurationDays(
 
   if (
     typeof durationDays !== "number" ||
-    !LINKEDIN_POST_POLL_DURATION_DAYS.includes(durationDays as LinkedInPollDurationDays)
+    !LINKEDIN_POST_POLL_DURATION_DAYS.includes(
+      durationDays as LinkedInPollDurationDays,
+    )
   ) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
       `durationDays must be one of: ${LINKEDIN_POST_POLL_DURATION_DAYS.join(", ")}.`,
       {
         duration_days: durationDays,
-        supported_duration_days: LINKEDIN_POST_POLL_DURATION_DAYS
-      }
+        supported_duration_days: LINKEDIN_POST_POLL_DURATION_DAYS,
+      },
     );
   }
 
@@ -1353,7 +1401,7 @@ function getRequiredStringField(
   source: Record<string, unknown>,
   key: string,
   actionId: string,
-  location: "target" | "payload"
+  location: "target" | "payload",
 ): string {
   const value = source[key];
   if (typeof value === "string" && value.trim().length > 0) {
@@ -1366,22 +1414,24 @@ function getRequiredStringField(
     {
       action_id: actionId,
       location,
-      key
-    }
+      key,
+    },
   );
 }
 
 function toAutomationError(
   error: unknown,
   message: string,
-  details: Record<string, unknown>
+  details: Record<string, unknown>,
 ): LinkedInBuddyError {
   if (error instanceof LinkedInBuddyError) {
     return error;
   }
 
   if (error instanceof playwrightErrors.TimeoutError) {
-    return new LinkedInBuddyError("TIMEOUT", message, details, { cause: error });
+    return new LinkedInBuddyError("TIMEOUT", message, details, {
+      cause: error,
+    });
   }
 
   if (
@@ -1389,25 +1439,11 @@ function toAutomationError(
     /(net::|ERR_|ECONN|ENOTFOUND|EAI_AGAIN|socket hang up)/i.test(error.message)
   ) {
     return new LinkedInBuddyError("NETWORK_ERROR", message, details, {
-      cause: error
+      cause: error,
     });
   }
 
   return asLinkedInBuddyError(error, "UNKNOWN", message);
-}
-
-function formatRateLimitState(
-  state: RateLimiterState
-): Record<string, number | boolean | string> {
-  return {
-    counter_key: state.counterKey,
-    window_start_ms: state.windowStartMs,
-    window_size_ms: state.windowSizeMs,
-    count: state.count,
-    limit: state.limit,
-    remaining: state.remaining,
-    allowed: state.allowed
-  };
 }
 
 function escapeRegExp(value: string): string {
@@ -1431,7 +1467,7 @@ async function captureScreenshotArtifact(
   runtime: LinkedInPostsExecutorRuntime,
   page: Page,
   relativePath: string,
-  metadata: Record<string, unknown> = {}
+  metadata: Record<string, unknown> = {},
 ): Promise<string> {
   const absolutePath = runtime.artifacts.resolve(relativePath);
   await page.screenshot({ path: absolutePath, fullPage: true });
@@ -1442,7 +1478,7 @@ async function captureScreenshotArtifact(
 function registerTraceArtifact(
   runtime: LinkedInPostsExecutorRuntime,
   relativePath: string,
-  metadata: Record<string, unknown>
+  metadata: Record<string, unknown>,
 ): void {
   runtime.artifacts.registerArtifact(relativePath, "application/zip", metadata);
 }
@@ -1450,7 +1486,7 @@ function registerTraceArtifact(
 async function waitForCondition(
   condition: () => Promise<boolean>,
   timeoutMs: number,
-  intervalMs: number = 250
+  intervalMs: number = 250,
 ): Promise<boolean> {
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {
@@ -1476,7 +1512,12 @@ async function isLocatorVisible(locator: Locator): Promise<boolean> {
 async function isAnyLocatorVisible(locator: Locator): Promise<boolean> {
   const count = Math.min(await locator.count().catch(() => 0), 4);
   for (let index = 0; index < count; index += 1) {
-    if (await locator.nth(index).isVisible().catch(() => false)) {
+    if (
+      await locator
+        .nth(index)
+        .isVisible()
+        .catch(() => false)
+    ) {
       return true;
     }
   }
@@ -1492,7 +1533,7 @@ async function findVisibleLocatorOrThrow(
   page: Page,
   candidates: SelectorCandidate[],
   selectorKey: string,
-  artifactPaths: string[]
+  artifactPaths: string[],
 ): Promise<{ locator: Locator; key: string }> {
   for (const candidate of candidates) {
     const locator = candidate.locatorFactory(page).first();
@@ -1510,9 +1551,11 @@ async function findVisibleLocatorOrThrow(
     {
       selector_key: selectorKey,
       current_url: page.url(),
-      attempted_selectors: candidates.map((candidate) => candidate.selectorHint),
-      artifact_paths: artifactPaths
-    }
+      attempted_selectors: candidates.map(
+        (candidate) => candidate.selectorHint,
+      ),
+      artifact_paths: artifactPaths,
+    },
   );
 }
 
@@ -1521,7 +1564,7 @@ async function findVisibleScopedLocatorOrThrow(
   candidates: ScopedSelectorCandidate[],
   selectorKey: string,
   artifactPaths: string[],
-  currentUrl: string
+  currentUrl: string,
 ): Promise<{ locator: Locator; key: string }> {
   for (const candidate of candidates) {
     const locator = candidate.locatorFactory(root).first();
@@ -1539,15 +1582,17 @@ async function findVisibleScopedLocatorOrThrow(
     {
       selector_key: selectorKey,
       current_url: currentUrl,
-      attempted_selectors: candidates.map((candidate) => candidate.selectorHint),
-      artifact_paths: artifactPaths
-    }
+      attempted_selectors: candidates.map(
+        (candidate) => candidate.selectorHint,
+      ),
+      artifact_paths: artifactPaths,
+    },
   );
 }
 
 async function findOptionalVisibleLocator(
   page: Page,
-  candidates: SelectorCandidate[]
+  candidates: SelectorCandidate[],
 ): Promise<{ locator: Locator; key: string } | null> {
   for (const candidate of candidates) {
     const locator = candidate.locatorFactory(page).first();
@@ -1563,7 +1608,7 @@ async function findPresentLocatorOrThrow(
   page: Page,
   candidates: SelectorCandidate[],
   selectorKey: string,
-  artifactPaths: string[]
+  artifactPaths: string[],
 ): Promise<{ locator: Locator; key: string }> {
   for (const candidate of candidates) {
     const locator = candidate.locatorFactory(page).first();
@@ -1578,15 +1623,17 @@ async function findPresentLocatorOrThrow(
     {
       selector_key: selectorKey,
       current_url: page.url(),
-      attempted_selectors: candidates.map((candidate) => candidate.selectorHint),
-      artifact_paths: artifactPaths
-    }
+      attempted_selectors: candidates.map(
+        (candidate) => candidate.selectorHint,
+      ),
+      artifact_paths: artifactPaths,
+    },
   );
 }
 
 async function findPresentLocatorCollection(
   page: Page,
-  candidates: SelectorCandidate[]
+  candidates: SelectorCandidate[],
 ): Promise<{ locator: Locator; key: string } | null> {
   for (const candidate of candidates) {
     const locator = candidate.locatorFactory(page);
@@ -1600,7 +1647,7 @@ async function findPresentLocatorCollection(
 
 async function findOptionalScopedLocator(
   root: Locator,
-  candidates: ScopedSelectorCandidate[]
+  candidates: ScopedSelectorCandidate[],
 ): Promise<{ locator: Locator; key: string } | null> {
   for (const candidate of candidates) {
     const locator = candidate.locatorFactory(root).first();
@@ -1614,7 +1661,7 @@ async function findOptionalScopedLocator(
 
 async function findPresentScopedLocator(
   root: Locator,
-  candidates: ScopedSelectorCandidate[]
+  candidates: ScopedSelectorCandidate[],
 ): Promise<{ locator: Locator; key: string } | null> {
   for (const candidate of candidates) {
     const locator = candidate.locatorFactory(root).first();
@@ -1629,13 +1676,13 @@ async function findPresentScopedLocator(
 async function waitForVisibleSurface(
   page: Page,
   selectors: readonly string[],
-  errorMessage: string
+  errorMessage: string,
 ): Promise<void> {
   for (const selector of selectors) {
     try {
       await page.locator(selector).first().waitFor({
         state: "visible",
-        timeout: 5_000
+        timeout: 5_000,
       });
       return;
     } catch {
@@ -1643,21 +1690,17 @@ async function waitForVisibleSurface(
     }
   }
 
-  throw new LinkedInBuddyError(
-    "UI_CHANGED_SELECTOR_FAILED",
-    errorMessage,
-    {
-      current_url: page.url(),
-      attempted_selectors: [...selectors]
-    }
-  );
+  throw new LinkedInBuddyError("UI_CHANGED_SELECTOR_FAILED", errorMessage, {
+    current_url: page.url(),
+    attempted_selectors: [...selectors],
+  });
 }
 
 export async function waitForFeedSurface(page: Page): Promise<void> {
   await waitForVisibleSurface(
     page,
     LINKEDIN_POST_FEED_SURFACE_SELECTORS,
-    "Could not locate LinkedIn feed surface."
+    "Could not locate LinkedIn feed surface.",
   );
 }
 
@@ -1665,7 +1708,7 @@ async function waitForProfileActivitySurface(page: Page): Promise<void> {
   await waitForVisibleSurface(
     page,
     LINKEDIN_POST_ACTIVITY_SURFACE_SELECTORS,
-    "Could not locate LinkedIn profile activity surface."
+    "Could not locate LinkedIn profile activity surface.",
   );
 }
 
@@ -1684,111 +1727,110 @@ const POST_UI_ACTION_LABELS: Record<
 > = {
   edit: {
     en: ["Edit post", "Edit"],
-    da: ["Rediger opslag", "Rediger"]
+    da: ["Rediger opslag", "Rediger"],
   },
   delete: {
     en: ["Delete post", "Delete", "Remove"],
-    da: ["Slet opslag", "Slet", "Fjern"]
+    da: ["Slet opslag", "Slet", "Fjern"],
   },
   media: {
-    en: [
-      "Add media",
-      "Add a photo",
-      "Add a photo or video",
-      "Photo",
-      "Video"
-    ],
+    en: ["Add media", "Add a photo", "Add a photo or video", "Photo", "Video"],
     da: [
       "Tilføj medier",
       "Tilføj et billede",
       "Tilføj et billede eller en video",
       "Foto",
       "Billede",
-      "Video"
-    ]
+      "Video",
+    ],
   },
   poll: {
     en: ["Create a poll", "Poll"],
-    da: ["Opret en afstemning", "Afstemning"]
+    da: ["Opret en afstemning", "Afstemning"],
   },
   question: {
     en: ["Question"],
-    da: ["Spørgsmål"]
+    da: ["Spørgsmål"],
   },
   option: {
     en: ["Option"],
-    da: ["Valgmulighed", "Svarmulighed", "Mulighed"]
+    da: ["Valgmulighed", "Svarmulighed", "Mulighed"],
   },
   duration: {
     en: ["Duration"],
-    da: ["Varighed"]
-  }
+    da: ["Varighed"],
+  },
 };
 
 function getPostUiActionLabels(
   key: PostUiActionLabelKey,
-  locale: LinkedInSelectorLocale
+  locale: LinkedInSelectorLocale,
 ): string[] {
-  const localized = POST_UI_ACTION_LABELS[key][locale] ?? POST_UI_ACTION_LABELS[key].en;
+  const localized =
+    POST_UI_ACTION_LABELS[key][locale] ?? POST_UI_ACTION_LABELS[key].en;
   return Array.from(new Set([...localized, ...POST_UI_ACTION_LABELS[key].en]));
 }
 
 function buildAriaLabelContainsSelector(
   tagNames: string | readonly string[],
-  labels: readonly string[]
+  labels: readonly string[],
 ): string {
   const resolvedTagNames = Array.isArray(tagNames) ? tagNames : [tagNames];
   return resolvedTagNames
     .flatMap((tagName) =>
       labels.map(
-        (label) => `${tagName}[aria-label*="${escapeCssAttributeValue(label)}" i]`
-      )
+        (label) =>
+          `${tagName}[aria-label*="${escapeCssAttributeValue(label)}" i]`,
+      ),
     )
     .join(", ");
 }
 
 function formatPollDurationLabels(
   durationDays: LinkedInPollDurationDays,
-  locale: LinkedInSelectorLocale
+  locale: LinkedInSelectorLocale,
 ): string[] {
   const englishLabels = {
     1: ["1 day", "One day"],
     3: ["3 days"],
     7: ["1 week", "7 days"],
-    14: ["2 weeks", "14 days"]
+    14: ["2 weeks", "14 days"],
   } satisfies Record<LinkedInPollDurationDays, string[]>;
 
   const danishLabels = {
     1: ["1 dag"],
     3: ["3 dage"],
     7: ["1 uge", "7 dage"],
-    14: ["2 uger", "14 dage"]
+    14: ["2 uger", "14 dage"],
   } satisfies Record<LinkedInPollDurationDays, string[]>;
 
-  const localized = locale === "da" ? danishLabels[durationDays] : englishLabels[durationDays];
-  return Array.from(new Set([...(localized ?? []), ...englishLabels[durationDays]]));
+  const localized =
+    locale === "da" ? danishLabels[durationDays] : englishLabels[durationDays];
+  return Array.from(
+    new Set([...(localized ?? []), ...englishLabels[durationDays]]),
+  );
 }
 
 function createComposerRootCandidates(
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): SelectorCandidate[] {
   const postExactRegex = buildLinkedInSelectorPhraseRegex(
     "post",
     selectorLocale,
-    { exact: true }
+    { exact: true },
   );
   const postExactRegexHint = formatLinkedInSelectorRegexHint(
     "post",
     selectorLocale,
-    { exact: true }
+    { exact: true },
   );
   const composerPromptRegex = buildLinkedInSelectorPhraseRegex(
     "what_do_you_want_to_talk_about",
-    selectorLocale
+    selectorLocale,
   );
   const composerPromptRegexHint = formatLinkedInSelectorRegexHint(
     "what_do_you_want_to_talk_about",
-    selectorLocale
+    selectorLocale,
   );
 
   return [
@@ -1798,7 +1840,7 @@ function createComposerRootCandidates(
       locatorFactory: (page) =>
         page
           .locator("[role='dialog']")
-          .filter({ has: page.locator("[contenteditable='true'], textarea") })
+          .filter({ has: page.locator("[contenteditable='true'], textarea") }),
     },
     {
       key: "dialog-with-post-button",
@@ -1806,7 +1848,7 @@ function createComposerRootCandidates(
       locatorFactory: (page) =>
         page
           .locator("[role='dialog']")
-          .filter({ has: page.getByRole("button", { name: postExactRegex }) })
+          .filter({ has: page.getByRole("button", { name: postExactRegex }) }),
     },
     {
       key: "dialog-with-prompt",
@@ -1814,27 +1856,27 @@ function createComposerRootCandidates(
       locatorFactory: (page) =>
         page
           .locator("[role='dialog']")
-          .filter({ has: page.getByText(composerPromptRegex) })
+          .filter({ has: page.getByText(composerPromptRegex) }),
     },
     {
       key: "share-box-open",
       selectorHint: ".share-box__open, .share-creation-state",
       locatorFactory: (page) =>
-        page.locator(".share-box__open, .share-creation-state")
-    }
+        page.locator(".share-box__open, .share-creation-state"),
+    },
   ];
 }
 
 function createComposerInputCandidates(
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): ScopedSelectorCandidate[] {
   const composerInputRegex = buildLinkedInSelectorPhraseRegex(
     ["what_do_you_want_to_talk_about", "start_post"],
-    selectorLocale
+    selectorLocale,
   );
   const composerInputRegexHint = formatLinkedInSelectorRegexHint(
     ["what_do_you_want_to_talk_about", "start_post"],
-    selectorLocale
+    selectorLocale,
   );
 
   return [
@@ -1843,34 +1885,36 @@ function createComposerInputCandidates(
       selectorHint: `getByRole(textbox, ${composerInputRegexHint})`,
       locatorFactory: (root) =>
         root.getByRole("textbox", {
-          name: composerInputRegex
-        })
+          name: composerInputRegex,
+        }),
     },
     {
       key: "ql-editor",
       selectorHint: ".ql-editor[contenteditable='true']",
-      locatorFactory: (root) => root.locator(".ql-editor[contenteditable='true']")
+      locatorFactory: (root) =>
+        root.locator(".ql-editor[contenteditable='true']"),
     },
     {
       key: "contenteditable-role-textbox",
       selectorHint: "[contenteditable='true'][role='textbox']",
-      locatorFactory: (root) => root.locator("[contenteditable='true'][role='textbox']")
+      locatorFactory: (root) =>
+        root.locator("[contenteditable='true'][role='textbox']"),
     },
     {
       key: "contenteditable",
       selectorHint: "[contenteditable='true']",
-      locatorFactory: (root) => root.locator("[contenteditable='true']")
+      locatorFactory: (root) => root.locator("[contenteditable='true']"),
     },
     {
       key: "textarea",
       selectorHint: "textarea",
-      locatorFactory: (root) => root.locator("textarea")
-    }
+      locatorFactory: (root) => root.locator("textarea"),
+    },
   ];
 }
 
 function createVisibilityButtonCandidates(
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): ScopedSelectorCandidate[] {
   const visibilityRegex = buildLinkedInSelectorPhraseRegex(
     [
@@ -1878,9 +1922,9 @@ function createVisibilityButtonCandidates(
       "connections_only",
       "who_can_see_your_post",
       "visibility",
-      "post_settings"
+      "post_settings",
     ],
-    selectorLocale
+    selectorLocale,
   );
   const visibilityRegexHint = formatLinkedInSelectorRegexHint(
     [
@@ -1888,9 +1932,9 @@ function createVisibilityButtonCandidates(
       "connections_only",
       "who_can_see_your_post",
       "visibility",
-      "post_settings"
+      "post_settings",
     ],
-    selectorLocale
+    selectorLocale,
   );
   const visibilityAriaSelector = buildLinkedInAriaLabelContainsSelector(
     "button",
@@ -1899,17 +1943,17 @@ function createVisibilityButtonCandidates(
       "connections_only",
       "who_can_see_your_post",
       "visibility",
-      "post_settings"
+      "post_settings",
     ],
-    selectorLocale
+    selectorLocale,
   );
   const visibilityTextRegex = buildLinkedInSelectorPhraseRegex(
     ["anyone", "connections_only"],
-    selectorLocale
+    selectorLocale,
   );
   const visibilityTextRegexHint = formatLinkedInSelectorRegexHint(
     ["anyone", "connections_only"],
-    selectorLocale
+    selectorLocale,
   );
 
   return [
@@ -1918,60 +1962,61 @@ function createVisibilityButtonCandidates(
       selectorHint: `getByRole(button, ${visibilityRegexHint})`,
       locatorFactory: (root) =>
         root.getByRole("button", {
-          name: visibilityRegex
-        })
+          name: visibilityRegex,
+        }),
     },
     {
       key: "aria-label-visibility",
       selectorHint: visibilityAriaSelector,
-      locatorFactory: (root) => root.locator(visibilityAriaSelector)
+      locatorFactory: (root) => root.locator(visibilityAriaSelector),
     },
     {
       key: "button-text-visibility",
       selectorHint: `button hasText ${visibilityTextRegexHint}`,
       locatorFactory: (root) =>
-        root.locator("button").filter({ hasText: visibilityTextRegex })
-    }
+        root.locator("button").filter({ hasText: visibilityTextRegex }),
+    },
   ];
 }
 
 function getVisibilityPhraseKey(
-  visibility: LinkedInPostVisibility
+  visibility: LinkedInPostVisibility,
 ): LinkedInSelectorPhraseKey {
   return visibility === "connections" ? "connections_only" : "anyone";
 }
 
 function createVisibilityOptionCandidates(
   visibility: LinkedInPostVisibility,
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): SelectorCandidate[] {
   const visibilityPhraseKey = getVisibilityPhraseKey(visibility);
   const labelRegex = buildLinkedInSelectorPhraseRegex(
     visibilityPhraseKey,
     selectorLocale,
-    { exact: true }
+    { exact: true },
   );
   const labelRegexHint = formatLinkedInSelectorRegexHint(
     visibilityPhraseKey,
     selectorLocale,
-    { exact: true }
+    { exact: true },
   );
 
   return [
     {
       key: "role-radio-visibility-option",
       selectorHint: `getByRole(radio, ${labelRegexHint})`,
-      locatorFactory: (page) => page.getByRole("radio", { name: labelRegex })
+      locatorFactory: (page) => page.getByRole("radio", { name: labelRegex }),
     },
     {
       key: "role-button-visibility-option",
       selectorHint: `getByRole(button, ${labelRegexHint})`,
-      locatorFactory: (page) => page.getByRole("button", { name: labelRegex })
+      locatorFactory: (page) => page.getByRole("button", { name: labelRegex }),
     },
     {
       key: "label-visibility-option",
       selectorHint: `label hasText ${labelRegexHint}`,
-      locatorFactory: (page) => page.locator("label").filter({ hasText: labelRegex })
+      locatorFactory: (page) =>
+        page.locator("label").filter({ hasText: labelRegex }),
     },
     {
       key: "generic-visibility-option",
@@ -1979,245 +2024,260 @@ function createVisibilityOptionCandidates(
       locatorFactory: (page) =>
         page
           .locator("[role='radio'], button, label, li")
-          .filter({ hasText: labelRegex })
-    }
+          .filter({ hasText: labelRegex }),
+    },
   ];
 }
 
 function createVisibilityDoneButtonCandidates(
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): SelectorCandidate[] {
   const doneRegex = buildLinkedInSelectorPhraseRegex(
     ["done", "save"],
-    selectorLocale
+    selectorLocale,
   );
   const doneRegexHint = formatLinkedInSelectorRegexHint(
     ["done", "save"],
-    selectorLocale
+    selectorLocale,
   );
 
   return [
     {
       key: "role-button-done",
       selectorHint: `getByRole(button, ${doneRegexHint})`,
-      locatorFactory: (page) => page.getByRole("button", { name: doneRegex })
+      locatorFactory: (page) => page.getByRole("button", { name: doneRegex }),
     },
     {
       key: "button-text-done",
       selectorHint: `button hasText ${doneRegexHint}`,
-      locatorFactory: (page) => page.locator("button").filter({ hasText: doneRegex })
-    }
+      locatorFactory: (page) =>
+        page.locator("button").filter({ hasText: doneRegex }),
+    },
   ];
 }
 
 function createPublishButtonCandidates(
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): ScopedSelectorCandidate[] {
   const postExactRegex = buildLinkedInSelectorPhraseRegex(
     "post",
     selectorLocale,
-    { exact: true }
+    { exact: true },
   );
   const postExactRegexHint = formatLinkedInSelectorRegexHint(
     "post",
     selectorLocale,
-    { exact: true }
+    { exact: true },
   );
 
   return [
     {
       key: "role-button-post",
       selectorHint: `getByRole(button, ${postExactRegexHint})`,
-      locatorFactory: (root) => root.getByRole("button", { name: postExactRegex })
+      locatorFactory: (root) =>
+        root.getByRole("button", { name: postExactRegex }),
     },
     {
       key: "share-actions-primary",
       selectorHint: ".share-actions__primary-action",
-      locatorFactory: (root) => root.locator(".share-actions__primary-action")
+      locatorFactory: (root) => root.locator(".share-actions__primary-action"),
     },
     {
       key: "submit-button",
       selectorHint: "button[type='submit']",
-      locatorFactory: (root) => root.locator("button[type='submit']")
-    }
+      locatorFactory: (root) => root.locator("button[type='submit']"),
+    },
   ];
 }
 
 function createScopedSaveButtonCandidates(
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): ScopedSelectorCandidate[] {
   const saveRegex = buildLinkedInSelectorPhraseRegex(
     ["save", "done"],
-    selectorLocale
+    selectorLocale,
   );
   const saveRegexHint = formatLinkedInSelectorRegexHint(
     ["save", "done"],
-    selectorLocale
+    selectorLocale,
   );
   const saveAriaSelector = buildLinkedInAriaLabelContainsSelector(
     ["button", "[role='button']"],
     ["save", "done"],
-    selectorLocale
+    selectorLocale,
   );
 
   return [
     {
       key: "dialog-role-button-save",
       selectorHint: `getByRole(button, ${saveRegexHint})`,
-      locatorFactory: (root) => root.getByRole("button", { name: saveRegex })
+      locatorFactory: (root) => root.getByRole("button", { name: saveRegex }),
     },
     {
       key: "dialog-aria-button-save",
       selectorHint: saveAriaSelector,
-      locatorFactory: (root) => root.locator(saveAriaSelector)
+      locatorFactory: (root) => root.locator(saveAriaSelector),
     },
     {
       key: "dialog-button-text-save",
       selectorHint: `button hasText ${saveRegexHint}`,
-      locatorFactory: (root) => root.locator("button").filter({ hasText: saveRegex })
-    }
+      locatorFactory: (root) =>
+        root.locator("button").filter({ hasText: saveRegex }),
+    },
   ];
 }
 
 function createPostMenuButtonCandidates(
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): ScopedSelectorCandidate[] {
   const menuRegex = buildLinkedInSelectorPhraseRegex(
     ["more", "more_actions"],
-    selectorLocale
+    selectorLocale,
   );
   const menuRegexHint = formatLinkedInSelectorRegexHint(
     ["more", "more_actions"],
-    selectorLocale
+    selectorLocale,
   );
   const menuAriaSelector = buildLinkedInAriaLabelContainsSelector(
     ["button", "[role='button']"],
     ["more", "more_actions"],
-    selectorLocale
+    selectorLocale,
   );
 
   return [
     {
       key: "post-menu-button-role",
       selectorHint: `getByRole(button, ${menuRegexHint})`,
-      locatorFactory: (root) => root.getByRole("button", { name: menuRegex })
+      locatorFactory: (root) => root.getByRole("button", { name: menuRegex }),
     },
     {
       key: "post-menu-button-aria",
       selectorHint: menuAriaSelector,
-      locatorFactory: (root) => root.locator(menuAriaSelector)
+      locatorFactory: (root) => root.locator(menuAriaSelector),
     },
     {
       key: "post-menu-button-feed-control",
-      selectorHint: ".feed-shared-control-menu__trigger, .artdeco-dropdown__trigger",
+      selectorHint:
+        ".feed-shared-control-menu__trigger, .artdeco-dropdown__trigger",
       locatorFactory: (root) =>
-        root.locator(".feed-shared-control-menu__trigger, .artdeco-dropdown__trigger")
-    }
+        root.locator(
+          ".feed-shared-control-menu__trigger, .artdeco-dropdown__trigger",
+        ),
+    },
   ];
 }
 
 function createPostMenuActionCandidates(
   labels: readonly string[],
-  keyPrefix: string
+  keyPrefix: string,
 ): SelectorCandidate[] {
   const exactRegex = buildTextRegex(labels, true);
   const textRegex = buildTextRegex(labels);
   const ariaSelector = buildAriaLabelContainsSelector(
     ["button", "[role='button']", "[role='menuitem']"],
-    labels
+    labels,
   );
 
   return [
     {
       key: `${keyPrefix}-menuitem-role`,
       selectorHint: `[role='menuitem'] hasText ${textRegex.source}`,
-      locatorFactory: (page) => page.locator("[role='menuitem']").filter({ hasText: textRegex })
+      locatorFactory: (page) =>
+        page.locator("[role='menuitem']").filter({ hasText: textRegex }),
     },
     {
       key: `${keyPrefix}-dropdown-button-text`,
       selectorHint: `.artdeco-dropdown__content-inner button hasText ${textRegex.source}`,
       locatorFactory: (page) =>
         page
-          .locator(".artdeco-dropdown__content-inner button, .artdeco-dropdown__content-inner li")
-          .filter({ hasText: textRegex })
+          .locator(
+            ".artdeco-dropdown__content-inner button, .artdeco-dropdown__content-inner li",
+          )
+          .filter({ hasText: textRegex }),
     },
     {
       key: `${keyPrefix}-action-aria`,
       selectorHint: ariaSelector,
-      locatorFactory: (page) => page.locator(ariaSelector)
+      locatorFactory: (page) => page.locator(ariaSelector),
     },
     {
       key: `${keyPrefix}-button-exact`,
       selectorHint: `button exact ${exactRegex.source}`,
-      locatorFactory: (page) => page.locator("button, [role='button']").filter({ hasText: exactRegex })
-    }
+      locatorFactory: (page) =>
+        page.locator("button, [role='button']").filter({ hasText: exactRegex }),
+    },
   ];
 }
 
 function createDeleteConfirmButtonCandidates(
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): ScopedSelectorCandidate[] {
   const labels = getPostUiActionLabels("delete", selectorLocale);
   const deleteRegex = buildTextRegex(labels);
   const deleteExactRegex = buildTextRegex(labels, true);
   const deleteAriaSelector = buildAriaLabelContainsSelector(
     ["button", "[role='button']"],
-    labels
+    labels,
   );
 
   return [
     {
       key: "delete-confirm-role-exact",
       selectorHint: `getByRole(button, ${deleteExactRegex.source})`,
-      locatorFactory: (root) => root.getByRole("button", { name: deleteExactRegex })
+      locatorFactory: (root) =>
+        root.getByRole("button", { name: deleteExactRegex }),
     },
     {
       key: "delete-confirm-aria",
       selectorHint: deleteAriaSelector,
-      locatorFactory: (root) => root.locator(deleteAriaSelector)
+      locatorFactory: (root) => root.locator(deleteAriaSelector),
     },
     {
       key: "delete-confirm-button-text",
       selectorHint: `button hasText ${deleteRegex.source}`,
-      locatorFactory: (root) => root.locator("button").filter({ hasText: deleteRegex })
-    }
+      locatorFactory: (root) =>
+        root.locator("button").filter({ hasText: deleteRegex }),
+    },
   ];
 }
 
 function createMediaButtonCandidates(
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): ScopedSelectorCandidate[] {
   const labels = getPostUiActionLabels("media", selectorLocale);
   const mediaRegex = buildTextRegex(labels);
   const mediaExactRegex = buildTextRegex(labels, true);
   const mediaAriaSelector = buildAriaLabelContainsSelector(
     ["button", "[role='button']"],
-    labels
+    labels,
   );
 
   return [
     {
       key: "media-button-role-exact",
       selectorHint: `getByRole(button, ${mediaExactRegex.source})`,
-      locatorFactory: (root) => root.getByRole("button", { name: mediaExactRegex })
+      locatorFactory: (root) =>
+        root.getByRole("button", { name: mediaExactRegex }),
     },
     {
       key: "media-button-aria",
       selectorHint: mediaAriaSelector,
-      locatorFactory: (root) => root.locator(mediaAriaSelector)
+      locatorFactory: (root) => root.locator(mediaAriaSelector),
     },
     {
       key: "media-button-text",
       selectorHint: `button hasText ${mediaRegex.source}`,
       locatorFactory: (root) =>
-        root.locator("button, [role='button']").filter({ hasText: mediaRegex })
+        root.locator("button, [role='button']").filter({ hasText: mediaRegex }),
     },
     {
       key: "media-button-footer-icon",
       selectorHint: ".share-box-footer button, footer button",
       locatorFactory: (root) =>
-        root.locator(".share-box-footer button, .share-creation-state__footer button")
-    }
+        root.locator(
+          ".share-box-footer button, .share-creation-state__footer button",
+        ),
+    },
   ];
 }
 
@@ -2226,14 +2286,14 @@ function createMediaInputCandidates(): ScopedSelectorCandidate[] {
     {
       key: "media-input-file",
       selectorHint: "input[type='file']",
-      locatorFactory: (root) => root.locator("input[type='file']")
+      locatorFactory: (root) => root.locator("input[type='file']"),
     },
     {
       key: "media-input-accept-image-video",
       selectorHint: "input[accept*='image'], input[accept*='video']",
       locatorFactory: (root) =>
-        root.locator("input[accept*='image'], input[accept*='video']")
-    }
+        root.locator("input[accept*='image'], input[accept*='video']"),
+    },
   ];
 }
 
@@ -2242,105 +2302,108 @@ function createPageMediaInputCandidates(): SelectorCandidate[] {
     {
       key: "page-media-input-file",
       selectorHint: "input[type='file']",
-      locatorFactory: (page) => page.locator("input[type='file']")
+      locatorFactory: (page) => page.locator("input[type='file']"),
     },
     {
       key: "page-media-input-accept-image-video",
       selectorHint: "input[accept*='image'], input[accept*='video']",
       locatorFactory: (page) =>
-        page.locator("input[accept*='image'], input[accept*='video']")
-    }
+        page.locator("input[accept*='image'], input[accept*='video']"),
+    },
   ];
 }
 
 function createPollButtonCandidates(
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): ScopedSelectorCandidate[] {
   const labels = getPostUiActionLabels("poll", selectorLocale);
   const pollRegex = buildTextRegex(labels);
   const pollExactRegex = buildTextRegex(labels, true);
   const pollAriaSelector = buildAriaLabelContainsSelector(
     ["button", "[role='button']"],
-    labels
+    labels,
   );
 
   return [
     {
       key: "poll-button-role-exact",
       selectorHint: `getByRole(button, ${pollExactRegex.source})`,
-      locatorFactory: (root) => root.getByRole("button", { name: pollExactRegex })
+      locatorFactory: (root) =>
+        root.getByRole("button", { name: pollExactRegex }),
     },
     {
       key: "poll-button-aria",
       selectorHint: pollAriaSelector,
-      locatorFactory: (root) => root.locator(pollAriaSelector)
+      locatorFactory: (root) => root.locator(pollAriaSelector),
     },
     {
       key: "poll-button-text",
       selectorHint: `button hasText ${pollRegex.source}`,
       locatorFactory: (root) =>
-        root.locator("button, [role='button']").filter({ hasText: pollRegex })
-    }
+        root.locator("button, [role='button']").filter({ hasText: pollRegex }),
+    },
   ];
 }
 
 function createPollQuestionInputCandidates(
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): SelectorCandidate[] {
   const labels = getPostUiActionLabels("question", selectorLocale);
   const questionRegex = buildTextRegex(labels);
   const questionAriaSelector = buildAriaLabelContainsSelector(
     ["input", "textarea"],
-    labels
+    labels,
   );
 
   return [
     {
       key: "poll-question-role-textbox",
       selectorHint: `getByRole(textbox, ${questionRegex.source})`,
-      locatorFactory: (page) => page.getByRole("textbox", { name: questionRegex })
+      locatorFactory: (page) =>
+        page.getByRole("textbox", { name: questionRegex }),
     },
     {
       key: "poll-question-aria",
       selectorHint: questionAriaSelector,
-      locatorFactory: (page) => page.locator(questionAriaSelector)
+      locatorFactory: (page) => page.locator(questionAriaSelector),
     },
     {
       key: "poll-question-name",
       selectorHint: "input[name*='question'], textarea[name*='question']",
       locatorFactory: (page) =>
-        page.locator("input[name*='question' i], textarea[name*='question' i]")
-    }
+        page.locator("input[name*='question' i], textarea[name*='question' i]"),
+    },
   ];
 }
 
 function createPollOptionInputCandidates(
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): SelectorCandidate[] {
   const labels = getPostUiActionLabels("option", selectorLocale);
   const optionRegex = buildTextRegex(labels);
   const optionAriaSelector = buildAriaLabelContainsSelector(
     ["input", "textarea"],
-    labels
+    labels,
   );
 
   return [
     {
       key: "poll-option-role-textbox",
       selectorHint: `getByRole(textbox, ${optionRegex.source})`,
-      locatorFactory: (page) => page.getByRole("textbox", { name: optionRegex })
+      locatorFactory: (page) =>
+        page.getByRole("textbox", { name: optionRegex }),
     },
     {
       key: "poll-option-aria",
       selectorHint: optionAriaSelector,
-      locatorFactory: (page) => page.locator(optionAriaSelector)
+      locatorFactory: (page) => page.locator(optionAriaSelector),
     },
     {
       key: "poll-option-name",
       selectorHint: "input[name*='option'], textarea[name*='option']",
       locatorFactory: (page) =>
-        page.locator("input[name*='option' i], textarea[name*='option' i]")
-    }
+        page.locator("input[name*='option' i], textarea[name*='option' i]"),
+    },
   ];
 }
 
@@ -2350,43 +2413,46 @@ function createPollDurationSelectCandidates(): SelectorCandidate[] {
       key: "poll-duration-select-labeled",
       selectorHint: "select[aria-label*='Duration'], select[name*='duration']",
       locatorFactory: (page) =>
-        page.locator("select[aria-label*='Duration' i], select[name*='duration' i]")
+        page.locator(
+          "select[aria-label*='Duration' i], select[name*='duration' i]",
+        ),
     },
     {
       key: "poll-duration-select-generic",
       selectorHint: "select",
-      locatorFactory: (page) => page.locator("select")
-    }
+      locatorFactory: (page) => page.locator("select"),
+    },
   ];
 }
 
 function createPollDurationButtonCandidates(
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): SelectorCandidate[] {
   const labels = getPostUiActionLabels("duration", selectorLocale);
   const durationRegex = buildTextRegex(labels);
   const durationAriaSelector = buildAriaLabelContainsSelector(
     ["button", "[role='button']"],
-    labels
+    labels,
   );
 
   return [
     {
       key: "poll-duration-button-role",
       selectorHint: `getByRole(button, ${durationRegex.source})`,
-      locatorFactory: (page) => page.getByRole("button", { name: durationRegex })
+      locatorFactory: (page) =>
+        page.getByRole("button", { name: durationRegex }),
     },
     {
       key: "poll-duration-button-aria",
       selectorHint: durationAriaSelector,
-      locatorFactory: (page) => page.locator(durationAriaSelector)
-    }
+      locatorFactory: (page) => page.locator(durationAriaSelector),
+    },
   ];
 }
 
 function createPollDurationOptionCandidates(
   durationDays: LinkedInPollDurationDays,
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): SelectorCandidate[] {
   const labels = formatPollDurationLabels(durationDays, selectorLocale);
   const durationRegex = buildTextRegex(labels);
@@ -2396,88 +2462,98 @@ function createPollDurationOptionCandidates(
     {
       key: "poll-duration-option-menuitem",
       selectorHint: `[role='menuitem'] hasText ${durationRegex.source}`,
-      locatorFactory: (page) => page.locator("[role='menuitem']").filter({ hasText: durationRegex })
+      locatorFactory: (page) =>
+        page.locator("[role='menuitem']").filter({ hasText: durationRegex }),
     },
     {
       key: "poll-duration-option-role",
       selectorHint: `getByRole(option, ${durationExactRegex.source})`,
-      locatorFactory: (page) => page.getByRole("option", { name: durationExactRegex })
+      locatorFactory: (page) =>
+        page.getByRole("option", { name: durationExactRegex }),
     },
     {
       key: "poll-duration-option-generic",
       selectorHint: `button, li hasText ${durationRegex.source}`,
       locatorFactory: (page) =>
-        page.locator("button, li, div[role='button']").filter({ hasText: durationRegex })
-    }
+        page
+          .locator("button, li, div[role='button']")
+          .filter({ hasText: durationRegex }),
+    },
   ];
 }
 
 function createComposerCloseButtonCandidates(
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): ScopedSelectorCandidate[] {
   const closeRegex = buildLinkedInSelectorPhraseRegex(
     ["dismiss", "close"],
-    selectorLocale
+    selectorLocale,
   );
   const closeRegexHint = formatLinkedInSelectorRegexHint(
     ["dismiss", "close"],
-    selectorLocale
+    selectorLocale,
   );
   const closeAriaSelector = buildLinkedInAriaLabelContainsSelector(
     "button",
     ["dismiss", "close"],
-    selectorLocale
+    selectorLocale,
   );
 
   return [
     {
       key: "role-button-dismiss",
       selectorHint: `getByRole(button, ${closeRegexHint})`,
-      locatorFactory: (root) => root.getByRole("button", { name: closeRegex })
+      locatorFactory: (root) => root.getByRole("button", { name: closeRegex }),
     },
     {
       key: "aria-dismiss-close",
       selectorHint: closeAriaSelector,
-      locatorFactory: (root) => root.locator(closeAriaSelector)
-    }
+      locatorFactory: (root) => root.locator(closeAriaSelector),
+    },
   ];
 }
 
 function createDiscardDialogCandidates(
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): SelectorCandidate[] {
   const discardRegex = buildLinkedInSelectorPhraseRegex(
     ["discard", "leave"],
-    selectorLocale
+    selectorLocale,
   );
   const discardRegexHint = formatLinkedInSelectorRegexHint(
     ["discard", "leave"],
-    selectorLocale
+    selectorLocale,
   );
 
   return [
     {
       key: "role-button-discard",
       selectorHint: `getByRole(button, ${discardRegexHint})`,
-      locatorFactory: (page) => page.getByRole("button", { name: discardRegex })
+      locatorFactory: (page) =>
+        page.getByRole("button", { name: discardRegex }),
     },
     {
       key: "button-text-discard",
       selectorHint: `button hasText ${discardRegexHint}`,
-      locatorFactory: (page) => page.locator("button").filter({ hasText: discardRegex })
-    }
+      locatorFactory: (page) =>
+        page.locator("button").filter({ hasText: discardRegex }),
+    },
   ];
 }
 
 async function openPostComposer(
   page: Page,
   selectorLocale: LinkedInSelectorLocale,
-  artifactPaths: string[]
+  artifactPaths: string[],
 ): Promise<{ composerRoot: Locator; triggerKey: string; rootKey: string }> {
   await page.goto(LINKEDIN_FEED_URL, { waitUntil: "domcontentloaded" });
   await waitForNetworkIdleBestEffort(page);
-  const triggerCandidates = createFeedPostComposerTriggerCandidates(selectorLocale);
-  const visibleTrigger = await findOptionalVisibleLocator(page, triggerCandidates);
+  const triggerCandidates =
+    createFeedPostComposerTriggerCandidates(selectorLocale);
+  const visibleTrigger = await findOptionalVisibleLocator(
+    page,
+    triggerCandidates,
+  );
   if (!visibleTrigger) {
     await waitForFeedSurface(page);
   }
@@ -2488,7 +2564,7 @@ async function openPostComposer(
       page,
       triggerCandidates,
       "post_composer_trigger",
-      artifactPaths
+      artifactPaths,
     ));
   await trigger.locator.click({ timeout: 5_000 });
 
@@ -2496,24 +2572,24 @@ async function openPostComposer(
     page,
     createComposerRootCandidates(selectorLocale),
     "post_composer_root",
-    artifactPaths
+    artifactPaths,
   );
 
   return {
     composerRoot: root.locator,
     triggerKey: trigger.key,
-    rootKey: root.key
+    rootKey: root.key,
   };
 }
 
 async function closeComposerBestEffort(
   page: Page,
   composerRoot: Locator,
-  selectorLocale: LinkedInSelectorLocale
+  selectorLocale: LinkedInSelectorLocale,
 ): Promise<void> {
   const closeButton = await findOptionalScopedLocator(
     composerRoot,
-    createComposerCloseButtonCandidates(selectorLocale)
+    createComposerCloseButtonCandidates(selectorLocale),
   );
 
   try {
@@ -2528,13 +2604,18 @@ async function closeComposerBestEffort(
 
   const discardButton = await findOptionalVisibleLocator(
     page,
-    createDiscardDialogCandidates(selectorLocale)
+    createDiscardDialogCandidates(selectorLocale),
   );
   if (discardButton) {
-    await discardButton.locator.click({ timeout: 2_000 }).catch(() => undefined);
+    await discardButton.locator
+      .click({ timeout: 2_000 })
+      .catch(() => undefined);
   }
 
-  await waitForCondition(async () => !(await isAnyLocatorVisible(composerRoot)), 5_000);
+  await waitForCondition(
+    async () => !(await isAnyLocatorVisible(composerRoot)),
+    5_000,
+  );
 }
 
 async function setComposerText(
@@ -2542,14 +2623,14 @@ async function setComposerText(
   composerRoot: Locator,
   selectorLocale: LinkedInSelectorLocale,
   text: string,
-  artifactPaths: string[]
+  artifactPaths: string[],
 ): Promise<string> {
   const composerInput = await findVisibleScopedLocatorOrThrow(
     composerRoot,
     createComposerInputCandidates(selectorLocale),
     "post_composer_input",
     artifactPaths,
-    page.url()
+    page.url(),
   );
 
   await composerInput.locator.click({ timeout: 5_000 });
@@ -2572,7 +2653,10 @@ async function readLocatorDetails(locator: Locator): Promise<string> {
     return normalizeText(ariaLabel);
   }
 
-  const textContent = await locator.first().innerText().catch(() => "");
+  const textContent = await locator
+    .first()
+    .innerText()
+    .catch(() => "");
   return normalizeText(textContent);
 }
 
@@ -2581,7 +2665,7 @@ async function setPostVisibility(
   composerRoot: Locator,
   selectorLocale: LinkedInSelectorLocale,
   visibility: LinkedInPostVisibility,
-  artifactPaths: string[]
+  artifactPaths: string[],
 ): Promise<string> {
   const audienceLabel = LINKEDIN_POST_VISIBILITY_MAP[visibility].audienceLabel;
   const visibilityButton = await findVisibleScopedLocatorOrThrow(
@@ -2589,7 +2673,7 @@ async function setPostVisibility(
     createVisibilityButtonCandidates(selectorLocale),
     "post_visibility_button",
     artifactPaths,
-    page.url()
+    page.url(),
   );
 
   const currentLabel = await readLocatorDetails(visibilityButton.locator);
@@ -2603,13 +2687,13 @@ async function setPostVisibility(
     page,
     createVisibilityOptionCandidates(visibility, selectorLocale),
     "post_visibility_option",
-    artifactPaths
+    artifactPaths,
   );
   await option.locator.click({ timeout: 5_000 });
 
   const doneButton = await findOptionalVisibleLocator(
     page,
-    createVisibilityDoneButtonCandidates(selectorLocale)
+    createVisibilityDoneButtonCandidates(selectorLocale),
   );
   if (doneButton) {
     await doneButton.locator.click({ timeout: 5_000 });
@@ -2618,7 +2702,7 @@ async function setPostVisibility(
   const updated = await waitForCondition(async () => {
     const nextButton = await findOptionalScopedLocator(
       composerRoot,
-      createVisibilityButtonCandidates(selectorLocale)
+      createVisibilityButtonCandidates(selectorLocale),
     );
     if (!nextButton) {
       return false;
@@ -2637,8 +2721,8 @@ async function setPostVisibility(
         requested_visibility: visibility,
         requested_audience_label: audienceLabel,
         selector_key: visibilityButton.key,
-        artifact_paths: artifactPaths
-      }
+        artifact_paths: artifactPaths,
+      },
     );
   }
 
@@ -2654,7 +2738,7 @@ async function waitForVisibleDialog(page: Page): Promise<Locator> {
 async function setTextInputValue(
   page: Page,
   locator: Locator,
-  value: string
+  value: string,
 ): Promise<void> {
   await locator.click({ timeout: 5_000 });
 
@@ -2671,7 +2755,7 @@ async function setTextInputValue(
 async function findTargetPostLocator(
   page: Page,
   postUrl: string,
-  artifactPaths: string[]
+  artifactPaths: string[],
 ): Promise<TargetPostLocator> {
   const postIdentity = extractPostIdentity(postUrl);
   const activityId = extractActivityId(postIdentity || postUrl);
@@ -2684,20 +2768,20 @@ async function findTargetPostLocator(
         key: "post-root-data-urn-exact",
         selectorHint: `[data-urn="${postIdentity}"]`,
         locatorFactory: (targetPage) =>
-          targetPage.locator(`[data-urn="${escapedIdentity}"]`)
+          targetPage.locator(`[data-urn="${escapedIdentity}"]`),
       },
       {
         key: "post-root-data-urn-contains",
         selectorHint: `[data-urn*="${postIdentity}"]`,
         locatorFactory: (targetPage) =>
-          targetPage.locator(`[data-urn*="${escapedIdentity}"]`)
+          targetPage.locator(`[data-urn*="${escapedIdentity}"]`),
       },
       {
         key: "post-root-permalink-identity",
         selectorHint: `article:has(a[href*="${postIdentity}"])`,
         locatorFactory: (targetPage) =>
-          targetPage.locator(`article:has(a[href*="${escapedIdentity}"])`)
-      }
+          targetPage.locator(`article:has(a[href*="${escapedIdentity}"])`),
+      },
     );
   }
 
@@ -2708,14 +2792,14 @@ async function findTargetPostLocator(
         key: "post-root-data-urn-activity",
         selectorHint: `[data-urn*="${activityId}"]`,
         locatorFactory: (targetPage) =>
-          targetPage.locator(`[data-urn*="${escapedActivityId}"]`)
+          targetPage.locator(`[data-urn*="${escapedActivityId}"]`),
       },
       {
         key: "post-root-permalink-activity",
         selectorHint: `article:has(a[href*="${activityId}"])`,
         locatorFactory: (targetPage) =>
-          targetPage.locator(`article:has(a[href*="${escapedActivityId}"])`)
-      }
+          targetPage.locator(`article:has(a[href*="${escapedActivityId}"])`),
+      },
     );
   }
 
@@ -2723,27 +2807,27 @@ async function findTargetPostLocator(
     {
       key: "post-root-first-data-urn",
       selectorHint: "[data-urn]",
-      locatorFactory: (targetPage) => targetPage.locator("[data-urn]")
+      locatorFactory: (targetPage) => targetPage.locator("[data-urn]"),
     },
     {
       key: "post-root-first-article",
       selectorHint: "article",
-      locatorFactory: (targetPage) => targetPage.locator("article")
-    }
+      locatorFactory: (targetPage) => targetPage.locator("article"),
+    },
   );
 
   const resolved = await findVisibleLocatorOrThrow(
     page,
     candidates,
     "post_root",
-    artifactPaths
+    artifactPaths,
   );
 
   return {
     locator: resolved.locator,
     key: resolved.key,
     postIdentity,
-    activityId
+    activityId,
   };
 }
 
@@ -2751,21 +2835,23 @@ async function openTargetPostActionMenu(
   page: Page,
   targetPost: TargetPostLocator,
   selectorLocale: LinkedInSelectorLocale,
-  artifactPaths: string[]
+  artifactPaths: string[],
 ): Promise<string> {
   const menuButton = await findVisibleScopedLocatorOrThrow(
     targetPost.locator,
     createPostMenuButtonCandidates(selectorLocale),
     "post_action_menu_button",
     artifactPaths,
-    page.url()
+    page.url(),
   );
 
   await menuButton.locator.click({ timeout: 5_000 });
   const menuOpened = await waitForCondition(
     async () =>
-      isAnyLocatorVisible(page.locator("[role='menu'], .artdeco-dropdown__content-inner")),
-    5_000
+      isAnyLocatorVisible(
+        page.locator("[role='menu'], .artdeco-dropdown__content-inner"),
+      ),
+    5_000,
   );
 
   if (!menuOpened) {
@@ -2775,8 +2861,8 @@ async function openTargetPostActionMenu(
       {
         current_url: page.url(),
         selector_key: menuButton.key,
-        artifact_paths: artifactPaths
-      }
+        artifact_paths: artifactPaths,
+      },
     );
   }
 
@@ -2788,12 +2874,12 @@ async function attachMediaToComposer(
   composerRoot: Locator,
   selectorLocale: LinkedInSelectorLocale,
   attachments: ValidatedMediaAttachment[],
-  artifactPaths: string[]
+  artifactPaths: string[],
 ): Promise<{ mediaButtonKey: string | null; mediaInputKey: string }> {
   let mediaButtonKey: string | null = null;
   let mediaInput = await findPresentScopedLocator(
     composerRoot,
-    createMediaInputCandidates()
+    createMediaInputCandidates(),
   );
 
   if (!mediaInput) {
@@ -2802,34 +2888,37 @@ async function attachMediaToComposer(
       createMediaButtonCandidates(selectorLocale),
       "post_media_button",
       artifactPaths,
-      page.url()
+      page.url(),
     );
 
     mediaButtonKey = mediaButton.key;
     await mediaButton.locator.click({ timeout: 5_000 });
 
     mediaInput =
-      (await findPresentScopedLocator(composerRoot, createMediaInputCandidates())) ??
+      (await findPresentScopedLocator(
+        composerRoot,
+        createMediaInputCandidates(),
+      )) ??
       (await findPresentLocatorOrThrow(
         page,
         createPageMediaInputCandidates(),
         "post_media_input",
-        artifactPaths
+        artifactPaths,
       ));
   }
 
   await mediaInput.locator.setInputFiles(
-    attachments.map((attachment) => attachment.absolutePath)
+    attachments.map((attachment) => attachment.absolutePath),
   );
   await waitForNetworkIdleBestEffort(page, 10_000).catch(() => undefined);
 
   const attachmentsReady = await waitForCondition(async () => {
     const previewLocator = composerRoot.locator(
-      ".share-preview, .share-box__preview, .share-image, img, video, [data-test-id*='media']"
+      ".share-preview, .share-box__preview, .share-image, img, video, [data-test-id*='media']",
     );
     const publishButton = await findOptionalScopedLocator(
       composerRoot,
-      createPublishButtonCandidates(selectorLocale)
+      createPublishButtonCandidates(selectorLocale),
     );
     const publishEnabled = publishButton
       ? await publishButton.locator.isEnabled().catch(() => false)
@@ -2844,14 +2933,14 @@ async function attachMediaToComposer(
       {
         current_url: page.url(),
         media_paths: attachments.map((attachment) => attachment.path),
-        artifact_paths: artifactPaths
-      }
+        artifact_paths: artifactPaths,
+      },
     );
   }
 
   return {
     mediaButtonKey,
-    mediaInputKey: mediaInput.key
+    mediaInputKey: mediaInput.key,
   };
 }
 
@@ -2859,7 +2948,7 @@ async function resolvePollOptionInput(
   page: Page,
   selectorLocale: LinkedInSelectorLocale,
   optionIndex: number,
-  artifactPaths: string[]
+  artifactPaths: string[],
 ): Promise<{ locator: Locator; key: string }> {
   for (const candidate of createPollOptionInputCandidates(selectorLocale)) {
     const locator = candidate.locatorFactory(page);
@@ -2873,7 +2962,7 @@ async function resolvePollOptionInput(
       await resolved.waitFor({ state: "visible", timeout: 2_500 });
       return {
         locator: resolved,
-        key: `${candidate.key}-${optionIndex}`
+        key: `${candidate.key}-${optionIndex}`,
       };
     } catch {
       // Try next candidate collection.
@@ -2886,8 +2975,8 @@ async function resolvePollOptionInput(
     {
       current_url: page.url(),
       option_index: optionIndex,
-      artifact_paths: artifactPaths
-    }
+      artifact_paths: artifactPaths,
+    },
   );
 }
 
@@ -2895,11 +2984,11 @@ async function setPollDuration(
   page: Page,
   selectorLocale: LinkedInSelectorLocale,
   durationDays: LinkedInPollDurationDays,
-  artifactPaths: string[]
+  artifactPaths: string[],
 ): Promise<string | null> {
   const durationSelect = await findPresentLocatorCollection(
     page,
-    createPollDurationSelectCandidates()
+    createPollDurationSelectCandidates(),
   );
   if (durationSelect) {
     const select = durationSelect.locator.first();
@@ -2925,7 +3014,7 @@ async function setPollDuration(
 
   const durationButton = await findOptionalVisibleLocator(
     page,
-    createPollDurationButtonCandidates(selectorLocale)
+    createPollDurationButtonCandidates(selectorLocale),
   );
   if (!durationButton) {
     if (durationDays === 7) {
@@ -2938,8 +3027,8 @@ async function setPollDuration(
       {
         current_url: page.url(),
         duration_days: durationDays,
-        artifact_paths: artifactPaths
-      }
+        artifact_paths: artifactPaths,
+      },
     );
   }
 
@@ -2948,7 +3037,7 @@ async function setPollDuration(
     page,
     createPollDurationOptionCandidates(durationDays, selectorLocale),
     "poll_duration_option",
-    artifactPaths
+    artifactPaths,
   );
   await durationOption.locator.click({ timeout: 5_000 });
   return durationButton.key;
@@ -2961,7 +3050,7 @@ async function fillPollComposerFields(
   question: string,
   options: string[],
   durationDays: LinkedInPollDurationDays,
-  artifactPaths: string[]
+  artifactPaths: string[],
 ): Promise<{
   pollButtonKey: string;
   questionInputKey: string;
@@ -2973,7 +3062,7 @@ async function fillPollComposerFields(
     createPollButtonCandidates(selectorLocale),
     "post_poll_button",
     artifactPaths,
-    page.url()
+    page.url(),
   );
   await pollButton.locator.click({ timeout: 5_000 });
 
@@ -2981,7 +3070,7 @@ async function fillPollComposerFields(
     page,
     createPollQuestionInputCandidates(selectorLocale),
     "poll_question_input",
-    artifactPaths
+    artifactPaths,
   );
   await setTextInputValue(page, questionInput.locator, question);
 
@@ -2991,7 +3080,7 @@ async function fillPollComposerFields(
       page,
       selectorLocale,
       index,
-      artifactPaths
+      artifactPaths,
     );
     await setTextInputValue(page, optionInput.locator, options[index] ?? "");
     optionInputKeys.push(optionInput.key);
@@ -3001,18 +3090,20 @@ async function fillPollComposerFields(
     page,
     selectorLocale,
     durationDays,
-    artifactPaths
+    artifactPaths,
   );
 
   return {
     pollButtonKey: pollButton.key,
     questionInputKey: questionInput.key,
     optionInputKeys,
-    durationKey
+    durationKey,
   };
 }
 
-async function extractPostSnippetFromLocator(targetPost: Locator): Promise<string> {
+async function extractPostSnippetFromLocator(
+  targetPost: Locator,
+): Promise<string> {
   const text = normalizeText(await targetPost.innerText().catch(() => ""));
   return createVerificationSnippet(text);
 }
@@ -3021,13 +3112,13 @@ async function verifyUpdatedPostAtUrl(
   page: Page,
   postUrl: string,
   text: string,
-  artifactPaths: string[]
+  artifactPaths: string[],
 ): Promise<{ verified: true; postUrl: string }> {
   const snippet = createVerificationSnippet(text);
   if (!snippet) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "Cannot verify an updated post with empty text content."
+      "Cannot verify an updated post with empty text content.",
     );
   }
 
@@ -3046,14 +3137,14 @@ async function verifyUpdatedPostAtUrl(
       {
         post_url: postUrl,
         verification_snippet: snippet,
-        artifact_paths: artifactPaths
-      }
+        artifact_paths: artifactPaths,
+      },
     );
   }
 
   return {
     verified: true,
-    postUrl
+    postUrl,
   };
 }
 
@@ -3061,7 +3152,7 @@ async function verifyDeletedPostAtUrl(
   page: Page,
   postUrl: string,
   previousSnippet: string,
-  artifactPaths: string[]
+  artifactPaths: string[],
 ): Promise<{ verified: true; postUrl: string }> {
   await page.goto(postUrl, { waitUntil: "domcontentloaded" });
   await waitForNetworkIdleBestEffort(page);
@@ -3082,26 +3173,30 @@ async function verifyDeletedPostAtUrl(
       {
         post_url: postUrl,
         verification_snippet: previousSnippet,
-        artifact_paths: artifactPaths
-      }
+        artifact_paths: artifactPaths,
+      },
     );
   }
 
   return {
     verified: true,
-    postUrl
+    postUrl,
   };
 }
 
 async function findVisiblePostBySnippet(
   page: Page,
-  snippet: string
+  snippet: string,
 ): Promise<Locator | null> {
   const postCandidates = [
     page
       .locator("article, .feed-shared-update-v2, .occludable-update")
       .filter({ hasText: snippet }),
-    page.getByText(snippet).locator("xpath=ancestor-or-self::*[self::article or contains(@class, 'feed-shared-update-v2') or contains(@class, 'occludable-update')]")
+    page
+      .getByText(snippet)
+      .locator(
+        "xpath=ancestor-or-self::*[self::article or contains(@class, 'feed-shared-update-v2') or contains(@class, 'occludable-update')]",
+      ),
   ];
 
   for (const candidate of postCandidates) {
@@ -3115,14 +3210,16 @@ async function findVisiblePostBySnippet(
 
 async function extractPublishedPostUrl(
   page: Page,
-  postRoot: Locator | null
+  postRoot: Locator | null,
 ): Promise<string | null> {
   if (!postRoot) {
     return null;
   }
 
   const href = await postRoot
-    .locator("a[href*='/feed/update/'], a[href*='/posts/'], a[href*='/activity/']")
+    .locator(
+      "a[href*='/feed/update/'], a[href*='/posts/'], a[href*='/activity/']",
+    )
     .first()
     .getAttribute("href")
     .catch(() => null);
@@ -3143,7 +3240,7 @@ type PublishedPostVerificationSurface = "feed" | "profile_activity";
 async function locatePublishedPostOnSurface(
   page: Page,
   snippet: string,
-  surface: PublishedPostVerificationSurface
+  surface: PublishedPostVerificationSurface,
 ): Promise<Locator | null> {
   if (surface === "feed") {
     if (!page.url().startsWith(LINKEDIN_FEED_URL)) {
@@ -3156,7 +3253,7 @@ async function locatePublishedPostOnSurface(
   }
 
   await page.goto(LINKEDIN_PROFILE_ACTIVITY_URL, {
-    waitUntil: "domcontentloaded"
+    waitUntil: "domcontentloaded",
   });
   await waitForNetworkIdleBestEffort(page);
   await scrollLinkedInPageToTop(page);
@@ -3167,7 +3264,7 @@ async function locatePublishedPostOnSurface(
 export async function verifyPublishedPost(
   page: Page,
   text: string,
-  artifactPaths: string[]
+  artifactPaths: string[],
 ): Promise<{
   verified: true;
   postUrl: string | null;
@@ -3177,13 +3274,13 @@ export async function verifyPublishedPost(
   if (!snippet) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "Cannot verify a post with empty text content."
+      "Cannot verify a post with empty text content.",
     );
   }
 
   const surfaces: readonly PublishedPostVerificationSurface[] = [
     "feed",
-    "profile_activity"
+    "profile_activity",
   ];
   let locatedSurface: PublishedPostVerificationSurface | null = null;
   let postRoot: Locator | null = null;
@@ -3198,7 +3295,11 @@ export async function verifyPublishedPost(
   if (!postRoot) {
     const verified = await waitForCondition(async () => {
       for (const surface of surfaces) {
-        const located = await locatePublishedPostOnSurface(page, snippet, surface);
+        const located = await locatePublishedPostOnSurface(
+          page,
+          snippet,
+          surface,
+        );
         if (located) {
           postRoot = located;
           locatedSurface = surface;
@@ -3217,8 +3318,8 @@ export async function verifyPublishedPost(
           current_url: page.url(),
           verification_snippet: snippet,
           artifact_paths: artifactPaths,
-          verification_urls: [LINKEDIN_FEED_URL, LINKEDIN_PROFILE_ACTIVITY_URL]
-        }
+          verification_urls: [LINKEDIN_FEED_URL, LINKEDIN_PROFILE_ACTIVITY_URL],
+        },
       );
     }
   }
@@ -3226,7 +3327,7 @@ export async function verifyPublishedPost(
   return {
     verified: true,
     postUrl: await extractPublishedPostUrl(page, postRoot),
-    surface: locatedSurface ?? "feed"
+    surface: locatedSurface ?? "feed",
   };
 }
 
@@ -3234,21 +3335,24 @@ export class LinkedInPostsService {
   constructor(private readonly runtime: LinkedInPostsRuntime) {}
 
   async prepareCreate(
-    input: PrepareCreatePostInput
+    input: PrepareCreatePostInput,
   ): Promise<PreparedActionResult> {
     const profileName = input.profileName ?? "default";
     const lintResult = await lintLinkedInPostContent(
       input.text,
-      this.runtime.postSafetyLint
+      this.runtime.postSafetyLint,
     );
     const validatedText = lintResult.validatedText;
-    const visibility = normalizeLinkedInPostVisibility(input.visibility, "public");
+    const visibility = normalizeLinkedInPostVisibility(
+      input.visibility,
+      "public",
+    );
     const tracePath = `linkedin/trace-post-prepare-${Date.now()}.zip`;
     const artifactPaths: string[] = [tracePath];
 
     await this.runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: this.runtime.cdpUrl
+      cdpUrl: this.runtime.cdpUrl,
     });
 
     try {
@@ -3256,7 +3360,7 @@ export class LinkedInPostsService {
         {
           cdpUrl: this.runtime.cdpUrl,
           profileName,
-          headless: true
+          headless: true,
         },
         async (context) => {
           const page = await getOrCreatePage(context);
@@ -3266,48 +3370,53 @@ export class LinkedInPostsService {
             await context.tracing.start({
               screenshots: true,
               snapshots: true,
-              sources: true
+              sources: true,
             });
             tracingStarted = true;
 
-            const { composerRoot, triggerKey, rootKey } = await openPostComposer(
-              page,
-              this.runtime.selectorLocale,
-              artifactPaths
-            );
+            const { composerRoot, triggerKey, rootKey } =
+              await openPostComposer(
+                page,
+                this.runtime.selectorLocale,
+                artifactPaths,
+              );
 
             const screenshotPath = `linkedin/screenshot-post-prepare-${Date.now()}.png`;
-            await captureScreenshotArtifact(this.runtime, page, screenshotPath, {
-              action: "prepare_create_post",
-              profile_name: profileName,
-              visibility,
-              trigger_selector_key: triggerKey,
-              composer_selector_key: rootKey
-            });
+            await captureScreenshotArtifact(
+              this.runtime,
+              page,
+              screenshotPath,
+              {
+                action: "prepare_create_post",
+                profile_name: profileName,
+                visibility,
+                trigger_selector_key: triggerKey,
+                composer_selector_key: rootKey,
+              },
+            );
             artifactPaths.push(screenshotPath);
 
             await closeComposerBestEffort(
               page,
               composerRoot,
-              this.runtime.selectorLocale
+              this.runtime.selectorLocale,
             );
 
-            const rateLimitState = this.runtime.rateLimiter.peek(
-              CREATE_POST_RATE_LIMIT_CONFIG
-            );
+            const rateLimitState: RateLimiterState =
+              this.runtime.rateLimiter.peek(CREATE_POST_RATE_LIMIT_CONFIG);
 
             const target = {
               profile_name: profileName,
               visibility,
               visibility_label: LINKEDIN_POST_VISIBILITY_MAP[visibility].label,
-              compose_url: LINKEDIN_FEED_URL
+              compose_url: LINKEDIN_FEED_URL,
             };
 
             const preview = {
               summary: `Create ${LINKEDIN_POST_VISIBILITY_MAP[visibility].label.toLowerCase()} LinkedIn post`,
               target,
               outbound: {
-                text: validatedText.normalizedText
+                text: validatedText.normalizedText,
               },
               validation: {
                 character_count: validatedText.characterCount,
@@ -3320,17 +3429,18 @@ export class LinkedInPostsService {
                 contains_hashtag: validatedText.containsHashtag,
                 checked_url_count: lintResult.urls.length,
                 checked_urls: lintResult.urls,
-                banned_phrase_count: this.runtime.postSafetyLint.bannedPhrases.length,
+                banned_phrase_count:
+                  this.runtime.postSafetyLint.bannedPhrases.length,
                 link_preview_validation_enabled:
                   this.runtime.postSafetyLint.validateLinkPreviews,
                 link_preview_validation_timeout_ms:
-                  this.runtime.postSafetyLint.linkPreviewValidationTimeoutMs
+                  this.runtime.postSafetyLint.linkPreviewValidationTimeoutMs,
               },
               artifacts: artifactPaths.map((path) => ({
                 type: path.endsWith(".zip") ? "trace" : "screenshot",
-                path
+                path,
               })),
-              rate_limit: formatRateLimitState(rateLimitState)
+              rate_limit: formatRateLimitState(rateLimitState),
             } satisfies Record<string, unknown>;
 
             return this.runtime.twoPhaseCommit.prepare({
@@ -3338,78 +3448,102 @@ export class LinkedInPostsService {
               target,
               payload: {
                 text: validatedText.normalizedText,
-                visibility
+                visibility,
               },
               preview,
-              ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+              ...(input.operatorNote
+                ? { operatorNote: input.operatorNote }
+                : {}),
             });
           } catch (error) {
             const failureScreenshot = `linkedin/screenshot-post-prepare-error-${Date.now()}.png`;
             try {
-              await captureScreenshotArtifact(this.runtime, page, failureScreenshot, {
-                action: "prepare_create_post_error",
-                profile_name: profileName,
-                visibility
-              });
+              await captureScreenshotArtifact(
+                this.runtime,
+                page,
+                failureScreenshot,
+                {
+                  action: "prepare_create_post_error",
+                  profile_name: profileName,
+                  visibility,
+                },
+              );
               artifactPaths.push(failureScreenshot);
             } catch {
               // Best effort.
             }
 
-            throw toAutomationError(error, "Failed to prepare LinkedIn post creation.", {
-              profile_name: profileName,
-              current_url: page.url(),
-              requested_visibility: visibility,
-              artifact_paths: artifactPaths
-            });
+            throw toAutomationError(
+              error,
+              "Failed to prepare LinkedIn post creation.",
+              {
+                profile_name: profileName,
+                current_url: page.url(),
+                requested_visibility: visibility,
+                artifact_paths: artifactPaths,
+              },
+            );
           } finally {
             if (tracingStarted) {
               try {
-                const absoluteTracePath = this.runtime.artifacts.resolve(tracePath);
+                const absoluteTracePath =
+                  this.runtime.artifacts.resolve(tracePath);
                 await context.tracing.stop({ path: absoluteTracePath });
                 registerTraceArtifact(this.runtime, tracePath, {
                   action: "prepare_create_post",
                   profile_name: profileName,
-                  visibility
+                  visibility,
                 });
               } catch (error) {
-                this.runtime.logger.log("warn", "linkedin.post.prepare.trace.stop_failed", {
-                  profile_name: profileName,
-                  message: error instanceof Error ? error.message : String(error)
-                });
+                this.runtime.logger.log(
+                  "warn",
+                  "linkedin.post.prepare.trace.stop_failed",
+                  {
+                    profile_name: profileName,
+                    message:
+                      error instanceof Error ? error.message : String(error),
+                  },
+                );
               }
             }
           }
-        }
+        },
       );
 
       return prepared;
     } catch (error) {
-      throw toAutomationError(error, "Failed to prepare LinkedIn post creation.", {
-        profile_name: profileName,
-        requested_visibility: visibility,
-        artifact_paths: artifactPaths
-      });
+      throw toAutomationError(
+        error,
+        "Failed to prepare LinkedIn post creation.",
+        {
+          profile_name: profileName,
+          requested_visibility: visibility,
+          artifact_paths: artifactPaths,
+        },
+      );
     }
   }
 
   async prepareCreateMedia(
-    input: PrepareCreateMediaPostInput
+    input: PrepareCreateMediaPostInput,
   ): Promise<PreparedActionResult> {
     const profileName = input.profileName ?? "default";
     const lintResult = await lintLinkedInPostContent(
       input.text,
-      this.runtime.postSafetyLint
+      this.runtime.postSafetyLint,
     );
     const validatedText = lintResult.validatedText;
     const attachments = validateLinkedInPostMediaAttachments(input.mediaPaths);
-    const visibility = normalizeLinkedInPostVisibility(input.visibility, "public");
+    const visibility = normalizeLinkedInPostVisibility(
+      input.visibility,
+      "public",
+    );
     const tracePath = `linkedin/trace-post-media-prepare-${Date.now()}.zip`;
     const artifactPaths: string[] = [tracePath];
 
     await this.runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: this.runtime.cdpUrl
+      cdpUrl: this.runtime.cdpUrl,
     });
 
     try {
@@ -3417,7 +3551,7 @@ export class LinkedInPostsService {
         {
           cdpUrl: this.runtime.cdpUrl,
           profileName,
-          headless: true
+          headless: true,
         },
         async (context) => {
           const page = await getOrCreatePage(context);
@@ -3427,23 +3561,24 @@ export class LinkedInPostsService {
             await context.tracing.start({
               screenshots: true,
               snapshots: true,
-              sources: true
+              sources: true,
             });
             tracingStarted = true;
 
-            const { composerRoot, triggerKey, rootKey } = await openPostComposer(
-              page,
-              this.runtime.selectorLocale,
-              artifactPaths
-            );
+            const { composerRoot, triggerKey, rootKey } =
+              await openPostComposer(
+                page,
+                this.runtime.selectorLocale,
+                artifactPaths,
+              );
             const mediaSurface =
               (await findPresentScopedLocator(
                 composerRoot,
-                createMediaInputCandidates()
+                createMediaInputCandidates(),
               )) ??
               (await findOptionalScopedLocator(
                 composerRoot,
-                createMediaButtonCandidates(this.runtime.selectorLocale)
+                createMediaButtonCandidates(this.runtime.selectorLocale),
               ));
 
             if (!mediaSurface) {
@@ -3452,37 +3587,41 @@ export class LinkedInPostsService {
                 "Could not locate LinkedIn media controls in the post composer.",
                 {
                   current_url: page.url(),
-                  artifact_paths: artifactPaths
-                }
+                  artifact_paths: artifactPaths,
+                },
               );
             }
 
             const screenshotPath = `linkedin/screenshot-post-media-prepare-${Date.now()}.png`;
-            await captureScreenshotArtifact(this.runtime, page, screenshotPath, {
-              action: "prepare_create_media_post",
-              profile_name: profileName,
-              visibility,
-              trigger_selector_key: triggerKey,
-              composer_selector_key: rootKey,
-              media_surface_selector_key: mediaSurface.key
-            });
+            await captureScreenshotArtifact(
+              this.runtime,
+              page,
+              screenshotPath,
+              {
+                action: "prepare_create_media_post",
+                profile_name: profileName,
+                visibility,
+                trigger_selector_key: triggerKey,
+                composer_selector_key: rootKey,
+                media_surface_selector_key: mediaSurface.key,
+              },
+            );
             artifactPaths.push(screenshotPath);
 
             await closeComposerBestEffort(
               page,
               composerRoot,
-              this.runtime.selectorLocale
+              this.runtime.selectorLocale,
             );
 
-            const rateLimitState = this.runtime.rateLimiter.peek(
-              CREATE_POST_RATE_LIMIT_CONFIG
-            );
+            const rateLimitState: RateLimiterState =
+              this.runtime.rateLimiter.peek(CREATE_POST_RATE_LIMIT_CONFIG);
 
             const target = {
               profile_name: profileName,
               visibility,
               visibility_label: LINKEDIN_POST_VISIBILITY_MAP[visibility].label,
-              compose_url: LINKEDIN_FEED_URL
+              compose_url: LINKEDIN_FEED_URL,
             };
 
             const preview = {
@@ -3494,8 +3633,8 @@ export class LinkedInPostsService {
                   path: attachment.path,
                   file_name: attachment.fileName,
                   kind: attachment.kind,
-                  size_bytes: attachment.sizeBytes
-                }))
+                  size_bytes: attachment.sizeBytes,
+                })),
               },
               validation: {
                 character_count: validatedText.characterCount,
@@ -3508,19 +3647,20 @@ export class LinkedInPostsService {
                 contains_hashtag: validatedText.containsHashtag,
                 checked_url_count: lintResult.urls.length,
                 checked_urls: lintResult.urls,
-                banned_phrase_count: this.runtime.postSafetyLint.bannedPhrases.length,
+                banned_phrase_count:
+                  this.runtime.postSafetyLint.bannedPhrases.length,
                 link_preview_validation_enabled:
                   this.runtime.postSafetyLint.validateLinkPreviews,
                 link_preview_validation_timeout_ms:
                   this.runtime.postSafetyLint.linkPreviewValidationTimeoutMs,
                 media_count: attachments.length,
-                media_kind: attachments[0]?.kind ?? null
+                media_kind: attachments[0]?.kind ?? null,
               },
               artifacts: artifactPaths.map((path) => ({
                 type: path.endsWith(".zip") ? "trace" : "screenshot",
-                path
+                path,
               })),
-              rate_limit: formatRateLimitState(rateLimitState)
+              rate_limit: formatRateLimitState(rateLimitState),
             } satisfies Record<string, unknown>;
 
             return this.runtime.twoPhaseCommit.prepare({
@@ -3529,19 +3669,28 @@ export class LinkedInPostsService {
               payload: {
                 text: validatedText.normalizedText,
                 visibility,
-                media_paths: attachments.map((attachment) => attachment.absolutePath)
+                media_paths: attachments.map(
+                  (attachment) => attachment.absolutePath,
+                ),
               },
               preview,
-              ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+              ...(input.operatorNote
+                ? { operatorNote: input.operatorNote }
+                : {}),
             });
           } catch (error) {
             const failureScreenshot = `linkedin/screenshot-post-media-prepare-error-${Date.now()}.png`;
             try {
-              await captureScreenshotArtifact(this.runtime, page, failureScreenshot, {
-                action: "prepare_create_media_post_error",
-                profile_name: profileName,
-                visibility
-              });
+              await captureScreenshotArtifact(
+                this.runtime,
+                page,
+                failureScreenshot,
+                {
+                  action: "prepare_create_media_post_error",
+                  profile_name: profileName,
+                  visibility,
+                },
+              );
               artifactPaths.push(failureScreenshot);
             } catch {
               // Best effort.
@@ -3554,18 +3703,19 @@ export class LinkedInPostsService {
                 profile_name: profileName,
                 current_url: page.url(),
                 requested_visibility: visibility,
-                artifact_paths: artifactPaths
-              }
+                artifact_paths: artifactPaths,
+              },
             );
           } finally {
             if (tracingStarted) {
               try {
-                const absoluteTracePath = this.runtime.artifacts.resolve(tracePath);
+                const absoluteTracePath =
+                  this.runtime.artifacts.resolve(tracePath);
                 await context.tracing.stop({ path: absoluteTracePath });
                 registerTraceArtifact(this.runtime, tracePath, {
                   action: "prepare_create_media_post",
                   profile_name: profileName,
-                  visibility
+                  visibility,
                 });
               } catch (error) {
                 this.runtime.logger.log(
@@ -3573,13 +3723,14 @@ export class LinkedInPostsService {
                   "linkedin.post.prepare_media.trace.stop_failed",
                   {
                     profile_name: profileName,
-                    message: error instanceof Error ? error.message : String(error)
-                  }
+                    message:
+                      error instanceof Error ? error.message : String(error),
+                  },
                 );
               }
             }
           }
-        }
+        },
       );
 
       return prepared;
@@ -3590,30 +3741,33 @@ export class LinkedInPostsService {
         {
           profile_name: profileName,
           requested_visibility: visibility,
-          artifact_paths: artifactPaths
-        }
+          artifact_paths: artifactPaths,
+        },
       );
     }
   }
 
   async prepareCreatePoll(
-    input: PrepareCreatePollPostInput
+    input: PrepareCreatePollPostInput,
   ): Promise<PreparedActionResult> {
     const profileName = input.profileName ?? "default";
     const lintResult = await lintOptionalLinkedInPostContent(
       input.text,
-      this.runtime.postSafetyLint
+      this.runtime.postSafetyLint,
     );
     const question = normalizePollQuestion(input.question);
     const options = normalizePollOptions(input.options);
     const durationDays = normalizePollDurationDays(input.durationDays);
-    const visibility = normalizeLinkedInPostVisibility(input.visibility, "public");
+    const visibility = normalizeLinkedInPostVisibility(
+      input.visibility,
+      "public",
+    );
     const tracePath = `linkedin/trace-post-poll-prepare-${Date.now()}.zip`;
     const artifactPaths: string[] = [tracePath];
 
     await this.runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: this.runtime.cdpUrl
+      cdpUrl: this.runtime.cdpUrl,
     });
 
     try {
@@ -3621,7 +3775,7 @@ export class LinkedInPostsService {
         {
           cdpUrl: this.runtime.cdpUrl,
           profileName,
-          headless: true
+          headless: true,
         },
         async (context) => {
           const page = await getOrCreatePage(context);
@@ -3631,48 +3785,53 @@ export class LinkedInPostsService {
             await context.tracing.start({
               screenshots: true,
               snapshots: true,
-              sources: true
+              sources: true,
             });
             tracingStarted = true;
 
-            const { composerRoot, triggerKey, rootKey } = await openPostComposer(
-              page,
-              this.runtime.selectorLocale,
-              artifactPaths
-            );
+            const { composerRoot, triggerKey, rootKey } =
+              await openPostComposer(
+                page,
+                this.runtime.selectorLocale,
+                artifactPaths,
+              );
             const pollButton = await findVisibleScopedLocatorOrThrow(
               composerRoot,
               createPollButtonCandidates(this.runtime.selectorLocale),
               "post_poll_button",
               artifactPaths,
-              page.url()
+              page.url(),
             );
 
             const screenshotPath = `linkedin/screenshot-post-poll-prepare-${Date.now()}.png`;
-            await captureScreenshotArtifact(this.runtime, page, screenshotPath, {
-              action: "prepare_create_poll_post",
-              profile_name: profileName,
-              visibility,
-              trigger_selector_key: triggerKey,
-              composer_selector_key: rootKey,
-              poll_button_selector_key: pollButton.key
-            });
+            await captureScreenshotArtifact(
+              this.runtime,
+              page,
+              screenshotPath,
+              {
+                action: "prepare_create_poll_post",
+                profile_name: profileName,
+                visibility,
+                trigger_selector_key: triggerKey,
+                composer_selector_key: rootKey,
+                poll_button_selector_key: pollButton.key,
+              },
+            );
             artifactPaths.push(screenshotPath);
 
             await closeComposerBestEffort(
               page,
               composerRoot,
-              this.runtime.selectorLocale
+              this.runtime.selectorLocale,
             );
 
-            const rateLimitState = this.runtime.rateLimiter.peek(
-              CREATE_POST_RATE_LIMIT_CONFIG
-            );
+            const rateLimitState: RateLimiterState =
+              this.runtime.rateLimiter.peek(CREATE_POST_RATE_LIMIT_CONFIG);
             const target = {
               profile_name: profileName,
               visibility,
               visibility_label: LINKEDIN_POST_VISIBILITY_MAP[visibility].label,
-              compose_url: LINKEDIN_FEED_URL
+              compose_url: LINKEDIN_FEED_URL,
             };
 
             const preview = {
@@ -3684,7 +3843,7 @@ export class LinkedInPostsService {
                   : {}),
                 question,
                 options,
-                duration_days: durationDays
+                duration_days: durationDays,
               },
               validation: {
                 text_provided: lintResult !== null,
@@ -3694,50 +3853,62 @@ export class LinkedInPostsService {
                       line_count: lintResult.validatedText.lineCount,
                       paragraph_count: lintResult.validatedText.paragraphCount,
                       contains_url: lintResult.validatedText.containsUrl,
-                      contains_mention: lintResult.validatedText.containsMention,
-                      contains_hashtag: lintResult.validatedText.containsHashtag,
+                      contains_mention:
+                        lintResult.validatedText.containsMention,
+                      contains_hashtag:
+                        lintResult.validatedText.containsHashtag,
                       checked_url_count: lintResult.urls.length,
-                      checked_urls: lintResult.urls
+                      checked_urls: lintResult.urls,
                     }
                   : {}),
                 max_length: this.runtime.postSafetyLint.maxLength,
                 linkedin_max_length: LINKEDIN_POST_MAX_LENGTH,
-                banned_phrase_count: this.runtime.postSafetyLint.bannedPhrases.length,
+                banned_phrase_count:
+                  this.runtime.postSafetyLint.bannedPhrases.length,
                 link_preview_validation_enabled:
                   this.runtime.postSafetyLint.validateLinkPreviews,
                 link_preview_validation_timeout_ms:
                   this.runtime.postSafetyLint.linkPreviewValidationTimeoutMs,
                 poll_option_count: options.length,
-                poll_duration_days: durationDays
+                poll_duration_days: durationDays,
               },
               artifacts: artifactPaths.map((path) => ({
                 type: path.endsWith(".zip") ? "trace" : "screenshot",
-                path
+                path,
               })),
-              rate_limit: formatRateLimitState(rateLimitState)
+              rate_limit: formatRateLimitState(rateLimitState),
             } satisfies Record<string, unknown>;
 
             return this.runtime.twoPhaseCommit.prepare({
               actionType: CREATE_POLL_POST_ACTION_TYPE,
               target,
               payload: {
-                ...(lintResult ? { text: lintResult.validatedText.normalizedText } : {}),
+                ...(lintResult
+                  ? { text: lintResult.validatedText.normalizedText }
+                  : {}),
                 question,
                 options,
                 duration_days: durationDays,
-                visibility
+                visibility,
               },
               preview,
-              ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+              ...(input.operatorNote
+                ? { operatorNote: input.operatorNote }
+                : {}),
             });
           } catch (error) {
             const failureScreenshot = `linkedin/screenshot-post-poll-prepare-error-${Date.now()}.png`;
             try {
-              await captureScreenshotArtifact(this.runtime, page, failureScreenshot, {
-                action: "prepare_create_poll_post_error",
-                profile_name: profileName,
-                visibility
-              });
+              await captureScreenshotArtifact(
+                this.runtime,
+                page,
+                failureScreenshot,
+                {
+                  action: "prepare_create_poll_post_error",
+                  profile_name: profileName,
+                  visibility,
+                },
+              );
               artifactPaths.push(failureScreenshot);
             } catch {
               // Best effort.
@@ -3750,18 +3921,19 @@ export class LinkedInPostsService {
                 profile_name: profileName,
                 current_url: page.url(),
                 requested_visibility: visibility,
-                artifact_paths: artifactPaths
-              }
+                artifact_paths: artifactPaths,
+              },
             );
           } finally {
             if (tracingStarted) {
               try {
-                const absoluteTracePath = this.runtime.artifacts.resolve(tracePath);
+                const absoluteTracePath =
+                  this.runtime.artifacts.resolve(tracePath);
                 await context.tracing.stop({ path: absoluteTracePath });
                 registerTraceArtifact(this.runtime, tracePath, {
                   action: "prepare_create_poll_post",
                   profile_name: profileName,
-                  visibility
+                  visibility,
                 });
               } catch (error) {
                 this.runtime.logger.log(
@@ -3769,13 +3941,14 @@ export class LinkedInPostsService {
                   "linkedin.post.prepare_poll.trace.stop_failed",
                   {
                     profile_name: profileName,
-                    message: error instanceof Error ? error.message : String(error)
-                  }
+                    message:
+                      error instanceof Error ? error.message : String(error),
+                  },
                 );
               }
             }
           }
-        }
+        },
       );
 
       return prepared;
@@ -3786,18 +3959,20 @@ export class LinkedInPostsService {
         {
           profile_name: profileName,
           requested_visibility: visibility,
-          artifact_paths: artifactPaths
-        }
+          artifact_paths: artifactPaths,
+        },
       );
     }
   }
 
-  async prepareEdit(input: PrepareEditPostInput): Promise<PreparedActionResult> {
+  async prepareEdit(
+    input: PrepareEditPostInput,
+  ): Promise<PreparedActionResult> {
     const profileName = input.profileName ?? "default";
     const postUrl = resolvePostUrl(input.postUrl);
     const lintResult = await lintLinkedInPostContent(
       input.text,
-      this.runtime.postSafetyLint
+      this.runtime.postSafetyLint,
     );
     const validatedText = lintResult.validatedText;
     const tracePath = `linkedin/trace-post-edit-prepare-${Date.now()}.zip`;
@@ -3805,7 +3980,7 @@ export class LinkedInPostsService {
 
     await this.runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: this.runtime.cdpUrl
+      cdpUrl: this.runtime.cdpUrl,
     });
 
     try {
@@ -3813,7 +3988,7 @@ export class LinkedInPostsService {
         {
           cdpUrl: this.runtime.cdpUrl,
           profileName,
-          headless: true
+          headless: true,
         },
         async (context) => {
           const page = await getOrCreatePage(context);
@@ -3823,57 +3998,67 @@ export class LinkedInPostsService {
             await context.tracing.start({
               screenshots: true,
               snapshots: true,
-              sources: true
+              sources: true,
             });
             tracingStarted = true;
 
             await page.goto(postUrl, { waitUntil: "domcontentloaded" });
             await waitForNetworkIdleBestEffort(page);
 
-            const targetPost = await findTargetPostLocator(page, postUrl, artifactPaths);
-            const currentSnippet = await extractPostSnippetFromLocator(targetPost.locator);
+            const targetPost = await findTargetPostLocator(
+              page,
+              postUrl,
+              artifactPaths,
+            );
+            const currentSnippet = await extractPostSnippetFromLocator(
+              targetPost.locator,
+            );
             const menuButtonKey = await openTargetPostActionMenu(
               page,
               targetPost,
               this.runtime.selectorLocale,
-              artifactPaths
+              artifactPaths,
             );
             const editAction = await findVisibleLocatorOrThrow(
               page,
               createPostMenuActionCandidates(
                 getPostUiActionLabels("edit", this.runtime.selectorLocale),
-                "post-edit"
+                "post-edit",
               ),
               "post_edit_menu_item",
-              artifactPaths
+              artifactPaths,
             );
 
             const screenshotPath = `linkedin/screenshot-post-edit-prepare-${Date.now()}.png`;
-            await captureScreenshotArtifact(this.runtime, page, screenshotPath, {
-              action: "prepare_edit_post",
-              profile_name: profileName,
-              post_url: postUrl,
-              target_post_selector_key: targetPost.key,
-              menu_button_selector_key: menuButtonKey,
-              edit_selector_key: editAction.key
-            });
+            await captureScreenshotArtifact(
+              this.runtime,
+              page,
+              screenshotPath,
+              {
+                action: "prepare_edit_post",
+                profile_name: profileName,
+                post_url: postUrl,
+                target_post_selector_key: targetPost.key,
+                menu_button_selector_key: menuButtonKey,
+                edit_selector_key: editAction.key,
+              },
+            );
             artifactPaths.push(screenshotPath);
             await page.keyboard.press("Escape").catch(() => undefined);
 
-            const rateLimitState = this.runtime.rateLimiter.peek(
-              EDIT_POST_RATE_LIMIT_CONFIG
-            );
+            const rateLimitState: RateLimiterState =
+              this.runtime.rateLimiter.peek(EDIT_POST_RATE_LIMIT_CONFIG);
             const target = {
               profile_name: profileName,
               post_url: postUrl,
-              current_verification_snippet: currentSnippet
+              current_verification_snippet: currentSnippet,
             };
 
             const preview = {
               summary: `Edit LinkedIn post ${postUrl}`,
               target,
               outbound: {
-                text: validatedText.normalizedText
+                text: validatedText.normalizedText,
               },
               validation: {
                 character_count: validatedText.characterCount,
@@ -3886,17 +4071,18 @@ export class LinkedInPostsService {
                 contains_hashtag: validatedText.containsHashtag,
                 checked_url_count: lintResult.urls.length,
                 checked_urls: lintResult.urls,
-                banned_phrase_count: this.runtime.postSafetyLint.bannedPhrases.length,
+                banned_phrase_count:
+                  this.runtime.postSafetyLint.bannedPhrases.length,
                 link_preview_validation_enabled:
                   this.runtime.postSafetyLint.validateLinkPreviews,
                 link_preview_validation_timeout_ms:
-                  this.runtime.postSafetyLint.linkPreviewValidationTimeoutMs
+                  this.runtime.postSafetyLint.linkPreviewValidationTimeoutMs,
               },
               artifacts: artifactPaths.map((path) => ({
                 type: path.endsWith(".zip") ? "trace" : "screenshot",
-                path
+                path,
               })),
-              rate_limit: formatRateLimitState(rateLimitState)
+              rate_limit: formatRateLimitState(rateLimitState),
             } satisfies Record<string, unknown>;
 
             return this.runtime.twoPhaseCommit.prepare({
@@ -3904,39 +4090,51 @@ export class LinkedInPostsService {
               target,
               payload: {
                 post_url: postUrl,
-                text: validatedText.normalizedText
+                text: validatedText.normalizedText,
               },
               preview,
-              ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+              ...(input.operatorNote
+                ? { operatorNote: input.operatorNote }
+                : {}),
             });
           } catch (error) {
             const failureScreenshot = `linkedin/screenshot-post-edit-prepare-error-${Date.now()}.png`;
             try {
-              await captureScreenshotArtifact(this.runtime, page, failureScreenshot, {
-                action: "prepare_edit_post_error",
-                profile_name: profileName,
-                post_url: postUrl
-              });
+              await captureScreenshotArtifact(
+                this.runtime,
+                page,
+                failureScreenshot,
+                {
+                  action: "prepare_edit_post_error",
+                  profile_name: profileName,
+                  post_url: postUrl,
+                },
+              );
               artifactPaths.push(failureScreenshot);
             } catch {
               // Best effort.
             }
 
-            throw toAutomationError(error, "Failed to prepare LinkedIn post edit.", {
-              profile_name: profileName,
-              current_url: page.url(),
-              post_url: postUrl,
-              artifact_paths: artifactPaths
-            });
+            throw toAutomationError(
+              error,
+              "Failed to prepare LinkedIn post edit.",
+              {
+                profile_name: profileName,
+                current_url: page.url(),
+                post_url: postUrl,
+                artifact_paths: artifactPaths,
+              },
+            );
           } finally {
             if (tracingStarted) {
               try {
-                const absoluteTracePath = this.runtime.artifacts.resolve(tracePath);
+                const absoluteTracePath =
+                  this.runtime.artifacts.resolve(tracePath);
                 await context.tracing.stop({ path: absoluteTracePath });
                 registerTraceArtifact(this.runtime, tracePath, {
                   action: "prepare_edit_post",
                   profile_name: profileName,
-                  post_url: postUrl
+                  post_url: postUrl,
                 });
               } catch (error) {
                 this.runtime.logger.log(
@@ -3944,13 +4142,14 @@ export class LinkedInPostsService {
                   "linkedin.post.prepare_edit.trace.stop_failed",
                   {
                     profile_name: profileName,
-                    message: error instanceof Error ? error.message : String(error)
-                  }
+                    message:
+                      error instanceof Error ? error.message : String(error),
+                  },
                 );
               }
             }
           }
-        }
+        },
       );
 
       return prepared;
@@ -3958,13 +4157,13 @@ export class LinkedInPostsService {
       throw toAutomationError(error, "Failed to prepare LinkedIn post edit.", {
         profile_name: profileName,
         post_url: postUrl,
-        artifact_paths: artifactPaths
+        artifact_paths: artifactPaths,
       });
     }
   }
 
   async prepareDelete(
-    input: PrepareDeletePostInput
+    input: PrepareDeletePostInput,
   ): Promise<PreparedActionResult> {
     const profileName = input.profileName ?? "default";
     const postUrl = resolvePostUrl(input.postUrl);
@@ -3973,7 +4172,7 @@ export class LinkedInPostsService {
 
     await this.runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: this.runtime.cdpUrl
+      cdpUrl: this.runtime.cdpUrl,
     });
 
     try {
@@ -3981,7 +4180,7 @@ export class LinkedInPostsService {
         {
           cdpUrl: this.runtime.cdpUrl,
           profileName,
-          headless: true
+          headless: true,
         },
         async (context) => {
           const page = await getOrCreatePage(context);
@@ -3991,105 +4190,127 @@ export class LinkedInPostsService {
             await context.tracing.start({
               screenshots: true,
               snapshots: true,
-              sources: true
+              sources: true,
             });
             tracingStarted = true;
 
             await page.goto(postUrl, { waitUntil: "domcontentloaded" });
             await waitForNetworkIdleBestEffort(page);
 
-            const targetPost = await findTargetPostLocator(page, postUrl, artifactPaths);
-            const currentSnippet = await extractPostSnippetFromLocator(targetPost.locator);
+            const targetPost = await findTargetPostLocator(
+              page,
+              postUrl,
+              artifactPaths,
+            );
+            const currentSnippet = await extractPostSnippetFromLocator(
+              targetPost.locator,
+            );
             const menuButtonKey = await openTargetPostActionMenu(
               page,
               targetPost,
               this.runtime.selectorLocale,
-              artifactPaths
+              artifactPaths,
             );
             const deleteAction = await findVisibleLocatorOrThrow(
               page,
               createPostMenuActionCandidates(
                 getPostUiActionLabels("delete", this.runtime.selectorLocale),
-                "post-delete"
+                "post-delete",
               ),
               "post_delete_menu_item",
-              artifactPaths
+              artifactPaths,
             );
 
             const screenshotPath = `linkedin/screenshot-post-delete-prepare-${Date.now()}.png`;
-            await captureScreenshotArtifact(this.runtime, page, screenshotPath, {
-              action: "prepare_delete_post",
-              profile_name: profileName,
-              post_url: postUrl,
-              target_post_selector_key: targetPost.key,
-              menu_button_selector_key: menuButtonKey,
-              delete_selector_key: deleteAction.key
-            });
+            await captureScreenshotArtifact(
+              this.runtime,
+              page,
+              screenshotPath,
+              {
+                action: "prepare_delete_post",
+                profile_name: profileName,
+                post_url: postUrl,
+                target_post_selector_key: targetPost.key,
+                menu_button_selector_key: menuButtonKey,
+                delete_selector_key: deleteAction.key,
+              },
+            );
             artifactPaths.push(screenshotPath);
             await page.keyboard.press("Escape").catch(() => undefined);
 
-            const rateLimitState = this.runtime.rateLimiter.peek(
-              DELETE_POST_RATE_LIMIT_CONFIG
-            );
+            const rateLimitState: RateLimiterState =
+              this.runtime.rateLimiter.peek(DELETE_POST_RATE_LIMIT_CONFIG);
             const target = {
               profile_name: profileName,
               post_url: postUrl,
-              current_verification_snippet: currentSnippet
+              current_verification_snippet: currentSnippet,
             };
 
             const preview = {
               summary: `Delete LinkedIn post ${postUrl}`,
               target,
               outbound: {
-                destructive: true
+                destructive: true,
               },
               validation: {
-                destructive: true
+                destructive: true,
               },
               artifacts: artifactPaths.map((path) => ({
                 type: path.endsWith(".zip") ? "trace" : "screenshot",
-                path
+                path,
               })),
-              rate_limit: formatRateLimitState(rateLimitState)
+              rate_limit: formatRateLimitState(rateLimitState),
             } satisfies Record<string, unknown>;
 
             return this.runtime.twoPhaseCommit.prepare({
               actionType: DELETE_POST_ACTION_TYPE,
               target,
               payload: {
-                post_url: postUrl
+                post_url: postUrl,
               },
               preview,
-              ...(input.operatorNote ? { operatorNote: input.operatorNote } : {})
+              ...(input.operatorNote
+                ? { operatorNote: input.operatorNote }
+                : {}),
             });
           } catch (error) {
             const failureScreenshot = `linkedin/screenshot-post-delete-prepare-error-${Date.now()}.png`;
             try {
-              await captureScreenshotArtifact(this.runtime, page, failureScreenshot, {
-                action: "prepare_delete_post_error",
-                profile_name: profileName,
-                post_url: postUrl
-              });
+              await captureScreenshotArtifact(
+                this.runtime,
+                page,
+                failureScreenshot,
+                {
+                  action: "prepare_delete_post_error",
+                  profile_name: profileName,
+                  post_url: postUrl,
+                },
+              );
               artifactPaths.push(failureScreenshot);
             } catch {
               // Best effort.
             }
 
-            throw toAutomationError(error, "Failed to prepare LinkedIn post deletion.", {
-              profile_name: profileName,
-              current_url: page.url(),
-              post_url: postUrl,
-              artifact_paths: artifactPaths
-            });
+            throw toAutomationError(
+              error,
+              "Failed to prepare LinkedIn post deletion.",
+              {
+                profile_name: profileName,
+                current_url: page.url(),
+                post_url: postUrl,
+                artifact_paths: artifactPaths,
+              },
+            );
           } finally {
             if (tracingStarted) {
               try {
-                const absoluteTracePath = this.runtime.artifacts.resolve(tracePath);
+                const absoluteTracePath =
+                  this.runtime.artifacts.resolve(tracePath);
                 await context.tracing.stop({ path: absoluteTracePath });
                 registerTraceArtifact(this.runtime, tracePath, {
                   action: "prepare_delete_post",
                   profile_name: profileName,
-                  post_url: postUrl
+                  post_url: postUrl,
                 });
               } catch (error) {
                 this.runtime.logger.log(
@@ -4097,22 +4318,27 @@ export class LinkedInPostsService {
                   "linkedin.post.prepare_delete.trace.stop_failed",
                   {
                     profile_name: profileName,
-                    message: error instanceof Error ? error.message : String(error)
-                  }
+                    message:
+                      error instanceof Error ? error.message : String(error),
+                  },
                 );
               }
             }
           }
-        }
+        },
       );
 
       return prepared;
     } catch (error) {
-      throw toAutomationError(error, "Failed to prepare LinkedIn post deletion.", {
-        profile_name: profileName,
-        post_url: postUrl,
-        artifact_paths: artifactPaths
-      });
+      throw toAutomationError(
+        error,
+        "Failed to prepare LinkedIn post deletion.",
+        {
+          profile_name: profileName,
+          post_url: postUrl,
+          artifact_paths: artifactPaths,
+        },
+      );
     }
   }
 }
@@ -4121,7 +4347,7 @@ function getOptionalStringField(
   source: Record<string, unknown>,
   key: string,
   actionId: string,
-  location: "target" | "payload"
+  location: "target" | "payload",
 ): string | undefined {
   const value = source[key];
   if (value === undefined || value === null) {
@@ -4138,8 +4364,8 @@ function getOptionalStringField(
     {
       action_id: actionId,
       location,
-      key
-    }
+      key,
+    },
   );
 }
 
@@ -4147,7 +4373,7 @@ function getRequiredStringArrayField(
   source: Record<string, unknown>,
   key: string,
   actionId: string,
-  location: "target" | "payload"
+  location: "target" | "payload",
 ): string[] {
   const value = source[key];
   if (
@@ -4163,8 +4389,8 @@ function getRequiredStringArrayField(
     {
       action_id: actionId,
       location,
-      key
-    }
+      key,
+    },
   );
 }
 
@@ -4172,7 +4398,7 @@ function getRequiredIntegerField(
   source: Record<string, unknown>,
   key: string,
   actionId: string,
-  location: "target" | "payload"
+  location: "target" | "payload",
 ): number {
   const value = source[key];
   if (typeof value === "number" && Number.isInteger(value)) {
@@ -4185,38 +4411,46 @@ function getRequiredIntegerField(
     {
       action_id: actionId,
       location,
-      key
-    }
+      key,
+    },
   );
 }
 
-class CreatePostActionExecutor
-  implements ActionExecutor<LinkedInPostsExecutorRuntime>
-{
+class CreatePostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRuntime> {
   async execute(
-    input: ActionExecutorInput<LinkedInPostsExecutorRuntime>
+    input: ActionExecutorInput<LinkedInPostsExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
     const runtime = input.runtime;
     const action = input.action;
     const profileName = getProfileName(action.target);
-    const text = getRequiredStringField(action.payload, "text", action.id, "payload");
+    const text = getRequiredStringField(
+      action.payload,
+      "text",
+      action.id,
+      "payload",
+    );
     const visibility = normalizeLinkedInPostVisibility(
-      getRequiredStringField(action.payload, "visibility", action.id, "payload"),
-      "public"
+      getRequiredStringField(
+        action.payload,
+        "visibility",
+        action.id,
+        "payload",
+      ),
+      "public",
     );
     const tracePath = `linkedin/trace-post-confirm-${Date.now()}.zip`;
     const artifactPaths: string[] = [tracePath];
 
     await runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: runtime.cdpUrl
+      cdpUrl: runtime.cdpUrl,
     });
 
     return runtime.profileManager.runWithContext(
       {
         cdpUrl: runtime.cdpUrl,
         profileName,
-        headless: true
+        headless: true,
       },
       async (context) => {
         const page = await getOrCreatePage(context);
@@ -4226,44 +4460,38 @@ class CreatePostActionExecutor
           await context.tracing.start({
             screenshots: true,
             snapshots: true,
-            sources: true
+            sources: true,
           });
           tracingStarted = true;
 
-          const rateLimitState = runtime.rateLimiter.consume(
-            CREATE_POST_RATE_LIMIT_CONFIG
-          );
-          if (!rateLimitState.allowed) {
-            throw new LinkedInBuddyError(
-              "RATE_LIMITED",
-              "LinkedIn create_post confirm is rate limited for the current window.",
-              {
-                action_id: action.id,
-                profile_name: profileName,
-                requested_visibility: visibility,
-                rate_limit: formatRateLimitState(rateLimitState)
-              }
-            );
-          }
+          const rateLimitState = consumeRateLimitOrThrow(runtime.rateLimiter, {
+            config: CREATE_POST_RATE_LIMIT_CONFIG,
+            message: createConfirmRateLimitMessage(CREATE_POST_ACTION_TYPE),
+            details: {
+              action_id: action.id,
+              profile_name: profileName,
+              requested_visibility: visibility,
+            },
+          });
 
           const { composerRoot, triggerKey, rootKey } = await openPostComposer(
             page,
             runtime.selectorLocale,
-            artifactPaths
+            artifactPaths,
           );
           const visibilityKey = await setPostVisibility(
             page,
             composerRoot,
             runtime.selectorLocale,
             visibility,
-            artifactPaths
+            artifactPaths,
           );
           const inputKey = await setComposerText(
             page,
             composerRoot,
             runtime.selectorLocale,
             text,
-            artifactPaths
+            artifactPaths,
           );
 
           const prePublishScreenshot = `linkedin/screenshot-post-confirm-before-${Date.now()}.png`;
@@ -4274,7 +4502,7 @@ class CreatePostActionExecutor
             trigger_selector_key: triggerKey,
             composer_selector_key: rootKey,
             visibility_selector_key: visibilityKey,
-            input_selector_key: inputKey
+            input_selector_key: inputKey,
           });
           artifactPaths.push(prePublishScreenshot);
 
@@ -4283,7 +4511,7 @@ class CreatePostActionExecutor
             createPublishButtonCandidates(runtime.selectorLocale),
             "post_publish_button",
             artifactPaths,
-            page.url()
+            page.url(),
           );
           const publishEnabled = await waitForCondition(async () => {
             try {
@@ -4302,25 +4530,37 @@ class CreatePostActionExecutor
                 profile_name: profileName,
                 requested_visibility: visibility,
                 selector_key: publishButton.key,
-                artifact_paths: artifactPaths
-              }
+                artifact_paths: artifactPaths,
+              },
             );
           }
 
           await publishButton.locator.click({ timeout: 5_000 });
-          await waitForCondition(async () => !(await isAnyLocatorVisible(composerRoot)), 10_000);
+          await waitForCondition(
+            async () => !(await isAnyLocatorVisible(composerRoot)),
+            10_000,
+          );
           await waitForNetworkIdleBestEffort(page, 10_000);
 
-          const verification = await verifyPublishedPost(page, text, artifactPaths);
+          const verification = await verifyPublishedPost(
+            page,
+            text,
+            artifactPaths,
+          );
 
           const postPublishScreenshot = `linkedin/screenshot-post-confirm-after-${Date.now()}.png`;
-          await captureScreenshotArtifact(runtime, page, postPublishScreenshot, {
-            action: CREATE_POST_ACTION_TYPE,
-            profile_name: profileName,
-            visibility,
-            published_post_url: verification.postUrl,
-            verification_surface: verification.surface
-          });
+          await captureScreenshotArtifact(
+            runtime,
+            page,
+            postPublishScreenshot,
+            {
+              action: CREATE_POST_ACTION_TYPE,
+              profile_name: profileName,
+              visibility,
+              published_post_url: verification.postUrl,
+              verification_surface: verification.surface,
+            },
+          );
           artifactPaths.push(postPublishScreenshot);
 
           return {
@@ -4331,9 +4571,9 @@ class CreatePostActionExecutor
               verification_snippet: createVerificationSnippet(text),
               published_post_url: verification.postUrl,
               verification_surface: verification.surface,
-              rate_limit: formatRateLimitState(rateLimitState)
+              rate_limit: formatRateLimitState(rateLimitState),
             },
-            artifacts: artifactPaths
+            artifacts: artifactPaths,
           };
         } catch (error) {
           const failureScreenshot = `linkedin/screenshot-post-confirm-error-${Date.now()}.png`;
@@ -4341,20 +4581,24 @@ class CreatePostActionExecutor
             await captureScreenshotArtifact(runtime, page, failureScreenshot, {
               action: `${CREATE_POST_ACTION_TYPE}_error`,
               profile_name: profileName,
-              visibility
+              visibility,
             });
             artifactPaths.push(failureScreenshot);
           } catch {
             // Best effort.
           }
 
-          throw toAutomationError(error, "Failed to execute LinkedIn create_post action.", {
-            action_id: action.id,
-            profile_name: profileName,
-            current_url: page.url(),
-            requested_visibility: visibility,
-            artifact_paths: artifactPaths
-          });
+          throw toAutomationError(
+            error,
+            "Failed to execute LinkedIn create_post action.",
+            {
+              action_id: action.id,
+              profile_name: profileName,
+              current_url: page.url(),
+              requested_visibility: visibility,
+              artifact_paths: artifactPaths,
+            },
+          );
         } finally {
           if (tracingStarted) {
             try {
@@ -4363,40 +4607,53 @@ class CreatePostActionExecutor
               registerTraceArtifact(runtime, tracePath, {
                 action: CREATE_POST_ACTION_TYPE,
                 profile_name: profileName,
-                visibility
+                visibility,
               });
             } catch (error) {
-              runtime.logger.log("warn", "linkedin.post.confirm.trace.stop_failed", {
-                action_id: action.id,
-                message: error instanceof Error ? error.message : String(error)
-              });
+              runtime.logger.log(
+                "warn",
+                "linkedin.post.confirm.trace.stop_failed",
+                {
+                  action_id: action.id,
+                  message:
+                    error instanceof Error ? error.message : String(error),
+                },
+              );
             }
           }
         }
-      }
+      },
     );
   }
 }
 
-class CreateMediaPostActionExecutor
-  implements ActionExecutor<LinkedInPostsExecutorRuntime>
-{
+class CreateMediaPostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRuntime> {
   async execute(
-    input: ActionExecutorInput<LinkedInPostsExecutorRuntime>
+    input: ActionExecutorInput<LinkedInPostsExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
     const runtime = input.runtime;
     const action = input.action;
     const profileName = getProfileName(action.target);
-    const text = getRequiredStringField(action.payload, "text", action.id, "payload");
+    const text = getRequiredStringField(
+      action.payload,
+      "text",
+      action.id,
+      "payload",
+    );
     const visibility = normalizeLinkedInPostVisibility(
-      getRequiredStringField(action.payload, "visibility", action.id, "payload"),
-      "public"
+      getRequiredStringField(
+        action.payload,
+        "visibility",
+        action.id,
+        "payload",
+      ),
+      "public",
     );
     const mediaPaths = getRequiredStringArrayField(
       action.payload,
       "media_paths",
       action.id,
-      "payload"
+      "payload",
     );
     const attachments = validateLinkedInPostMediaAttachments(mediaPaths);
     const tracePath = `linkedin/trace-post-media-confirm-${Date.now()}.zip`;
@@ -4404,14 +4661,14 @@ class CreateMediaPostActionExecutor
 
     await runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: runtime.cdpUrl
+      cdpUrl: runtime.cdpUrl,
     });
 
     return runtime.profileManager.runWithContext(
       {
         cdpUrl: runtime.cdpUrl,
         profileName,
-        headless: true
+        headless: true,
       },
       async (context) => {
         const page = await getOrCreatePage(context);
@@ -4421,51 +4678,47 @@ class CreateMediaPostActionExecutor
           await context.tracing.start({
             screenshots: true,
             snapshots: true,
-            sources: true
+            sources: true,
           });
           tracingStarted = true;
 
-          const rateLimitState = runtime.rateLimiter.consume(
-            CREATE_POST_RATE_LIMIT_CONFIG
-          );
-          if (!rateLimitState.allowed) {
-            throw new LinkedInBuddyError(
-              "RATE_LIMITED",
-              "LinkedIn create_media_post confirm is rate limited for the current window.",
-              {
-                action_id: action.id,
-                profile_name: profileName,
-                requested_visibility: visibility,
-                rate_limit: formatRateLimitState(rateLimitState)
-              }
-            );
-          }
+          const rateLimitState = consumeRateLimitOrThrow(runtime.rateLimiter, {
+            config: CREATE_POST_RATE_LIMIT_CONFIG,
+            message: createConfirmRateLimitMessage(
+              CREATE_MEDIA_POST_ACTION_TYPE,
+            ),
+            details: {
+              action_id: action.id,
+              profile_name: profileName,
+              requested_visibility: visibility,
+            },
+          });
 
           const { composerRoot, triggerKey, rootKey } = await openPostComposer(
             page,
             runtime.selectorLocale,
-            artifactPaths
+            artifactPaths,
           );
           const visibilityKey = await setPostVisibility(
             page,
             composerRoot,
             runtime.selectorLocale,
             visibility,
-            artifactPaths
+            artifactPaths,
           );
           const inputKey = await setComposerText(
             page,
             composerRoot,
             runtime.selectorLocale,
             text,
-            artifactPaths
+            artifactPaths,
           );
           const { mediaButtonKey, mediaInputKey } = await attachMediaToComposer(
             page,
             composerRoot,
             runtime.selectorLocale,
             attachments,
-            artifactPaths
+            artifactPaths,
           );
 
           const prePublishScreenshot = `linkedin/screenshot-post-media-confirm-before-${Date.now()}.png`;
@@ -4480,7 +4733,7 @@ class CreateMediaPostActionExecutor
             media_button_selector_key: mediaButtonKey,
             media_input_selector_key: mediaInputKey,
             media_count: attachments.length,
-            media_kind: attachments[0]?.kind ?? null
+            media_kind: attachments[0]?.kind ?? null,
           });
           artifactPaths.push(prePublishScreenshot);
 
@@ -4489,7 +4742,7 @@ class CreateMediaPostActionExecutor
             createPublishButtonCandidates(runtime.selectorLocale),
             "post_publish_button",
             artifactPaths,
-            page.url()
+            page.url(),
           );
           const publishEnabled = await waitForCondition(async () => {
             try {
@@ -4508,30 +4761,39 @@ class CreateMediaPostActionExecutor
                 profile_name: profileName,
                 requested_visibility: visibility,
                 selector_key: publishButton.key,
-                artifact_paths: artifactPaths
-              }
+                artifact_paths: artifactPaths,
+              },
             );
           }
 
           await publishButton.locator.click({ timeout: 5_000 });
           await waitForCondition(
             async () => !(await isAnyLocatorVisible(composerRoot)),
-            10_000
+            10_000,
           );
           await waitForNetworkIdleBestEffort(page, 10_000);
 
-          const verification = await verifyPublishedPost(page, text, artifactPaths);
+          const verification = await verifyPublishedPost(
+            page,
+            text,
+            artifactPaths,
+          );
 
           const postPublishScreenshot = `linkedin/screenshot-post-media-confirm-after-${Date.now()}.png`;
-          await captureScreenshotArtifact(runtime, page, postPublishScreenshot, {
-            action: CREATE_MEDIA_POST_ACTION_TYPE,
-            profile_name: profileName,
-            visibility,
-            published_post_url: verification.postUrl,
-            verification_surface: verification.surface,
-            media_count: attachments.length,
-            media_kind: attachments[0]?.kind ?? null
-          });
+          await captureScreenshotArtifact(
+            runtime,
+            page,
+            postPublishScreenshot,
+            {
+              action: CREATE_MEDIA_POST_ACTION_TYPE,
+              profile_name: profileName,
+              visibility,
+              published_post_url: verification.postUrl,
+              verification_surface: verification.surface,
+              media_count: attachments.length,
+              media_kind: attachments[0]?.kind ?? null,
+            },
+          );
           artifactPaths.push(postPublishScreenshot);
 
           return {
@@ -4545,9 +4807,9 @@ class CreateMediaPostActionExecutor
               verification_snippet: createVerificationSnippet(text),
               published_post_url: verification.postUrl,
               verification_surface: verification.surface,
-              rate_limit: formatRateLimitState(rateLimitState)
+              rate_limit: formatRateLimitState(rateLimitState),
             },
-            artifacts: artifactPaths
+            artifacts: artifactPaths,
           };
         } catch (error) {
           const failureScreenshot = `linkedin/screenshot-post-media-confirm-error-${Date.now()}.png`;
@@ -4555,7 +4817,7 @@ class CreateMediaPostActionExecutor
             await captureScreenshotArtifact(runtime, page, failureScreenshot, {
               action: `${CREATE_MEDIA_POST_ACTION_TYPE}_error`,
               profile_name: profileName,
-              visibility
+              visibility,
             });
             artifactPaths.push(failureScreenshot);
           } catch {
@@ -4570,8 +4832,8 @@ class CreateMediaPostActionExecutor
               profile_name: profileName,
               current_url: page.url(),
               requested_visibility: visibility,
-              artifact_paths: artifactPaths
-            }
+              artifact_paths: artifactPaths,
+            },
           );
         } finally {
           if (tracingStarted) {
@@ -4581,44 +4843,67 @@ class CreateMediaPostActionExecutor
               registerTraceArtifact(runtime, tracePath, {
                 action: CREATE_MEDIA_POST_ACTION_TYPE,
                 profile_name: profileName,
-                visibility
+                visibility,
               });
             } catch (error) {
-              runtime.logger.log("warn", "linkedin.post.confirm_media.trace.stop_failed", {
-                action_id: action.id,
-                message: error instanceof Error ? error.message : String(error)
-              });
+              runtime.logger.log(
+                "warn",
+                "linkedin.post.confirm_media.trace.stop_failed",
+                {
+                  action_id: action.id,
+                  message:
+                    error instanceof Error ? error.message : String(error),
+                },
+              );
             }
           }
         }
-      }
+      },
     );
   }
 }
 
-class CreatePollPostActionExecutor
-  implements ActionExecutor<LinkedInPostsExecutorRuntime>
-{
+class CreatePollPostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRuntime> {
   async execute(
-    input: ActionExecutorInput<LinkedInPostsExecutorRuntime>
+    input: ActionExecutorInput<LinkedInPostsExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
     const runtime = input.runtime;
     const action = input.action;
     const profileName = getProfileName(action.target);
-    const text = getOptionalStringField(action.payload, "text", action.id, "payload");
-    const question = getRequiredStringField(action.payload, "question", action.id, "payload");
+    const text = getOptionalStringField(
+      action.payload,
+      "text",
+      action.id,
+      "payload",
+    );
+    const question = getRequiredStringField(
+      action.payload,
+      "question",
+      action.id,
+      "payload",
+    );
     const options = getRequiredStringArrayField(
       action.payload,
       "options",
       action.id,
-      "payload"
+      "payload",
     );
     const durationDays = normalizePollDurationDays(
-      getRequiredIntegerField(action.payload, "duration_days", action.id, "payload")
+      getRequiredIntegerField(
+        action.payload,
+        "duration_days",
+        action.id,
+        "payload",
+      ),
     );
     const visibility = normalizeLinkedInPostVisibility(
-      getRequiredStringField(action.payload, "visibility", action.id, "payload"),
-      "public"
+      getRequiredStringField(
+        action.payload,
+        "visibility",
+        action.id,
+        "payload",
+      ),
+      "public",
     );
     const verificationText = text ?? question;
     const tracePath = `linkedin/trace-post-poll-confirm-${Date.now()}.zip`;
@@ -4626,14 +4911,14 @@ class CreatePollPostActionExecutor
 
     await runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: runtime.cdpUrl
+      cdpUrl: runtime.cdpUrl,
     });
 
     return runtime.profileManager.runWithContext(
       {
         cdpUrl: runtime.cdpUrl,
         profileName,
-        headless: true
+        headless: true,
       },
       async (context) => {
         const page = await getOrCreatePage(context);
@@ -4643,37 +4928,33 @@ class CreatePollPostActionExecutor
           await context.tracing.start({
             screenshots: true,
             snapshots: true,
-            sources: true
+            sources: true,
           });
           tracingStarted = true;
 
-          const rateLimitState = runtime.rateLimiter.consume(
-            CREATE_POST_RATE_LIMIT_CONFIG
-          );
-          if (!rateLimitState.allowed) {
-            throw new LinkedInBuddyError(
-              "RATE_LIMITED",
-              "LinkedIn create_poll_post confirm is rate limited for the current window.",
-              {
-                action_id: action.id,
-                profile_name: profileName,
-                requested_visibility: visibility,
-                rate_limit: formatRateLimitState(rateLimitState)
-              }
-            );
-          }
+          const rateLimitState = consumeRateLimitOrThrow(runtime.rateLimiter, {
+            config: CREATE_POST_RATE_LIMIT_CONFIG,
+            message: createConfirmRateLimitMessage(
+              CREATE_POLL_POST_ACTION_TYPE,
+            ),
+            details: {
+              action_id: action.id,
+              profile_name: profileName,
+              requested_visibility: visibility,
+            },
+          });
 
           const { composerRoot, triggerKey, rootKey } = await openPostComposer(
             page,
             runtime.selectorLocale,
-            artifactPaths
+            artifactPaths,
           );
           const visibilityKey = await setPostVisibility(
             page,
             composerRoot,
             runtime.selectorLocale,
             visibility,
-            artifactPaths
+            artifactPaths,
           );
           const inputKey = text
             ? await setComposerText(
@@ -4681,7 +4962,7 @@ class CreatePollPostActionExecutor
                 composerRoot,
                 runtime.selectorLocale,
                 text,
-                artifactPaths
+                artifactPaths,
               )
             : null;
           const pollFields = await fillPollComposerFields(
@@ -4691,7 +4972,7 @@ class CreatePollPostActionExecutor
             question,
             options,
             durationDays,
-            artifactPaths
+            artifactPaths,
           );
 
           const prePublishScreenshot = `linkedin/screenshot-post-poll-confirm-before-${Date.now()}.png`;
@@ -4708,7 +4989,7 @@ class CreatePollPostActionExecutor
             poll_option_selector_keys: pollFields.optionInputKeys,
             poll_duration_selector_key: pollFields.durationKey,
             poll_option_count: options.length,
-            poll_duration_days: durationDays
+            poll_duration_days: durationDays,
           });
           artifactPaths.push(prePublishScreenshot);
 
@@ -4717,7 +4998,7 @@ class CreatePollPostActionExecutor
             createPublishButtonCandidates(runtime.selectorLocale),
             "post_publish_button",
             artifactPaths,
-            page.url()
+            page.url(),
           );
           const publishEnabled = await waitForCondition(async () => {
             try {
@@ -4736,34 +5017,39 @@ class CreatePollPostActionExecutor
                 profile_name: profileName,
                 requested_visibility: visibility,
                 selector_key: publishButton.key,
-                artifact_paths: artifactPaths
-              }
+                artifact_paths: artifactPaths,
+              },
             );
           }
 
           await publishButton.locator.click({ timeout: 5_000 });
           await waitForCondition(
             async () => !(await isAnyLocatorVisible(composerRoot)),
-            10_000
+            10_000,
           );
           await waitForNetworkIdleBestEffort(page, 10_000);
 
           const verification = await verifyPublishedPost(
             page,
             verificationText,
-            artifactPaths
+            artifactPaths,
           );
 
           const postPublishScreenshot = `linkedin/screenshot-post-poll-confirm-after-${Date.now()}.png`;
-          await captureScreenshotArtifact(runtime, page, postPublishScreenshot, {
-            action: CREATE_POLL_POST_ACTION_TYPE,
-            profile_name: profileName,
-            visibility,
-            published_post_url: verification.postUrl,
-            verification_surface: verification.surface,
-            poll_option_count: options.length,
-            poll_duration_days: durationDays
-          });
+          await captureScreenshotArtifact(
+            runtime,
+            page,
+            postPublishScreenshot,
+            {
+              action: CREATE_POLL_POST_ACTION_TYPE,
+              profile_name: profileName,
+              visibility,
+              published_post_url: verification.postUrl,
+              verification_surface: verification.surface,
+              poll_option_count: options.length,
+              poll_duration_days: durationDays,
+            },
+          );
           artifactPaths.push(postPublishScreenshot);
 
           return {
@@ -4778,9 +5064,9 @@ class CreatePollPostActionExecutor
               verification_snippet: createVerificationSnippet(verificationText),
               published_post_url: verification.postUrl,
               verification_surface: verification.surface,
-              rate_limit: formatRateLimitState(rateLimitState)
+              rate_limit: formatRateLimitState(rateLimitState),
             },
-            artifacts: artifactPaths
+            artifacts: artifactPaths,
           };
         } catch (error) {
           const failureScreenshot = `linkedin/screenshot-post-poll-confirm-error-${Date.now()}.png`;
@@ -4788,7 +5074,7 @@ class CreatePollPostActionExecutor
             await captureScreenshotArtifact(runtime, page, failureScreenshot, {
               action: `${CREATE_POLL_POST_ACTION_TYPE}_error`,
               profile_name: profileName,
-              visibility
+              visibility,
             });
             artifactPaths.push(failureScreenshot);
           } catch {
@@ -4803,8 +5089,8 @@ class CreatePollPostActionExecutor
               profile_name: profileName,
               current_url: page.url(),
               requested_visibility: visibility,
-              artifact_paths: artifactPaths
-            }
+              artifact_paths: artifactPaths,
+            },
           );
         } finally {
           if (tracingStarted) {
@@ -4814,47 +5100,55 @@ class CreatePollPostActionExecutor
               registerTraceArtifact(runtime, tracePath, {
                 action: CREATE_POLL_POST_ACTION_TYPE,
                 profile_name: profileName,
-                visibility
+                visibility,
               });
             } catch (error) {
-              runtime.logger.log("warn", "linkedin.post.confirm_poll.trace.stop_failed", {
-                action_id: action.id,
-                message: error instanceof Error ? error.message : String(error)
-              });
+              runtime.logger.log(
+                "warn",
+                "linkedin.post.confirm_poll.trace.stop_failed",
+                {
+                  action_id: action.id,
+                  message:
+                    error instanceof Error ? error.message : String(error),
+                },
+              );
             }
           }
         }
-      }
+      },
     );
   }
 }
 
-class EditPostActionExecutor
-  implements ActionExecutor<LinkedInPostsExecutorRuntime>
-{
+class EditPostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRuntime> {
   async execute(
-    input: ActionExecutorInput<LinkedInPostsExecutorRuntime>
+    input: ActionExecutorInput<LinkedInPostsExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
     const runtime = input.runtime;
     const action = input.action;
     const profileName = getProfileName(action.target);
     const postUrl = resolvePostUrl(
-      getRequiredStringField(action.payload, "post_url", action.id, "payload")
+      getRequiredStringField(action.payload, "post_url", action.id, "payload"),
     );
-    const text = getRequiredStringField(action.payload, "text", action.id, "payload");
+    const text = getRequiredStringField(
+      action.payload,
+      "text",
+      action.id,
+      "payload",
+    );
     const tracePath = `linkedin/trace-post-edit-confirm-${Date.now()}.zip`;
     const artifactPaths: string[] = [tracePath];
 
     await runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: runtime.cdpUrl
+      cdpUrl: runtime.cdpUrl,
     });
 
     return runtime.profileManager.runWithContext(
       {
         cdpUrl: runtime.cdpUrl,
         profileName,
-        headless: true
+        headless: true,
       },
       async (context) => {
         const page = await getOrCreatePage(context);
@@ -4864,42 +5158,42 @@ class EditPostActionExecutor
           await context.tracing.start({
             screenshots: true,
             snapshots: true,
-            sources: true
+            sources: true,
           });
           tracingStarted = true;
 
-          const rateLimitState = runtime.rateLimiter.consume(EDIT_POST_RATE_LIMIT_CONFIG);
-          if (!rateLimitState.allowed) {
-            throw new LinkedInBuddyError(
-              "RATE_LIMITED",
-              "LinkedIn edit_post confirm is rate limited for the current window.",
-              {
-                action_id: action.id,
-                profile_name: profileName,
-                post_url: postUrl,
-                rate_limit: formatRateLimitState(rateLimitState)
-              }
-            );
-          }
+          const rateLimitState = consumeRateLimitOrThrow(runtime.rateLimiter, {
+            config: EDIT_POST_RATE_LIMIT_CONFIG,
+            message: createConfirmRateLimitMessage(EDIT_POST_ACTION_TYPE),
+            details: {
+              action_id: action.id,
+              profile_name: profileName,
+              post_url: postUrl,
+            },
+          });
 
           await page.goto(postUrl, { waitUntil: "domcontentloaded" });
           await waitForNetworkIdleBestEffort(page);
 
-          const targetPost = await findTargetPostLocator(page, postUrl, artifactPaths);
+          const targetPost = await findTargetPostLocator(
+            page,
+            postUrl,
+            artifactPaths,
+          );
           const menuButtonKey = await openTargetPostActionMenu(
             page,
             targetPost,
             runtime.selectorLocale,
-            artifactPaths
+            artifactPaths,
           );
           const editAction = await findVisibleLocatorOrThrow(
             page,
             createPostMenuActionCandidates(
               getPostUiActionLabels("edit", runtime.selectorLocale),
-              "post-edit"
+              "post-edit",
             ),
             "post_edit_menu_item",
-            artifactPaths
+            artifactPaths,
           );
           await editAction.locator.click({ timeout: 5_000 });
 
@@ -4909,14 +5203,14 @@ class EditPostActionExecutor
             dialog,
             runtime.selectorLocale,
             text,
-            artifactPaths
+            artifactPaths,
           );
           const saveButton = await findVisibleScopedLocatorOrThrow(
             dialog,
             createScopedSaveButtonCandidates(runtime.selectorLocale),
             "post_edit_save_button",
             artifactPaths,
-            page.url()
+            page.url(),
           );
 
           const preSaveScreenshot = `linkedin/screenshot-post-edit-confirm-before-${Date.now()}.png`;
@@ -4928,7 +5222,7 @@ class EditPostActionExecutor
             menu_button_selector_key: menuButtonKey,
             edit_selector_key: editAction.key,
             input_selector_key: inputKey,
-            save_selector_key: saveButton.key
+            save_selector_key: saveButton.key,
           });
           artifactPaths.push(preSaveScreenshot);
 
@@ -4949,20 +5243,23 @@ class EditPostActionExecutor
                 profile_name: profileName,
                 post_url: postUrl,
                 selector_key: saveButton.key,
-                artifact_paths: artifactPaths
-              }
+                artifact_paths: artifactPaths,
+              },
             );
           }
 
           await saveButton.locator.click({ timeout: 5_000 });
-          await waitForCondition(async () => !(await isAnyLocatorVisible(dialog)), 10_000);
+          await waitForCondition(
+            async () => !(await isAnyLocatorVisible(dialog)),
+            10_000,
+          );
           await waitForNetworkIdleBestEffort(page, 10_000);
 
           const verification = await verifyUpdatedPostAtUrl(
             page,
             postUrl,
             text,
-            artifactPaths
+            artifactPaths,
           );
 
           const postSaveScreenshot = `linkedin/screenshot-post-edit-confirm-after-${Date.now()}.png`;
@@ -4970,7 +5267,7 @@ class EditPostActionExecutor
             action: EDIT_POST_ACTION_TYPE,
             profile_name: profileName,
             post_url: postUrl,
-            published_post_url: verification.postUrl
+            published_post_url: verification.postUrl,
           });
           artifactPaths.push(postSaveScreenshot);
 
@@ -4980,9 +5277,9 @@ class EditPostActionExecutor
               edited: true,
               post_url: postUrl,
               verification_snippet: createVerificationSnippet(text),
-              rate_limit: formatRateLimitState(rateLimitState)
+              rate_limit: formatRateLimitState(rateLimitState),
             },
-            artifacts: artifactPaths
+            artifacts: artifactPaths,
           };
         } catch (error) {
           const failureScreenshot = `linkedin/screenshot-post-edit-confirm-error-${Date.now()}.png`;
@@ -4990,20 +5287,24 @@ class EditPostActionExecutor
             await captureScreenshotArtifact(runtime, page, failureScreenshot, {
               action: `${EDIT_POST_ACTION_TYPE}_error`,
               profile_name: profileName,
-              post_url: postUrl
+              post_url: postUrl,
             });
             artifactPaths.push(failureScreenshot);
           } catch {
             // Best effort.
           }
 
-          throw toAutomationError(error, "Failed to execute LinkedIn edit_post action.", {
-            action_id: action.id,
-            profile_name: profileName,
-            current_url: page.url(),
-            post_url: postUrl,
-            artifact_paths: artifactPaths
-          });
+          throw toAutomationError(
+            error,
+            "Failed to execute LinkedIn edit_post action.",
+            {
+              action_id: action.id,
+              profile_name: profileName,
+              current_url: page.url(),
+              post_url: postUrl,
+              artifact_paths: artifactPaths,
+            },
+          );
         } finally {
           if (tracingStarted) {
             try {
@@ -5012,46 +5313,49 @@ class EditPostActionExecutor
               registerTraceArtifact(runtime, tracePath, {
                 action: EDIT_POST_ACTION_TYPE,
                 profile_name: profileName,
-                post_url: postUrl
+                post_url: postUrl,
               });
             } catch (error) {
-              runtime.logger.log("warn", "linkedin.post.confirm_edit.trace.stop_failed", {
-                action_id: action.id,
-                message: error instanceof Error ? error.message : String(error)
-              });
+              runtime.logger.log(
+                "warn",
+                "linkedin.post.confirm_edit.trace.stop_failed",
+                {
+                  action_id: action.id,
+                  message:
+                    error instanceof Error ? error.message : String(error),
+                },
+              );
             }
           }
         }
-      }
+      },
     );
   }
 }
 
-class DeletePostActionExecutor
-  implements ActionExecutor<LinkedInPostsExecutorRuntime>
-{
+class DeletePostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRuntime> {
   async execute(
-    input: ActionExecutorInput<LinkedInPostsExecutorRuntime>
+    input: ActionExecutorInput<LinkedInPostsExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
     const runtime = input.runtime;
     const action = input.action;
     const profileName = getProfileName(action.target);
     const postUrl = resolvePostUrl(
-      getRequiredStringField(action.payload, "post_url", action.id, "payload")
+      getRequiredStringField(action.payload, "post_url", action.id, "payload"),
     );
     const tracePath = `linkedin/trace-post-delete-confirm-${Date.now()}.zip`;
     const artifactPaths: string[] = [tracePath];
 
     await runtime.auth.ensureAuthenticated({
       profileName,
-      cdpUrl: runtime.cdpUrl
+      cdpUrl: runtime.cdpUrl,
     });
 
     return runtime.profileManager.runWithContext(
       {
         cdpUrl: runtime.cdpUrl,
         profileName,
-        headless: true
+        headless: true,
       },
       async (context) => {
         const page = await getOrCreatePage(context);
@@ -5061,45 +5365,45 @@ class DeletePostActionExecutor
           await context.tracing.start({
             screenshots: true,
             snapshots: true,
-            sources: true
+            sources: true,
           });
           tracingStarted = true;
 
-          const rateLimitState = runtime.rateLimiter.consume(
-            DELETE_POST_RATE_LIMIT_CONFIG
-          );
-          if (!rateLimitState.allowed) {
-            throw new LinkedInBuddyError(
-              "RATE_LIMITED",
-              "LinkedIn delete_post confirm is rate limited for the current window.",
-              {
-                action_id: action.id,
-                profile_name: profileName,
-                post_url: postUrl,
-                rate_limit: formatRateLimitState(rateLimitState)
-              }
-            );
-          }
+          const rateLimitState = consumeRateLimitOrThrow(runtime.rateLimiter, {
+            config: DELETE_POST_RATE_LIMIT_CONFIG,
+            message: createConfirmRateLimitMessage(DELETE_POST_ACTION_TYPE),
+            details: {
+              action_id: action.id,
+              profile_name: profileName,
+              post_url: postUrl,
+            },
+          });
 
           await page.goto(postUrl, { waitUntil: "domcontentloaded" });
           await waitForNetworkIdleBestEffort(page);
 
-          const targetPost = await findTargetPostLocator(page, postUrl, artifactPaths);
-          const currentSnippet = await extractPostSnippetFromLocator(targetPost.locator);
+          const targetPost = await findTargetPostLocator(
+            page,
+            postUrl,
+            artifactPaths,
+          );
+          const currentSnippet = await extractPostSnippetFromLocator(
+            targetPost.locator,
+          );
           const menuButtonKey = await openTargetPostActionMenu(
             page,
             targetPost,
             runtime.selectorLocale,
-            artifactPaths
+            artifactPaths,
           );
           const deleteAction = await findVisibleLocatorOrThrow(
             page,
             createPostMenuActionCandidates(
               getPostUiActionLabels("delete", runtime.selectorLocale),
-              "post-delete"
+              "post-delete",
             ),
             "post_delete_menu_item",
-            artifactPaths
+            artifactPaths,
           );
 
           const preDeleteScreenshot = `linkedin/screenshot-post-delete-confirm-before-${Date.now()}.png`;
@@ -5110,7 +5414,7 @@ class DeletePostActionExecutor
             target_post_selector_key: targetPost.key,
             menu_button_selector_key: menuButtonKey,
             delete_selector_key: deleteAction.key,
-            current_verification_snippet: currentSnippet
+            current_verification_snippet: currentSnippet,
           });
           artifactPaths.push(preDeleteScreenshot);
 
@@ -5123,11 +5427,14 @@ class DeletePostActionExecutor
               createDeleteConfirmButtonCandidates(runtime.selectorLocale),
               "post_delete_confirm_button",
               artifactPaths,
-              page.url()
+              page.url(),
             );
             confirmButtonKey = confirmButton.key;
             await confirmButton.locator.click({ timeout: 5_000 });
-            await waitForCondition(async () => !(await isAnyLocatorVisible(dialog)), 10_000);
+            await waitForCondition(
+              async () => !(await isAnyLocatorVisible(dialog)),
+              10_000,
+            );
           }
           await waitForNetworkIdleBestEffort(page, 10_000);
 
@@ -5135,7 +5442,7 @@ class DeletePostActionExecutor
             page,
             postUrl,
             currentSnippet,
-            artifactPaths
+            artifactPaths,
           );
 
           const postDeleteScreenshot = `linkedin/screenshot-post-delete-confirm-after-${Date.now()}.png`;
@@ -5144,7 +5451,7 @@ class DeletePostActionExecutor
             profile_name: profileName,
             post_url: postUrl,
             confirm_selector_key: confirmButtonKey,
-            published_post_url: verification.postUrl
+            published_post_url: verification.postUrl,
           });
           artifactPaths.push(postDeleteScreenshot);
 
@@ -5154,9 +5461,9 @@ class DeletePostActionExecutor
               deleted: true,
               post_url: postUrl,
               verification_snippet: currentSnippet,
-              rate_limit: formatRateLimitState(rateLimitState)
+              rate_limit: formatRateLimitState(rateLimitState),
             },
-            artifacts: artifactPaths
+            artifacts: artifactPaths,
           };
         } catch (error) {
           const failureScreenshot = `linkedin/screenshot-post-delete-confirm-error-${Date.now()}.png`;
@@ -5164,7 +5471,7 @@ class DeletePostActionExecutor
             await captureScreenshotArtifact(runtime, page, failureScreenshot, {
               action: `${DELETE_POST_ACTION_TYPE}_error`,
               profile_name: profileName,
-              post_url: postUrl
+              post_url: postUrl,
             });
             artifactPaths.push(failureScreenshot);
           } catch {
@@ -5179,8 +5486,8 @@ class DeletePostActionExecutor
               profile_name: profileName,
               current_url: page.url(),
               post_url: postUrl,
-              artifact_paths: artifactPaths
-            }
+              artifact_paths: artifactPaths,
+            },
           );
         } finally {
           if (tracingStarted) {
@@ -5190,17 +5497,22 @@ class DeletePostActionExecutor
               registerTraceArtifact(runtime, tracePath, {
                 action: DELETE_POST_ACTION_TYPE,
                 profile_name: profileName,
-                post_url: postUrl
+                post_url: postUrl,
               });
             } catch (error) {
-              runtime.logger.log("warn", "linkedin.post.confirm_delete.trace.stop_failed", {
-                action_id: action.id,
-                message: error instanceof Error ? error.message : String(error)
-              });
+              runtime.logger.log(
+                "warn",
+                "linkedin.post.confirm_delete.trace.stop_failed",
+                {
+                  action_id: action.id,
+                  message:
+                    error instanceof Error ? error.message : String(error),
+                },
+              );
             }
           }
         }
-      }
+      },
     );
   }
 }
@@ -5211,6 +5523,6 @@ export function createPostActionExecutors(): ActionExecutorRegistry<LinkedInPost
     [CREATE_MEDIA_POST_ACTION_TYPE]: new CreateMediaPostActionExecutor(),
     [CREATE_POLL_POST_ACTION_TYPE]: new CreatePollPostActionExecutor(),
     [EDIT_POST_ACTION_TYPE]: new EditPostActionExecutor(),
-    [DELETE_POST_ACTION_TYPE]: new DeletePostActionExecutor()
+    [DELETE_POST_ACTION_TYPE]: new DeletePostActionExecutor(),
   };
 }

--- a/packages/core/src/rateLimiter.ts
+++ b/packages/core/src/rateLimiter.ts
@@ -16,6 +16,10 @@ export interface RateLimiterState {
   limit: number;
   remaining: number;
   allowed: boolean;
+  /** Millisecond timestamp when the current rate-limit window ends. */
+  windowEndsAtMs: number;
+  /** Milliseconds until the current window resets (0 when already past). */
+  retryAfterMs: number;
 }
 
 export interface ConsumeRateLimitOrThrowInput {
@@ -24,23 +28,56 @@ export interface ConsumeRateLimitOrThrowInput {
   details?: Record<string, unknown>;
 }
 
+/**
+ * Formats a human-readable description of the retry-after duration.
+ *
+ * @example
+ * ```ts
+ * formatRetryAfter(90_000);  // "1m 30s"
+ * formatRetryAfter(3_600_000); // "1h 0m"
+ * formatRetryAfter(0); // "now"
+ * ```
+ */
+export function formatRetryAfter(retryAfterMs: number): string {
+  if (retryAfterMs <= 0) {
+    return "now";
+  }
+
+  const totalSeconds = Math.ceil(retryAfterMs / 1_000);
+  const hours = Math.floor(totalSeconds / 3_600);
+  const minutes = Math.floor((totalSeconds % 3_600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+
+  return `${seconds}s`;
+}
+
 export function formatRateLimitState(
-  state: RateLimiterState
+  state: RateLimiterState,
 ): Record<string, number | boolean | string> {
   return {
     counter_key: state.counterKey,
     window_start_ms: state.windowStartMs,
     window_size_ms: state.windowSizeMs,
+    window_ends_at_ms: state.windowEndsAtMs,
+    retry_after_ms: state.retryAfterMs,
     count: state.count,
     limit: state.limit,
     remaining: state.remaining,
-    allowed: state.allowed
+    allowed: state.allowed,
   };
 }
 
 export function peekRateLimitPreview(
   rateLimiter: Pick<RateLimiter, "peek">,
-  config: ConsumeRateLimitInput
+  config: ConsumeRateLimitInput,
 ): Record<string, number | boolean | string> {
   return formatRateLimitState(rateLimiter.peek(config));
 }
@@ -57,18 +94,71 @@ export function createConfirmRateLimitMessage(actionType: string): string {
 
 export function consumeRateLimitOrThrow(
   rateLimiter: Pick<RateLimiter, "consume">,
-  input: ConsumeRateLimitOrThrowInput
+  input: ConsumeRateLimitOrThrowInput,
 ): RateLimiterState {
   const rateLimitState = rateLimiter.consume(input.config);
 
   if (!rateLimitState.allowed) {
-    throw new LinkedInBuddyError("RATE_LIMITED", input.message, {
-      ...(input.details ?? {}),
-      rate_limit: formatRateLimitState(rateLimitState)
-    });
+    const retryHint =
+      rateLimitState.retryAfterMs > 0
+        ? ` Try again in ${formatRetryAfter(rateLimitState.retryAfterMs)}.`
+        : "";
+
+    throw new LinkedInBuddyError(
+      "RATE_LIMITED",
+      `${input.message}${retryHint}`,
+      {
+        ...(input.details ?? {}),
+        rate_limit: formatRateLimitState(rateLimitState),
+      },
+    );
   }
 
   return rateLimitState;
+}
+
+function buildRateLimiterState(
+  input: ConsumeRateLimitInput,
+  windowStartMs: number,
+  count: number,
+  nowMs: number,
+): RateLimiterState {
+  const windowEndsAtMs = windowStartMs + input.windowSizeMs;
+  const retryAfterMs = Math.max(0, windowEndsAtMs - nowMs);
+
+  return {
+    counterKey: input.counterKey,
+    windowStartMs,
+    windowSizeMs: input.windowSizeMs,
+    count,
+    limit: input.limit,
+    remaining: Math.max(0, input.limit - count),
+    allowed: count < input.limit,
+    windowEndsAtMs,
+    retryAfterMs,
+  };
+}
+
+function buildConsumeRateLimiterState(
+  input: ConsumeRateLimitInput,
+  windowStartMs: number,
+  count: number,
+  nowMs: number,
+): RateLimiterState {
+  const windowEndsAtMs = windowStartMs + input.windowSizeMs;
+  const retryAfterMs = Math.max(0, windowEndsAtMs - nowMs);
+
+  return {
+    counterKey: input.counterKey,
+    windowStartMs,
+    windowSizeMs: input.windowSizeMs,
+    count,
+    limit: input.limit,
+    remaining: Math.max(0, input.limit - count),
+    allowed: count <= input.limit,
+    windowEndsAtMs,
+    retryAfterMs,
+  };
 }
 
 export class RateLimiter {
@@ -76,7 +166,8 @@ export class RateLimiter {
 
   peek(input: ConsumeRateLimitInput): RateLimiterState {
     const nowMs = input.nowMs ?? Date.now();
-    const windowStartMs = Math.floor(nowMs / input.windowSizeMs) * input.windowSizeMs;
+    const windowStartMs =
+      Math.floor(nowMs / input.windowSizeMs) * input.windowSizeMs;
     const existing = this.db.getRateLimitCounter(input.counterKey);
 
     const inSameWindow =
@@ -86,24 +177,13 @@ export class RateLimiter {
 
     const count = inSameWindow ? existing.count : 0;
 
-    return {
-      counterKey: input.counterKey,
-      windowStartMs,
-      windowSizeMs: input.windowSizeMs,
-      count,
-      limit: input.limit,
-      remaining: Math.max(0, input.limit - count),
-      allowed: count < input.limit
-    };
-  }
-
-  get(input: ConsumeRateLimitInput): RateLimiterState {
-    return this.peek(input);
+    return buildRateLimiterState(input, windowStartMs, count, nowMs);
   }
 
   consume(input: ConsumeRateLimitInput): RateLimiterState {
     const nowMs = input.nowMs ?? Date.now();
-    const windowStartMs = Math.floor(nowMs / input.windowSizeMs) * input.windowSizeMs;
+    const windowStartMs =
+      Math.floor(nowMs / input.windowSizeMs) * input.windowSizeMs;
     const existing = this.db.getRateLimitCounter(input.counterKey);
 
     const inSameWindow =
@@ -118,17 +198,9 @@ export class RateLimiter {
       windowStartMs,
       windowSizeMs: input.windowSizeMs,
       count,
-      updatedAtMs: nowMs
+      updatedAtMs: nowMs,
     });
 
-    return {
-      counterKey: input.counterKey,
-      windowStartMs,
-      windowSizeMs: input.windowSizeMs,
-      count,
-      limit: input.limit,
-      remaining: Math.max(0, input.limit - count),
-      allowed: count <= input.limit
-    };
+    return buildConsumeRateLimiterState(input, windowStartMs, count, nowMs);
   }
 }

--- a/packages/core/test/rateLimiter.test.ts
+++ b/packages/core/test/rateLimiter.test.ts
@@ -1,5 +1,16 @@
-import { describe, expect, it } from "vitest";
-import { AssistantDatabase, RateLimiter } from "../src/index.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  AssistantDatabase,
+  LinkedInBuddyError,
+  RateLimiter,
+  consumeRateLimitOrThrow,
+  createConfirmRateLimitMessage,
+  formatRateLimitState,
+  formatRetryAfter,
+  peekRateLimitPreview,
+  type ConsumeRateLimitInput,
+  type RateLimiterState,
+} from "../src/index.js";
 
 describe("rate limit counters", () => {
   it("increments counters inside the same window and blocks above limit", () => {
@@ -10,25 +21,25 @@ describe("rate limit counters", () => {
       counterKey: "linkedin.session.status",
       windowSizeMs: 1_000,
       limit: 3,
-      nowMs: 101
+      nowMs: 101,
     });
     const second = limiter.consume({
       counterKey: "linkedin.session.status",
       windowSizeMs: 1_000,
       limit: 3,
-      nowMs: 550
+      nowMs: 550,
     });
     const third = limiter.consume({
       counterKey: "linkedin.session.status",
       windowSizeMs: 1_000,
       limit: 3,
-      nowMs: 999
+      nowMs: 999,
     });
     const fourth = limiter.consume({
       counterKey: "linkedin.session.status",
       windowSizeMs: 1_000,
       limit: 3,
-      nowMs: 999
+      nowMs: 999,
     });
 
     expect(first.count).toBe(1);
@@ -49,14 +60,14 @@ describe("rate limit counters", () => {
       counterKey: "linkedin.session.status",
       windowSizeMs: 1_000,
       limit: 10,
-      nowMs: 999
+      nowMs: 999,
     });
 
     const nextWindow = limiter.consume({
       counterKey: "linkedin.session.status",
       windowSizeMs: 1_000,
       limit: 10,
-      nowMs: 1_000
+      nowMs: 1_000,
     });
 
     expect(nextWindow.count).toBe(1);
@@ -73,13 +84,13 @@ describe("rate limit counters", () => {
       counterKey: "tool.a",
       windowSizeMs: 60_000,
       limit: 5,
-      nowMs: 10
+      nowMs: 10,
     });
     const b = limiter.consume({
       counterKey: "tool.b",
       windowSizeMs: 60_000,
       limit: 5,
-      nowMs: 10
+      nowMs: 10,
     });
 
     expect(a.count).toBe(1);
@@ -88,7 +99,7 @@ describe("rate limit counters", () => {
     db.close();
   });
 
-  it("peek does not consume and get mirrors peek state", () => {
+  it("peek does not consume", () => {
     const db = new AssistantDatabase(":memory:");
     const limiter = new RateLimiter(db);
 
@@ -96,33 +107,426 @@ describe("rate limit counters", () => {
       counterKey: "tool.peek",
       windowSizeMs: 60_000,
       limit: 2,
-      nowMs: 1_000
-    });
-    const getBefore = limiter.get({
-      counterKey: "tool.peek",
-      windowSizeMs: 60_000,
-      limit: 2,
-      nowMs: 1_000
+      nowMs: 1_000,
     });
     const consume = limiter.consume({
       counterKey: "tool.peek",
       windowSizeMs: 60_000,
       limit: 2,
-      nowMs: 1_000
+      nowMs: 1_000,
     });
     const peekAfter = limiter.peek({
       counterKey: "tool.peek",
       windowSizeMs: 60_000,
       limit: 2,
-      nowMs: 1_000
+      nowMs: 1_000,
     });
 
     expect(peekBefore.count).toBe(0);
-    expect(getBefore.count).toBe(0);
     expect(consume.count).toBe(1);
     expect(peekAfter.count).toBe(1);
     expect(peekAfter.remaining).toBe(1);
 
     db.close();
+  });
+
+  it("consume at exact limit is allowed, next call is blocked", () => {
+    const db = new AssistantDatabase(":memory:");
+    const limiter = new RateLimiter(db);
+
+    const atLimit = limiter.consume({
+      counterKey: "tool.boundary",
+      windowSizeMs: 1_000,
+      limit: 1,
+      nowMs: 100,
+    });
+    const overLimit = limiter.consume({
+      counterKey: "tool.boundary",
+      windowSizeMs: 1_000,
+      limit: 1,
+      nowMs: 100,
+    });
+
+    expect(atLimit.count).toBe(1);
+    expect(atLimit.allowed).toBe(true);
+    expect(atLimit.remaining).toBe(0);
+    expect(overLimit.count).toBe(2);
+    expect(overLimit.allowed).toBe(false);
+    expect(overLimit.remaining).toBe(0);
+
+    db.close();
+  });
+
+  it("same key with different window sizes are treated as same counter", () => {
+    const db = new AssistantDatabase(":memory:");
+    const limiter = new RateLimiter(db);
+
+    limiter.consume({
+      counterKey: "tool.shared",
+      windowSizeMs: 60_000,
+      limit: 10,
+      nowMs: 1_000,
+    });
+    const result = limiter.peek({
+      counterKey: "tool.shared",
+      windowSizeMs: 120_000,
+      limit: 10,
+      nowMs: 1_000,
+    });
+
+    expect(result.count).toBe(0);
+
+    db.close();
+  });
+
+  it("handles exact window boundary transition", () => {
+    const db = new AssistantDatabase(":memory:");
+    const limiter = new RateLimiter(db);
+
+    const inWindow = limiter.consume({
+      counterKey: "tool.exact",
+      windowSizeMs: 1_000,
+      limit: 5,
+      nowMs: 999,
+    });
+    const atBoundary = limiter.consume({
+      counterKey: "tool.exact",
+      windowSizeMs: 1_000,
+      limit: 5,
+      nowMs: 1_000,
+    });
+
+    expect(inWindow.windowStartMs).toBe(0);
+    expect(inWindow.count).toBe(1);
+    expect(atBoundary.windowStartMs).toBe(1_000);
+    expect(atBoundary.count).toBe(1);
+
+    db.close();
+  });
+
+  it("populates windowEndsAtMs and retryAfterMs", () => {
+    const db = new AssistantDatabase(":memory:");
+    const limiter = new RateLimiter(db);
+
+    const result = limiter.consume({
+      counterKey: "tool.timing",
+      windowSizeMs: 10_000,
+      limit: 5,
+      nowMs: 3_000,
+    });
+
+    expect(result.windowStartMs).toBe(0);
+    expect(result.windowEndsAtMs).toBe(10_000);
+    expect(result.retryAfterMs).toBe(7_000);
+
+    const peek = limiter.peek({
+      counterKey: "tool.timing",
+      windowSizeMs: 10_000,
+      limit: 5,
+      nowMs: 8_000,
+    });
+
+    expect(peek.windowEndsAtMs).toBe(10_000);
+    expect(peek.retryAfterMs).toBe(2_000);
+
+    db.close();
+  });
+});
+
+describe("formatRetryAfter", () => {
+  it("returns 'now' for zero or negative values", () => {
+    expect(formatRetryAfter(0)).toBe("now");
+    expect(formatRetryAfter(-1_000)).toBe("now");
+  });
+
+  it("formats seconds only", () => {
+    expect(formatRetryAfter(5_000)).toBe("5s");
+    expect(formatRetryAfter(59_000)).toBe("59s");
+  });
+
+  it("formats minutes and seconds", () => {
+    expect(formatRetryAfter(90_000)).toBe("1m 30s");
+    expect(formatRetryAfter(60_000)).toBe("1m 0s");
+  });
+
+  it("formats hours and minutes", () => {
+    expect(formatRetryAfter(3_600_000)).toBe("1h 0m");
+    expect(formatRetryAfter(5_400_000)).toBe("1h 30m");
+    expect(formatRetryAfter(86_400_000)).toBe("24h 0m");
+  });
+
+  it("rounds up partial seconds", () => {
+    expect(formatRetryAfter(500)).toBe("1s");
+    expect(formatRetryAfter(1_500)).toBe("2s");
+  });
+});
+
+describe("formatRateLimitState", () => {
+  it("maps camelCase state to snake_case record with timing fields", () => {
+    const state: RateLimiterState = {
+      counterKey: "linkedin.feed.like_post",
+      windowStartMs: 3_600_000,
+      windowSizeMs: 3_600_000,
+      count: 5,
+      limit: 30,
+      remaining: 25,
+      allowed: true,
+      windowEndsAtMs: 7_200_000,
+      retryAfterMs: 3_600_000,
+    };
+
+    const formatted = formatRateLimitState(state);
+
+    expect(formatted).toEqual({
+      counter_key: "linkedin.feed.like_post",
+      window_start_ms: 3_600_000,
+      window_size_ms: 3_600_000,
+      window_ends_at_ms: 7_200_000,
+      retry_after_ms: 3_600_000,
+      count: 5,
+      limit: 30,
+      remaining: 25,
+      allowed: true,
+    });
+  });
+
+  it("includes all required fields for a blocked state", () => {
+    const state: RateLimiterState = {
+      counterKey: "test.key",
+      windowStartMs: 0,
+      windowSizeMs: 1_000,
+      count: 10,
+      limit: 5,
+      remaining: 0,
+      allowed: false,
+      windowEndsAtMs: 1_000,
+      retryAfterMs: 500,
+    };
+
+    const formatted = formatRateLimitState(state);
+    expect(formatted.allowed).toBe(false);
+    expect(formatted.remaining).toBe(0);
+    expect(formatted.count).toBe(10);
+    expect(formatted.window_ends_at_ms).toBe(1_000);
+    expect(formatted.retry_after_ms).toBe(500);
+  });
+});
+
+describe("peekRateLimitPreview", () => {
+  it("returns formatted state from peek without consuming", () => {
+    const peekState: RateLimiterState = {
+      counterKey: "test.action",
+      windowStartMs: 0,
+      windowSizeMs: 60_000,
+      count: 3,
+      limit: 10,
+      remaining: 7,
+      allowed: true,
+      windowEndsAtMs: 60_000,
+      retryAfterMs: 59_000,
+    };
+
+    const rateLimiter = {
+      peek: vi.fn().mockReturnValue(peekState),
+    };
+
+    const config: ConsumeRateLimitInput = {
+      counterKey: "test.action",
+      windowSizeMs: 60_000,
+      limit: 10,
+    };
+
+    const preview = peekRateLimitPreview(rateLimiter, config);
+
+    expect(rateLimiter.peek).toHaveBeenCalledWith(config);
+    expect(preview).toEqual({
+      counter_key: "test.action",
+      window_start_ms: 0,
+      window_size_ms: 60_000,
+      window_ends_at_ms: 60_000,
+      retry_after_ms: 59_000,
+      count: 3,
+      limit: 10,
+      remaining: 7,
+      allowed: true,
+    });
+  });
+});
+
+describe("createConfirmRateLimitMessage", () => {
+  it("extracts last segment from dotted action type", () => {
+    expect(createConfirmRateLimitMessage("feed.like_post")).toBe(
+      "LinkedIn like_post confirm is rate limited for the current window.",
+    );
+  });
+
+  it("extracts last segment from deeply nested action type", () => {
+    expect(createConfirmRateLimitMessage("jobs.alerts.create")).toBe(
+      "LinkedIn create confirm is rate limited for the current window.",
+    );
+  });
+
+  it("returns full string for single-segment action type", () => {
+    expect(createConfirmRateLimitMessage("like")).toBe(
+      "LinkedIn like confirm is rate limited for the current window.",
+    );
+  });
+
+  it("handles action type with leading dot", () => {
+    expect(createConfirmRateLimitMessage(".send_message")).toBe(
+      "LinkedIn send_message confirm is rate limited for the current window.",
+    );
+  });
+
+  it("falls back to full string for empty action type", () => {
+    expect(createConfirmRateLimitMessage("")).toBe(
+      "LinkedIn  confirm is rate limited for the current window.",
+    );
+  });
+});
+
+describe("consumeRateLimitOrThrow", () => {
+  it("returns state when allowed", () => {
+    const allowedState: RateLimiterState = {
+      counterKey: "test.action",
+      windowStartMs: 0,
+      windowSizeMs: 60_000,
+      count: 1,
+      limit: 10,
+      remaining: 9,
+      allowed: true,
+      windowEndsAtMs: 60_000,
+      retryAfterMs: 59_000,
+    };
+
+    const rateLimiter = {
+      consume: vi.fn().mockReturnValue(allowedState),
+    };
+
+    const config: ConsumeRateLimitInput = {
+      counterKey: "test.action",
+      windowSizeMs: 60_000,
+      limit: 10,
+    };
+
+    const result = consumeRateLimitOrThrow(rateLimiter, {
+      config,
+      message: "Test rate limited.",
+      details: { action_id: "pa_123" },
+    });
+
+    expect(result).toBe(allowedState);
+    expect(rateLimiter.consume).toHaveBeenCalledWith(config);
+  });
+
+  it("throws LinkedInBuddyError with RATE_LIMITED code when blocked", () => {
+    const blockedState: RateLimiterState = {
+      counterKey: "test.action",
+      windowStartMs: 0,
+      windowSizeMs: 60_000,
+      count: 11,
+      limit: 10,
+      remaining: 0,
+      allowed: false,
+      windowEndsAtMs: 60_000,
+      retryAfterMs: 30_000,
+    };
+
+    const rateLimiter = {
+      consume: vi.fn().mockReturnValue(blockedState),
+    };
+
+    const config: ConsumeRateLimitInput = {
+      counterKey: "test.action",
+      windowSizeMs: 60_000,
+      limit: 10,
+    };
+
+    try {
+      consumeRateLimitOrThrow(rateLimiter, {
+        config,
+        message: "Test rate limited.",
+        details: { action_id: "pa_456" },
+      });
+      expect.fail("Expected error to be thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(LinkedInBuddyError);
+      const buddyError = error as LinkedInBuddyError;
+      expect(buddyError.code).toBe("RATE_LIMITED");
+      expect(buddyError.message).toContain("Test rate limited.");
+      expect(buddyError.message).toContain("Try again in 30s");
+      expect(buddyError.details.action_id).toBe("pa_456");
+      expect(buddyError.details.rate_limit).toEqual(
+        formatRateLimitState(blockedState),
+      );
+    }
+  });
+
+  it("works without details", () => {
+    const blockedState: RateLimiterState = {
+      counterKey: "test.action",
+      windowStartMs: 0,
+      windowSizeMs: 60_000,
+      count: 11,
+      limit: 10,
+      remaining: 0,
+      allowed: false,
+      windowEndsAtMs: 60_000,
+      retryAfterMs: 0,
+    };
+
+    const rateLimiter = {
+      consume: vi.fn().mockReturnValue(blockedState),
+    };
+
+    try {
+      consumeRateLimitOrThrow(rateLimiter, {
+        config: {
+          counterKey: "test.action",
+          windowSizeMs: 60_000,
+          limit: 10,
+        },
+        message: "No details provided.",
+      });
+      expect.fail("Expected error to be thrown");
+    } catch (error) {
+      const buddyError = error as LinkedInBuddyError;
+      expect(buddyError.details.rate_limit).toBeDefined();
+      expect(Object.keys(buddyError.details)).toEqual(["rate_limit"]);
+    }
+  });
+
+  it("omits retry hint when retryAfterMs is 0", () => {
+    const blockedState: RateLimiterState = {
+      counterKey: "test.action",
+      windowStartMs: 0,
+      windowSizeMs: 60_000,
+      count: 11,
+      limit: 10,
+      remaining: 0,
+      allowed: false,
+      windowEndsAtMs: 60_000,
+      retryAfterMs: 0,
+    };
+
+    const rateLimiter = {
+      consume: vi.fn().mockReturnValue(blockedState),
+    };
+
+    try {
+      consumeRateLimitOrThrow(rateLimiter, {
+        config: {
+          counterKey: "test.action",
+          windowSizeMs: 60_000,
+          limit: 10,
+        },
+        message: "Rate limited.",
+      });
+      expect.fail("Expected error to be thrown");
+    } catch (error) {
+      const buddyError = error as LinkedInBuddyError;
+      expect(buddyError.message).toBe("Rate limited.");
+      expect(buddyError.message).not.toContain("Try again");
+    }
   });
 });


### PR DESCRIPTION
## Summary

Multi-phase quality pass on the rate limiting feature from PR #323 (issue #311), as specified in #360.

## Changes

### Phase 3: Simplify + Refactor
- Removed dead `RateLimiter.get()` method (alias for `peek()` with zero external usage)
- Migrated 5 executor files from inline `consume()+check` blocks to the shared `consumeRateLimitOrThrow()` helper:
  - `linkedinFeed.ts` — 7 blocks migrated, local `formatRateLimitState` duplicate removed
  - `linkedinFollowups.ts` — 1 block migrated, local duplicate removed
  - `linkedinInbox.ts` — 5 blocks migrated, local duplicate removed
  - `linkedinJobs.ts` — 5 blocks migrated, local duplicate removed
  - `linkedinPosts.ts` — 5 blocks migrated, local duplicate removed
- Net removal of 5 duplicate `formatRateLimitState()` functions (~60 lines of dead code)

### Phase 4: Test
- Added 21 new unit tests covering:
  - `formatRateLimitState()`, `peekRateLimitPreview()`, `createConfirmRateLimitMessage()`, `consumeRateLimitOrThrow()`
  - `formatRetryAfter()` (seconds, minutes, hours, rounding, zero/negative edge cases)
  - Edge cases: exact limit boundary, window boundary transition, different window sizes, new `windowEndsAtMs`/`retryAfterMs` fields
- Test count: 1104 → 1125 (all passing)

### Phase 5: Harden
- Added `windowEndsAtMs` and `retryAfterMs` fields to `RateLimiterState` interface
- Refactored `RateLimiter.peek()` and `consume()` to use shared `buildRateLimiterState()`/`buildConsumeRateLimiterState()` helpers
- Updated `formatRateLimitState()` to include `window_ends_at_ms` and `retry_after_ms`
- Updated test utility mock stubs for new fields

### Phase 6: UX/QoL
- Added `formatRetryAfter()` helper — formats ms as human-readable ("1h 30m", "5m 20s", "30s", "now")
- Enhanced `consumeRateLimitOrThrow()` to append "Try again in X" hint when `retryAfterMs > 0`

### Phase 7: Verify — Skipped
Requires a live LinkedIn session (Joi Ascend test account). Not feasible in automated pass.

### Phase 8: Docs
- Created `docs/rate-limiting.md` — comprehensive architecture guide with rate limit policies, error handling, prepare preview metadata, and developer guide for adding new limits
- Added entry to README.md docs map table

## Quality Gates
- ✅ `npm run lint` — clean
- ✅ `npm test` — 1125/1125 passed
- ⚠️ `npm run typecheck` / `npm run build` — all errors are pre-existing in `packages/cli/` and `packages/mcp/` (unrelated to this PR)

Closes #360