### PR TITLE
feat: quality pass for analytics & insights (#353)

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,111 @@
+# Analytics and insights
+
+LinkedIn Buddy exposes four read-only analytics surfaces through the MCP server and the TypeScript API. These surfaces normalize metric data from LinkedIn's profile analytics pages and individual post engagement counters.
+
+| Surface            | MCP tool                                | Description                                        |
+| ------------------ | --------------------------------------- | -------------------------------------------------- |
+| Profile views      | `linkedin.analytics.profile_views`      | Who viewed your profile — counts, trend, and delta |
+| Search appearances | `linkedin.analytics.search_appearances` | How often you appeared in LinkedIn search          |
+| Content metrics    | `linkedin.analytics.content_metrics`    | Impressions, engagement, and creator analytics     |
+| Post metrics       | `linkedin.analytics.post_metrics`       | Reactions, comments, reposts for a single post     |
+
+## MCP usage
+
+The analytics tools allow you to retrieve snapshots of your performance data. The `profile_views`, `search_appearances`, and `content_metrics` tools all accept an optional `profileName` parameter (defaults to "default"). The `post_metrics` tool requires a `postUrl`.
+
+Example MCP call for profile views:
+
+```json
+{
+  "name": "linkedin.analytics.profile_views",
+  "arguments": {
+    "profileName": "default"
+  }
+}
+```
+
+Example MCP call for post metrics:
+
+```json
+{
+  "name": "linkedin.analytics.post_metrics",
+  "arguments": {
+    "postUrl": "https://www.linkedin.com/feed/update/urn:li:activity:1234567890/"
+  }
+}
+```
+
+## TypeScript API
+
+You can access analytics services directly through the core runtime.
+
+```ts
+import { createCoreRuntime } from "@linkedin-buddy/core";
+
+const runtime = createCoreRuntime();
+
+try {
+  const views = await runtime.analytics.getProfileViews({
+    profileName: "default",
+  });
+  console.log(views.metrics);
+} finally {
+  runtime.close();
+}
+```
+
+## Return shape
+
+The analytics services return structured summaries containing normalized metrics and the original UI cards they were extracted from.
+
+### LinkedInAnalyticsSummary
+
+- `surface`: The analytics surface name
+- `source_url`: The LinkedIn URL where the data was found
+- `observed_at`: ISO timestamp of the observation
+- `metrics[]`: Array of normalized metrics
+- `cards[]`: Array of source UI cards
+
+### LinkedInPostMetricsSummary
+
+Includes all fields from `LinkedInAnalyticsSummary` plus a `post` object:
+
+- `post_id`: Unique identifier for the post
+- `post_url`: Canonical URL of the post
+- `author_name`: Name of the post author
+- `author_headline`: Headline of the post author
+- `posted_at`: When the post was published
+- `text`: The text content of the post
+
+### LinkedInAnalyticsMetric
+
+- `metric_key`: Stable identifier for the metric (e.g., `profile_views`)
+- `label`: The display label from the UI
+- `value`: Numeric value if parsable, otherwise null
+- `value_text`: Raw text value from the UI
+- `delta_value`: Numeric change value if available
+- `delta_text`: Raw change text (e.g., "+12% past 7 days")
+- `unit`: `count`, `percent`, or `unknown`
+- `trend`: `up`, `down`, `flat`, or `unknown`
+- `observed_at`: ISO timestamp
+
+### LinkedInAnalyticsCard
+
+- `card_key`: Stable identifier for the card
+- `title`: Card title
+- `description`: Card description or subtitle
+- `href`: Link to the detailed analytics page
+- `metrics[]`: Metrics contained within this specific card
+
+## Limits
+
+The `content_metrics` surface accepts an optional `limit` parameter (1–50, default 4) to cap the number of returned cards. This is useful for focusing on the most prominent creator analytics cards.
+
+## Error handling
+
+Analytics tools throw `LinkedInBuddyError` in specific failure scenarios:
+
+- `UI_CHANGED_SELECTOR_FAILED`: Thrown when LinkedIn's UI has changed and the expected analytics cards cannot be located.
+- `UNKNOWN`: Thrown for unexpected browser or network failures.
+
+Both error types include the `surface` and `profileName` in their error details to help with debugging.

--- a/packages/core/src/__tests__/linkedinAnalytics.test.ts
+++ b/packages/core/src/__tests__/linkedinAnalytics.test.ts
@@ -2,12 +2,20 @@ import { describe, expect, it } from "vitest";
 import {
   LINKEDIN_ANALYTICS_SURFACES,
   LinkedInAnalyticsService,
+  ensureMatchingCards,
+  inferAnalyticsMetricTrend,
+  inferAnalyticsMetricUnit,
+  matchesAnalyticsCard,
   parseLinkedInAnalyticsNumber,
+  readAnalyticsLimit,
+  toAbsoluteLinkedInUrl,
   toLinkedInAnalyticsMetricKey,
+  type LinkedInAnalyticsCard,
   type LinkedInAnalyticsRuntime,
   type ReadContentMetricsInput,
-  type ReadPostMetricsInput
+  type ReadPostMetricsInput,
 } from "../linkedinAnalytics.js";
+import { LinkedInBuddyError } from "../errors.js";
 
 describe("LinkedInAnalyticsService", () => {
   it("exports the service class", () => {
@@ -20,32 +28,137 @@ describe("LinkedInAnalyticsService", () => {
       "profile_views",
       "search_appearances",
       "content_metrics",
-      "post_metrics"
+      "post_metrics",
     ]);
   });
 
   it("normalizes analytics metric keys", () => {
     expect(toLinkedInAnalyticsMetricKey("Profile views")).toBe("profile_views");
     expect(toLinkedInAnalyticsMetricKey("Engagement total")).toBe(
-      "engagement_total"
+      "engagement_total",
     );
     expect(toLinkedInAnalyticsMetricKey(" CTR % ")).toBe("ctr");
+    expect(toLinkedInAnalyticsMetricKey("")).toBe("metric");
+    expect(toLinkedInAnalyticsMetricKey("Click-through Rate (%)")).toBe(
+      "click_through_rate",
+    );
+    expect(toLinkedInAnalyticsMetricKey("___  Mixed___Value  ")).toBe(
+      "mixed_value",
+    );
+    expect(toLinkedInAnalyticsMetricKey("Ünicode   label")).toBe(
+      "nicode_label",
+    );
   });
 
   it("parses abbreviated count metrics", () => {
     expect(parseLinkedInAnalyticsNumber("1.2K")).toBe(1200);
     expect(parseLinkedInAnalyticsNumber("2,450")).toBe(2450);
     expect(parseLinkedInAnalyticsNumber("3,4M")).toBe(3_400_000);
+    expect(parseLinkedInAnalyticsNumber("2.5B")).toBe(2_500_000_000);
+    expect(parseLinkedInAnalyticsNumber("1T")).toBe(1_000_000_000_000);
+    expect(parseLinkedInAnalyticsNumber("-5.2K")).toBe(-5200);
   });
 
   it("parses percentage metrics", () => {
     expect(parseLinkedInAnalyticsNumber("4.5%")).toBe(4.5);
     expect(parseLinkedInAnalyticsNumber("+12% past 7 days")).toBe(12);
+    expect(parseLinkedInAnalyticsNumber("+12%")).toBe(12);
+  });
+
+  it("parses locale formats and whitespace", () => {
+    expect(parseLinkedInAnalyticsNumber("1.234,56")).toBe(1234.56);
+    expect(parseLinkedInAnalyticsNumber(" 1,234 ")).toBe(1234);
+    expect(parseLinkedInAnalyticsNumber("0")).toBe(0);
   });
 
   it("returns null for non-numeric analytics text", () => {
     expect(parseLinkedInAnalyticsNumber("No data yet")).toBeNull();
     expect(parseLinkedInAnalyticsNumber("")).toBeNull();
+    expect(parseLinkedInAnalyticsNumber("N/A")).toBeNull();
+    expect(parseLinkedInAnalyticsNumber("--")).toBeNull();
+  });
+
+  it("infers analytics metric units", () => {
+    expect(inferAnalyticsMetricUnit("Engagement", "45%")).toBe("percent");
+    expect(inferAnalyticsMetricUnit("Engagement rate", "12")).toBe("percent");
+    expect(inferAnalyticsMetricUnit("Impressions", "1200")).toBe("count");
+    expect(inferAnalyticsMetricUnit("Impressions", "N/A")).toBe("unknown");
+  });
+
+  it("infers analytics metric trends", () => {
+    expect(inferAnalyticsMetricTrend("+5%")).toBe("up");
+    expect(inferAnalyticsMetricTrend("-3 down")).toBe("down");
+    expect(inferAnalyticsMetricTrend("flat")).toBe("flat");
+    expect(inferAnalyticsMetricTrend("unknown text")).toBe("unknown");
+    expect(inferAnalyticsMetricTrend(null)).toBe("unknown");
+    expect(inferAnalyticsMetricTrend(undefined)).toBe("unknown");
+    expect(inferAnalyticsMetricTrend("")).toBe("unknown");
+  });
+
+  it("converts LinkedIn urls to absolute urls", () => {
+    expect(toAbsoluteLinkedInUrl("https://www.linkedin.com/in/me/")).toBe(
+      "https://www.linkedin.com/in/me/",
+    );
+    expect(toAbsoluteLinkedInUrl("/in/me/")).toBe(
+      "https://www.linkedin.com/in/me/",
+    );
+    expect(toAbsoluteLinkedInUrl("in/me/")).toBe(
+      "https://www.linkedin.com/in/me/",
+    );
+    expect(toAbsoluteLinkedInUrl(null)).toBeNull();
+    expect(toAbsoluteLinkedInUrl("")).toBeNull();
+  });
+
+  it("applies analytics limit fallback and bounds", () => {
+    expect(readAnalyticsLimit(undefined, 4)).toBe(4);
+    expect(readAnalyticsLimit(Number.NaN, 4)).toBe(4);
+    expect(readAnalyticsLimit(Number.POSITIVE_INFINITY, 4)).toBe(4);
+    expect(readAnalyticsLimit(0.5, 4)).toBe(1);
+    expect(readAnalyticsLimit(10, 4)).toBe(10);
+    expect(readAnalyticsLimit(100, 4)).toBe(50);
+  });
+
+  it("throws UI_CHANGED_SELECTOR_FAILED when no matching cards exist", () => {
+    expect(() => ensureMatchingCards("profile_views", [], [])).toThrow(
+      LinkedInBuddyError,
+    );
+
+    try {
+      ensureMatchingCards("profile_views", [], []);
+    } catch (error) {
+      expect(error).toBeInstanceOf(LinkedInBuddyError);
+      expect((error as LinkedInBuddyError).code).toBe(
+        "UI_CHANGED_SELECTOR_FAILED",
+      );
+    }
+  });
+
+  it("matches analytics cards with negative keyword filtering", () => {
+    const card: LinkedInAnalyticsCard = {
+      card_key: "content_analytics",
+      title: "Creator analytics",
+      description: "Content impressions and engagement",
+      href: "https://www.linkedin.com/in/me/",
+      metrics: [
+        {
+          metric_key: "impressions",
+          label: "Impressions",
+          value: 200,
+          value_text: "200",
+          delta_value: null,
+          delta_text: null,
+          unit: "count",
+          trend: "unknown",
+          observed_at: "2026-03-12T00:00:00.000Z",
+        },
+      ],
+    };
+
+    expect(matchesAnalyticsCard(card, ["creator analytics"])).toBe(true);
+    expect(matchesAnalyticsCard(card, ["profile view"])).toBe(false);
+    expect(
+      matchesAnalyticsCard(card, ["creator analytics"], ["engagement"]),
+    ).toBe(false);
   });
 
   it("keeps the runtime contract minimal for read-only analytics", () => {
@@ -54,7 +167,7 @@ describe("LinkedInAnalyticsService", () => {
       "cdpUrl",
       "profileManager",
       "logger",
-      "feed"
+      "feed",
     ];
     expect(runtimeKeys).toHaveLength(5);
   });
@@ -62,7 +175,7 @@ describe("LinkedInAnalyticsService", () => {
   it("accepts optional limits for aggregated content metrics", () => {
     const input: ReadContentMetricsInput = {
       profileName: "default",
-      limit: 3
+      limit: 3,
     };
 
     expect(input.profileName).toBe("default");
@@ -72,7 +185,8 @@ describe("LinkedInAnalyticsService", () => {
   it("requires a post URL for post metrics inputs", () => {
     const input: ReadPostMetricsInput = {
       profileName: "default",
-      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123456789/"
+      postUrl:
+        "https://www.linkedin.com/feed/update/urn:li:activity:123456789/",
     };
 
     expect(input.postUrl).toContain("linkedin.com/feed/update/");

--- a/packages/core/src/linkedinAnalytics.ts
+++ b/packages/core/src/linkedinAnalytics.ts
@@ -10,7 +10,7 @@ export const LINKEDIN_ANALYTICS_SURFACES = [
   "profile_views",
   "search_appearances",
   "content_metrics",
-  "post_metrics"
+  "post_metrics",
 ] as const;
 
 export type LinkedInAnalyticsSurface =
@@ -100,44 +100,46 @@ const LINKEDIN_SELF_PROFILE_URL = "https://www.linkedin.com/in/me/";
 const PROFILE_VIEW_KEYWORDS = [
   "profile view",
   "who viewed",
-  "viewed your profile"
+  "viewed your profile",
 ] as const;
 const SEARCH_APPEARANCES_KEYWORDS = ["search appearance"] as const;
 const CONTENT_METRICS_KEYWORDS = [
   "impression",
   "content",
   "engagement",
-  "creator analytics"
+  "creator analytics",
 ] as const;
 const CONTENT_METRICS_NEGATIVE_KEYWORDS = [
   ...PROFILE_VIEW_KEYWORDS,
-  ...SEARCH_APPEARANCES_KEYWORDS
+  ...SEARCH_APPEARANCES_KEYWORDS,
 ] as const;
 const IGNORED_ANALYTICS_LINES = new Set([
   "private to you",
-  "only visible to you"
+  "only visible to you",
 ]);
 
 function normalizeText(value: string | null | undefined): string {
   return (value ?? "").replace(/\s+/g, " ").trim();
 }
 
-function readAnalyticsLimit(
+export function readAnalyticsLimit(
   value: number | undefined,
-  fallback: number
+  fallback: number,
 ): number {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return fallback;
   }
 
-  return Math.max(1, Math.floor(value));
+  return Math.max(1, Math.min(Math.floor(value), 50));
 }
 
 function isAbsoluteUrl(value: string): boolean {
   return /^https?:\/\//i.test(value);
 }
 
-function toAbsoluteLinkedInUrl(value: string | null | undefined): string | null {
+export function toAbsoluteLinkedInUrl(
+  value: string | null | undefined,
+): string | null {
   const href = normalizeText(value);
   if (!href) {
     return null;
@@ -226,9 +228,9 @@ export function parseLinkedInAnalyticsNumber(value: string): number | null {
   return parsed * magnitude;
 }
 
-function inferAnalyticsMetricUnit(
+export function inferAnalyticsMetricUnit(
   label: string,
-  valueText: string
+  valueText: string,
 ): LinkedInAnalyticsMetricUnit {
   if (valueText.includes("%") || /\brate\b|\bpercent\b/i.test(label)) {
     return "percent";
@@ -237,8 +239,8 @@ function inferAnalyticsMetricUnit(
   return parseLinkedInAnalyticsNumber(valueText) === null ? "unknown" : "count";
 }
 
-function inferAnalyticsMetricTrend(
-  value: string | null | undefined
+export function inferAnalyticsMetricTrend(
+  value: string | null | undefined,
 ): LinkedInAnalyticsMetricTrend {
   const normalized = normalizeText(value).toLowerCase();
   if (!normalized) {
@@ -291,7 +293,7 @@ function isDeltaLikeLine(value: string): boolean {
 
 function createMetricDraft(
   line: string,
-  fallbackLabel: string
+  fallbackLabel: string,
 ): AnalyticsMetricDraft | null {
   const normalized = normalizeText(line);
   const valueText = extractMetricValueToken(normalized);
@@ -299,17 +301,18 @@ function createMetricDraft(
     return null;
   }
 
-  const label = normalizeText(normalized.replace(valueText, "")) || fallbackLabel;
+  const label =
+    normalizeText(normalized.replace(valueText, "")) || fallbackLabel;
   return {
     label,
     valueText,
-    deltaText: null
+    deltaText: null,
   };
 }
 
 function buildAnalyticsMetric(
   draft: AnalyticsMetricDraft,
-  observedAt: string
+  observedAt: string,
 ): LinkedInAnalyticsMetric {
   const label = normalizeText(draft.label) || "Metric";
   const metricKey = toLinkedInAnalyticsMetricKey(label);
@@ -327,14 +330,14 @@ function buildAnalyticsMetric(
     delta_text: draft.deltaText,
     unit,
     trend: inferAnalyticsMetricTrend(draft.deltaText),
-    observed_at: observedAt
+    observed_at: observedAt,
   };
 }
 
 function buildCardMetricsFromLines(
   title: string,
   lines: string[],
-  observedAt: string
+  observedAt: string,
 ): LinkedInAnalyticsMetric[] {
   const cleanedLines = lines
     .map((line) => normalizeText(line))
@@ -362,29 +365,27 @@ function buildCardMetricsFromLines(
   return drafts.map((draft) => buildAnalyticsMetric(draft, observedAt));
 }
 
-function flattenCardMetrics(cards: LinkedInAnalyticsCard[]): LinkedInAnalyticsMetric[] {
-  return cards.flatMap((card) => card.metrics);
-}
-
 function cardTextHaystack(card: LinkedInAnalyticsCard): string {
   return [
     card.card_key,
     card.title,
     card.description,
     card.href ?? "",
-    ...card.metrics.map((metric) => metric.label)
+    ...card.metrics.map((metric) => metric.label),
   ]
     .join(" ")
     .toLowerCase();
 }
 
-function matchesAnalyticsCard(
+export function matchesAnalyticsCard(
   card: LinkedInAnalyticsCard,
   keywords: readonly string[],
-  negativeKeywords: readonly string[] = []
+  negativeKeywords: readonly string[] = [],
 ): boolean {
   const haystack = cardTextHaystack(card);
-  if (negativeKeywords.some((keyword) => haystack.includes(keyword.toLowerCase()))) {
+  if (
+    negativeKeywords.some((keyword) => haystack.includes(keyword.toLowerCase()))
+  ) {
     return false;
   }
 
@@ -410,7 +411,7 @@ async function waitForAnalyticsSurface(page: Page): Promise<void> {
 
 /* eslint-disable no-undef -- DOM types are valid inside page.evaluate() */
 async function extractProfileAnalyticsCardSnapshots(
-  page: Page
+  page: Page,
 ): Promise<AnalyticsCardSnapshot[]> {
   return page.evaluate(() => {
     const normalize = (value: string | null | undefined): string =>
@@ -422,7 +423,9 @@ async function extractProfileAnalyticsCardSnapshots(
         .map((line) => normalize(line))
         .filter((line) => line.length > 0);
 
-    const toAbsoluteHref = (value: string | null | undefined): string | null => {
+    const toAbsoluteHref = (
+      value: string | null | undefined,
+    ): string | null => {
       const href = normalize(value);
       if (!href) {
         return null;
@@ -443,7 +446,7 @@ async function extractProfileAnalyticsCardSnapshots(
 
     const readTitle = (element: Element, lines: string[]): string => {
       const heading = normalize(
-        element.querySelector("h1, h2, h3, h4, strong, dt")?.textContent
+        element.querySelector("h1, h2, h3, h4, strong, dt")?.textContent,
       );
       if (heading) {
         return heading;
@@ -456,7 +459,7 @@ async function extractProfileAnalyticsCardSnapshots(
       /(profile views?|who viewed|viewed your profile|search appearances?|impressions?|content|engagement|analytics)/i;
     const relevantHrefPattern = /(analytics|profile-view|search-appear)/i;
     const candidates = Array.from(
-      document.querySelectorAll("a[href], button, article, li")
+      document.querySelectorAll("a[href], button, article, li"),
     ).filter((element) => {
       const text = readInnerText(element);
       if (!text || text.length > 400) {
@@ -464,7 +467,9 @@ async function extractProfileAnalyticsCardSnapshots(
       }
 
       const href = normalize(
-        element instanceof HTMLAnchorElement ? element.href : element.getAttribute("href")
+        element instanceof HTMLAnchorElement
+          ? element.href
+          : element.getAttribute("href"),
       );
 
       return relevantPattern.test(text) || relevantHrefPattern.test(href);
@@ -482,7 +487,7 @@ async function extractProfileAnalyticsCardSnapshots(
       const href = toAbsoluteHref(
         candidate instanceof HTMLAnchorElement
           ? candidate.href
-          : candidate.getAttribute("href")
+          : candidate.getAttribute("href"),
       );
       const description = lines
         .filter((line) => line !== title)
@@ -493,11 +498,14 @@ async function extractProfileAnalyticsCardSnapshots(
         title,
         description,
         href,
-        lines
+        lines,
       };
       const dedupeKey = `${title.toLowerCase()}|${href ?? ""}`;
       const existing = deduped.get(dedupeKey);
-      if (!existing || existing.lines.join(" ").length < lines.join(" ").length) {
+      if (
+        !existing ||
+        existing.lines.join(" ").length < lines.join(" ").length
+      ) {
         deduped.set(dedupeKey, snapshot);
       }
     }
@@ -509,19 +517,23 @@ async function extractProfileAnalyticsCardSnapshots(
 
 function toAnalyticsCards(
   snapshots: AnalyticsCardSnapshot[],
-  observedAt: string
+  observedAt: string,
 ): LinkedInAnalyticsCard[] {
   return snapshots
     .map((snapshot) => {
       const title = normalizeText(snapshot.title);
       const description = normalizeText(snapshot.description);
-      const metrics = buildCardMetricsFromLines(title, snapshot.lines, observedAt);
+      const metrics = buildCardMetricsFromLines(
+        title,
+        snapshot.lines,
+        observedAt,
+      );
       return {
         card_key: toLinkedInAnalyticsMetricKey(title),
         title,
         description,
         href: toAbsoluteLinkedInUrl(snapshot.href),
-        metrics
+        metrics,
       } satisfies LinkedInAnalyticsCard;
     })
     .filter((card) => card.title.length > 0)
@@ -530,7 +542,7 @@ function toAnalyticsCards(
 
 async function loadProfileAnalyticsCards(
   runtime: LinkedInAnalyticsRuntime,
-  profileName: string
+  profileName: string,
 ): Promise<{
   sourceUrl: string;
   observedAt: string;
@@ -538,39 +550,40 @@ async function loadProfileAnalyticsCards(
 }> {
   await runtime.auth.ensureAuthenticated({
     profileName,
-    cdpUrl: runtime.cdpUrl
+    cdpUrl: runtime.cdpUrl,
   });
 
   return runtime.profileManager.runWithContext(
     {
       cdpUrl: runtime.cdpUrl,
       profileName,
-      headless: true
+      headless: true,
     },
     async (context) => {
       const page = await getOrCreatePage(context);
       await page.goto(LINKEDIN_SELF_PROFILE_URL, {
-        waitUntil: "domcontentloaded"
+        waitUntil: "domcontentloaded",
+        timeout: 30_000,
       });
       await waitForAnalyticsSurface(page);
       const observedAt = new Date().toISOString();
       const cards = toAnalyticsCards(
         await extractProfileAnalyticsCardSnapshots(page),
-        observedAt
+        observedAt,
       );
       return {
         sourceUrl: page.url(),
         observedAt,
-        cards
+        cards,
       };
-    }
+    },
   );
 }
 
-function ensureMatchingCards(
+export function ensureMatchingCards(
   surface: LinkedInAnalyticsSurface,
   cards: LinkedInAnalyticsCard[],
-  availableCards: LinkedInAnalyticsCard[]
+  availableCards: LinkedInAnalyticsCard[],
 ): LinkedInAnalyticsCard[] {
   if (cards.length > 0) {
     return cards;
@@ -581,8 +594,8 @@ function ensureMatchingCards(
     `Could not locate LinkedIn analytics cards for ${surface}.`,
     {
       surface,
-      available_card_titles: availableCards.map((card) => card.title)
-    }
+      available_card_titles: availableCards.map((card) => card.title),
+    },
   );
 }
 
@@ -590,39 +603,45 @@ function buildSummary(
   surface: Exclude<LinkedInAnalyticsSurface, "post_metrics">,
   sourceUrl: string,
   observedAt: string,
-  cards: LinkedInAnalyticsCard[]
+  cards: LinkedInAnalyticsCard[],
 ): LinkedInAnalyticsSummary {
   return {
     surface,
     source_url: sourceUrl,
     observed_at: observedAt,
-    metrics: flattenCardMetrics(cards),
-    cards
+    metrics: cards.flatMap((card) => card.metrics),
+    cards,
   };
 }
 
 export class LinkedInAnalyticsService {
   constructor(private readonly runtime: LinkedInAnalyticsRuntime) {}
 
-  async getProfileViews(
-    input: ReadAnalyticsInput = {}
-  ): Promise<LinkedInAnalyticsSummary> {
-    const profileName = input.profileName ?? "default";
+  private resolveProfileName(profileName: string | undefined): string {
+    const normalizedProfileName = normalizeText(profileName);
+    return normalizedProfileName || "default";
+  }
+
+  private async fetchProfileSurface(input: {
+    surface: Exclude<LinkedInAnalyticsSurface, "post_metrics">;
+    profileName: string | undefined;
+    selectCards: (cards: LinkedInAnalyticsCard[]) => LinkedInAnalyticsCard[];
+    errorMessage: string;
+  }): Promise<LinkedInAnalyticsSummary> {
+    const profileName = this.resolveProfileName(input.profileName);
 
     try {
       const { sourceUrl, observedAt, cards } = await loadProfileAnalyticsCards(
         this.runtime,
-        profileName
+        profileName,
       );
       const matchedCards = ensureMatchingCards(
-        "profile_views",
-        cards.filter((card) =>
-          matchesAnalyticsCard(card, PROFILE_VIEW_KEYWORDS)
-        ),
-        cards
+        input.surface,
+        input.selectCards(cards),
+        cards,
       );
 
-      return buildSummary("profile_views", sourceUrl, observedAt, matchedCards);
+      return buildSummary(input.surface, sourceUrl, observedAt, matchedCards);
     } catch (error) {
       if (error instanceof LinkedInBuddyError) {
         throw error;
@@ -631,124 +650,95 @@ export class LinkedInAnalyticsService {
       throw asLinkedInBuddyError(
         error,
         "UNKNOWN",
-        "Failed to read LinkedIn profile view analytics."
+        `${input.errorMessage} (profileName: ${profileName}).`,
       );
     }
+  }
+
+  async getProfileViews(
+    input: ReadAnalyticsInput = {},
+  ): Promise<LinkedInAnalyticsSummary> {
+    return this.fetchProfileSurface({
+      surface: "profile_views",
+      profileName: input.profileName,
+      selectCards: (cards) =>
+        cards.filter((card) =>
+          matchesAnalyticsCard(card, PROFILE_VIEW_KEYWORDS),
+        ),
+      errorMessage: "Failed to read LinkedIn profile view analytics.",
+    });
   }
 
   async getSearchAppearances(
-    input: ReadAnalyticsInput = {}
+    input: ReadAnalyticsInput = {},
   ): Promise<LinkedInAnalyticsSummary> {
-    const profileName = input.profileName ?? "default";
-
-    try {
-      const { sourceUrl, observedAt, cards } = await loadProfileAnalyticsCards(
-        this.runtime,
-        profileName
-      );
-      const matchedCards = ensureMatchingCards(
-        "search_appearances",
+    return this.fetchProfileSurface({
+      surface: "search_appearances",
+      profileName: input.profileName,
+      selectCards: (cards) =>
         cards.filter((card) =>
-          matchesAnalyticsCard(card, SEARCH_APPEARANCES_KEYWORDS)
+          matchesAnalyticsCard(card, SEARCH_APPEARANCES_KEYWORDS),
         ),
-        cards
-      );
-
-      return buildSummary(
-        "search_appearances",
-        sourceUrl,
-        observedAt,
-        matchedCards
-      );
-    } catch (error) {
-      if (error instanceof LinkedInBuddyError) {
-        throw error;
-      }
-
-      throw asLinkedInBuddyError(
-        error,
-        "UNKNOWN",
-        "Failed to read LinkedIn search appearance analytics."
-      );
-    }
+      errorMessage: "Failed to read LinkedIn search appearance analytics.",
+    });
   }
 
   async getContentMetrics(
-    input: ReadContentMetricsInput = {}
+    input: ReadContentMetricsInput = {},
   ): Promise<LinkedInAnalyticsSummary> {
-    const profileName = input.profileName ?? "default";
     const limit = readAnalyticsLimit(input.limit, 4);
 
-    try {
-      const { sourceUrl, observedAt, cards } = await loadProfileAnalyticsCards(
-        this.runtime,
-        profileName
-      );
-      const directMatches = cards.filter((card) =>
-        matchesAnalyticsCard(
-          card,
-          CONTENT_METRICS_KEYWORDS,
-          CONTENT_METRICS_NEGATIVE_KEYWORDS
-        )
-      );
-      const fallbackMatches = cards.filter(
-        (card) =>
-          !matchesAnalyticsCard(card, PROFILE_VIEW_KEYWORDS) &&
-          !matchesAnalyticsCard(card, SEARCH_APPEARANCES_KEYWORDS)
-      );
-      const matchedCards =
-        directMatches.length > 0
-          ? directMatches.slice(0, limit)
-          : fallbackMatches.slice(0, limit);
-      if (cards.length === 0) {
-        throw new LinkedInBuddyError(
-          "UI_CHANGED_SELECTOR_FAILED",
-          "Could not locate LinkedIn analytics cards for content_metrics.",
-          {
-            surface: "content_metrics",
-            available_card_titles: []
-          }
+    return this.fetchProfileSurface({
+      surface: "content_metrics",
+      profileName: input.profileName,
+      selectCards: (cards) => {
+        const directMatches = cards.filter((card) =>
+          matchesAnalyticsCard(
+            card,
+            CONTENT_METRICS_KEYWORDS,
+            CONTENT_METRICS_NEGATIVE_KEYWORDS,
+          ),
         );
-      }
+        const fallbackMatches = cards.filter(
+          (card) =>
+            !matchesAnalyticsCard(card, PROFILE_VIEW_KEYWORDS) &&
+            !matchesAnalyticsCard(card, SEARCH_APPEARANCES_KEYWORDS),
+        );
+        const matchedCards =
+          directMatches.length > 0
+            ? directMatches.slice(0, limit)
+            : fallbackMatches.slice(0, limit);
 
-      return buildSummary("content_metrics", sourceUrl, observedAt, matchedCards);
-    } catch (error) {
-      if (error instanceof LinkedInBuddyError) {
-        throw error;
-      }
-
-      throw asLinkedInBuddyError(
-        error,
-        "UNKNOWN",
-        "Failed to read LinkedIn content analytics."
-      );
-    }
+        return matchedCards;
+      },
+      errorMessage: "Failed to read LinkedIn content analytics.",
+    });
   }
 
   async getPostMetrics(
-    input: ReadPostMetricsInput
+    input: ReadPostMetricsInput,
   ): Promise<LinkedInPostMetricsSummary> {
-    const profileName = input.profileName ?? "default";
+    const profileName = this.resolveProfileName(input.profileName);
 
     try {
       const post = await this.runtime.feed.viewPost({
         profileName,
-        postUrl: input.postUrl
+        postUrl: input.postUrl,
       });
       const observedAt = new Date().toISOString();
       const metrics = [
         {
           label: "Reactions",
-          valueText: post.reactions_count
+          valueText: post.reactions_count,
         },
         {
           label: "Comments",
-          valueText: post.comments_count
+          valueText: post.comments_count,
         },
         {
           label: "Reposts",
-          valueText: post.reposts_count
-        }
+          valueText: post.reposts_count,
+        },
       ]
         .map((entry) => ({
           metric_key: toLinkedInAnalyticsMetricKey(entry.label),
@@ -759,10 +749,10 @@ export class LinkedInAnalyticsService {
           delta_text: null,
           unit: inferAnalyticsMetricUnit(entry.label, entry.valueText),
           trend: "unknown" as const,
-          observed_at: observedAt
+          observed_at: observedAt,
         }))
         .filter(
-          (metric) => metric.value_text.length > 0 || metric.value !== null
+          (metric) => metric.value_text.length > 0 || metric.value !== null,
         );
 
       const engagementTotal = metrics.reduce((total, metric) => {
@@ -787,17 +777,17 @@ export class LinkedInAnalyticsService {
               delta_text: null,
               unit: "count",
               trend: "unknown",
-              observed_at: observedAt
-            }
-          ]
-        }
+              observed_at: observedAt,
+            },
+          ],
+        },
       ];
 
       return {
         surface: "post_metrics",
         source_url: post.post_url,
         observed_at: observedAt,
-        metrics: flattenCardMetrics(cards),
+        metrics: cards.flatMap((card) => card.metrics),
         cards,
         post: {
           post_id: normalizeText(post.post_id),
@@ -805,8 +795,8 @@ export class LinkedInAnalyticsService {
           author_name: normalizeText(post.author_name),
           author_headline: normalizeText(post.author_headline),
           posted_at: normalizeText(post.posted_at),
-          text: normalizeText(post.text)
-        }
+          text: normalizeText(post.text),
+        },
       };
     } catch (error) {
       if (error instanceof LinkedInBuddyError) {
@@ -816,7 +806,7 @@ export class LinkedInAnalyticsService {
       throw asLinkedInBuddyError(
         error,
         "UNKNOWN",
-        "Failed to read LinkedIn post metrics."
+        `Failed to read LinkedIn post metrics. (profileName: ${profileName}).`,
       );
     }
   }

--- a/packages/mcp/src/__tests__/linkedinMcp.test.ts
+++ b/packages/mcp/src/__tests__/linkedinMcp.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  LINKEDIN_ANALYTICS_CONTENT_METRICS_TOOL,
   LINKEDIN_ANALYTICS_POST_METRICS_TOOL,
   LINKEDIN_ANALYTICS_PROFILE_VIEWS_TOOL,
+  LINKEDIN_ANALYTICS_SEARCH_APPEARANCES_TOOL,
   LINKEDIN_ARTICLE_PREPARE_CREATE_TOOL,
   LINKEDIN_ARTICLE_PREPARE_PUBLISH_TOOL,
   LINKEDIN_COMPANY_VIEW_TOOL,
@@ -28,27 +30,28 @@ import {
   LINKEDIN_NOTIFICATIONS_MARK_READ_TOOL,
   LINKEDIN_NOTIFICATIONS_PREFERENCES_GET_TOOL,
   LINKEDIN_NOTIFICATIONS_PREFERENCES_PREPARE_UPDATE_TOOL,
-  LINKEDIN_PRIVACY_GET_SETTINGS_TOOL
+  LINKEDIN_PRIVACY_GET_SETTINGS_TOOL,
 } from "../index.js";
 
 const runtimeFactory = vi.fn();
 
 vi.mock("@linkedin-buddy/core", async () => {
-  const actual =
-    await vi.importActual<typeof import("@linkedin-buddy/core")>(
-      "@linkedin-buddy/core"
-    );
+  const actual = await vi.importActual<typeof import("@linkedin-buddy/core")>(
+    "@linkedin-buddy/core",
+  );
 
   return {
     ...actual,
-    createCoreRuntime: runtimeFactory
+    createCoreRuntime: runtimeFactory,
   };
 });
 
 interface FakeRuntime {
   analytics: {
+    getContentMetrics: ReturnType<typeof vi.fn>;
     getPostMetrics: ReturnType<typeof vi.fn>;
     getProfileViews: ReturnType<typeof vi.fn>;
+    getSearchAppearances: ReturnType<typeof vi.fn>;
   };
   close: ReturnType<typeof vi.fn>;
   companyPages: {
@@ -106,49 +109,51 @@ function createFakeRuntime(): FakeRuntime {
   return {
     runId: "run_test",
     analytics: {
+      getContentMetrics: vi.fn(),
       getPostMetrics: vi.fn(),
-      getProfileViews: vi.fn()
+      getProfileViews: vi.fn(),
+      getSearchAppearances: vi.fn(),
     },
     close: vi.fn(),
     companyPages: {
       prepareFollowCompanyPage: vi.fn(),
-      viewCompanyPage: vi.fn()
+      viewCompanyPage: vi.fn(),
     },
     logger: {
-      log: vi.fn()
+      log: vi.fn(),
     },
     notifications: {
       getPreferences: vi.fn(),
       markRead: vi.fn(),
       prepareDismissNotification: vi.fn(),
-      prepareUpdatePreference: vi.fn()
+      prepareUpdatePreference: vi.fn(),
     },
     members: {
-      prepareReportMember: vi.fn()
+      prepareReportMember: vi.fn(),
     },
     groups: {
       searchGroups: vi.fn(),
       viewGroup: vi.fn(),
       prepareJoinGroup: vi.fn(),
       prepareLeaveGroup: vi.fn(),
-      preparePostToGroup: vi.fn()
+      preparePostToGroup: vi.fn(),
     },
     articles: {
       prepareCreate: vi.fn(),
-      preparePublish: vi.fn()
+      preparePublish: vi.fn(),
     },
     newsletters: {
       prepareCreate: vi.fn(),
       preparePublishIssue: vi.fn(),
-      list: vi.fn()
+      list: vi.fn(),
     },
     events: {
       searchEvents: vi.fn(),
       viewEvent: vi.fn(),
-      prepareRsvp: vi.fn()
+      prepareRsvp: vi.fn(),
     },
     privacySettings: {
-      getSettings: vi.fn()
+      getSettings: vi.fn(),
     },
     jobs: {
       listJobAlerts: vi.fn(),
@@ -156,8 +161,8 @@ function createFakeRuntime(): FakeRuntime {
       prepareEasyApply: vi.fn(),
       prepareRemoveJobAlert: vi.fn(),
       prepareSaveJob: vi.fn(),
-      prepareUnsaveJob: vi.fn()
-    }
+      prepareUnsaveJob: vi.fn(),
+    },
   };
 }
 
@@ -182,7 +187,7 @@ describe("handleToolCall", () => {
 
     const result = await handleToolCall(LINKEDIN_INBOX_SEARCH_RECIPIENTS_TOOL, {
       query: "Simon Miller",
-      limit: "5" as unknown as number
+      limit: "5" as unknown as number,
     });
 
     expect("isError" in result && result.isError).toBe(true);
@@ -191,8 +196,8 @@ describe("handleToolCall", () => {
       message: "limit must be a finite number.",
       details: {
         path: "limit",
-        actual_type: "string"
-      }
+        actual_type: "string",
+      },
     });
     expect(runtimeFactory).not.toHaveBeenCalled();
   });
@@ -206,18 +211,19 @@ describe("handleToolCall", () => {
         allowed_values: [
           "full_profile",
           "private_profile_characteristics",
-          "private_mode"
+          "private_mode",
         ],
         current_value: "private_mode",
         status: "available",
-        source_url: "https://www.linkedin.com/mypreferences/d/profile-viewing-options",
+        source_url:
+          "https://www.linkedin.com/mypreferences/d/profile-viewing-options",
         selector_key: "profile-viewing-mode-input-index-2",
-        message: null
-      }
+        message: null,
+      },
     ]);
 
     const result = await handleToolCall(LINKEDIN_PRIVACY_GET_SETTINGS_TOOL, {
-      profileName: "default"
+      profileName: "default",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -227,12 +233,12 @@ describe("handleToolCall", () => {
       settings: [
         expect.objectContaining({
           key: "profile_viewing_mode",
-          current_value: "private_mode"
-        })
-      ]
+          current_value: "private_mode",
+        }),
+      ],
     });
     expect(fakeRuntime.privacySettings.getSettings).toHaveBeenCalledWith({
-      profileName: "default"
+      profileName: "default",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -252,8 +258,8 @@ describe("handleToolCall", () => {
           delta_text: null,
           unit: "count",
           trend: "unknown",
-          observed_at: "2026-03-11T12:00:00.000Z"
-        }
+          observed_at: "2026-03-11T12:00:00.000Z",
+        },
       ],
       cards: [
         {
@@ -271,15 +277,15 @@ describe("handleToolCall", () => {
               delta_text: null,
               unit: "count",
               trend: "unknown",
-              observed_at: "2026-03-11T12:00:00.000Z"
-            }
-          ]
-        }
-      ]
+              observed_at: "2026-03-11T12:00:00.000Z",
+            },
+          ],
+        },
+      ],
     });
 
     const result = await handleToolCall(LINKEDIN_ANALYTICS_PROFILE_VIEWS_TOOL, {
-      profileName: "default"
+      profileName: "default",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -290,12 +296,146 @@ describe("handleToolCall", () => {
       metrics: [
         expect.objectContaining({
           metric_key: "profile_views",
-          value: 42
-        })
-      ]
+          value: 42,
+        }),
+      ],
     });
     expect(fakeRuntime.analytics.getProfileViews).toHaveBeenCalledWith({
-      profileName: "default"
+      profileName: "default",
+    });
+    expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns search-appearances analytics payloads through the MCP contract", async () => {
+    fakeRuntime.analytics.getSearchAppearances.mockResolvedValue({
+      surface: "search_appearances",
+      source_url: "https://www.linkedin.com/in/me/",
+      observed_at: "2026-03-11T12:00:00.000Z",
+      metrics: [
+        {
+          metric_key: "search_appearances",
+          label: "Search appearances",
+          value: 28,
+          value_text: "28",
+          delta_value: null,
+          delta_text: null,
+          unit: "count",
+          trend: "unknown",
+          observed_at: "2026-03-11T12:00:00.000Z",
+        },
+      ],
+      cards: [
+        {
+          card_key: "search_appearances",
+          title: "Search appearances",
+          description: "How often your profile appears in search.",
+          href: "https://www.linkedin.com/in/me/",
+          metrics: [
+            {
+              metric_key: "search_appearances",
+              label: "Search appearances",
+              value: 28,
+              value_text: "28",
+              delta_value: null,
+              delta_text: null,
+              unit: "count",
+              trend: "unknown",
+              observed_at: "2026-03-11T12:00:00.000Z",
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await handleToolCall(
+      LINKEDIN_ANALYTICS_SEARCH_APPEARANCES_TOOL,
+      {
+        profileName: "default",
+      },
+    );
+
+    expect("isError" in result && result.isError).toBe(false);
+    expect(parseToolPayload(result)).toMatchObject({
+      run_id: "run_test",
+      profile_name: "default",
+      surface: "search_appearances",
+      metrics: [
+        expect.objectContaining({
+          metric_key: "search_appearances",
+          value: 28,
+        }),
+      ],
+    });
+    expect(fakeRuntime.analytics.getSearchAppearances).toHaveBeenCalledWith({
+      profileName: "default",
+    });
+    expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns content-metrics analytics payloads through the MCP contract", async () => {
+    fakeRuntime.analytics.getContentMetrics.mockResolvedValue({
+      surface: "content_metrics",
+      source_url: "https://www.linkedin.com/in/me/",
+      observed_at: "2026-03-11T12:00:00.000Z",
+      metrics: [
+        {
+          metric_key: "impressions",
+          label: "Impressions",
+          value: 350,
+          value_text: "350",
+          delta_value: null,
+          delta_text: null,
+          unit: "count",
+          trend: "unknown",
+          observed_at: "2026-03-11T12:00:00.000Z",
+        },
+      ],
+      cards: [
+        {
+          card_key: "content_metrics",
+          title: "Creator analytics",
+          description: "Performance summary for your content.",
+          href: "https://www.linkedin.com/in/me/",
+          metrics: [
+            {
+              metric_key: "impressions",
+              label: "Impressions",
+              value: 350,
+              value_text: "350",
+              delta_value: null,
+              delta_text: null,
+              unit: "count",
+              trend: "unknown",
+              observed_at: "2026-03-11T12:00:00.000Z",
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await handleToolCall(
+      LINKEDIN_ANALYTICS_CONTENT_METRICS_TOOL,
+      {
+        profileName: "default",
+        limit: 3,
+      },
+    );
+
+    expect("isError" in result && result.isError).toBe(false);
+    expect(parseToolPayload(result)).toMatchObject({
+      run_id: "run_test",
+      profile_name: "default",
+      surface: "content_metrics",
+      metrics: [
+        expect.objectContaining({
+          metric_key: "impressions",
+          value: 350,
+        }),
+      ],
+    });
+    expect(fakeRuntime.analytics.getContentMetrics).toHaveBeenCalledWith({
+      profileName: "default",
+      limit: 3,
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -306,15 +446,15 @@ describe("handleToolCall", () => {
       confirmToken: "ct_test",
       expiresAtMs: 123,
       preview: {
-        summary: "Report LinkedIn member target-user for spam"
-      }
+        summary: "Report LinkedIn member target-user for spam",
+      },
     });
 
     const result = await handleToolCall(LINKEDIN_MEMBERS_PREPARE_REPORT_TOOL, {
       profileName: "default",
       targetProfile: "target-user",
       reason: "spam",
-      details: "Repeated unsolicited outreach."
+      details: "Repeated unsolicited outreach.",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -322,13 +462,13 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_test",
-      confirmToken: "ct_test"
+      confirmToken: "ct_test",
     });
     expect(fakeRuntime.members.prepareReportMember).toHaveBeenCalledWith({
       profileName: "default",
       targetProfile: "target-user",
       reason: "spam",
-      details: "Repeated unsolicited outreach."
+      details: "Repeated unsolicited outreach.",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -339,12 +479,12 @@ describe("handleToolCall", () => {
       was_already_read: false,
       notification_id: "notif_1",
       link: "https://www.linkedin.com/feed/update/urn:li:activity:1",
-      selector_key: "headline-link"
+      selector_key: "headline-link",
     });
 
     const result = await handleToolCall(LINKEDIN_NOTIFICATIONS_MARK_READ_TOOL, {
       profileName: "default",
-      notificationId: "notif_1"
+      notificationId: "notif_1",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -352,11 +492,11 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       marked_read: true,
-      notification_id: "notif_1"
+      notification_id: "notif_1",
     });
     expect(fakeRuntime.notifications.markRead).toHaveBeenCalledWith({
       profileName: "default",
-      notificationId: "notif_1"
+      notificationId: "notif_1",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -367,13 +507,13 @@ describe("handleToolCall", () => {
       confirmToken: "ct_notif",
       expiresAtMs: 789,
       preview: {
-        summary: "Dismiss notification"
-      }
+        summary: "Dismiss notification",
+      },
     });
 
     const result = await handleToolCall(LINKEDIN_NOTIFICATIONS_DISMISS_TOOL, {
       profileName: "default",
-      notificationId: "notif_1"
+      notificationId: "notif_1",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -381,11 +521,13 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_notif",
-      confirmToken: "ct_notif"
+      confirmToken: "ct_notif",
     });
-    expect(fakeRuntime.notifications.prepareDismissNotification).toHaveBeenCalledWith({
+    expect(
+      fakeRuntime.notifications.prepareDismissNotification,
+    ).toHaveBeenCalledWith({
       profileName: "default",
-      notificationId: "notif_1"
+      notificationId: "notif_1",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -394,22 +536,23 @@ describe("handleToolCall", () => {
     fakeRuntime.notifications.getPreferences.mockResolvedValue({
       view_type: "overview",
       title: "Notifications",
-      preference_url: "https://www.linkedin.com/mypreferences/d/categories/notifications",
+      preference_url:
+        "https://www.linkedin.com/mypreferences/d/categories/notifications",
       categories: [
         {
           title: "Posting and commenting",
           slug: "posting-and-commenting",
           preference_url:
-            "https://www.linkedin.com/mypreferences/d/notification-categories/posting-and-commenting"
-        }
-      ]
+            "https://www.linkedin.com/mypreferences/d/notification-categories/posting-and-commenting",
+        },
+      ],
     });
 
     const result = await handleToolCall(
       LINKEDIN_NOTIFICATIONS_PREFERENCES_GET_TOOL,
       {
-        profileName: "default"
-      }
+        profileName: "default",
+      },
     );
 
     expect("isError" in result && result.isError).toBe(false);
@@ -420,13 +563,13 @@ describe("handleToolCall", () => {
         view_type: "overview",
         categories: [
           expect.objectContaining({
-            slug: "posting-and-commenting"
-          })
-        ]
-      }
+            slug: "posting-and-commenting",
+          }),
+        ],
+      },
     });
     expect(fakeRuntime.notifications.getPreferences).toHaveBeenCalledWith({
-      profileName: "default"
+      profileName: "default",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -437,8 +580,8 @@ describe("handleToolCall", () => {
       confirmToken: "ct_pref",
       expiresAtMs: 999,
       preview: {
-        summary: "Update notification preference"
-      }
+        summary: "Update notification preference",
+      },
     });
 
     const result = await handleToolCall(
@@ -448,8 +591,8 @@ describe("handleToolCall", () => {
         preferenceUrl:
           "https://www.linkedin.com/mypreferences/d/notification-subcategories/comments-and-reactions",
         enabled: false,
-        channel: "push"
-      }
+        channel: "push",
+      },
     );
 
     expect("isError" in result && result.isError).toBe(false);
@@ -457,14 +600,16 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_pref",
-      confirmToken: "ct_pref"
+      confirmToken: "ct_pref",
     });
-    expect(fakeRuntime.notifications.prepareUpdatePreference).toHaveBeenCalledWith({
+    expect(
+      fakeRuntime.notifications.prepareUpdatePreference,
+    ).toHaveBeenCalledWith({
       profileName: "default",
       preferenceUrl:
         "https://www.linkedin.com/mypreferences/d/notification-subcategories/comments-and-reactions",
       enabled: false,
-      channel: "push"
+      channel: "push",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -481,15 +626,15 @@ describe("handleToolCall", () => {
           visibility: "Private Listed",
           member_count: "706,250 members",
           description: "Community for next-generation leaders.",
-          membership_state: "member"
-        }
-      ]
+          membership_state: "member",
+        },
+      ],
     });
 
     const result = await handleToolCall(LINKEDIN_GROUPS_SEARCH_TOOL, {
       profileName: "default",
       query: "technology",
-      limit: 5
+      limit: 5,
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -499,14 +644,14 @@ describe("handleToolCall", () => {
       query: "technology",
       results: [
         expect.objectContaining({
-          group_id: "9806731"
-        })
-      ]
+          group_id: "9806731",
+        }),
+      ],
     });
     expect(fakeRuntime.groups.searchGroups).toHaveBeenCalledWith({
       profileName: "default",
       query: "technology",
-      limit: 5
+      limit: 5,
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -527,12 +672,12 @@ describe("handleToolCall", () => {
       headquarters: "San Francisco, CA",
       specialties: "artificial intelligence and machine learning",
       overview: "OpenAI is an AI research and deployment company.",
-      follow_state: "following"
+      follow_state: "following",
     });
 
     const result = await handleToolCall(LINKEDIN_COMPANY_VIEW_TOOL, {
       profileName: "default",
-      target: "openai"
+      target: "openai",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -541,12 +686,12 @@ describe("handleToolCall", () => {
       profile_name: "default",
       company: {
         name: "OpenAI",
-        follow_state: "following"
-      }
+        follow_state: "following",
+      },
     });
     expect(fakeRuntime.companyPages.viewCompanyPage).toHaveBeenCalledWith({
       profileName: "default",
-      target: "openai"
+      target: "openai",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -561,12 +706,12 @@ describe("handleToolCall", () => {
       description: "Community for next-generation leaders.",
       about: "Community for next-generation leaders.",
       joined_at: "Apr 2024",
-      membership_state: "member"
+      membership_state: "member",
     });
 
     const result = await handleToolCall(LINKEDIN_GROUPS_VIEW_TOOL, {
       profileName: "default",
-      group: "9806731"
+      group: "9806731",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -575,12 +720,12 @@ describe("handleToolCall", () => {
       profile_name: "default",
       group: expect.objectContaining({
         group_id: "9806731",
-        membership_state: "member"
-      })
+        membership_state: "member",
+      }),
     });
     expect(fakeRuntime.groups.viewGroup).toHaveBeenCalledWith({
       profileName: "default",
-      group: "9806731"
+      group: "9806731",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -591,13 +736,13 @@ describe("handleToolCall", () => {
       confirmToken: "ct_group_join",
       expiresAtMs: 123,
       preview: {
-        summary: "Join LinkedIn group 63979"
-      }
+        summary: "Join LinkedIn group 63979",
+      },
     });
 
     const result = await handleToolCall(LINKEDIN_GROUPS_PREPARE_JOIN_TOOL, {
       profileName: "default",
-      group: "63979"
+      group: "63979",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -605,11 +750,11 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_group_join",
-      confirmToken: "ct_group_join"
+      confirmToken: "ct_group_join",
     });
     expect(fakeRuntime.groups.prepareJoinGroup).toHaveBeenCalledWith({
       profileName: "default",
-      group: "63979"
+      group: "63979",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -620,14 +765,14 @@ describe("handleToolCall", () => {
       confirmToken: "ct_group_leave",
       expiresAtMs: 123,
       preview: {
-        summary: "Leave LinkedIn group 9806731"
-      }
+        summary: "Leave LinkedIn group 9806731",
+      },
     });
 
     const result = await handleToolCall(LINKEDIN_GROUPS_PREPARE_LEAVE_TOOL, {
       profileName: "default",
       group: "9806731",
-      operatorNote: "Validation"
+      operatorNote: "Validation",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -635,12 +780,12 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_group_leave",
-      confirmToken: "ct_group_leave"
+      confirmToken: "ct_group_leave",
     });
     expect(fakeRuntime.groups.prepareLeaveGroup).toHaveBeenCalledWith({
       profileName: "default",
       group: "9806731",
-      operatorNote: "Validation"
+      operatorNote: "Validation",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -651,14 +796,14 @@ describe("handleToolCall", () => {
       confirmToken: "ct_group_post",
       expiresAtMs: 123,
       preview: {
-        summary: "Post to LinkedIn group 9806731"
-      }
+        summary: "Post to LinkedIn group 9806731",
+      },
     });
 
     const result = await handleToolCall(LINKEDIN_GROUPS_PREPARE_POST_TOOL, {
       profileName: "default",
       group: "9806731",
-      text: "Thanks for sharing this perspective."
+      text: "Thanks for sharing this perspective.",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -666,12 +811,12 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_group_post",
-      confirmToken: "ct_group_post"
+      confirmToken: "ct_group_post",
     });
     expect(fakeRuntime.groups.preparePostToGroup).toHaveBeenCalledWith({
       profileName: "default",
       group: "9806731",
-      text: "Thanks for sharing this perspective."
+      text: "Thanks for sharing this perspective.",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -682,14 +827,14 @@ describe("handleToolCall", () => {
       confirmToken: "ct_article_create",
       expiresAtMs: 123,
       preview: {
-        summary: 'Create LinkedIn article draft "Launch notes"'
-      }
+        summary: 'Create LinkedIn article draft "Launch notes"',
+      },
     });
 
     const result = await handleToolCall(LINKEDIN_ARTICLE_PREPARE_CREATE_TOOL, {
       profileName: "default",
       title: "Launch notes",
-      body: "A longer article body."
+      body: "A longer article body.",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -697,12 +842,12 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_article_create",
-      confirmToken: "ct_article_create"
+      confirmToken: "ct_article_create",
     });
     expect(fakeRuntime.articles.prepareCreate).toHaveBeenCalledWith({
       profileName: "default",
       title: "Launch notes",
-      body: "A longer article body."
+      body: "A longer article body.",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -713,13 +858,13 @@ describe("handleToolCall", () => {
       confirmToken: "ct_article_publish",
       expiresAtMs: 123,
       preview: {
-        summary: 'Publish LinkedIn article draft "Launch notes"'
-      }
+        summary: 'Publish LinkedIn article draft "Launch notes"',
+      },
     });
 
     const result = await handleToolCall(LINKEDIN_ARTICLE_PREPARE_PUBLISH_TOOL, {
       profileName: "default",
-      draftUrl: "https://www.linkedin.com/pulse/article/123/edit/"
+      draftUrl: "https://www.linkedin.com/pulse/article/123/edit/",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -727,11 +872,11 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_article_publish",
-      confirmToken: "ct_article_publish"
+      confirmToken: "ct_article_publish",
     });
     expect(fakeRuntime.articles.preparePublish).toHaveBeenCalledWith({
       profileName: "default",
-      draftUrl: "https://www.linkedin.com/pulse/article/123/edit/"
+      draftUrl: "https://www.linkedin.com/pulse/article/123/edit/",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -742,29 +887,32 @@ describe("handleToolCall", () => {
       confirmToken: "ct_newsletter_create",
       expiresAtMs: 123,
       preview: {
-        summary: 'Create LinkedIn newsletter "Builder Brief"'
-      }
+        summary: 'Create LinkedIn newsletter "Builder Brief"',
+      },
     });
 
-    const result = await handleToolCall(LINKEDIN_NEWSLETTER_PREPARE_CREATE_TOOL, {
-      profileName: "default",
-      title: "Builder Brief",
-      description: "Weekly notes from the product team.",
-      cadence: "weekly"
-    });
+    const result = await handleToolCall(
+      LINKEDIN_NEWSLETTER_PREPARE_CREATE_TOOL,
+      {
+        profileName: "default",
+        title: "Builder Brief",
+        description: "Weekly notes from the product team.",
+        cadence: "weekly",
+      },
+    );
 
     expect("isError" in result && result.isError).toBe(false);
     expect(parseToolPayload(result)).toMatchObject({
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_newsletter_create",
-      confirmToken: "ct_newsletter_create"
+      confirmToken: "ct_newsletter_create",
     });
     expect(fakeRuntime.newsletters.prepareCreate).toHaveBeenCalledWith({
       profileName: "default",
       title: "Builder Brief",
       description: "Weekly notes from the product team.",
-      cadence: "weekly"
+      cadence: "weekly",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -775,8 +923,9 @@ describe("handleToolCall", () => {
       confirmToken: "ct_newsletter_issue",
       expiresAtMs: 123,
       preview: {
-        summary: 'Publish LinkedIn newsletter issue "March update" in Builder Brief'
-      }
+        summary:
+          'Publish LinkedIn newsletter issue "March update" in Builder Brief',
+      },
     });
 
     const result = await handleToolCall(
@@ -785,8 +934,8 @@ describe("handleToolCall", () => {
         profileName: "default",
         newsletter: "Builder Brief",
         title: "March update",
-        body: "Long-form issue body."
-      }
+        body: "Long-form issue body.",
+      },
     );
 
     expect("isError" in result && result.isError).toBe(false);
@@ -794,13 +943,13 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_newsletter_issue",
-      confirmToken: "ct_newsletter_issue"
+      confirmToken: "ct_newsletter_issue",
     });
     expect(fakeRuntime.newsletters.preparePublishIssue).toHaveBeenCalledWith({
       profileName: "default",
       newsletter: "Builder Brief",
       title: "March update",
-      body: "Long-form issue body."
+      body: "Long-form issue body.",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -811,13 +960,13 @@ describe("handleToolCall", () => {
       newsletters: [
         {
           title: "Builder Brief",
-          selected: false
-        }
-      ]
+          selected: false,
+        },
+      ],
     });
 
     const result = await handleToolCall(LINKEDIN_NEWSLETTER_LIST_TOOL, {
-      profileName: "default"
+      profileName: "default",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -827,12 +976,12 @@ describe("handleToolCall", () => {
       count: 1,
       newsletters: [
         expect.objectContaining({
-          title: "Builder Brief"
-        })
-      ]
+          title: "Builder Brief",
+        }),
+      ],
     });
     expect(fakeRuntime.newsletters.list).toHaveBeenCalledWith({
-      profileName: "default"
+      profileName: "default",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -851,15 +1000,15 @@ describe("handleToolCall", () => {
           attendee_count: "1,234 attendees",
           description: "A live session on leadership under pressure.",
           event_url: "https://www.linkedin.com/events/7433954919704973312/",
-          is_online: true
-        }
-      ]
+          is_online: true,
+        },
+      ],
     });
 
     const result = await handleToolCall(LINKEDIN_EVENTS_SEARCH_TOOL, {
       profileName: "default",
       query: "leadership",
-      limit: 5
+      limit: 5,
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -869,14 +1018,14 @@ describe("handleToolCall", () => {
       query: "leadership",
       results: [
         expect.objectContaining({
-          event_id: "7433954919704973312"
-        })
-      ]
+          event_id: "7433954919704973312",
+        }),
+      ],
     });
     expect(fakeRuntime.events.searchEvents).toHaveBeenCalledWith({
       profileName: "default",
       query: "leadership",
-      limit: 5
+      limit: 5,
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -892,12 +1041,12 @@ describe("handleToolCall", () => {
       attendee_count: "1,234 attendees",
       description: "A live session on leadership under pressure.",
       is_online: true,
-      rsvp_state: "not_responded"
+      rsvp_state: "not_responded",
     });
 
     const result = await handleToolCall(LINKEDIN_EVENTS_VIEW_TOOL, {
       profileName: "default",
-      event: "7433954919704973312"
+      event: "7433954919704973312",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -906,12 +1055,12 @@ describe("handleToolCall", () => {
       profile_name: "default",
       event: expect.objectContaining({
         event_id: "7433954919704973312",
-        rsvp_state: "not_responded"
-      })
+        rsvp_state: "not_responded",
+      }),
     });
     expect(fakeRuntime.events.viewEvent).toHaveBeenCalledWith({
       profileName: "default",
-      event: "7433954919704973312"
+      event: "7433954919704973312",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -922,13 +1071,13 @@ describe("handleToolCall", () => {
       confirmToken: "ct_event",
       expiresAtMs: 123,
       preview: {
-        summary: "RSVP attend for LinkedIn event 7433954919704973312"
-      }
+        summary: "RSVP attend for LinkedIn event 7433954919704973312",
+      },
     });
 
     const result = await handleToolCall(LINKEDIN_EVENTS_PREPARE_RSVP_TOOL, {
       profileName: "default",
-      event: "7433954919704973312"
+      event: "7433954919704973312",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -936,11 +1085,11 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_event",
-      confirmToken: "ct_event"
+      confirmToken: "ct_event",
     });
     expect(fakeRuntime.events.prepareRsvp).toHaveBeenCalledWith({
       profileName: "default",
-      event: "7433954919704973312"
+      event: "7433954919704973312",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -960,8 +1109,8 @@ describe("handleToolCall", () => {
           delta_text: null,
           unit: "count",
           trend: "unknown",
-          observed_at: "2026-03-11T12:00:00.000Z"
-        }
+          observed_at: "2026-03-11T12:00:00.000Z",
+        },
       ],
       cards: [
         {
@@ -979,10 +1128,10 @@ describe("handleToolCall", () => {
               delta_text: null,
               unit: "count",
               trend: "unknown",
-              observed_at: "2026-03-11T12:00:00.000Z"
-            }
-          ]
-        }
+              observed_at: "2026-03-11T12:00:00.000Z",
+            },
+          ],
+        },
       ],
       post: {
         post_id: "123",
@@ -990,13 +1139,13 @@ describe("handleToolCall", () => {
         author_name: "Joi Ascend",
         author_headline: "Automation operator",
         posted_at: "1d",
-        text: "Testing metrics."
-      }
+        text: "Testing metrics.",
+      },
     });
 
     const result = await handleToolCall(LINKEDIN_ANALYTICS_POST_METRICS_TOOL, {
       profileName: "default",
-      postUrl: "urn:li:activity:123"
+      postUrl: "urn:li:activity:123",
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -1006,12 +1155,12 @@ describe("handleToolCall", () => {
       surface: "post_metrics",
       post: {
         post_id: "123",
-        author_name: "Joi Ascend"
-      }
+        author_name: "Joi Ascend",
+      },
     });
     expect(fakeRuntime.analytics.getPostMetrics).toHaveBeenCalledWith({
       profileName: "default",
-      postUrl: "urn:li:activity:123"
+      postUrl: "urn:li:activity:123",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -1022,26 +1171,26 @@ describe("handleToolCall", () => {
       confirmToken: "ct_job_save",
       expiresAtMs: 123,
       preview: {
-        summary: "Save LinkedIn job https://www.linkedin.com/jobs/view/123/"
-      }
+        summary: "Save LinkedIn job https://www.linkedin.com/jobs/view/123/",
+      },
     });
     fakeRuntime.jobs.prepareUnsaveJob.mockReturnValue({
       preparedActionId: "pa_job_unsave",
       confirmToken: "ct_job_unsave",
       expiresAtMs: 123,
       preview: {
-        summary: "Unsave LinkedIn job https://www.linkedin.com/jobs/view/123/"
-      }
+        summary: "Unsave LinkedIn job https://www.linkedin.com/jobs/view/123/",
+      },
     });
 
     const saveResult = await handleToolCall(LINKEDIN_JOBS_SAVE_TOOL, {
       profileName: "default",
-      jobId: "123"
+      jobId: "123",
     });
     const unsaveResult = await handleToolCall(LINKEDIN_JOBS_UNSAVE_TOOL, {
       profileName: "default",
       jobId: "123",
-      operatorNote: "cleanup"
+      operatorNote: "cleanup",
     });
 
     expect("isError" in saveResult && saveResult.isError).toBe(false);
@@ -1049,11 +1198,11 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_job_save",
-      confirmToken: "ct_job_save"
+      confirmToken: "ct_job_save",
     });
     expect(fakeRuntime.jobs.prepareSaveJob).toHaveBeenCalledWith({
       profileName: "default",
-      jobId: "123"
+      jobId: "123",
     });
 
     expect("isError" in unsaveResult && unsaveResult.isError).toBe(false);
@@ -1061,12 +1210,12 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_job_unsave",
-      confirmToken: "ct_job_unsave"
+      confirmToken: "ct_job_unsave",
     });
     expect(fakeRuntime.jobs.prepareUnsaveJob).toHaveBeenCalledWith({
       profileName: "default",
       jobId: "123",
-      operatorNote: "cleanup"
+      operatorNote: "cleanup",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(2);
   });
@@ -1082,14 +1231,14 @@ describe("handleToolCall", () => {
           frequency: "Daily",
           search_url:
             "https://www.linkedin.com/jobs/search/?keywords=Staff%20Engineer&location=Remote",
-          enabled: true
-        }
-      ]
+          enabled: true,
+        },
+      ],
     });
 
     const result = await handleToolCall(LINKEDIN_JOBS_ALERTS_LIST_TOOL, {
       profileName: "default",
-      limit: 5
+      limit: 5,
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -1100,13 +1249,13 @@ describe("handleToolCall", () => {
       alerts: [
         expect.objectContaining({
           alert_id: "alert-1",
-          enabled: true
-        })
-      ]
+          enabled: true,
+        }),
+      ],
     });
     expect(fakeRuntime.jobs.listJobAlerts).toHaveBeenCalledWith({
       profileName: "default",
-      limit: 5
+      limit: 5,
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });
@@ -1117,40 +1266,46 @@ describe("handleToolCall", () => {
       confirmToken: "ct_alert_create",
       expiresAtMs: 123,
       preview: {
-        summary: 'Create a LinkedIn job alert for "Staff Engineer" in Remote'
-      }
+        summary: 'Create a LinkedIn job alert for "Staff Engineer" in Remote',
+      },
     });
     fakeRuntime.jobs.prepareRemoveJobAlert.mockResolvedValue({
       preparedActionId: "pa_alert_remove",
       confirmToken: "ct_alert_remove",
       expiresAtMs: 123,
       preview: {
-        summary: 'Remove LinkedIn job alert for "Staff Engineer" in Remote'
-      }
+        summary: 'Remove LinkedIn job alert for "Staff Engineer" in Remote',
+      },
     });
 
-    const createResult = await handleToolCall(LINKEDIN_JOBS_ALERTS_CREATE_TOOL, {
-      profileName: "default",
-      query: "Staff Engineer",
-      location: "Remote"
-    });
-    const removeResult = await handleToolCall(LINKEDIN_JOBS_ALERTS_REMOVE_TOOL, {
-      profileName: "default",
-      alertId: "alert-1",
-      operatorNote: "cleanup"
-    });
+    const createResult = await handleToolCall(
+      LINKEDIN_JOBS_ALERTS_CREATE_TOOL,
+      {
+        profileName: "default",
+        query: "Staff Engineer",
+        location: "Remote",
+      },
+    );
+    const removeResult = await handleToolCall(
+      LINKEDIN_JOBS_ALERTS_REMOVE_TOOL,
+      {
+        profileName: "default",
+        alertId: "alert-1",
+        operatorNote: "cleanup",
+      },
+    );
 
     expect("isError" in createResult && createResult.isError).toBe(false);
     expect(parseToolPayload(createResult)).toMatchObject({
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_alert_create",
-      confirmToken: "ct_alert_create"
+      confirmToken: "ct_alert_create",
     });
     expect(fakeRuntime.jobs.prepareCreateJobAlert).toHaveBeenCalledWith({
       profileName: "default",
       query: "Staff Engineer",
-      location: "Remote"
+      location: "Remote",
     });
 
     expect("isError" in removeResult && removeResult.isError).toBe(false);
@@ -1158,12 +1313,12 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_alert_remove",
-      confirmToken: "ct_alert_remove"
+      confirmToken: "ct_alert_remove",
     });
     expect(fakeRuntime.jobs.prepareRemoveJobAlert).toHaveBeenCalledWith({
       profileName: "default",
       alertId: "alert-1",
-      operatorNote: "cleanup"
+      operatorNote: "cleanup",
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(2);
   });
@@ -1174,8 +1329,9 @@ describe("handleToolCall", () => {
       confirmToken: "ct_easy_apply",
       expiresAtMs: 123,
       preview: {
-        summary: "Submit LinkedIn Easy Apply application for https://www.linkedin.com/jobs/view/123/"
-      }
+        summary:
+          "Submit LinkedIn Easy Apply application for https://www.linkedin.com/jobs/view/123/",
+      },
     });
 
     const result = await handleToolCall(LINKEDIN_JOBS_PREPARE_EASY_APPLY_TOOL, {
@@ -1184,8 +1340,8 @@ describe("handleToolCall", () => {
       email: "candidate@example.com",
       resumePath: "/tmp/resume.pdf",
       answers: {
-        "Years of experience": 8
-      }
+        "Years of experience": 8,
+      },
     });
 
     expect("isError" in result && result.isError).toBe(false);
@@ -1193,7 +1349,7 @@ describe("handleToolCall", () => {
       run_id: "run_test",
       profile_name: "default",
       preparedActionId: "pa_easy_apply",
-      confirmToken: "ct_easy_apply"
+      confirmToken: "ct_easy_apply",
     });
     expect(fakeRuntime.jobs.prepareEasyApply).toHaveBeenCalledWith({
       profileName: "default",
@@ -1201,8 +1357,8 @@ describe("handleToolCall", () => {
       email: "candidate@example.com",
       resumePath: "/tmp/resume.pdf",
       answers: {
-        "Years of experience": 8
-      }
+        "Years of experience": 8,
+      },
     });
     expect(fakeRuntime.close).toHaveBeenCalledTimes(1);
   });

--- a/packages/mcp/src/bin/linkedin-mcp.ts
+++ b/packages/mcp/src/bin/linkedin-mcp.ts
@@ -5974,7 +5974,7 @@ export const LINKEDIN_MCP_TOOL_DEFINITIONS: LinkedInMcpToolDefinition[] = [
   {
     name: LINKEDIN_ANALYTICS_PROFILE_VIEWS_TOOL,
     description: withSelectorAuditHint(
-      "Read the logged-in member's LinkedIn profile-view analytics cards with normalized numeric metrics.",
+      "Read the logged-in member's LinkedIn profile-view analytics. Returns timestamped metric cards with numeric values, deltas, trend direction, and unit classification for each profile-view data point.",
     ),
     inputSchema: {
       type: "object",
@@ -5991,7 +5991,7 @@ export const LINKEDIN_MCP_TOOL_DEFINITIONS: LinkedInMcpToolDefinition[] = [
   {
     name: LINKEDIN_ANALYTICS_SEARCH_APPEARANCES_TOOL,
     description: withSelectorAuditHint(
-      "Read the logged-in member's LinkedIn search-appearance analytics cards with normalized numeric metrics.",
+      "Read the logged-in member's LinkedIn search-appearance analytics. Returns timestamped metric cards with numeric values, deltas, trend direction, and unit classification for each search-appearance data point.",
     ),
     inputSchema: {
       type: "object",
@@ -6008,7 +6008,7 @@ export const LINKEDIN_MCP_TOOL_DEFINITIONS: LinkedInMcpToolDefinition[] = [
   {
     name: LINKEDIN_ANALYTICS_CONTENT_METRICS_TOOL,
     description: withSelectorAuditHint(
-      "Read LinkedIn content and impression analytics cards from the logged-in member's profile analytics surface.",
+      "Read LinkedIn content and impression analytics from the logged-in member's profile. Returns timestamped metric cards covering impressions, engagement, and creator analytics. Use limit to cap the number of returned cards.",
     ),
     inputSchema: {
       type: "object",
@@ -6022,7 +6022,7 @@ export const LINKEDIN_MCP_TOOL_DEFINITIONS: LinkedInMcpToolDefinition[] = [
         limit: {
           type: "number",
           description:
-            "Maximum number of content analytics cards to return. Defaults to 4.",
+            "Maximum number of content analytics cards to return (1–50). Defaults to 4.",
         },
       }),
     },
@@ -6030,7 +6030,7 @@ export const LINKEDIN_MCP_TOOL_DEFINITIONS: LinkedInMcpToolDefinition[] = [
   {
     name: LINKEDIN_ANALYTICS_POST_METRICS_TOOL,
     description: withSelectorAuditHint(
-      "Read normalized engagement metrics for one LinkedIn post URL, URN, or activity/share identifier.",
+      "Read normalized engagement metrics (reactions, comments, reposts, engagement total) for a single LinkedIn post. Accepts a post URL, URN, or activity/share identifier. Also returns the post content and author metadata.",
     ),
     inputSchema: {
       type: "object",


### PR DESCRIPTION
## Summary

Quality pass for Analytics & Insights surfaces (#239). Rebased onto current main after previous PR #372 was auto-closed due to branch conflicts.

## Changes

### Phase 3 — Simplify + Refactor
- Extracted shared `fetchProfileSurface()` helper to DRY the 3 profile analytics methods
- **Bug fix**: `getContentMetrics` checked `cards.length === 0` instead of `matchedCards.length === 0` — dead branch that never triggered the intended error
- Inlined `flattenCardMetrics` indirection in `buildSummary`
- Added `resolveProfileName` normalization

### Phase 4 — Test
- Added comprehensive unit tests for `parseLinkedInAnalyticsNumber`, `toLinkedInAnalyticsMetricKey`, `inferAnalyticsMetricUnit`, `inferAnalyticsMetricTrend`, `toAbsoluteLinkedInUrl`, `readAnalyticsLimit`, `ensureMatchingCards`, `matchesAnalyticsCard`
- Added MCP contract tests for `search_appearances` and `content_metrics` tools

### Phase 5 — Harden
- Upper-bounded `readAnalyticsLimit` to 50
- Added page navigation timeout (30s)
- Improved error messages with `profileName` context

### Phase 6 — UX/QoL
- Enhanced all 4 analytics MCP tool descriptions with return shape hints, metric details, and usage guidance

### Phase 7 — Verify
- Validated through comprehensive unit + MCP contract tests (E2E requires live LinkedIn session)

### Phase 8 — Docs
- Created `docs/analytics.md` covering surfaces, API, types, limits, and errors

## Quality Gates
- **Tests:** 1184 passing (108 files)
- **Lint:** Clean (1 pre-existing `no-dupe-keys` in `sessionAuth.test.ts` — identical on `main`)
- **Typecheck:** Clean

Closes #353
