### PR TITLE
docs: add Joi Ascend profile seeding runbook (#310)

### DIFF
--- a/docs/profile-seeds/joi-ascend-runbook.md
+++ b/docs/profile-seeds/joi-ascend-runbook.md
@@ -1,0 +1,105 @@
+# Joi Ascend — Profile Seeding Runbook
+
+Manual execution guide for populating the Joi Ascend test account. Run these
+commands in order on a machine with a display (headless login is blocked by
+LinkedIn CAPTCHA, see #367).
+
+## Prerequisites
+
+- Node 22+
+- `npm install && npm run build` completed
+- Environment variables set: `LINKEDIN_TEST_EMAIL`, `LINKEDIN_TEST_PASSWORD`
+
+## Step 1: Authenticate (manual browser)
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin login --profile default
+```
+
+This opens a visible Chromium window. Complete any CAPTCHA manually, then wait
+for the CLI to confirm authentication.
+
+Verify:
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin status --profile default
+```
+
+Expected: `"authenticated": true`. Check `identity.fullName` is **Joi Ascend**.
+If identity is anything other than Joi Ascend, **stop all work**.
+
+## Step 2: Inspect current editable surface
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin profile editable --profile default
+```
+
+Review the output to understand which profile sections are currently populated
+and which are empty.
+
+## Step 3: Apply profile spec
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin profile apply-spec \
+  --spec docs/profile-seeds/joi-ascend-profile.json \
+  --allow-partial \
+  --yes \
+  --delay-ms 4000 \
+  --profile default
+```
+
+This applies the Joi Ascend persona: intro, about, experience, education,
+certifications, languages, projects, and volunteer experience. Skills are
+skipped (not exposed by the current profile edit automation).
+
+Verify:
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin profile view me --profile default
+```
+
+## Step 4: Run activity seeding
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin seed activity \
+  --spec docs/profile-seeds/joi-ascend-activity.json \
+  --delay-ms 4500 \
+  --yes \
+  --profile default \
+  --output reports/activity-seed-joi-ascend.json
+```
+
+This publishes 5 professional posts (connections visibility), runs job
+discovery searches, and checks notifications. No connection invites or targeted
+engagement.
+
+## Step 5: Final verification
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin profile view me --profile default
+npm exec -w @linkedin-buddy/cli -- linkedin feed list --limit 5 --profile default
+```
+
+Confirm:
+
+- Profile is populated with Joi Ascend professional identity
+- Experience at Signikant is visible
+- Posts are visible in the feed
+
+## Troubleshooting
+
+| Symptom                               | Fix                                                                          |
+| ------------------------------------- | ---------------------------------------------------------------------------- |
+| `authenticated: false` after login    | Re-run `linkedin login`, complete CAPTCHA                                    |
+| `identity.fullName` is not Joi Ascend | Wrong account. Clear cookies: `linkedin logout`, re-login with correct creds |
+| `RATE_LIMITED` error                  | Run `linkedin rate-limit --clear`, wait 30 minutes, retry                    |
+| Profile edit fails on a section       | Add `--allow-partial` to skip unsupported fields                             |
+| Activity seed hangs                   | Check `~/.linkedin-buddy/keep-alive.log` for session expiry                  |
+
+## References
+
+- Profile spec: `docs/profile-seeds/joi-ascend-profile.json`
+- Activity spec: `docs/profile-seeds/joi-ascend-activity.json`
+- Login fix: commit `6e6e8f4` (selector + cookie consent + returning-user)
+- CAPTCHA blocker: #367
+- SDUI selector fix: #366

--- a/packages/core/src/__tests__/sessionAuth.test.ts
+++ b/packages/core/src/__tests__/sessionAuth.test.ts
@@ -144,7 +144,6 @@ function createContextWithPage(page: Page): BrowserContext {
     pages: vi.fn(() => [page]),
     newPage: vi.fn(async () => page),
     cookies: vi.fn(async () => []),
-    clearCookies: vi.fn(async () => undefined),
     addCookies: vi.fn(async () => undefined),
   } as unknown as BrowserContext;
 }


### PR DESCRIPTION
## Summary

Add manual execution runbook for Joi Ascend profile seeding and fix a pre-existing lint error.

## Context

Issue #310 requested executing profile seeding and activity population against the live Joi Ascend test account. The login fix (selectors, cookie consent, returning-user handling) was completed and merged via PR #371. The Joi Ascend profile and activity specs were included in that PR.

**Execution status:** Headless login reaches the correct form and submits credentials successfully, but LinkedIn's server-side CAPTCHA detection blocks all headless authentication attempts (tested with both `moderate` and `paranoid` evasion levels). This is tracked in #367. Profile seeding requires manual (non-headless) login on a machine with a display.

## Changes

- **`docs/profile-seeds/joi-ascend-runbook.md`** — Step-by-step manual execution guide covering authentication, profile spec application, activity seeding, and verification. Includes troubleshooting table.
- **`packages/core/src/__tests__/sessionAuth.test.ts`** — Remove duplicate `clearCookies` key introduced during the #385 merge (lint error fix).

## What was already completed (in prior PRs)

- Login selector fix for SDUI pages (#371)
- Cookie consent banner dismissal (#371)
- Returning-user page variant handling (#371)
- Joi Ascend profile spec (`docs/profile-seeds/joi-ascend-profile.json`) (#371)
- Joi Ascend activity spec (`docs/profile-seeds/joi-ascend-activity.json`) (#371)
- CAPTCHA cooldown tracking and cookie clearing (#385, #388)

## What remains (manual execution needed)

After merging, an operator should run the runbook on a machine with a display:
1. `linkedin login` (non-headless, complete CAPTCHA manually)
2. Verify identity is Joi Ascend
3. `linkedin profile apply-spec --spec docs/profile-seeds/joi-ascend-profile.json`
4. `linkedin seed activity --spec docs/profile-seeds/joi-ascend-activity.json`

## Quality gates

- [x] Build: `npm run build` clean
- [x] Lint: `npm run lint` clean (after removing duplicate key)
- [x] Typecheck: `npm run typecheck` clean
- [x] Tests: 1175 passed (108 test files)

Refs #310
