### PR TITLE
fix: clear cookies before headless login to prevent SDUI page variant (#366)

### DIFF
--- a/packages/core/src/__tests__/sessionAuth.test.ts
+++ b/packages/core/src/__tests__/sessionAuth.test.ts
@@ -45,7 +45,12 @@ function createMockPage(options: {
   selfProfileGotoUrl?: string;
   textContent?: (selector: string, currentUrl: string) => string | null;
   waitForUrlResult?: string;
-}): { page: Page; gotoCalls: string[]; setUrl: (url: string) => void } {
+}): {
+  page: Page;
+  gotoCalls: string[];
+  typeCalls: Array<{ selector: string; value: string }>;
+  setUrl: (url: string) => void;
+} {
   let currentUrl = options.initialUrl;
   const gotoCalls: string[] = [];
 
@@ -135,6 +140,7 @@ function createMockPage(options: {
 
 function createContextWithPage(page: Page): BrowserContext {
   return {
+    clearCookies: vi.fn(async () => undefined),
     pages: vi.fn(() => [page]),
     newPage: vi.fn(async () => page),
   } as unknown as BrowserContext;
@@ -451,6 +457,197 @@ describe("LinkedInAuthService auth flow", () => {
 
     expect(result.authenticated).toBe(true);
     expect(result.checkpoint).toBe(false);
+    expect(typeCalls).toHaveLength(2);
+    expect(typeCalls[0]!.value).toBe("test@example.com");
+    expect(typeCalls[1]!.value).toBe("secret");
+  });
+
+  it("headlessLogin clears cookies before navigating to the login page", async () => {
+    let waitCount = 0;
+    let navVisible = false;
+
+    const { page, setUrl } = createMockPage({
+      initialUrl: "https://www.linkedin.com/login",
+      onWait: () => {
+        waitCount += 1;
+        if (waitCount === 1) {
+          navVisible = true;
+          setUrl("https://www.linkedin.com/feed/");
+        }
+      },
+      isVisible: (selector, currentUrl) => {
+        if (selector.includes("username")) {
+          return currentUrl.includes("/login");
+        }
+
+        if (
+          selector.includes("session_password") ||
+          selector.includes("password")
+        ) {
+          return currentUrl.includes("/login");
+        }
+
+        if (selector === "nav.global-nav") {
+          return navVisible;
+        }
+
+        return false;
+      },
+    });
+
+    const context = createContextWithPage(page);
+    const profileManager = {
+      runWithContext: vi.fn(async (_options, callback) => callback(context)),
+    } as const;
+    const auth = new LinkedInAuthService(
+      profileManager as unknown as ProfileManager,
+    );
+
+    await auth.headlessLogin({
+      email: "test@example.com",
+      password: "secret",
+      pollIntervalMs: 1,
+      timeoutMs: 100,
+    });
+
+    expect(context.clearCookies as ReturnType<typeof vi.fn>).toHaveBeenCalled();
+  });
+
+  it("headlessLogin detects SDUI page and retries after clearing cookies", async () => {
+    let waitCount = 0;
+    let navVisible = false;
+    let evaluateCallCount = 0;
+
+    const { page, gotoCalls, setUrl } = createMockPage({
+      initialUrl: "https://www.linkedin.com/login",
+      onWait: () => {
+        waitCount += 1;
+        if (waitCount === 1) {
+          navVisible = true;
+          setUrl("https://www.linkedin.com/feed/");
+        }
+      },
+      isVisible: (selector, currentUrl) => {
+        if (selector.includes("username")) {
+          return currentUrl.includes("/login");
+        }
+
+        if (
+          selector.includes("session_password") ||
+          selector.includes("password")
+        ) {
+          return currentUrl.includes("/login");
+        }
+
+        if (selector === "nav.global-nav") {
+          return navVisible;
+        }
+
+        return false;
+      },
+    });
+
+    const evaluateFn = page.evaluate as ReturnType<typeof vi.fn>;
+    evaluateFn.mockImplementation(async () => {
+      evaluateCallCount += 1;
+      // First evaluate call: dismissCookieConsentBanner → undefined
+      // Second evaluate call: SDUI detection → true (SDUI detected)
+      // Third evaluate call: dismissCookieConsentBanner after retry → undefined
+      if (evaluateCallCount === 2) return true;
+      return undefined;
+    });
+
+    const context = createContextWithPage(page);
+    const profileManager = {
+      runWithContext: vi.fn(async (_options, callback) => callback(context)),
+    } as const;
+    const auth = new LinkedInAuthService(
+      profileManager as unknown as ProfileManager,
+    );
+
+    const result = await auth.headlessLogin({
+      email: "test@example.com",
+      password: "secret",
+      pollIntervalMs: 1,
+      timeoutMs: 100,
+    });
+
+    expect(result.authenticated).toBe(true);
+
+    // Proactive clear + SDUI fallback clear = at least 2 calls
+    const clearCalls = (context.clearCookies as ReturnType<typeof vi.fn>).mock
+      .calls;
+    expect(clearCalls.length).toBeGreaterThanOrEqual(2);
+
+    // Login page navigated to at least twice (initial + SDUI retry)
+    const loginNavs = gotoCalls.filter((u) => u.includes("/login"));
+    expect(loginNavs.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("headlessLogin types email after cookie-clear fallback for returning user page", async () => {
+    let clearCount = 0;
+    let waitCount = 0;
+    let navVisible = false;
+
+    const { page, typeCalls, setUrl } = createMockPage({
+      initialUrl: "https://www.linkedin.com/login",
+      onWait: () => {
+        waitCount += 1;
+        if (waitCount === 1) {
+          navVisible = true;
+          setUrl("https://www.linkedin.com/feed/");
+        }
+      },
+      isVisible: (selector, currentUrl) => {
+        // Before the second cookie clear, nothing is visible (SDUI page)
+        // After the second clear (fallback path), standard form appears
+        if (clearCount < 2) return false;
+
+        if (selector.includes("username")) {
+          return currentUrl.includes("/login");
+        }
+
+        if (
+          selector.includes("session_password") ||
+          selector.includes("password")
+        ) {
+          return currentUrl.includes("/login");
+        }
+
+        if (selector === "nav.global-nav") {
+          return navVisible;
+        }
+
+        return false;
+      },
+    });
+
+    const clearCookies = vi.fn(async () => {
+      clearCount += 1;
+    });
+    const context = {
+      clearCookies,
+      pages: vi.fn(() => [page]),
+      newPage: vi.fn(async () => page),
+    } as unknown as BrowserContext;
+
+    const profileManager = {
+      runWithContext: vi.fn(async (_options, callback) => callback(context)),
+    } as const;
+    const auth = new LinkedInAuthService(
+      profileManager as unknown as ProfileManager,
+    );
+
+    const result = await auth.headlessLogin({
+      email: "test@example.com",
+      password: "secret",
+      pollIntervalMs: 1,
+      timeoutMs: 100,
+    });
+
+    expect(result.authenticated).toBe(true);
+
+    // Both email and password must be typed after cookie-clear retry
     expect(typeCalls).toHaveLength(2);
     expect(typeCalls[0]!.value).toBe("test@example.com");
     expect(typeCalls[1]!.value).toBe("secret");

--- a/packages/core/src/auth/session.ts
+++ b/packages/core/src/auth/session.ts
@@ -381,6 +381,14 @@ export class LinkedInAuthService {
           await this.warmBrowserProfile(page);
         }
 
+        // Persistent profiles accumulate tracking cookies (bcookie, bscookie,
+        // JSESSIONID) from prior commands (status, health, etc.) that cause
+        // LinkedIn to serve an SDUI React-rendered login page.  The SDUI
+        // variant uses custom components instead of standard form inputs,
+        // breaking our selectors.  Clear cookies so the login navigation
+        // always receives the traditional server-rendered form.
+        await context.clearCookies();
+
         await page.goto("https://www.linkedin.com/login", {
           waitUntil: "domcontentloaded",
         });
@@ -409,7 +417,21 @@ export class LinkedInAuthService {
 
         await dismissCookieConsentBanner(page);
 
-        const emailInputVisible = await page
+        // Fallback: detect SDUI login variant that may survive cookie clearing
+        // (e.g. browser-level storage, cached service-worker responses).
+        const isSduiPage = await page
+          .evaluate(() => document.querySelector("[data-sdui-screen]") !== null)
+          .catch(() => false);
+
+        if (isSduiPage) {
+          await context.clearCookies();
+          await page.goto("https://www.linkedin.com/login", {
+            waitUntil: "domcontentloaded",
+          });
+          await dismissCookieConsentBanner(page);
+        }
+
+        let emailInputVisible = await page
           .locator(LINKEDIN_LOGIN_EMAIL_INPUT_SELECTOR)
           .first()
           .waitFor({ state: "visible", timeout: 8_000 })
@@ -429,7 +451,7 @@ export class LinkedInAuthService {
             .catch(() => false);
 
           if (!passwordVisible) {
-            await context.clearCookies({ domain: ".linkedin.com" });
+            await context.clearCookies();
             await page.goto("https://www.linkedin.com/login", {
               waitUntil: "domcontentloaded",
             });
@@ -438,6 +460,7 @@ export class LinkedInAuthService {
               .locator(LINKEDIN_LOGIN_EMAIL_INPUT_SELECTOR)
               .first()
               .waitFor({ state: "visible", timeout: 10_000 });
+            emailInputVisible = true;
           } else {
             // Inject the email into the hidden session_key field via JS so the
             // server receives the correct address on form submission.


### PR DESCRIPTION
## Summary

Fix headless login failing with `scrollIntoViewIfNeeded: Timeout` on persistent browser profiles that have previously visited LinkedIn. LinkedIn serves an SDUI React-rendered login page to returning browsers, which lacks the traditional form inputs our selectors expect.

## Changes

### `packages/core/src/auth/session.ts`
- **Proactive cookie clearing**: Clear all cookies after optional warm browsing but before navigating to `/login`. Persistent profiles accumulate tracking cookies (`bcookie`, `bscookie`, `JSESSIONID`) that trigger LinkedIn's SDUI variant.
- **SDUI fallback detection**: After navigation, check for `[data-sdui-screen]` attribute. If detected despite proactive clearing, force a complete cookie clear and retry. Defense-in-depth against non-cookie SDUI triggers (e.g., browser-level storage, service worker cache).
- **Fix `emailInputVisible` variable**: Changed from `const` to `let` and update to `true` after the cookie-clear retry path succeeds. Previously, the email was never typed into the fresh form after a successful retry, causing login to fail silently.
- Changed existing fallback `clearCookies({ domain: ".linkedin.com" })` to `clearCookies()` (no filter) to ensure all LinkedIn cookies are cleared regardless of domain variant (`www.linkedin.com` vs `.linkedin.com`).

### `packages/core/src/__tests__/sessionAuth.test.ts`
- Added `clearCookies` mock to `createContextWithPage` helper
- Fixed return type of `createMockPage` to include `typeCalls` (pre-existing type annotation gap)
- Added 3 new tests:
  - Verifies proactive cookie clearing happens before login navigation
  - Verifies SDUI page detection triggers cookie clear + retry
  - Verifies email AND password are typed after cookie-clear fallback

## Test Results

All 1151 tests pass across 108 test files. Lint and typecheck clean on changed files. Pre-existing build errors in CLI/MCP packages (stealth plugin dependencies) are unrelated.

Closes #366
