### PR TITLE
fix: allow manual CAPTCHA resolution in headed login mode (#369)

### DIFF
--- a/packages/core/src/auth/session.ts
+++ b/packages/core/src/auth/session.ts
@@ -496,7 +496,26 @@ export class LinkedInAuthService {
         const signInButton = page.locator(
           "button[type='submit'][data-litms-control-urn='login-submit'], button[type='submit']:has-text('Sign in')",
         );
-        await signInButton.first().click();
+
+        try {
+          await signInButton.first().click();
+        } catch {
+          await page
+            .evaluate(() => {
+              const form = document.querySelector<HTMLFormElement>(
+                "form.login__form, form[action*='login-submit'], form[data-id='sign-in-form']",
+              );
+              if (form) {
+                form.submit();
+                return;
+              }
+              const btn = document.querySelector<HTMLButtonElement>(
+                "button[type='submit']",
+              );
+              btn?.click();
+            })
+            .catch(() => undefined);
+        }
 
         await page.waitForTimeout(2_000);
 
@@ -658,25 +677,33 @@ export class LinkedInAuthService {
             } else if (checkpointType === "app_approval") {
               // Continue polling while LinkedIn awaits approval from a trusted device.
             } else if (checkpointType === "captcha") {
-              const rateLimitState = await recordRateLimit();
-              return {
-                ...status,
-                timedOut: false,
-                checkpoint: true,
-                checkpointType: "captcha",
-                rateLimitActive: true,
-                rateLimitUntil: rateLimitState.rateLimitedUntil,
-              };
+              if (!useHeaded) {
+                const rateLimitState = await recordRateLimit();
+                return {
+                  ...status,
+                  timedOut: false,
+                  checkpoint: true,
+                  checkpointType: "captcha",
+                  rateLimitActive: true,
+                  rateLimitUntil: rateLimitState.rateLimitedUntil,
+                };
+              }
+              // In headed mode, continue polling so the user can solve
+              // the CAPTCHA manually in the visible browser window.
             } else {
-              const rateLimitState = await recordRateLimit();
-              return {
-                ...status,
-                timedOut: false,
-                checkpoint: true,
-                checkpointType: "unknown",
-                rateLimitActive: true,
-                rateLimitUntil: rateLimitState.rateLimitedUntil,
-              };
+              if (!useHeaded) {
+                const rateLimitState = await recordRateLimit();
+                return {
+                  ...status,
+                  timedOut: false,
+                  checkpoint: true,
+                  checkpointType: "unknown",
+                  rateLimitActive: true,
+                  rateLimitUntil: rateLimitState.rateLimitedUntil,
+                };
+              }
+              // In headed mode, continue polling for unknown checkpoints
+              // to allow manual resolution in the visible browser.
             }
           }
 


### PR DESCRIPTION
## Summary

Fixes the headed login flow so users can manually solve CAPTCHAs in the visible browser window. Previously, `--headed` and `--headed-fallback` opened a browser but immediately returned on CAPTCHA detection instead of waiting for manual resolution.

## Changes

- **CAPTCHA checkpoint in headed mode**: When `useHeaded` is true, the CAPTCHA checkpoint branch now continues polling instead of returning immediately, allowing users to solve the CAPTCHA manually before the timeout expires
- **Unknown checkpoint in headed mode**: Same polling behavior for unknown checkpoint types in headed mode
- **Rate-limit recording deferred**: Rate-limit state is only recorded in headless mode (where CAPTCHA can't be solved), not in headed mode where the user may resolve it
- **Form submit fallback**: Added `page.evaluate()` fallback when the sign-in button click fails, submitting the form directly via DOM to handle overlay-blocked elements

## Context

Previous PR #374 addressed these same issues but was closed due to merge conflicts from parallel PR pile-up. This is a fresh implementation on top of current main, which already includes the cookie consent dismissal (#371), headed mode flags, and stealth/warming features (#376) from those parallel PRs.

## Verification

After merging, authenticate with:
```bash
LINKEDIN_EMAIL=... LINKEDIN_PASSWORD=... linkedin login --headed --timeout-minutes 10
```
Solve the CAPTCHA manually in the visible browser → CLI detects auth success → `linkedin status` returns `authenticated: true`.

## Quality Gates

- [x] Tests: 1175/1175 passing (108 test files)
- [x] LSP diagnostics: 0 errors on changed file
- [x] Build: outputs generated
- [x] Pre-existing issues: 2 TS errors in stealth.ts (missing type declarations), 1 lint error in sessionAuth.test.ts (duplicate key) — both present on main

Closes #369
