### PR TITLE
feat: session persistence with manual sign-in and reusable session state

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -63,6 +63,7 @@ import {
   createCoreRuntime,
   checkLinkedInFixtureStaleness,
   captureLinkedInSession,
+  checkStoredSessionHealth,
   deleteLocalData,
   loadLinkedInFixtureSet,
   normalizeLinkedInFeedReaction,
@@ -2224,6 +2225,72 @@ async function runAuthSessionCapture(
     session_file: result.filePath,
     session_name: result.sessionName,
   });
+}
+
+async function runManualLogin(
+  input: {
+    sessionName: string;
+    timeoutMinutes: number;
+    evasionLevel?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
+  assertNoExternalSessionOverrideForStoredSession(cdpUrl);
+  assertInteractiveTerminal(
+    "capture a stored LinkedIn session via manual login",
+  );
+
+  writeCliNotice(
+    `Opening a stealth-hardened Chromium window to capture session "${input.sessionName}".`,
+  );
+  writeCliNotice(
+    "Sign in manually. The browser closes automatically after the authenticated session is stored.",
+  );
+  writeCliNotice(
+    "Leave the LinkedIn window open after sign-in until the CLI confirms the session was captured. Press Ctrl+C if you need to cancel.",
+  );
+
+  const result = await captureLinkedInSession({
+    sessionName: input.sessionName,
+    timeoutMs: input.timeoutMinutes * 60_000,
+    stealth: true,
+    ...(input.evasionLevel ? { evasionLevel: input.evasionLevel } : {}),
+  });
+
+  printJson({
+    authenticated: result.authenticated,
+    captured_at: result.capturedAt,
+    checked_at: result.checkedAt,
+    current_url: result.currentUrl,
+    li_at_expires_at: result.liAtCookieExpiresAt,
+    session_file: result.filePath,
+    session_name: result.sessionName,
+    ...(result.fingerprint ? { fingerprint_captured: true } : {}),
+    ...(result.fingerprintPath
+      ? { fingerprint_path: result.fingerprintPath }
+      : {}),
+  });
+}
+
+async function runSessionCheck(sessionName: string): Promise<void> {
+  const result = await checkStoredSessionHealth(sessionName);
+  printJson({
+    healthy: result.healthy,
+    session_name: result.sessionName,
+    checked_at: result.checkedAt,
+    reason: result.reason,
+    session_exists: result.sessionExists,
+    has_auth_cookie: result.hasAuthCookie,
+    auth_cookie_expires_at: result.authCookieExpiresAt,
+    auth_cookie_expires_in_ms: result.authCookieExpiresInMs,
+    has_browser_fingerprint: result.hasBrowserFingerprint,
+    cookie_count: result.cookieCount,
+    guidance: result.guidance,
+  });
+
+  if (!result.healthy) {
+    process.exitCode = 1;
+  }
 }
 
 function isStoredSessionRefreshError(error: unknown): boolean {
@@ -9980,6 +10047,16 @@ export function createCliProgram(): Command {
       "Browse LinkedIn organically before login to reduce CAPTCHA risk",
       false,
     )
+    .option(
+      "--manual",
+      "Capture an encrypted stored session via manual browser login (stealth-hardened)",
+      false,
+    )
+    .option(
+      "-s, --session <session>",
+      "Stored session name (used with --manual)",
+      "default",
+    )
     .option("--email <email>", "LinkedIn email (or set LINKEDIN_EMAIL env var)")
     .option(
       "--password <password>",
@@ -10002,6 +10079,8 @@ export function createCliProgram(): Command {
         headed: boolean;
         headedFallback: boolean;
         warmProfile: boolean;
+        manual: boolean;
+        session: string;
         email?: string;
         password?: string;
         mfaCode?: string;
@@ -10011,6 +10090,17 @@ export function createCliProgram(): Command {
           options.timeoutMinutes,
           "timeout-minutes",
         );
+
+        if (options.manual) {
+          await runManualLogin(
+            {
+              sessionName: coerceProfileName(options.session, "session"),
+              timeoutMinutes,
+            },
+            readCdpUrl(),
+          );
+          return;
+        }
 
         if (options.headless) {
           const email = options.email ?? process.env.LINKEDIN_EMAIL;
@@ -10066,6 +10156,35 @@ export function createCliProgram(): Command {
         }
       },
     );
+
+  const sessionCommand = program
+    .command("session")
+    .description("Manage stored encrypted LinkedIn sessions");
+
+  sessionCommand
+    .command("check")
+    .description(
+      "Validate the health of a stored LinkedIn session without launching a browser",
+    )
+    .option("-s, --session <session>", "Stored session name", "default")
+    .addHelpText(
+      "after",
+      [
+        "",
+        "Checks:",
+        "  - whether the encrypted session file exists on disk",
+        "  - whether the li_at authentication cookie is present",
+        "  - whether the li_at cookie has expired",
+        "  - whether a browser fingerprint is stored for the session",
+        "",
+        "Examples:",
+        "  linkedin session check",
+        "  linkedin session check --session smoke",
+      ].join("\n"),
+    )
+    .action(async (options: { session: string }) => {
+      await runSessionCheck(coerceProfileName(options.session, "session"));
+    });
 
   const runFixtureRecordCommand = async (options: {
     har: boolean;

--- a/packages/core/src/auth/fingerprint.ts
+++ b/packages/core/src/auth/fingerprint.ts
@@ -1,0 +1,472 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  randomBytes,
+} from "node:crypto";
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { chromium, type Page } from "playwright-core";
+import { resolveConfigPaths } from "../config.js";
+import { LinkedInBuddyError } from "../errors.js";
+import { resolveLinkedInSessionStoreDir } from "./sessionStore.js";
+
+const SESSION_STORE_KEY_FILE_NAME = ".session-store.key";
+const FINGERPRINT_FILE_SUFFIX = ".fingerprint.enc.json";
+const FINGERPRINT_SCHEMA_VERSION = 1;
+const AES_GCM_IV_BYTES = 12;
+
+type BrowserType = typeof chromium;
+type PersistentLaunchOptions = NonNullable<
+  Parameters<BrowserType["launchPersistentContext"]>[1]
+>;
+
+type FingerprintLaunchOptions = Pick<
+  PersistentLaunchOptions,
+  | "viewport"
+  | "locale"
+  | "timezoneId"
+  | "userAgent"
+  | "colorScheme"
+  | "deviceScaleFactor"
+>;
+type FingerprintColorScheme = BrowserFingerprint["colorScheme"];
+
+interface StoredBrowserFingerprintEnvelope {
+  version: number;
+  algorithm: "aes-256-gcm";
+  ciphertext: string;
+  iv: string;
+  tag: string;
+}
+
+/**
+ * Browser-level fingerprint values captured from a live Playwright page.
+ */
+export interface BrowserFingerprint {
+  userAgent: string;
+  viewport: { width: number; height: number };
+  timezone: string;
+  locale: string;
+  platform: string;
+  webglRenderer: string | null;
+  deviceScaleFactor: number;
+  colorScheme: "light" | "dark" | "no-preference";
+  capturedAt: string;
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function normalizeSessionName(sessionName: string): string {
+  const normalized = sessionName.trim();
+  if (normalized.length === 0) {
+    throw new LinkedInBuddyError(
+      "ACTION_PRECONDITION_FAILED",
+      "session name must not be empty.",
+    );
+  }
+
+  if (normalized === "." || normalized === ".." || /[\\/]/u.test(normalized)) {
+    throw new LinkedInBuddyError(
+      "ACTION_PRECONDITION_FAILED",
+      "session name must not contain path separators or relative path segments.",
+      {
+        session_name: normalized,
+      },
+    );
+  }
+
+  return normalized;
+}
+
+function encodeBase64Url(value: Buffer): string {
+  return value.toString("base64url");
+}
+
+function deriveMachineBoundKey(rawKey: Buffer): Buffer {
+  return createHash("sha256")
+    .update(rawKey)
+    .update("\0")
+    .update(os.hostname())
+    .update("\0")
+    .update(os.userInfo().username)
+    .digest();
+}
+
+function decodeBase64Url(value: string, label: string): Buffer {
+  try {
+    return Buffer.from(value, "base64url");
+  } catch (error) {
+    throw new LinkedInBuddyError(
+      "ACTION_PRECONDITION_FAILED",
+      `Stored browser fingerprint ${label} is malformed. Capture a fresh fingerprint and retry.`,
+      {
+        label,
+      },
+      {
+        cause: error instanceof Error ? error : undefined,
+      },
+    );
+  }
+}
+
+async function ensureOwnerOnlyPermissions(targetPath: string): Promise<void> {
+  try {
+    await chmod(targetPath, 0o600);
+  } catch {
+    // Best effort: chmod is not reliable across every platform/filesystem.
+  }
+}
+
+async function readOrCreateMasterKey(storeDir: string): Promise<Buffer> {
+  const keyPath = path.join(storeDir, SESSION_STORE_KEY_FILE_NAME);
+
+  try {
+    const existingKey = await readFile(keyPath);
+    if (existingKey.length === 32) {
+      return deriveMachineBoundKey(existingKey);
+    }
+  } catch (error) {
+    if (!isNotFoundError(error)) {
+      throw error;
+    }
+  }
+
+  const rawKey = randomBytes(32);
+  await writeFile(keyPath, rawKey);
+  await ensureOwnerOnlyPermissions(keyPath);
+  return deriveMachineBoundKey(rawKey);
+}
+
+function validateStoredBrowserFingerprint(
+  value: unknown,
+  sessionName: string,
+  filePath: string,
+): BrowserFingerprint {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("userAgent" in value) ||
+    !("viewport" in value) ||
+    !("timezone" in value) ||
+    !("locale" in value) ||
+    !("platform" in value) ||
+    !("deviceScaleFactor" in value) ||
+    !("colorScheme" in value) ||
+    !("capturedAt" in value)
+  ) {
+    throw new LinkedInBuddyError(
+      "ACTION_PRECONDITION_FAILED",
+      `Stored browser fingerprint "${sessionName}" is unreadable. Capture a fresh fingerprint and retry.`,
+      {
+        file_path: filePath,
+        session_name: sessionName,
+      },
+    );
+  }
+
+  const candidate = value as Partial<BrowserFingerprint>;
+  if (
+    typeof candidate.userAgent !== "string" ||
+    typeof candidate.timezone !== "string" ||
+    typeof candidate.locale !== "string" ||
+    typeof candidate.platform !== "string" ||
+    typeof candidate.deviceScaleFactor !== "number" ||
+    (candidate.colorScheme !== "light" &&
+      candidate.colorScheme !== "dark" &&
+      candidate.colorScheme !== "no-preference") ||
+    typeof candidate.capturedAt !== "string" ||
+    typeof candidate.viewport !== "object" ||
+    candidate.viewport === null ||
+    typeof candidate.viewport.width !== "number" ||
+    typeof candidate.viewport.height !== "number" ||
+    !(
+      candidate.webglRenderer === null ||
+      typeof candidate.webglRenderer === "string"
+    )
+  ) {
+    throw new LinkedInBuddyError(
+      "ACTION_PRECONDITION_FAILED",
+      `Stored browser fingerprint "${sessionName}" is malformed. Capture a fresh fingerprint and retry.`,
+      {
+        file_path: filePath,
+        session_name: sessionName,
+      },
+    );
+  }
+
+  return {
+    userAgent: candidate.userAgent,
+    viewport: {
+      width: candidate.viewport.width,
+      height: candidate.viewport.height,
+    },
+    timezone: candidate.timezone,
+    locale: candidate.locale,
+    platform: candidate.platform,
+    webglRenderer: candidate.webglRenderer,
+    deviceScaleFactor: candidate.deviceScaleFactor,
+    colorScheme: candidate.colorScheme,
+    capturedAt: candidate.capturedAt,
+  };
+}
+
+function validateEnvelope(
+  envelope: unknown,
+  sessionName: string,
+  filePath: string,
+): StoredBrowserFingerprintEnvelope {
+  if (
+    typeof envelope !== "object" ||
+    envelope === null ||
+    !("version" in envelope) ||
+    !("algorithm" in envelope) ||
+    !("ciphertext" in envelope) ||
+    !("iv" in envelope) ||
+    !("tag" in envelope)
+  ) {
+    throw new LinkedInBuddyError(
+      "ACTION_PRECONDITION_FAILED",
+      `Stored browser fingerprint "${sessionName}" is malformed. Capture a fresh fingerprint and retry.`,
+      {
+        file_path: filePath,
+        session_name: sessionName,
+      },
+    );
+  }
+
+  const normalizedEnvelope =
+    envelope as Partial<StoredBrowserFingerprintEnvelope>;
+  if (
+    normalizedEnvelope.version !== FINGERPRINT_SCHEMA_VERSION ||
+    normalizedEnvelope.algorithm !== "aes-256-gcm" ||
+    typeof normalizedEnvelope.ciphertext !== "string" ||
+    typeof normalizedEnvelope.iv !== "string" ||
+    typeof normalizedEnvelope.tag !== "string"
+  ) {
+    throw new LinkedInBuddyError(
+      "ACTION_PRECONDITION_FAILED",
+      `Stored browser fingerprint "${sessionName}" is unreadable. Capture a fresh fingerprint and retry.`,
+      {
+        file_path: filePath,
+        session_name: sessionName,
+      },
+    );
+  }
+
+  return {
+    version: normalizedEnvelope.version,
+    algorithm: normalizedEnvelope.algorithm,
+    ciphertext: normalizedEnvelope.ciphertext,
+    iv: normalizedEnvelope.iv,
+    tag: normalizedEnvelope.tag,
+  };
+}
+
+/**
+ * Resolves the encrypted on-disk file path for a named stored browser
+ * fingerprint.
+ */
+export function resolveLinkedInFingerprintPath(
+  sessionName: string,
+  baseDir?: string,
+): string {
+  const normalizedSessionName = normalizeSessionName(sessionName);
+  return path.join(
+    resolveLinkedInSessionStoreDir(baseDir),
+    `${normalizedSessionName}${FINGERPRINT_FILE_SUFFIX}`,
+  );
+}
+
+/**
+ * Captures browser fingerprint signals from a live Playwright page.
+ */
+export async function captureBrowserFingerprint(
+  page: Page,
+): Promise<BrowserFingerprint> {
+  const viewportSize = page.viewportSize();
+  const browserSignals = await page.evaluate(() => {
+    const colorScheme: FingerprintColorScheme = globalThis.matchMedia(
+      "(prefers-color-scheme: dark)",
+    ).matches
+      ? "dark"
+      : globalThis.matchMedia("(prefers-color-scheme: light)").matches
+        ? "light"
+        : "no-preference";
+
+    const canvas = globalThis.document.createElement("canvas");
+    const context =
+      canvas.getContext("webgl") ?? canvas.getContext("experimental-webgl");
+    let webglRenderer: string | null = null;
+
+    if (context && "getExtension" in context && "getParameter" in context) {
+      const debugInfo = context.getExtension("WEBGL_debug_renderer_info") as {
+        UNMASKED_RENDERER_WEBGL: number;
+      } | null;
+
+      if (debugInfo) {
+        const renderer = context.getParameter(
+          debugInfo.UNMASKED_RENDERER_WEBGL,
+        );
+        webglRenderer = typeof renderer === "string" ? renderer : null;
+      }
+    }
+
+    return {
+      userAgent: globalThis.navigator.userAgent,
+      platform: globalThis.navigator.platform,
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      locale: globalThis.navigator.language,
+      webglRenderer,
+      deviceScaleFactor: globalThis.devicePixelRatio,
+      colorScheme,
+      fallbackViewport: {
+        width: globalThis.innerWidth,
+        height: globalThis.innerHeight,
+      },
+    };
+  });
+
+  return {
+    userAgent: browserSignals.userAgent,
+    viewport: viewportSize ?? browserSignals.fallbackViewport,
+    timezone: browserSignals.timezone,
+    locale: browserSignals.locale,
+    platform: browserSignals.platform,
+    webglRenderer: browserSignals.webglRenderer,
+    deviceScaleFactor: browserSignals.deviceScaleFactor,
+    colorScheme: browserSignals.colorScheme,
+    capturedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Encrypts and saves a named browser fingerprint in the session store.
+ */
+export async function saveBrowserFingerprint(
+  fingerprint: BrowserFingerprint,
+  sessionName: string,
+  baseDir?: string,
+): Promise<string> {
+  const normalizedSessionName = normalizeSessionName(sessionName);
+  const { profilesDir } = resolveConfigPaths(baseDir);
+  await mkdir(profilesDir, { recursive: true });
+
+  const storeDir = resolveLinkedInSessionStoreDir(baseDir);
+  await mkdir(storeDir, { recursive: true });
+
+  const filePath = resolveLinkedInFingerprintPath(
+    normalizedSessionName,
+    baseDir,
+  );
+  const encryptionKey = await readOrCreateMasterKey(storeDir);
+  const iv = randomBytes(AES_GCM_IV_BYTES);
+  const cipher = createCipheriv("aes-256-gcm", encryptionKey, iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(fingerprint), "utf8"),
+    cipher.final(),
+  ]);
+
+  const envelope: StoredBrowserFingerprintEnvelope = {
+    version: FINGERPRINT_SCHEMA_VERSION,
+    algorithm: "aes-256-gcm",
+    ciphertext: encodeBase64Url(ciphertext),
+    iv: encodeBase64Url(iv),
+    tag: encodeBase64Url(cipher.getAuthTag()),
+  };
+
+  await writeFile(filePath, `${JSON.stringify(envelope, null, 2)}\n`, "utf8");
+  await ensureOwnerOnlyPermissions(filePath);
+
+  return filePath;
+}
+
+/**
+ * Loads and decrypts a named browser fingerprint from the session store.
+ */
+export async function loadBrowserFingerprint(
+  sessionName: string,
+  baseDir?: string,
+): Promise<BrowserFingerprint> {
+  const normalizedSessionName = normalizeSessionName(sessionName);
+  const filePath = resolveLinkedInFingerprintPath(
+    normalizedSessionName,
+    baseDir,
+  );
+
+  let rawEnvelope: string;
+  try {
+    rawEnvelope = await readFile(filePath, "utf8");
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      throw new LinkedInBuddyError(
+        "AUTH_REQUIRED",
+        `No stored browser fingerprint named "${normalizedSessionName}" was found. Capture a fresh session and retry.`,
+        {
+          file_path: filePath,
+          session_name: normalizedSessionName,
+        },
+      );
+    }
+
+    throw error;
+  }
+
+  const parsedEnvelope = validateEnvelope(
+    JSON.parse(rawEnvelope) as unknown,
+    normalizedSessionName,
+    filePath,
+  );
+  const storeDir = resolveLinkedInSessionStoreDir(baseDir);
+  const encryptionKey = await readOrCreateMasterKey(storeDir);
+
+  try {
+    const decipher = createDecipheriv(
+      "aes-256-gcm",
+      encryptionKey,
+      decodeBase64Url(parsedEnvelope.iv, "iv"),
+    );
+    decipher.setAuthTag(decodeBase64Url(parsedEnvelope.tag, "tag"));
+    const decryptedPayload = Buffer.concat([
+      decipher.update(decodeBase64Url(parsedEnvelope.ciphertext, "ciphertext")),
+      decipher.final(),
+    ]).toString("utf8");
+
+    return validateStoredBrowserFingerprint(
+      JSON.parse(decryptedPayload) as unknown,
+      normalizedSessionName,
+      filePath,
+    );
+  } catch (error) {
+    throw new LinkedInBuddyError(
+      "ACTION_PRECONDITION_FAILED",
+      `Stored browser fingerprint "${normalizedSessionName}" could not be decrypted. Capture a fresh fingerprint and retry.`,
+      {
+        file_path: filePath,
+        session_name: normalizedSessionName,
+      },
+      {
+        cause: error instanceof Error ? error : undefined,
+      },
+    );
+  }
+}
+
+/**
+ * Maps a captured browser fingerprint into Playwright persistent launch options.
+ */
+export function applyBrowserFingerprint(
+  fingerprint: BrowserFingerprint,
+): FingerprintLaunchOptions {
+  return {
+    viewport: fingerprint.viewport,
+    locale: fingerprint.locale,
+    timezoneId: fingerprint.timezone,
+    userAgent: fingerprint.userAgent,
+    colorScheme: fingerprint.colorScheme,
+    deviceScaleFactor: fingerprint.deviceScaleFactor,
+  };
+}

--- a/packages/core/src/auth/session.ts
+++ b/packages/core/src/auth/session.ts
@@ -269,7 +269,7 @@ export class LinkedInAuthService {
           : "AUTH_REQUIRED";
       const guidance = status.rateLimitActive
         ? `Wait for cooldown expiry (${status.rateLimitUntil}) or clear it with "linkedin rate-limit --clear".`
-        : `Run "linkedin login --profile ${options.profileName ?? "default"}" first.`;
+        : `Run "linkedin login --manual --session ${options.profileName ?? "default"}" to capture a fresh session, or "linkedin login --profile ${options.profileName ?? "default"}" for interactive login.`;
       this.logger?.log("warn", "auth.session.ensure_authenticated.failed", {
         code,
         current_url: status.currentUrl,

--- a/packages/core/src/auth/sessionHealthCheck.ts
+++ b/packages/core/src/auth/sessionHealthCheck.ts
@@ -1,0 +1,285 @@
+import { readFile } from "node:fs/promises";
+import { LinkedInBuddyError } from "../errors.js";
+import { resolveLinkedInFingerprintPath } from "./fingerprint.js";
+import { LinkedInSessionStore } from "./sessionStore.js";
+
+type LoadedSession = Awaited<ReturnType<LinkedInSessionStore["load"]>>;
+type StoredCookie = LoadedSession["storageState"]["cookies"][number];
+
+const NO_SESSION_GUIDANCE =
+  'No stored session found. Run "linkedin login --manual" to authenticate.';
+const NO_AUTH_COOKIE_GUIDANCE =
+  'Stored session is missing the LinkedIn authentication cookie. Run "linkedin login --manual" to re-authenticate.';
+const EXPIRED_SESSION_GUIDANCE =
+  'LinkedIn session has expired. Run "linkedin login --manual" to re-authenticate.';
+const HEALTHY_SESSION_GUIDANCE = "LinkedIn session is valid and ready to use.";
+const NO_FINGERPRINT_NOTE =
+  " No browser fingerprint stored — headless sessions may lack fingerprint consistency.";
+
+/** Result from a lightweight session health check. */
+export interface SessionHealthCheckResult {
+  healthy: boolean;
+  sessionName: string;
+  checkedAt: string;
+  /** Reason for the health status. */
+  reason: string;
+  /** Whether the encrypted session file exists on disk. */
+  sessionExists: boolean;
+  /** Whether the li_at auth cookie is present. */
+  hasAuthCookie: boolean;
+  /** ISO timestamp when the li_at cookie expires, or null. */
+  authCookieExpiresAt: string | null;
+  /** Milliseconds until expiry (negative = already expired). */
+  authCookieExpiresInMs: number | null;
+  /** Whether a stored browser fingerprint exists for this session. */
+  hasBrowserFingerprint: boolean;
+  /** Cookie count in the stored session. */
+  cookieCount: number;
+  /** Actionable guidance for the operator. */
+  guidance: string;
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function resolveSessionName(sessionName?: string): string {
+  const normalized = (sessionName ?? "default").trim();
+  return normalized.length > 0 ? normalized : "default";
+}
+
+function getLiAtCookie(
+  cookies: readonly StoredCookie[],
+): StoredCookie | undefined {
+  return cookies.find(
+    (cookie) => cookie.name === "li_at" && cookie.value.trim().length > 0,
+  );
+}
+
+function getCookieExpiry(
+  cookie: StoredCookie | undefined,
+  checkedAtMs: number,
+): {
+  authCookieExpiresAt: string | null;
+  authCookieExpiresInMs: number | null;
+} {
+  if (!cookie || typeof cookie.expires !== "number" || cookie.expires <= 0) {
+    return {
+      authCookieExpiresAt: null,
+      authCookieExpiresInMs: null,
+    };
+  }
+
+  const expiresAtMs = cookie.expires * 1_000;
+  return {
+    authCookieExpiresAt: new Date(expiresAtMs).toISOString(),
+    authCookieExpiresInMs: expiresAtMs - checkedAtMs,
+  };
+}
+
+function isDecryptionFailure(error: unknown): boolean {
+  return (
+    error instanceof LinkedInBuddyError &&
+    error.code === "ACTION_PRECONDITION_FAILED" &&
+    error.message.toLowerCase().includes("could not be decrypted")
+  );
+}
+
+async function checkFingerprintExists(
+  sessionName: string,
+  baseDir?: string,
+): Promise<boolean> {
+  try {
+    await readFile(
+      resolveLinkedInFingerprintPath(sessionName, baseDir),
+      "utf8",
+    );
+    return true;
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return false;
+    }
+
+    return false;
+  }
+}
+
+/**
+ * Validates stored LinkedIn session health without launching a browser.
+ */
+export async function checkStoredSessionHealth(
+  sessionName?: string,
+  baseDir?: string,
+): Promise<SessionHealthCheckResult> {
+  const checkedAtMs = Date.now();
+  const checkedAt = new Date(checkedAtMs).toISOString();
+  const requestedSessionName = resolveSessionName(sessionName);
+  const store = new LinkedInSessionStore(baseDir);
+
+  let sessionExists = false;
+  try {
+    sessionExists = await store.exists(requestedSessionName);
+  } catch (error) {
+    if (error instanceof LinkedInBuddyError) {
+      return {
+        healthy: false,
+        sessionName: requestedSessionName,
+        checkedAt,
+        reason: "Session name is invalid.",
+        sessionExists: false,
+        hasAuthCookie: false,
+        authCookieExpiresAt: null,
+        authCookieExpiresInMs: null,
+        hasBrowserFingerprint: false,
+        cookieCount: 0,
+        guidance: NO_SESSION_GUIDANCE,
+      };
+    }
+
+    return {
+      healthy: false,
+      sessionName: requestedSessionName,
+      checkedAt,
+      reason: "Could not verify whether the stored session exists.",
+      sessionExists: false,
+      hasAuthCookie: false,
+      authCookieExpiresAt: null,
+      authCookieExpiresInMs: null,
+      hasBrowserFingerprint: false,
+      cookieCount: 0,
+      guidance: NO_SESSION_GUIDANCE,
+    };
+  }
+
+  const hasBrowserFingerprint = await checkFingerprintExists(
+    requestedSessionName,
+    baseDir,
+  );
+
+  if (!sessionExists) {
+    return {
+      healthy: false,
+      sessionName: requestedSessionName,
+      checkedAt,
+      reason: "No stored session file exists.",
+      sessionExists: false,
+      hasAuthCookie: false,
+      authCookieExpiresAt: null,
+      authCookieExpiresInMs: null,
+      hasBrowserFingerprint,
+      cookieCount: 0,
+      guidance: NO_SESSION_GUIDANCE,
+    };
+  }
+
+  let loadedSession: LoadedSession;
+  try {
+    loadedSession = await store.load(requestedSessionName);
+  } catch (error) {
+    if (error instanceof LinkedInBuddyError && error.code === "AUTH_REQUIRED") {
+      return {
+        healthy: false,
+        sessionName: requestedSessionName,
+        checkedAt,
+        reason: "No stored session file exists.",
+        sessionExists: false,
+        hasAuthCookie: false,
+        authCookieExpiresAt: null,
+        authCookieExpiresInMs: null,
+        hasBrowserFingerprint,
+        cookieCount: 0,
+        guidance: NO_SESSION_GUIDANCE,
+      };
+    }
+
+    if (isDecryptionFailure(error)) {
+      return {
+        healthy: false,
+        sessionName: requestedSessionName,
+        checkedAt,
+        reason:
+          "Could not decrypt stored session. Capture a fresh session and retry.",
+        sessionExists: true,
+        hasAuthCookie: false,
+        authCookieExpiresAt: null,
+        authCookieExpiresInMs: null,
+        hasBrowserFingerprint,
+        cookieCount: 0,
+        guidance:
+          'Stored session could not be read. Run "linkedin login --manual" to re-authenticate.',
+      };
+    }
+
+    return {
+      healthy: false,
+      sessionName: requestedSessionName,
+      checkedAt,
+      reason: "Stored session metadata is invalid.",
+      sessionExists: true,
+      hasAuthCookie: false,
+      authCookieExpiresAt: null,
+      authCookieExpiresInMs: null,
+      hasBrowserFingerprint,
+      cookieCount: 0,
+      guidance:
+        'Stored session data is invalid. Run "linkedin login --manual" to re-authenticate.',
+    };
+  }
+
+  const authCookie = getLiAtCookie(loadedSession.storageState.cookies);
+  const hasAuthCookie = Boolean(authCookie);
+  const { authCookieExpiresAt, authCookieExpiresInMs } = getCookieExpiry(
+    authCookie,
+    checkedAtMs,
+  );
+  const isExpired =
+    authCookieExpiresInMs !== null && authCookieExpiresInMs <= 0;
+
+  if (!hasAuthCookie) {
+    return {
+      healthy: false,
+      sessionName: loadedSession.metadata.sessionName,
+      checkedAt,
+      reason: "Stored session does not contain a usable li_at cookie.",
+      sessionExists: true,
+      hasAuthCookie: false,
+      authCookieExpiresAt,
+      authCookieExpiresInMs,
+      hasBrowserFingerprint,
+      cookieCount: loadedSession.metadata.cookieCount,
+      guidance: NO_AUTH_COOKIE_GUIDANCE,
+    };
+  }
+
+  if (isExpired) {
+    return {
+      healthy: false,
+      sessionName: loadedSession.metadata.sessionName,
+      checkedAt,
+      reason: "Stored li_at cookie is expired.",
+      sessionExists: true,
+      hasAuthCookie: true,
+      authCookieExpiresAt,
+      authCookieExpiresInMs,
+      hasBrowserFingerprint,
+      cookieCount: loadedSession.metadata.cookieCount,
+      guidance: EXPIRED_SESSION_GUIDANCE,
+    };
+  }
+
+  return {
+    healthy: true,
+    sessionName: loadedSession.metadata.sessionName,
+    checkedAt,
+    reason: "Stored li_at cookie is present and not expired.",
+    sessionExists: true,
+    hasAuthCookie: true,
+    authCookieExpiresAt,
+    authCookieExpiresInMs,
+    hasBrowserFingerprint,
+    cookieCount: loadedSession.metadata.cookieCount,
+    guidance: hasBrowserFingerprint
+      ? HEALTHY_SESSION_GUIDANCE
+      : `${HEALTHY_SESSION_GUIDANCE}${NO_FINGERPRINT_NOTE}`,
+  };
+}

--- a/packages/core/src/auth/sessionStore.ts
+++ b/packages/core/src/auth/sessionStore.ts
@@ -2,22 +2,33 @@ import {
   createCipheriv,
   createDecipheriv,
   createHash,
-  randomBytes
+  randomBytes,
 } from "node:crypto";
 import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { type Browser, type BrowserContext } from "playwright-core";
 import {
-  chromium,
-  type Browser,
-  type BrowserContext
-} from "playwright-core";
-import { ensureConfigPaths, resolveConfigPaths } from "../config.js";
+  ensureConfigPaths,
+  resolveConfigPaths,
+  resolveEvasionConfig,
+} from "../config.js";
 import { LinkedInBuddyError, asLinkedInBuddyError } from "../errors.js";
 import { wrapLinkedInBrowserContext } from "../linkedinPage.js";
 import {
+  applyStealthLaunchOptions,
+  createStealthChromium,
+  hardenBrowserContext,
+  resolveStealthConfig,
+} from "../stealth.js";
+import {
+  captureBrowserFingerprint,
+  saveBrowserFingerprint,
+  type BrowserFingerprint,
+} from "./fingerprint.js";
+import {
   inspectLinkedInSession,
-  type LinkedInSessionInspection
+  type LinkedInSessionInspection,
 } from "./sessionInspection.js";
 
 /**
@@ -38,7 +49,7 @@ const LINKEDIN_AUTH_COOKIE_NAMES = new Set([
   "JSESSIONID",
   "liap",
   "bscookie",
-  "bcookie"
+  "bcookie",
 ]);
 
 type StorageStateCookie = LinkedInBrowserStorageState["cookies"][number];
@@ -59,10 +70,13 @@ export interface LinkedInSessionCookieMetadata {
 }
 
 function isSupportedSameSite(
-  value: unknown
+  value: unknown,
 ): value is LinkedInSessionCookieMetadata["sameSite"] | undefined {
   return (
-    value === undefined || value === "Lax" || value === "Strict" || value === "None"
+    value === undefined ||
+    value === "Lax" ||
+    value === "Strict" ||
+    value === "None"
   );
 }
 
@@ -70,8 +84,12 @@ function isLinkedInCookie(cookie: Pick<StorageStateCookie, "domain">): boolean {
   return cookie.domain.toLowerCase().includes("linkedin.com");
 }
 
-function isLinkedInAuthCookie(cookie: Pick<StorageStateCookie, "name" | "domain">): boolean {
-  return isLinkedInCookie(cookie) && LINKEDIN_AUTH_COOKIE_NAMES.has(cookie.name);
+function isLinkedInAuthCookie(
+  cookie: Pick<StorageStateCookie, "name" | "domain">,
+): boolean {
+  return (
+    isLinkedInCookie(cookie) && LINKEDIN_AUTH_COOKIE_NAMES.has(cookie.name)
+  );
 }
 
 function toCookieExpiresAt(expires: number): string | null {
@@ -88,7 +106,7 @@ function toCookieExpiresAt(expires: number): string | null {
  */
 export function summarizeLinkedInSessionCookies(
   cookies: readonly StorageStateCookie[],
-  options: { nowMs?: number } = {}
+  options: { nowMs?: number } = {},
 ): LinkedInSessionCookieMetadata[] {
   const nowMs = options.nowMs ?? Date.now();
 
@@ -107,12 +125,18 @@ export function summarizeLinkedInSessionCookies(
         expiresInMs,
         httpOnly: cookie.httpOnly,
         secure: cookie.secure,
-        sameSite: cookie.sameSite
+        sameSite: cookie.sameSite,
       };
     })
     .sort((left, right) => {
-      const leftExpiry = left.expiresAt === null ? Number.POSITIVE_INFINITY : new Date(left.expiresAt).getTime();
-      const rightExpiry = right.expiresAt === null ? Number.POSITIVE_INFINITY : new Date(right.expiresAt).getTime();
+      const leftExpiry =
+        left.expiresAt === null
+          ? Number.POSITIVE_INFINITY
+          : new Date(left.expiresAt).getTime();
+      const rightExpiry =
+        right.expiresAt === null
+          ? Number.POSITIVE_INFINITY
+          : new Date(right.expiresAt).getTime();
 
       if (leftExpiry !== rightExpiry) {
         return leftExpiry - rightExpiry;
@@ -127,7 +151,7 @@ export function summarizeLinkedInSessionCookies(
  * storage-state snapshot.
  */
 export function getLinkedInSessionFingerprint(
-  storageState: Pick<LinkedInBrowserStorageState, "cookies">
+  storageState: Pick<LinkedInBrowserStorageState, "cookies">,
 ): string {
   const authCookiePayload = storageState.cookies
     .filter((cookie) => isLinkedInAuthCookie(cookie))
@@ -144,7 +168,7 @@ export function getLinkedInSessionFingerprint(
       expires: cookie.expires,
       httpOnly: cookie.httpOnly,
       secure: cookie.secure,
-      sameSite: cookie.sameSite
+      sameSite: cookie.sameSite,
     }));
 
   return createHash("sha256")
@@ -158,9 +182,11 @@ export function getLinkedInSessionFingerprint(
  */
 export async function restoreLinkedInSessionCookies(
   context: BrowserContext,
-  storageState: LinkedInBrowserStorageState
+  storageState: LinkedInBrowserStorageState,
 ): Promise<void> {
-  const cookiesToRestore = storageState.cookies.filter((cookie) => isLinkedInCookie(cookie));
+  const cookiesToRestore = storageState.cookies.filter((cookie) =>
+    isLinkedInCookie(cookie),
+  );
   if (cookiesToRestore.length === 0) {
     return;
   }
@@ -233,8 +259,7 @@ export interface RestoreStoredLinkedInSessionOptions {
 /**
  * Result returned when a stored LinkedIn session snapshot is restored.
  */
-export interface RestoreStoredLinkedInSessionResult
-  extends LoadStoredLinkedInSessionResult {
+export interface RestoreStoredLinkedInSessionResult extends LoadStoredLinkedInSessionResult {
   restoredFromBackup: boolean;
   restoredSessionName: string;
 }
@@ -244,6 +269,10 @@ export interface RestoreStoredLinkedInSessionResult
  */
 export interface CaptureLinkedInSessionOptions {
   baseDir?: string;
+  /** When true, apply stealth/evasion hardening to the capture browser. */
+  stealth?: boolean;
+  /** Evasion level to use if stealth is enabled. Defaults to env/config. */
+  evasionLevel?: string;
   pollIntervalMs?: number;
   sessionName?: string;
   timeoutMs?: number;
@@ -253,17 +282,23 @@ export interface CaptureLinkedInSessionOptions {
  * Result returned by `captureLinkedInSession()` after a successful manual login
  * capture.
  */
-export interface CaptureLinkedInSessionResult
-  extends StoredLinkedInSessionMetadata {
+export interface CaptureLinkedInSessionResult extends StoredLinkedInSessionMetadata {
   authenticated: true;
   checkedAt: string;
   currentUrl: string;
+  /** Browser fingerprint captured during manual login, if available. */
+  fingerprint?: BrowserFingerprint;
+  /** On-disk path where the fingerprint was stored. */
+  fingerprintPath?: string;
 }
 
 function withPlaywrightInstallHint(error: unknown): Error {
-  if (error instanceof Error && error.message.includes("Executable doesn't exist")) {
+  if (
+    error instanceof Error &&
+    error.message.includes("Executable doesn't exist")
+  ) {
     return new Error(
-      'Playwright browser executable is missing. Install Chromium with "npx playwright install chromium" or set PLAYWRIGHT_EXECUTABLE_PATH.'
+      'Playwright browser executable is missing. Install Chromium with "npx playwright install chromium" or set PLAYWRIGHT_EXECUTABLE_PATH.',
     );
   }
 
@@ -279,7 +314,7 @@ function normalizeSessionName(sessionName: string | undefined): string {
   if (normalized.length === 0) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "session name must not be empty."
+      "session name must not be empty.",
     );
   }
 
@@ -288,8 +323,8 @@ function normalizeSessionName(sessionName: string | undefined): string {
       "ACTION_PRECONDITION_FAILED",
       "session name must not contain path separators or relative path segments.",
       {
-        session_name: normalized
-      }
+        session_name: normalized,
+      },
     );
   }
 
@@ -302,28 +337,28 @@ function getBackupSessionName(sessionName: string, index: number): string {
 
 function getFallbackSessionNames(
   sessionName: string,
-  maxBackups: number
+  maxBackups: number,
 ): string[] {
   const normalizedSessionName = normalizeSessionName(sessionName);
   return [
     normalizedSessionName,
     ...Array.from({ length: maxBackups }, (_, index) =>
-      getBackupSessionName(normalizedSessionName, index + 1)
-    )
+      getBackupSessionName(normalizedSessionName, index + 1),
+    ),
   ];
 }
 
 function getLinkedInAuthCookie(
-  storageState: LinkedInBrowserStorageState
+  storageState: LinkedInBrowserStorageState,
 ): LinkedInBrowserStorageState["cookies"][number] | undefined {
   return storageState.cookies.find(
-    (cookie) => cookie.name === "li_at" && cookie.value.trim().length > 0
+    (cookie) => cookie.name === "li_at" && cookie.value.trim().length > 0,
   );
 }
 
 function isStoredSessionExpired(
   storageState: LinkedInBrowserStorageState,
-  referenceTimeMs: number = Date.now()
+  referenceTimeMs: number = Date.now(),
 ): boolean {
   const authCookie = getLinkedInAuthCookie(storageState);
   if (!authCookie) {
@@ -341,16 +376,16 @@ function createStoredSessionValidationError(
   message: string,
   sessionName: string,
   filePath: string,
-  cause?: Error
+  cause?: Error,
 ): LinkedInBuddyError {
   return new LinkedInBuddyError(
     "ACTION_PRECONDITION_FAILED",
     message,
     {
       file_path: filePath,
-      session_name: sessionName
+      session_name: sessionName,
     },
-    cause ? { cause } : undefined
+    cause ? { cause } : undefined,
   );
 }
 
@@ -376,20 +411,26 @@ function decodeBase64Url(value: string, label: string): Buffer {
       "ACTION_PRECONDITION_FAILED",
       `Stored LinkedIn session ${label} is malformed. Capture a fresh session and retry.`,
       {
-        label
+        label,
       },
       {
-        cause: error instanceof Error ? error : undefined
-      }
+        cause: error instanceof Error ? error : undefined,
+      },
     );
   }
 }
 
 function getLinkedInAuthCookieExpiry(
-  storageState: LinkedInBrowserStorageState
+  storageState: LinkedInBrowserStorageState,
 ): string | null {
-  const authCookie = storageState.cookies.find((cookie) => cookie.name === "li_at");
-  if (!authCookie || typeof authCookie.expires !== "number" || authCookie.expires <= 0) {
+  const authCookie = storageState.cookies.find(
+    (cookie) => cookie.name === "li_at",
+  );
+  if (
+    !authCookie ||
+    typeof authCookie.expires !== "number" ||
+    authCookie.expires <= 0
+  ) {
     return null;
   }
 
@@ -400,10 +441,10 @@ function createStoredSessionMetadata(
   sessionName: string,
   filePath: string,
   storageState: LinkedInBrowserStorageState,
-  capturedAt: string = new Date().toISOString()
+  capturedAt: string = new Date().toISOString(),
 ): StoredLinkedInSessionMetadata {
   const hasLinkedInAuthCookie = storageState.cookies.some(
-    (cookie) => cookie.name === "li_at" && cookie.value.trim().length > 0
+    (cookie) => cookie.name === "li_at" && cookie.value.trim().length > 0,
   );
 
   return {
@@ -416,13 +457,13 @@ function createStoredSessionMetadata(
     sessionName,
     sessionCookieFingerprint: getLinkedInSessionFingerprint(storageState),
     sessionCookies: summarizeLinkedInSessionCookies(storageState.cookies, {
-      nowMs: new Date(capturedAt).getTime()
-    })
+      nowMs: new Date(capturedAt).getTime(),
+    }),
   };
 }
 
 function toStoredMetadataRecord(
-  metadata: StoredLinkedInSessionMetadata
+  metadata: StoredLinkedInSessionMetadata,
 ): StoredLinkedInSessionMetadataRecord {
   return {
     capturedAt: metadata.capturedAt,
@@ -434,13 +475,15 @@ function toStoredMetadataRecord(
     ...(metadata.sessionCookieFingerprint
       ? { sessionCookieFingerprint: metadata.sessionCookieFingerprint }
       : {}),
-    ...(metadata.sessionCookies ? { sessionCookies: metadata.sessionCookies } : {})
+    ...(metadata.sessionCookies
+      ? { sessionCookies: metadata.sessionCookies }
+      : {}),
   };
 }
 
 function toStoredMetadata(
   metadata: StoredLinkedInSessionMetadataRecord,
-  filePath: string
+  filePath: string,
 ): StoredLinkedInSessionMetadata {
   return {
     capturedAt: metadata.capturedAt,
@@ -453,7 +496,9 @@ function toStoredMetadata(
     ...(metadata.sessionCookieFingerprint
       ? { sessionCookieFingerprint: metadata.sessionCookieFingerprint }
       : {}),
-    ...(metadata.sessionCookies ? { sessionCookies: metadata.sessionCookies } : {})
+    ...(metadata.sessionCookies
+      ? { sessionCookies: metadata.sessionCookies }
+      : {}),
   };
 }
 
@@ -488,7 +533,7 @@ async function readOrCreateMasterKey(storeDir: string): Promise<Buffer> {
 function validateEnvelope(
   envelope: unknown,
   sessionName: string,
-  filePath: string
+  filePath: string,
 ): StoredLinkedInSessionEnvelope {
   if (
     typeof envelope !== "object" ||
@@ -503,7 +548,7 @@ function validateEnvelope(
     throw createStoredSessionValidationError(
       `Stored LinkedIn session "${sessionName}" is malformed. Capture a fresh session and retry.`,
       sessionName,
-      filePath
+      filePath,
     );
   }
 
@@ -520,11 +565,12 @@ function validateEnvelope(
     throw createStoredSessionValidationError(
       `Stored LinkedIn session "${sessionName}" is unreadable. Capture a fresh session and retry.`,
       sessionName,
-      filePath
+      filePath,
     );
   }
 
-  const metadata = normalizedEnvelope.metadata as Partial<StoredLinkedInSessionMetadataRecord>;
+  const metadata =
+    normalizedEnvelope.metadata as Partial<StoredLinkedInSessionMetadataRecord>;
   if (
     typeof metadata.sessionName !== "string" ||
     typeof metadata.capturedAt !== "string" ||
@@ -545,11 +591,13 @@ function validateEnvelope(
             typeof cookie.name === "string" &&
             typeof cookie.domain === "string" &&
             typeof cookie.path === "string" &&
-            (cookie.expiresAt === null || typeof cookie.expiresAt === "string") &&
-            (cookie.expiresInMs === null || typeof cookie.expiresInMs === "number") &&
+            (cookie.expiresAt === null ||
+              typeof cookie.expiresAt === "string") &&
+            (cookie.expiresInMs === null ||
+              typeof cookie.expiresInMs === "number") &&
             typeof cookie.httpOnly === "boolean" &&
             typeof cookie.secure === "boolean" &&
-            isSupportedSameSite((cookie as { sameSite?: unknown }).sameSite)
+            isSupportedSameSite((cookie as { sameSite?: unknown }).sameSite),
         ))
     ) ||
     !(
@@ -560,7 +608,7 @@ function validateEnvelope(
     throw createStoredSessionValidationError(
       `Stored LinkedIn session "${sessionName}" is unreadable. Capture a fresh session and retry.`,
       sessionName,
-      filePath
+      filePath,
     );
   }
 
@@ -580,15 +628,17 @@ function validateEnvelope(
       ...(metadata.sessionCookieFingerprint
         ? { sessionCookieFingerprint: metadata.sessionCookieFingerprint }
         : {}),
-      ...(metadata.sessionCookies ? { sessionCookies: metadata.sessionCookies } : {})
-    }
+      ...(metadata.sessionCookies
+        ? { sessionCookies: metadata.sessionCookies }
+        : {}),
+    },
   };
 }
 
 function validateStorageState(
   value: unknown,
   sessionName: string,
-  filePath: string
+  filePath: string,
 ): LinkedInBrowserStorageState {
   if (
     typeof value !== "object" ||
@@ -601,7 +651,7 @@ function validateStorageState(
     throw createStoredSessionValidationError(
       `Stored LinkedIn session "${sessionName}" could not be decoded. Capture a fresh session and retry.`,
       sessionName,
-      filePath
+      filePath,
     );
   }
 
@@ -620,12 +670,12 @@ export function resolveLinkedInSessionStoreDir(baseDir?: string): string {
  */
 export function resolveStoredLinkedInSessionPath(
   sessionName: string = "default",
-  baseDir?: string
+  baseDir?: string,
 ): string {
   const normalizedSessionName = normalizeSessionName(sessionName);
   return path.join(
     resolveLinkedInSessionStoreDir(baseDir),
-    `${normalizedSessionName}${SESSION_FILE_SUFFIX}`
+    `${normalizedSessionName}${SESSION_FILE_SUFFIX}`,
   );
 }
 
@@ -652,7 +702,7 @@ export class LinkedInSessionStore {
    */
   async save(
     sessionName: string,
-    storageState: LinkedInBrowserStorageState
+    storageState: LinkedInBrowserStorageState,
   ): Promise<StoredLinkedInSessionMetadata> {
     const normalizedSessionName = normalizeSessionName(sessionName);
     ensureConfigPaths(resolveConfigPaths(this.baseDir));
@@ -663,7 +713,7 @@ export class LinkedInSessionStore {
     const metadata = createStoredSessionMetadata(
       normalizedSessionName,
       filePath,
-      storageState
+      storageState,
     );
 
     const encryptionKey = await readOrCreateMasterKey(storeDir);
@@ -672,7 +722,7 @@ export class LinkedInSessionStore {
     const plaintext = JSON.stringify(storageState);
     const ciphertext = Buffer.concat([
       cipher.update(plaintext, "utf8"),
-      cipher.final()
+      cipher.final(),
     ]);
     const tag = cipher.getAuthTag();
 
@@ -682,7 +732,7 @@ export class LinkedInSessionStore {
       ciphertext: encodeBase64Url(ciphertext),
       iv: encodeBase64Url(iv),
       tag: encodeBase64Url(tag),
-      metadata: toStoredMetadataRecord(metadata)
+      metadata: toStoredMetadataRecord(metadata),
     };
 
     await writeFile(filePath, `${JSON.stringify(envelope, null, 2)}\n`, "utf8");
@@ -698,7 +748,7 @@ export class LinkedInSessionStore {
   async saveWithBackups(
     sessionName: string,
     storageState: LinkedInBrowserStorageState,
-    options: SaveStoredLinkedInSessionOptions = {}
+    options: SaveStoredLinkedInSessionOptions = {},
   ): Promise<StoredLinkedInSessionMetadata> {
     const normalizedSessionName = normalizeSessionName(sessionName);
     const maxBackups = Math.max(0, options.maxBackups ?? 2);
@@ -707,7 +757,7 @@ export class LinkedInSessionStore {
       for (let backupIndex = maxBackups; backupIndex >= 2; backupIndex -= 1) {
         const sourceBackupName = getBackupSessionName(
           normalizedSessionName,
-          backupIndex - 1
+          backupIndex - 1,
         );
 
         if (!(await this.exists(sourceBackupName))) {
@@ -717,7 +767,7 @@ export class LinkedInSessionStore {
         const sourceBackup = await this.load(sourceBackupName);
         await this.save(
           getBackupSessionName(normalizedSessionName, backupIndex),
-          sourceBackup.storageState
+          sourceBackup.storageState,
         );
       }
 
@@ -725,7 +775,7 @@ export class LinkedInSessionStore {
         const previousPrimary = await this.load(normalizedSessionName);
         await this.save(
           getBackupSessionName(normalizedSessionName, 1),
-          previousPrimary.storageState
+          previousPrimary.storageState,
         );
       }
     }
@@ -751,7 +801,9 @@ export class LinkedInSessionStore {
   /**
    * Loads and decrypts a named stored LinkedIn session snapshot.
    */
-  async load(sessionName: string = "default"): Promise<LoadStoredLinkedInSessionResult> {
+  async load(
+    sessionName: string = "default",
+  ): Promise<LoadStoredLinkedInSessionResult> {
     const normalizedSessionName = normalizeSessionName(sessionName);
     const filePath = this.getSessionPath(normalizedSessionName);
 
@@ -765,8 +817,8 @@ export class LinkedInSessionStore {
           `No stored LinkedIn session named "${normalizedSessionName}" was found. Run "linkedin-buddy auth session --session ${normalizedSessionName}" first.`,
           {
             file_path: filePath,
-            session_name: normalizedSessionName
-          }
+            session_name: normalizedSessionName,
+          },
         );
       }
       throw error;
@@ -775,7 +827,7 @@ export class LinkedInSessionStore {
     const parsedEnvelope = validateEnvelope(
       JSON.parse(rawEnvelope) as unknown,
       normalizedSessionName,
-      filePath
+      filePath,
     );
     const storeDir = resolveLinkedInSessionStoreDir(this.baseDir);
     const encryptionKey = await readOrCreateMasterKey(storeDir);
@@ -785,30 +837,32 @@ export class LinkedInSessionStore {
       const decipher = createDecipheriv(
         "aes-256-gcm",
         encryptionKey,
-        decodeBase64Url(parsedEnvelope.iv, "iv")
+        decodeBase64Url(parsedEnvelope.iv, "iv"),
       );
       decipher.setAuthTag(decodeBase64Url(parsedEnvelope.tag, "tag"));
       const decryptedPayload = Buffer.concat([
-        decipher.update(decodeBase64Url(parsedEnvelope.ciphertext, "ciphertext")),
-        decipher.final()
+        decipher.update(
+          decodeBase64Url(parsedEnvelope.ciphertext, "ciphertext"),
+        ),
+        decipher.final(),
       ]).toString("utf8");
       storageState = validateStorageState(
         JSON.parse(decryptedPayload) as unknown,
         normalizedSessionName,
-        filePath
+        filePath,
       );
     } catch (error) {
       throw createStoredSessionValidationError(
         `Stored LinkedIn session "${normalizedSessionName}" could not be decrypted. Capture a fresh session and retry.`,
         normalizedSessionName,
         filePath,
-        error instanceof Error ? error : undefined
+        error instanceof Error ? error : undefined,
       );
     }
 
     return {
       metadata: toStoredMetadata(parsedEnvelope.metadata, filePath),
-      storageState
+      storageState,
     };
   }
 
@@ -818,7 +872,7 @@ export class LinkedInSessionStore {
    */
   async loadLatestAvailable(
     sessionName: string = "default",
-    options: RestoreStoredLinkedInSessionOptions = {}
+    options: RestoreStoredLinkedInSessionOptions = {},
   ): Promise<RestoreStoredLinkedInSessionResult> {
     const normalizedSessionName = normalizeSessionName(sessionName);
     const maxBackups = Math.max(0, options.maxBackups ?? 2);
@@ -826,7 +880,7 @@ export class LinkedInSessionStore {
 
     for (const candidateSessionName of getFallbackSessionNames(
       normalizedSessionName,
-      maxBackups
+      maxBackups,
     )) {
       try {
         const loadedSession = await this.load(candidateSessionName);
@@ -840,7 +894,7 @@ export class LinkedInSessionStore {
         return {
           ...loadedSession,
           restoredFromBackup: candidateSessionName !== normalizedSessionName,
-          restoredSessionName: candidateSessionName
+          restoredSessionName: candidateSessionName,
         };
       } catch (error) {
         if (
@@ -862,11 +916,11 @@ export class LinkedInSessionStore {
         session_name: normalizedSessionName,
         ...(lastValidationError instanceof Error
           ? { cause: lastValidationError.message }
-          : {})
+          : {}),
       },
       lastValidationError instanceof Error
         ? { cause: lastValidationError }
-        : undefined
+        : undefined,
     );
   }
 
@@ -877,9 +931,12 @@ export class LinkedInSessionStore {
   async restoreToContext(
     context: BrowserContext,
     sessionName: string = "default",
-    options: RestoreStoredLinkedInSessionOptions = {}
+    options: RestoreStoredLinkedInSessionOptions = {},
   ): Promise<RestoreStoredLinkedInSessionResult> {
-    const restoredSession = await this.loadLatestAvailable(sessionName, options);
+    const restoredSession = await this.loadLatestAvailable(
+      sessionName,
+      options,
+    );
 
     await context.addCookies(restoredSession.storageState.cookies);
     await restoreOriginStorageToContext(context, restoredSession.storageState);
@@ -896,7 +953,7 @@ async function getOrCreatePage(context: BrowserContext) {
 
 async function restoreOriginStorageToContext(
   context: BrowserContext,
-  storageState: LinkedInBrowserStorageState
+  storageState: LinkedInBrowserStorageState,
 ): Promise<void> {
   if (storageState.origins.length === 0) {
     return;
@@ -907,7 +964,7 @@ async function restoreOriginStorageToContext(
   for (const originState of storageState.origins) {
     try {
       await page.goto(originState.origin, {
-        waitUntil: "domcontentloaded"
+        waitUntil: "domcontentloaded",
       });
       await page.evaluate((localStorageEntries) => {
         globalThis.localStorage.clear();
@@ -924,11 +981,11 @@ async function restoreOriginStorageToContext(
 async function waitForManualLogin(
   context: BrowserContext,
   timeoutMs: number,
-  pollIntervalMs: number
+  pollIntervalMs: number,
 ): Promise<LinkedInSessionInspection> {
   const page = await getOrCreatePage(context);
   await page.goto("https://www.linkedin.com/login", {
-    waitUntil: "domcontentloaded"
+    waitUntil: "domcontentloaded",
   });
 
   const deadline = Date.now() + timeoutMs;
@@ -946,8 +1003,8 @@ async function waitForManualLogin(
       {
         current_url: lastStatus.currentUrl,
         reason: lastStatus.reason,
-        timeout_ms: timeoutMs
-      }
+        timeout_ms: timeoutMs,
+      },
     );
   }
 
@@ -959,7 +1016,7 @@ async function waitForManualLogin(
  * persists the resulting authenticated session snapshot.
  */
 export async function captureLinkedInSession(
-  options: CaptureLinkedInSessionOptions = {}
+  options: CaptureLinkedInSessionOptions = {},
 ): Promise<CaptureLinkedInSessionResult> {
   const sessionName = normalizeSessionName(options.sessionName);
   const timeoutMs = options.timeoutMs ?? DEFAULT_CAPTURE_TIMEOUT_MS;
@@ -969,13 +1026,13 @@ export async function captureLinkedInSession(
   if (timeoutMs <= 0 || !Number.isFinite(timeoutMs)) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "timeoutMs must be a positive number."
+      "timeoutMs must be a positive number.",
     );
   }
   if (pollIntervalMs <= 0 || !Number.isFinite(pollIntervalMs)) {
     throw new LinkedInBuddyError(
       "ACTION_PRECONDITION_FAILED",
-      "pollIntervalMs must be a positive number."
+      "pollIntervalMs must be a positive number.",
     );
   }
 
@@ -983,17 +1040,48 @@ export async function captureLinkedInSession(
   let context: BrowserContext | undefined;
   try {
     const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
-    browser = await chromium.launch({
-      headless: false,
-      ...(executablePath ? { executablePath } : {})
-    });
+    const useStealth = options.stealth ?? true;
+    const evasion = resolveEvasionConfig(
+      options.evasionLevel ? { level: options.evasionLevel } : {},
+    );
+    const stealthConfig = resolveStealthConfig(evasion.level);
+    const effectiveStealthConfig = useStealth
+      ? stealthConfig
+      : { ...stealthConfig, enabled: false };
+
+    const launcher = await createStealthChromium(effectiveStealthConfig);
+    const launchOptions = applyStealthLaunchOptions(
+      {
+        headless: false,
+        ...(executablePath ? { executablePath } : {}),
+      },
+      effectiveStealthConfig,
+    );
+    browser = await launcher.launch(launchOptions);
     context = await browser.newContext();
+    await hardenBrowserContext(context, effectiveStealthConfig);
     const status = await waitForManualLogin(
       wrapLinkedInBrowserContext(context),
       timeoutMs,
-      pollIntervalMs
+      pollIntervalMs,
     );
     const storageState = await context.storageState();
+    // Capture browser fingerprint from the authenticated page
+    const page = context.pages()[0];
+    let fingerprint: BrowserFingerprint | undefined;
+    let fingerprintPath: string | undefined;
+    if (page) {
+      try {
+        fingerprint = await captureBrowserFingerprint(page);
+        fingerprintPath = await saveBrowserFingerprint(
+          fingerprint,
+          sessionName,
+          options.baseDir,
+        );
+      } catch {
+        // Fingerprint capture is best-effort; session capture is the priority.
+      }
+    }
     const store = new LinkedInSessionStore(options.baseDir);
     const metadata = await store.save(sessionName, storageState);
 
@@ -1003,22 +1091,24 @@ export async function captureLinkedInSession(
         "LinkedIn login appeared successful, but no authenticated session cookie was captured. Capture the session again after the home feed loads fully.",
         {
           current_url: status.currentUrl,
-          session_name: sessionName
-        }
+          session_name: sessionName,
+        },
       );
     }
 
     return {
       ...metadata,
+      ...(fingerprint ? { fingerprint } : {}),
+      ...(fingerprintPath ? { fingerprintPath } : {}),
       authenticated: true,
       checkedAt: status.checkedAt,
-      currentUrl: status.currentUrl
+      currentUrl: status.currentUrl,
     };
   } catch (error) {
     throw asLinkedInBuddyError(
       withPlaywrightInstallHint(error),
       error instanceof LinkedInBuddyError ? error.code : "UNKNOWN",
-      "Failed to capture the LinkedIn browser session."
+      "Failed to capture the LinkedIn browser session.",
     );
   } finally {
     if (context) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,8 @@ export * from "./activityWatches.js";
 export * from "./auth/cookieTransplant.js";
 export * from "./auth/rateLimitState.js";
 export * from "./auth/session.js";
+export * from "./auth/fingerprint.js";
+export * from "./auth/sessionHealthCheck.js";
 export * from "./auth/sessionStore.js";
 export * from "./connectionPool.js";
 export * from "./config.js";

--- a/packages/core/src/profileManager.ts
+++ b/packages/core/src/profileManager.ts
@@ -21,6 +21,10 @@ import {
   resolveStealthConfig,
   type StealthConfig,
 } from "./stealth.js";
+import {
+  applyBrowserFingerprint,
+  loadBrowserFingerprint,
+} from "./auth/fingerprint.js";
 
 type PersistentLaunchOptions = NonNullable<
   Parameters<typeof chromium.launchPersistentContext>[1]
@@ -131,6 +135,19 @@ export class ProfileManager {
       const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
       if (executablePath) {
         launchOptions.executablePath = executablePath;
+      }
+
+      // Apply stored browser fingerprint (viewport, locale, timezone, user
+      // agent) when available so headless sessions reuse the same identity
+      // captured during manual login.
+      try {
+        const fingerprint = await loadBrowserFingerprint(profileName);
+        if (fingerprint) {
+          const fpOptions = applyBrowserFingerprint(fingerprint);
+          launchOptions = { ...launchOptions, ...fpOptions };
+        }
+      } catch {
+        // Fingerprint loading is best-effort; proceed without it.
       }
 
       // Apply stealth-specific launch options (viewport, locale, timezone,


### PR DESCRIPTION
## Summary

Closes #365

Implements session persistence with manual sign-in and reusable session state:

- **`linkedin login --manual`** — Opens a stealth-hardened headed Chromium browser for manual LinkedIn sign-in. Captures encrypted session state + browser fingerprint (viewport, locale, timezone, user agent, scale factor, color scheme). Supports `--session <name>` to label sessions.
- **`linkedin session check`** — Lightweight session health validation without launching a browser. Checks cookie expiry, fingerprint presence, and returns structured pass/fail with actionable guidance.
- **Browser fingerprint persistence** — Captures fingerprint signals during manual login, encrypts with AES-256-GCM (machine-bound key), and reloads into headless sessions via ProfileManager for identity consistency.
- **Stealth-hardened capture** — Manual login now uses `createStealthChromium()` + `hardenBrowserContext()` for anti-detection evasion during capture.
- **Error guidance** — `ensureAuthenticated()` now directs users to `login --manual` as the primary recovery path.

## Files Changed

| File | Change |
|------|--------|
| `packages/core/src/auth/fingerprint.ts` | **NEW** — Browser fingerprint capture, AES-256-GCM encrypted persistence, Playwright launch option generation |
| `packages/core/src/auth/sessionHealthCheck.ts` | **NEW** — Lightweight stored session health validation (cookie expiry, fingerprint, structured result) |
| `packages/core/src/auth/sessionStore.ts` | Enhanced `captureLinkedInSession()` with stealth hardening + fingerprint capture |
| `packages/core/src/auth/session.ts` | Updated `ensureAuthenticated()` guidance to mention `login --manual` |
| `packages/core/src/profileManager.ts` | Wired fingerprint loading into `runWithPersistentContext()` |
| `packages/core/src/index.ts` | Added exports for new modules |
| `packages/cli/src/bin/linkedin.ts` | Added `login --manual`, `session check` commands + helper functions |

## Quality Gates

- ✅ Lint: clean
- ✅ Tests: 108 files, 1148 tests passing (no regressions)
- ⚠️ Typecheck/Build: pre-existing errors only (cli `@linkedin-buddy/core` resolution, `playwright-extra` types)