### PR TITLE
fix: record CAPTCHA cooldown, clear tracking cookies, and improve headless login guidance (#367)

### DIFF
--- a/docs/evasion.md
+++ b/docs/evasion.md
@@ -402,6 +402,42 @@ const profile = resolveEvasionProfile(evasion.level);
 console.log(evasion.summary, profile.mouseOvershootFactor);
 ```
 
+## Headless login limitations
+
+LinkedIn's anti-automation systems actively detect headless browser logins. Even
+with `paranoid` evasion and stealth plugins enabled, headless login attempts may
+trigger a CAPTCHA checkpoint that cannot be solved without human interaction.
+Repeated headless attempts against the same account can escalate to a temporary
+account restriction.
+
+### What happens
+
+1. Headless login fills and submits the credential form.
+2. LinkedIn redirects to `/checkpoint/lg/login-submit` with a CAPTCHA challenge.
+3. The CLI detects the CAPTCHA, records a rate-limit cooldown, and exits.
+4. Subsequent headless login attempts within the cooldown window are blocked
+   automatically (exponential backoff: 2 h → 4 h → 8 h).
+
+### Recommended authentication methods
+
+| Method            | Command                                                       | Notes                                                       |
+| ----------------- | ------------------------------------------------------------- | ----------------------------------------------------------- |
+| Interactive login | `linkedin login --profile <name>`                             | Opens a headed browser. Human completes any challenge.      |
+| Session capture   | `linkedin auth session --session <name>`                      | Imports an encrypted session from a manual browser login.   |
+| Cookie transplant | `linkedin auth import-cookies --profile <name> --file <path>` | Reuses an exported session from another profile or machine. |
+| Headless login    | `linkedin login --headless --email <e> --password <p>`        | Works when no CAPTCHA is triggered. Use sparingly.          |
+
+### Reducing CAPTCHA risk for headless login
+
+- Use `--warm-profile` to browse LinkedIn organically before the login attempt.
+- Use `--headed-fallback` to automatically retry in headed mode when a CAPTCHA
+  is detected.
+- Avoid running headless login more than once per session window. The CLI tracks
+  CAPTCHA encounters and enforces a cooldown to prevent account restrictions.
+- Before headless login, the CLI clears non-essential tracking cookies from the
+  persistent profile to reduce the chance of being classified as a returning
+  automated visitor.
+
 ## Troubleshooting
 
 ### LinkedIn still shows a checkpoint, login wall, or CAPTCHA

--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -5245,6 +5245,8 @@ async function runHeadlessLogin(
       checkpoint: result.checkpoint,
       checkpointType: result.checkpointType,
       mfaRequired: result.mfaRequired,
+      rateLimitActive: result.rateLimitActive,
+      rateLimitUntil: result.rateLimitUntil,
     });
 
     printJson({ run_id: runtime.runId, ...result });

--- a/packages/cli/src/headlessLoginOutput.ts
+++ b/packages/cli/src/headlessLoginOutput.ts
@@ -8,14 +8,22 @@ export interface HeadlessLoginProgressReporterOptions {
   writeLine?: (line: string) => void;
 }
 
-function readBoolean(payload: Record<string, unknown>, key: string): boolean | null {
+function readBoolean(
+  payload: Record<string, unknown>,
+  key: string,
+): boolean | null {
   const value = payload[key];
   return typeof value === "boolean" ? value : null;
 }
 
-function readString(payload: Record<string, unknown>, key: string): string | null {
+function readString(
+  payload: Record<string, unknown>,
+  key: string,
+): string | null {
   const value = payload[key];
-  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
 }
 
 function formatFieldLabel(fieldLabel: string | null): string {
@@ -55,7 +63,9 @@ export class HeadlessLoginProgressReporter {
 
   constructor(options: HeadlessLoginProgressReporterOptions = {}) {
     this.enabled = options.enabled ?? true;
-    this.writeLine = options.writeLine ?? ((line: string) => process.stderr.write(`${line}\n`));
+    this.writeLine =
+      options.writeLine ??
+      ((line: string) => process.stderr.write(`${line}\n`));
   }
 
   handleLog(entry: HeadlessLoginProgressLogEntry): void {
@@ -66,7 +76,7 @@ export class HeadlessLoginProgressReporter {
     if (entry.event === "cli.login.headless.start") {
       const profileName = readString(entry.payload, "profileName");
       this.writeLine(
-        `Starting headless login${profileName ? ` for profile ${profileName}` : ""}.`
+        `Starting headless login${profileName ? ` for profile ${profileName}` : ""}.`,
       );
       return;
     }
@@ -77,7 +87,9 @@ export class HeadlessLoginProgressReporter {
         return;
       }
 
-      this.writeLine(`Typing ${formatFieldLabel(fieldLabel)} with human-like cadence...`);
+      this.writeLine(
+        `Typing ${formatFieldLabel(fieldLabel)} with human-like cadence...`,
+      );
       return;
     }
 
@@ -88,7 +100,9 @@ export class HeadlessLoginProgressReporter {
         return;
       }
 
-      this.writeLine(`Typed ${formatFieldLabel(fieldLabel)} with simulated keystrokes.`);
+      this.writeLine(
+        `Typed ${formatFieldLabel(fieldLabel)} with simulated keystrokes.`,
+      );
       return;
     }
 
@@ -97,7 +111,7 @@ export class HeadlessLoginProgressReporter {
       const reason = readString(entry.payload, "reason");
       const method = readString(entry.payload, "method");
       this.writeLine(
-        `Typing ${formatFieldLabel(fieldLabel)} fell back to direct input via ${formatFallbackMethod(method)} because ${formatFallbackReason(reason)}.`
+        `Typing ${formatFieldLabel(fieldLabel)} fell back to direct input via ${formatFallbackMethod(method)} because ${formatFallbackReason(reason)}.`,
       );
       return;
     }
@@ -105,7 +119,7 @@ export class HeadlessLoginProgressReporter {
     if (entry.event === "humanize.typing.fallback_failed") {
       const fieldLabel = readString(entry.payload, "field_label");
       this.writeLine(
-        `Typing ${formatFieldLabel(fieldLabel)} could not fall back to direct input.`
+        `Typing ${formatFieldLabel(fieldLabel)} could not fall back to direct input.`,
       );
       return;
     }
@@ -121,7 +135,9 @@ export class HeadlessLoginProgressReporter {
     }
 
     if (readBoolean(entry.payload, "timedOut")) {
-      this.writeLine("Headless login timed out before LinkedIn confirmed the session.");
+      this.writeLine(
+        "Headless login timed out before LinkedIn confirmed the session.",
+      );
       return;
     }
 
@@ -131,23 +147,55 @@ export class HeadlessLoginProgressReporter {
         this.writeLine(
           readBoolean(entry.payload, "mfaRequired")
             ? "Headless login requires a LinkedIn verification code."
-            : "Headless login stopped at a LinkedIn verification-code checkpoint."
+            : "Headless login stopped at a LinkedIn verification-code checkpoint.",
         );
         return;
       case "app_approval":
         this.writeLine("Headless login is waiting for LinkedIn app approval.");
         return;
-      case "captcha":
-        this.writeLine("Headless login stopped at a LinkedIn CAPTCHA checkpoint.");
+      case "captcha": {
+        const captchaCooldownUntil = readString(
+          entry.payload,
+          "rateLimitUntil",
+        );
+        this.writeLine(
+          "Headless login stopped at a LinkedIn CAPTCHA checkpoint.",
+        );
+        if (captchaCooldownUntil) {
+          this.writeLine(
+            `Cooldown active until ${captchaCooldownUntil}. Subsequent headless attempts will be blocked.`,
+          );
+        }
+        this.writeLine(
+          'Use "linkedin login" (non-headless) or "linkedin auth session" to authenticate manually.',
+        );
         return;
+      }
       case "rate_limited":
         this.writeLine("Headless login hit LinkedIn's rate-limit checkpoint.");
         return;
-      case "unknown":
-        this.writeLine("Headless login stopped at an unknown LinkedIn checkpoint.");
+      case "unknown": {
+        const unknownCooldownUntil = readString(
+          entry.payload,
+          "rateLimitUntil",
+        );
+        this.writeLine(
+          "Headless login stopped at an unknown LinkedIn checkpoint.",
+        );
+        if (unknownCooldownUntil) {
+          this.writeLine(
+            `Cooldown active until ${unknownCooldownUntil}. Subsequent headless attempts will be blocked.`,
+          );
+        }
+        this.writeLine(
+          'Use "linkedin login" (non-headless) or "linkedin auth session" to authenticate manually.',
+        );
         return;
+      }
       default:
-        this.writeLine("Headless login finished without an authenticated session.");
+        this.writeLine(
+          "Headless login finished without an authenticated session.",
+        );
     }
   }
 }

--- a/packages/cli/test/headlessLoginOutput.test.ts
+++ b/packages/cli/test/headlessLoginOutput.test.ts
@@ -8,8 +8,8 @@ function createReporter() {
     reporter: new HeadlessLoginProgressReporter({
       writeLine(line) {
         lines.push(line);
-      }
-    })
+      },
+    }),
   };
 }
 
@@ -19,19 +19,19 @@ describe("HeadlessLoginProgressReporter", () => {
 
     reporter.handleLog({
       event: "cli.login.headless.start",
-      payload: { profileName: "default" }
+      payload: { profileName: "default" },
     });
     reporter.handleLog({
       event: "humanize.typing.start",
-      payload: { field_label: "email" }
+      payload: { field_label: "email" },
     });
     reporter.handleLog({
       event: "humanize.typing.done",
-      payload: { field_label: "email", mode: "simulated" }
+      payload: { field_label: "email", mode: "simulated" },
     });
     reporter.handleLog({
       event: "humanize.typing.degraded",
-      payload: { field_label: "password", method: "fill", reason: "timeout" }
+      payload: { field_label: "password", method: "fill", reason: "timeout" },
     });
     reporter.handleLog({
       event: "cli.login.headless.done",
@@ -40,8 +40,8 @@ describe("HeadlessLoginProgressReporter", () => {
         checkpoint: true,
         checkpointType: "verification_code",
         mfaRequired: true,
-        timedOut: false
-      }
+        timedOut: false,
+      },
     });
 
     expect(lines).toEqual([
@@ -49,7 +49,7 @@ describe("HeadlessLoginProgressReporter", () => {
       "Typing email with human-like cadence...",
       "Typed email with simulated keystrokes.",
       "Typing password fell back to direct input via fill() because typing exceeded the safety budget.",
-      "Headless login requires a LinkedIn verification code."
+      "Headless login requires a LinkedIn verification code.",
     ]);
   });
 
@@ -61,11 +61,72 @@ describe("HeadlessLoginProgressReporter", () => {
       payload: {
         authenticated: true,
         checkpoint: false,
-        timedOut: false
-      }
+        timedOut: false,
+      },
     });
 
     expect(lines).toEqual(["Headless login authenticated successfully."]);
+  });
+
+  it("renders CAPTCHA checkpoint with cooldown and manual login guidance", () => {
+    const { lines, reporter } = createReporter();
+
+    reporter.handleLog({
+      event: "cli.login.headless.done",
+      payload: {
+        authenticated: false,
+        checkpoint: true,
+        checkpointType: "captcha",
+        timedOut: false,
+        rateLimitUntil: "2026-03-12T10:00:00.000Z",
+      },
+    });
+
+    expect(lines).toEqual([
+      "Headless login stopped at a LinkedIn CAPTCHA checkpoint.",
+      "Cooldown active until 2026-03-12T10:00:00.000Z. Subsequent headless attempts will be blocked.",
+      'Use "linkedin login" (non-headless) or "linkedin auth session" to authenticate manually.',
+    ]);
+  });
+
+  it("renders unknown checkpoint with cooldown and manual login guidance", () => {
+    const { lines, reporter } = createReporter();
+
+    reporter.handleLog({
+      event: "cli.login.headless.done",
+      payload: {
+        authenticated: false,
+        checkpoint: true,
+        checkpointType: "unknown",
+        timedOut: false,
+        rateLimitUntil: "2026-03-12T10:00:00.000Z",
+      },
+    });
+
+    expect(lines).toEqual([
+      "Headless login stopped at an unknown LinkedIn checkpoint.",
+      "Cooldown active until 2026-03-12T10:00:00.000Z. Subsequent headless attempts will be blocked.",
+      'Use "linkedin login" (non-headless) or "linkedin auth session" to authenticate manually.',
+    ]);
+  });
+
+  it("renders CAPTCHA checkpoint without cooldown when rateLimitUntil is absent", () => {
+    const { lines, reporter } = createReporter();
+
+    reporter.handleLog({
+      event: "cli.login.headless.done",
+      payload: {
+        authenticated: false,
+        checkpoint: true,
+        checkpointType: "captcha",
+        timedOut: false,
+      },
+    });
+
+    expect(lines).toEqual([
+      "Headless login stopped at a LinkedIn CAPTCHA checkpoint.",
+      'Use "linkedin login" (non-headless) or "linkedin auth session" to authenticate manually.',
+    ]);
   });
 
   it("stays quiet when disabled", () => {
@@ -74,12 +135,12 @@ describe("HeadlessLoginProgressReporter", () => {
       enabled: false,
       writeLine(line) {
         lines.push(line);
-      }
+      },
     });
 
     reporter.handleLog({
       event: "cli.login.headless.start",
-      payload: { profileName: "default" }
+      payload: { profileName: "default" },
     });
 
     expect(lines).toEqual([]);

--- a/packages/core/src/__tests__/headlessLogin.test.ts
+++ b/packages/core/src/__tests__/headlessLogin.test.ts
@@ -185,7 +185,7 @@ describe("HeadlessLoginResult interface", () => {
     expect(result.mfaRequired).toBeUndefined();
   });
 
-  it("can represent a captcha checkpoint", () => {
+  it("can represent a captcha checkpoint with cooldown", () => {
     const result: HeadlessLoginResult = {
       authenticated: false,
       checkedAt: new Date().toISOString(),
@@ -194,11 +194,15 @@ describe("HeadlessLoginResult interface", () => {
       timedOut: false,
       checkpoint: true,
       checkpointType: "captcha",
+      rateLimitActive: true,
+      rateLimitUntil: "2026-02-23T12:00:00.000Z",
     };
     expect(result.checkpointType).toBe("captcha");
+    expect(result.rateLimitActive).toBe(true);
+    expect(result.rateLimitUntil).toBeDefined();
   });
 
-  it("can represent an unknown checkpoint type", () => {
+  it("can represent an unknown checkpoint type with cooldown", () => {
     const result: HeadlessLoginResult = {
       authenticated: false,
       checkedAt: new Date().toISOString(),
@@ -207,8 +211,12 @@ describe("HeadlessLoginResult interface", () => {
       timedOut: false,
       checkpoint: true,
       checkpointType: "unknown",
+      rateLimitActive: true,
+      rateLimitUntil: "2026-02-23T12:00:00.000Z",
     };
     expect(result.checkpointType).toBe("unknown");
+    expect(result.rateLimitActive).toBe(true);
+    expect(result.rateLimitUntil).toBeDefined();
   });
 
   it("can represent a rate_limited checkpoint type", () => {

--- a/packages/core/src/__tests__/sessionAuth.test.ts
+++ b/packages/core/src/__tests__/sessionAuth.test.ts
@@ -137,6 +137,9 @@ function createContextWithPage(page: Page): BrowserContext {
   return {
     pages: vi.fn(() => [page]),
     newPage: vi.fn(async () => page),
+    cookies: vi.fn(async () => []),
+    clearCookies: vi.fn(async () => undefined),
+    addCookies: vi.fn(async () => undefined),
   } as unknown as BrowserContext;
 }
 
@@ -396,7 +399,9 @@ describe("LinkedInAuthService auth flow", () => {
     expect(result.checkpoint).toBe(true);
     expect(result.checkpointType).toBe("captcha");
     expect(result.currentUrl).toBe(checkpointUrl);
-    expect(rateLimitStateMocks.recordRateLimit).not.toHaveBeenCalled();
+    expect(rateLimitStateMocks.recordRateLimit).toHaveBeenCalledTimes(1);
+    expect(result.rateLimitActive).toBe(true);
+    expect(result.rateLimitUntil).toBe("2026-02-23T12:00:00.000Z");
     expect(typeCalls).toHaveLength(2);
     expect(page.type as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(2);
   });

--- a/packages/core/src/auth/session.ts
+++ b/packages/core/src/auth/session.ts
@@ -377,6 +377,8 @@ export class LinkedInAuthService {
       async (context) => {
         const page = await getPage(context);
 
+        await this.clearNonEssentialLinkedInCookies(context);
+
         if (warmProfile) {
           await this.warmBrowserProfile(page);
         }
@@ -633,18 +635,24 @@ export class LinkedInAuthService {
             } else if (checkpointType === "app_approval") {
               // Continue polling while LinkedIn awaits approval from a trusted device.
             } else if (checkpointType === "captcha") {
+              const rateLimitState = await recordRateLimit();
               return {
                 ...status,
                 timedOut: false,
                 checkpoint: true,
                 checkpointType: "captcha",
+                rateLimitActive: true,
+                rateLimitUntil: rateLimitState.rateLimitedUntil,
               };
             } else {
+              const rateLimitState = await recordRateLimit();
               return {
                 ...status,
                 timedOut: false,
                 checkpoint: true,
                 checkpointType: "unknown",
+                rateLimitActive: true,
+                rateLimitUntil: rateLimitState.rateLimitedUntil,
               };
             }
           }
@@ -703,6 +711,29 @@ export class LinkedInAuthService {
     state: RateLimitState | null;
   }> {
     return isInRateLimitCooldown();
+  }
+
+  /**
+   * Clears non-essential LinkedIn tracking cookies from the persistent profile
+   * before a headless login attempt. Preserves the `li_at` session cookie so
+   * the early-auth shortcut still works when the session is already valid.
+   *
+   * This reduces the risk of LinkedIn classifying the browser as a returning
+   * automated visitor based on accumulated tracking cookies from prior runs.
+   */
+  private async clearNonEssentialLinkedInCookies(
+    context: BrowserContext,
+  ): Promise<void> {
+    try {
+      const cookies = await context.cookies("https://www.linkedin.com");
+      const sessionCookie = cookies.find((c) => c.name === "li_at");
+      await context.clearCookies({ domain: ".linkedin.com" });
+      if (sessionCookie) {
+        await context.addCookies([sessionCookie]);
+      }
+    } catch {
+      // Best effort — failures should not block login.
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Prevents headless login from escalating CAPTCHA checkpoints into temporary account restrictions by recording CAPTCHA encounters as rate-limit cooldown events, clearing tracking cookies before login attempts, and guiding users toward manual authentication when headless login is blocked.

## Changes

### Core (`packages/core/src/auth/session.ts`)
- **CAPTCHA/unknown checkpoint cooldown**: When a CAPTCHA or unknown checkpoint is detected during headless login, `recordRateLimit()` is now called. This activates the existing exponential backoff (2h → 4h → 8h) so subsequent headless login attempts are automatically blocked until the cooldown expires.
- **Cookie clearing**: Added `clearNonEssentialLinkedInCookies()` which clears all LinkedIn tracking cookies (bcookie, bscookie, li_sugr, etc.) from the persistent profile before navigating to the login page, while preserving `li_at` for early auth detection. Reduces LinkedIn's ability to fingerprint the browser as a returning automated visitor.

### CLI (`packages/cli/src/headlessLoginOutput.ts`, `packages/cli/src/bin/linkedin.ts`)
- **Enhanced CAPTCHA output**: When CAPTCHA is detected, the CLI now shows the cooldown expiry timestamp and recommends manual authentication via `linkedin login` or `linkedin auth session`.
- **Log enrichment**: Added `rateLimitActive` and `rateLimitUntil` fields to the `cli.login.headless.done` log event for observability.

### Documentation (`docs/evasion.md`)
- Added "Headless login limitations" section documenting CAPTCHA risk, automatic cooldown behavior, recommended authentication methods, and tips for reducing CAPTCHA risk.

### Tests
- Updated `sessionAuth.test.ts`: CAPTCHA checkpoint now verifies `recordRateLimit` is called and result includes cooldown fields
- Updated `headlessLogin.test.ts`: CAPTCHA and unknown checkpoint results include `rateLimitActive`/`rateLimitUntil`
- Updated `headlessLoginOutput.test.ts`: Added 3 new tests for CAPTCHA cooldown messaging, unknown checkpoint messaging, and CAPTCHA without cooldown

## Test results
- **1151 tests pass** (108 test files)
- **Lint**: clean
- **Build/typecheck errors**: all pre-existing (unrelated to this PR)

Closes #367
