### PR TITLE
docs: quality pass for CLI aliases and rebrand (#362)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ If you touch outbound LinkedIn actions:
 
 This repo has three public surfaces that should stay in sync:
 
-- `linkedin` CLI
+- `linkedin` CLI (also available as `linkedin-buddy` and `lbud`)
 - `linkedin-mcp`
 - `@linkedin-buddy/core`
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ npm exec -w @linkedin-buddy/cli -- linkedin auth session --session default
 npm exec -w @linkedin-buddy/cli -- linkedin search "developer relations" --category people --limit 5
 ```
 
+> **Tip:** The CLI installs three equivalent binaries — `linkedin`, `linkedin-buddy`, and `lbud`. After a global `npm install` (once published) any of these work directly:
+>
+> ```bash
+> lbud search "developer relations" --category people --limit 5
+> ```
+
 ## Demo
 
 <p align="center">

--- a/packages/cli/test/binEntrypoint.test.ts
+++ b/packages/cli/test/binEntrypoint.test.ts
@@ -16,7 +16,7 @@ describe("CLI entrypoint detection", () => {
     }
   });
 
-  it("treats symlinked bin aliases as direct execution", async () => {
+  it("treats symlinked lbud alias as direct execution", async () => {
     tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-cli-entrypoint-"));
 
     const targetPath = path.join(tempDir, "linkedin.js");
@@ -25,7 +25,23 @@ describe("CLI entrypoint detection", () => {
     await writeFile(targetPath, "#!/usr/bin/env node\n", "utf8");
     await symlink(targetPath, aliasPath);
 
-    expect(isDirectExecution(pathToFileURL(targetPath).href, aliasPath)).toBe(true);
+    expect(isDirectExecution(pathToFileURL(targetPath).href, aliasPath)).toBe(
+      true,
+    );
+  });
+
+  it("treats symlinked linkedin-buddy alias as direct execution", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-cli-entrypoint-"));
+
+    const targetPath = path.join(tempDir, "linkedin.js");
+    const aliasPath = path.join(tempDir, "linkedin-buddy");
+
+    await writeFile(targetPath, "#!/usr/bin/env node\n", "utf8");
+    await symlink(targetPath, aliasPath);
+
+    expect(isDirectExecution(pathToFileURL(targetPath).href, aliasPath)).toBe(
+      true,
+    );
   });
 
   it("rejects unrelated entrypoints", async () => {
@@ -37,6 +53,8 @@ describe("CLI entrypoint detection", () => {
     await writeFile(targetPath, "#!/usr/bin/env node\n", "utf8");
     await writeFile(otherPath, "#!/usr/bin/env node\n", "utf8");
 
-    expect(isDirectExecution(pathToFileURL(targetPath).href, otherPath)).toBe(false);
+    expect(isDirectExecution(pathToFileURL(targetPath).href, otherPath)).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
## Summary

Quality pass for CLI aliases (#320) and rebrand (#242). Verifies all entry points resolve, imports use new names, and docs reflect the rebrand consistently.

## Verification Performed

### Phase 4 — Test
- All 1148 tests pass (108 test files)
- Zero remnants of `linkedin-owa-agentools` in codebase
- All imports use `@linkedin-buddy/*` package names
- All environment variables use `LINKEDIN_BUDDY_*` prefix
- `LinkedInBuddyError` used consistently throughout

### Phase 5 — Verify
- `npx linkedin --version` → 0.1.0
- `npx linkedin-buddy --version` → 0.1.0
- `npx lbud --version` → 0.1.0
- `node_modules/.bin/linkedin-mcp` symlink verified
- All bin symlinks resolve to `dist/bin/linkedin.js`

### Phase 8 — Docs
- README Quick Start now mentions all 3 CLI aliases with a tip block
- CONTRIBUTING.md surface list now mentions `linkedin-buddy` and `lbud` aliases
- 18 docs files already reference `linkedin-buddy` or `@linkedin-buddy` consistently

## Changes

- **README.md**: Add alias tip (`linkedin`, `linkedin-buddy`, `lbud`) after Quick Start step 3
- **CONTRIBUTING.md**: Mention CLI aliases in the public surfaces list
- **packages/cli/test/binEntrypoint.test.ts**: Add symlink test for `linkedin-buddy` alias, rename existing test for clarity

## Quality Gates

| Gate | Result |
|------|--------|
| `npm run typecheck` | Pass |
| `npm run lint` | Pass |
| `npm test` | 1148 passed (108 files) |
| `npm run build` | Pass |

Closes #362
