### PR TITLE
feat: quality pass for jobs (#238) (#354)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ See [`docs/repository-seo.md`](./docs/repository-seo.md) for the keyword targets
 | Articles and newsletters                 | [`docs/articles-newsletters.md`](./docs/articles-newsletters.md)         |
 | Notifications                            | [`docs/notifications.md`](./docs/notifications.md)                       |
 | Rate limiting                            | [`docs/rate-limiting.md`](./docs/rate-limiting.md)                       |
+| Jobs, alerts, and Easy Apply             | [`docs/jobs.md`](./docs/jobs.md)                                         |
 
 ## Contributing
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -1,0 +1,306 @@
+# Jobs
+
+LinkedIn Buddy supports searching, saving, and managing job alerts, as well as preparing Easy Apply submissions through the CLI, MCP server, and TypeScript API.
+
+## Overview
+
+| Action           | CLI                  | MCP Tool                           | Two-Phase |
+| ---------------- | -------------------- | ---------------------------------- | --------- |
+| Search jobs      | `jobs search`        | `linkedin.jobs.search`             | No        |
+| View job details | `jobs view`          | `linkedin.jobs.view`               | No        |
+| Save job         | `jobs save`          | `linkedin.jobs.save`               | Yes       |
+| Unsave job       | `jobs unsave`        | `linkedin.jobs.unsave`             | Yes       |
+| List job alerts  | `jobs alerts list`   | `linkedin.jobs.alerts.list`        | No        |
+| Create job alert | `jobs alerts create` | `linkedin.jobs.alerts.create`      | Yes       |
+| Remove job alert | `jobs alerts remove` | `linkedin.jobs.alerts.remove`      | Yes       |
+| Easy Apply       | `jobs easy-apply`    | `linkedin.jobs.prepare_easy_apply` | Yes       |
+
+All write operations follow the two-phase commit pattern: **prepare** returns a confirm token, then **confirm** executes the action.
+
+## CLI Usage
+
+### Search jobs
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin jobs search "product manager" \
+  --location Copenhagen --limit 10
+```
+
+Returns structured results with `job_id`, `title`, `company`, `location`, `posted_at`, `salary_range`, and `employment_type`.
+
+### View job details
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin jobs view --job-id 1234567890
+```
+
+Returns full details including `description`, `company_url`, `seniority_level`, `applicant_count`, and `is_remote`.
+
+### Save and unsave jobs
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin jobs save --job-id 1234567890
+npm exec -w @linkedin-buddy/cli -- linkedin actions confirm --token ct_...
+
+npm exec -w @linkedin-buddy/cli -- linkedin jobs unsave --job-id 1234567890
+npm exec -w @linkedin-buddy/cli -- linkedin actions confirm --token ct_...
+```
+
+### Manage job alerts
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin jobs alerts list --limit 20
+npm exec -w @linkedin-buddy/cli -- linkedin jobs alerts create --query "staff engineer" --location Remote
+npm exec -w @linkedin-buddy/cli -- linkedin actions confirm --token ct_...
+
+npm exec -w @linkedin-buddy/cli -- linkedin jobs alerts remove --query "staff engineer"
+npm exec -w @linkedin-buddy/cli -- linkedin actions confirm --token ct_...
+```
+
+Alerts can also be removed by `--alert-id` (from `alerts list`) or `--search-url`.
+
+### Easy Apply
+
+```bash
+npm exec -w @linkedin-buddy/cli -- linkedin jobs easy-apply --job-id 1234567890 \
+  --email candidate@example.com \
+  --phone "+45 1234 5678" \
+  --resume /path/to/resume.pdf \
+  --answers-file /path/to/answers.json
+npm exec -w @linkedin-buddy/cli -- linkedin actions confirm --token ct_...
+```
+
+The answers file is a JSON object keyed by field label:
+
+```json
+{
+  "Years of experience": 5,
+  "Need visa sponsorship": false,
+  "Preferred work arrangement": "Remote"
+}
+```
+
+### Common options
+
+All commands support:
+
+- `-p, --profile <profile>` — LinkedIn profile name (default: `default`)
+- `-o, --operator-note <note>` — Optional note attached to prepared actions
+- `--cdp-url <url>` — Connect to an existing Chrome DevTools Protocol session
+
+## MCP Usage
+
+### linkedin.jobs.search
+
+Search for LinkedIn job postings by keyword and optional location.
+
+**Parameters:**
+
+| Name          | Type   | Required | Description                         |
+| ------------- | ------ | -------- | ----------------------------------- |
+| `query`       | string | Yes      | Search keywords (max 400 chars)     |
+| `location`    | string | No       | Location filter                     |
+| `limit`       | number | No       | Max results (default: 10, max: 100) |
+| `profileName` | string | No       | Profile name (default: `default`)   |
+
+**Returns:** `{ results: [{ job_id, title, company, location, posted_at, job_url, salary_range, employment_type }], count }`
+
+### linkedin.jobs.view
+
+View details of a specific LinkedIn job posting.
+
+**Parameters:**
+
+| Name          | Type   | Required | Description  |
+| ------------- | ------ | -------- | ------------ |
+| `jobId`       | string | Yes      | Job ID       |
+| `profileName` | string | No       | Profile name |
+
+**Returns:** `{ job_id, title, company, company_url, location, description, salary_range, employment_type, seniority_level, applicant_count, is_remote }`
+
+### linkedin.jobs.save
+
+Prepare to save a LinkedIn job for later (low risk).
+
+**Parameters:**
+
+| Name           | Type   | Required | Description  |
+| -------------- | ------ | -------- | ------------ |
+| `jobId`        | string | Yes      | Job ID       |
+| `profileName`  | string | No       | Profile name |
+| `operatorNote` | string | No       | Audit note   |
+
+### linkedin.jobs.unsave
+
+Prepare to unsave a previously saved LinkedIn job (low risk).
+
+**Parameters:**
+
+| Name           | Type   | Required | Description  |
+| -------------- | ------ | -------- | ------------ |
+| `jobId`        | string | Yes      | Job ID       |
+| `profileName`  | string | No       | Profile name |
+| `operatorNote` | string | No       | Audit note   |
+
+### linkedin.jobs.alerts.list
+
+List LinkedIn job alerts for the current account.
+
+**Parameters:**
+
+| Name          | Type   | Required | Description                        |
+| ------------- | ------ | -------- | ---------------------------------- |
+| `limit`       | number | No       | Max alerts (default: 20, max: 100) |
+| `profileName` | string | No       | Profile name                       |
+
+**Returns:** `{ alerts: [{ alert_id, query, location, frequency, search_url, enabled }], count }`
+
+### linkedin.jobs.alerts.create
+
+Prepare to create a LinkedIn job alert from a search query (low risk).
+
+**Parameters:**
+
+| Name           | Type   | Required | Description                     |
+| -------------- | ------ | -------- | ------------------------------- |
+| `query`        | string | Yes      | Search keywords (max 400 chars) |
+| `location`     | string | No       | Location filter                 |
+| `profileName`  | string | No       | Profile name                    |
+| `operatorNote` | string | No       | Audit note                      |
+
+### linkedin.jobs.alerts.remove
+
+Prepare to remove a LinkedIn job alert (low risk). Provide one of `alertId`, `searchUrl`, or `query`.
+
+**Parameters:**
+
+| Name           | Type   | Required | Description                 |
+| -------------- | ------ | -------- | --------------------------- |
+| `alertId`      | string | No       | Alert ID from `alerts.list` |
+| `searchUrl`    | string | No       | LinkedIn jobs search URL    |
+| `query`        | string | No       | Alert query                 |
+| `location`     | string | No       | Alert location (with query) |
+| `profileName`  | string | No       | Profile name                |
+| `operatorNote` | string | No       | Audit note                  |
+
+### linkedin.jobs.prepare_easy_apply
+
+Prepare a LinkedIn Easy Apply submission (high risk). Fills multi-step forms.
+
+**Parameters:**
+
+| Name           | Type   | Required | Description                                                |
+| -------------- | ------ | -------- | ---------------------------------------------------------- |
+| `jobId`        | string | Yes      | Job ID                                                     |
+| `phoneNumber`  | string | No       | Phone (max 30 chars)                                       |
+| `email`        | string | No       | Email (max 254 chars)                                      |
+| `city`         | string | No       | City (max 200 chars)                                       |
+| `resumePath`   | string | No       | Path to resume file                                        |
+| `coverLetter`  | string | No       | Cover letter text (max 4,000 chars)                        |
+| `answers`      | object | No       | Field answers keyed by label (string/boolean/number/array) |
+| `profileName`  | string | No       | Profile name                                               |
+| `operatorNote` | string | No       | Audit note                                                 |
+
+## Rate Limits
+
+| Action       | Counter Key                   | Limit   |
+| ------------ | ----------------------------- | ------- |
+| Save job     | `linkedin.jobs.save`          | 40/hour |
+| Unsave job   | `linkedin.jobs.unsave`        | 40/hour |
+| Create alert | `linkedin.jobs.alerts.create` | 30/hour |
+| Remove alert | `linkedin.jobs.alerts.remove` | 30/hour |
+| Easy Apply   | `linkedin.jobs.easy_apply`    | 6/hour  |
+
+Rate limits are enforced at confirm time (not prepare time). The prepare response includes a `rate_limit` preview showing current usage.
+
+## Input Validation
+
+All inputs are validated before authentication or browser automation:
+
+- **Job ID**: Must be non-empty after whitespace trimming
+- **Search query**: Must be non-empty, max 400 characters
+- **Email**: Must match basic email format, max 254 characters
+- **Resume path**: Must point to an existing file (not directory)
+- **Easy Apply answers**: Values must be strings, booleans, numbers, or string arrays; nested objects rejected
+
+### Length Limits
+
+| Field        | Max Length       |
+| ------------ | ---------------- |
+| Search query | 400 characters   |
+| Phone number | 30 characters    |
+| Email        | 254 characters   |
+| City         | 200 characters   |
+| Cover letter | 4,000 characters |
+
+### Search and Alert Limits
+
+| Parameter     | Default | Maximum |
+| ------------- | ------- | ------- |
+| Job search    | 10      | 100     |
+| Alert listing | 20      | 100     |
+
+## TypeScript API
+
+```typescript
+import { createCoreRuntime } from "@linkedin-buddy/core";
+
+const runtime = createCoreRuntime();
+
+try {
+  // Search jobs
+  const results = await runtime.jobs.searchJobs({
+    query: "developer relations",
+    location: "Copenhagen",
+    limit: 5,
+  });
+  console.log(results.results.map((job) => job.title));
+
+  // View a specific job
+  const job = await runtime.jobs.viewJob({ jobId: "1234567890" });
+  console.log(job.description);
+
+  // Save a job (two-phase)
+  const saved = runtime.jobs.prepareSaveJob({ jobId: "1234567890" });
+  await runtime.twoPhaseCommit.confirmByToken({
+    confirmToken: saved.confirmToken,
+  });
+
+  // Create a job alert (two-phase)
+  const alert = runtime.jobs.prepareCreateJobAlert({
+    query: "staff engineer",
+    location: "Remote",
+  });
+  await runtime.twoPhaseCommit.confirmByToken({
+    confirmToken: alert.confirmToken,
+  });
+} finally {
+  runtime.close();
+}
+```
+
+## Error Codes
+
+| Code                         | When                                                         |
+| ---------------------------- | ------------------------------------------------------------ |
+| `ACTION_PRECONDITION_FAILED` | Invalid input (empty query, bad email, exceeds length limit) |
+| `RATE_LIMITED`               | Hourly rate limit exceeded for the action type               |
+| `AUTH_REQUIRED`              | LinkedIn session not authenticated                           |
+| `TARGET_NOT_FOUND`           | Alert ID not found when removing by ID                       |
+| `UI_CHANGED_SELECTOR_FAILED` | LinkedIn UI changed and selectors no longer match            |
+| `TIMEOUT`                    | Browser automation timed out                                 |
+| `NETWORK_ERROR`              | Network connectivity issue during automation                 |
+
+## Artifacts
+
+Every job write operation captures:
+
+- **Screenshots**: After-action screenshots of the LinkedIn job page
+- **Traces**: Playwright browser traces (`.zip`) for debugging
+- **Error screenshots**: Captured on failure for diagnostic purposes
+
+Artifacts are stored under `~/.linkedin-buddy/linkedin-buddy/runs/<run-id>/`.
+
+## E2E Verification
+
+Read-only operations (`jobs search`, `jobs view`, `jobs alerts list`) can be verified against any authenticated profile. Write operations (save, unsave, alerts, Easy Apply) require manual E2E testing against an approved test account per the [E2E testing safety rules](./e2e-testing.md).

--- a/packages/core/src/__tests__/linkedinJobs.test.ts
+++ b/packages/core/src/__tests__/linkedinJobs.test.ts
@@ -4,7 +4,14 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   CREATE_JOB_ALERT_ACTION_TYPE,
+  EASY_APPLY_CITY_MAX_LENGTH,
+  EASY_APPLY_COVER_LETTER_MAX_LENGTH,
+  EASY_APPLY_EMAIL_MAX_LENGTH,
   EASY_APPLY_JOB_ACTION_TYPE,
+  EASY_APPLY_PHONE_MAX_LENGTH,
+  JOB_ALERTS_LIMIT_MAX,
+  JOB_SEARCH_LIMIT_MAX,
+  JOB_SEARCH_QUERY_MAX_LENGTH,
   LINKEDIN_JOB_ALERTS_URL,
   LinkedInJobsService,
   REMOVE_JOB_ALERT_ACTION_TYPE,
@@ -19,25 +26,26 @@ import {
   type LinkedInJobSearchResult,
   type LinkedInJobsRuntime,
   type SearchJobsInput,
-  type ViewJobInput
+  type ViewJobInput,
 } from "../linkedinJobs.js";
+import { createBlockedRateLimiterStub } from "./rateLimiterTestUtils.js";
 
 describe("job URL builders", () => {
   it("builds a job search URL with query only", () => {
     expect(buildJobSearchUrl("software engineer")).toBe(
-      "https://www.linkedin.com/jobs/search/?keywords=software%20engineer"
+      "https://www.linkedin.com/jobs/search/?keywords=software%20engineer",
     );
   });
 
   it("builds a job search URL with query and location", () => {
     expect(buildJobSearchUrl("developer", "Copenhagen")).toBe(
-      "https://www.linkedin.com/jobs/search/?keywords=developer&location=Copenhagen"
+      "https://www.linkedin.com/jobs/search/?keywords=developer&location=Copenhagen",
     );
   });
 
   it("builds the job detail and alerts URLs", () => {
     expect(buildJobViewUrl("1234567890")).toBe(
-      "https://www.linkedin.com/jobs/view/1234567890/"
+      "https://www.linkedin.com/jobs/view/1234567890/",
     );
     expect(buildJobAlertsUrl()).toBe(LINKEDIN_JOB_ALERTS_URL);
   });
@@ -79,28 +87,34 @@ describe("LinkedInJobsService prepare actions", () => {
       preparedActionId: "pa_test",
       confirmToken: "ct_test",
       expiresAtMs: 123,
-      preview: input.preview
+      preview: input.preview,
     }));
     const rateLimiter = {
-      peek: vi.fn((config: { counterKey: string; windowSizeMs: number; limit: number }) => ({
-        counterKey: config.counterKey,
-        windowStartMs: 0,
-        windowSizeMs: config.windowSizeMs,
-        count: 0,
-        limit: config.limit,
-        remaining: config.limit,
-        allowed: true
-      }))
+      peek: vi.fn(
+        (config: {
+          counterKey: string;
+          windowSizeMs: number;
+          limit: number;
+        }) => ({
+          counterKey: config.counterKey,
+          windowStartMs: 0,
+          windowSizeMs: config.windowSizeMs,
+          count: 0,
+          limit: config.limit,
+          remaining: config.limit,
+          allowed: true,
+        }),
+      ),
     };
 
     const service = new LinkedInJobsService({
       twoPhaseCommit: { prepare },
-      rateLimiter
+      rateLimiter,
     } as unknown as ConstructorParameters<typeof LinkedInJobsService>[0]);
 
     return {
       service,
-      prepare
+      prepare,
     };
   }
 
@@ -108,64 +122,65 @@ describe("LinkedInJobsService prepare actions", () => {
     const { service, prepare } = createService();
 
     const savePrepared = service.prepareSaveJob({
-      jobId: "123"
+      jobId: "123",
     });
     const unsavePrepared = service.prepareUnsaveJob({
-      jobId: "123"
+      jobId: "123",
     });
     const createAlertPrepared = service.prepareCreateJobAlert({
       query: "staff engineer",
-      location: "Remote"
+      location: "Remote",
     });
     const removeAlertPrepared = await service.prepareRemoveJobAlert({
       query: "staff engineer",
-      location: "Remote"
+      location: "Remote",
     });
 
     expect(savePrepared.preview).toMatchObject({
-      summary: "Save LinkedIn job https://www.linkedin.com/jobs/view/123/ for later",
+      summary:
+        "Save LinkedIn job https://www.linkedin.com/jobs/view/123/ for later",
       outbound: {
-        action: "save"
+        action: "save",
       },
-      risk_level: "low"
+      risk_level: "low",
     });
     expect(unsavePrepared.preview).toMatchObject({
       summary: "Unsave LinkedIn job https://www.linkedin.com/jobs/view/123/",
       outbound: {
-        action: "unsave"
+        action: "unsave",
       },
-      risk_level: "low"
+      risk_level: "low",
     });
     expect(createAlertPrepared.preview).toMatchObject({
       summary: 'Create a LinkedIn job alert for "staff engineer" in Remote',
       outbound: {
-        action: "create_alert"
+        action: "create_alert",
       },
-      risk_level: "low"
+      risk_level: "low",
     });
     expect(removeAlertPrepared.preview).toMatchObject({
       summary: 'Remove LinkedIn job alert for "staff engineer" in Remote',
       outbound: {
-        action: "remove_alert"
+        action: "remove_alert",
       },
-      risk_level: "low"
+      risk_level: "low",
     });
 
     expect(prepare).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ actionType: SAVE_JOB_ACTION_TYPE })
+      expect.objectContaining({ actionType: SAVE_JOB_ACTION_TYPE }),
     );
     expect(prepare).toHaveBeenNthCalledWith(
       2,
-      expect.objectContaining({ actionType: UNSAVE_JOB_ACTION_TYPE })
+      expect.objectContaining({ actionType: UNSAVE_JOB_ACTION_TYPE }),
     );
     expect(prepare).toHaveBeenNthCalledWith(
       3,
-      expect.objectContaining({ actionType: CREATE_JOB_ALERT_ACTION_TYPE })
+      expect.objectContaining({ actionType: CREATE_JOB_ALERT_ACTION_TYPE }),
     );
     expect(prepare).toHaveBeenNthCalledWith(
       4,
-      expect.objectContaining({ actionType: REMOVE_JOB_ALERT_ACTION_TYPE })
+      expect.objectContaining({ actionType: REMOVE_JOB_ALERT_ACTION_TYPE }),
     );
   });
 
@@ -183,23 +198,24 @@ describe("LinkedInJobsService prepare actions", () => {
       resumePath,
       answers: {
         "Years of experience": 8,
-        "Need visa sponsorship": false
-      }
+        "Need visa sponsorship": false,
+      },
     });
 
     expect(prepared.preview).toMatchObject({
-      summary: "Submit LinkedIn Easy Apply application for https://www.linkedin.com/jobs/view/999/",
+      summary:
+        "Submit LinkedIn Easy Apply application for https://www.linkedin.com/jobs/view/999/",
       outbound: {
         action: "easy_apply",
         email_supplied: true,
         phone_number_supplied: true,
         resume_filename: "resume.pdf",
-        answer_keys: ["Years of experience", "Need visa sponsorship"]
+        answer_keys: ["Years of experience", "Need visa sponsorship"],
       },
-      risk_level: "high"
+      risk_level: "high",
     });
     expect(prepare).toHaveBeenCalledWith(
-      expect.objectContaining({ actionType: EASY_APPLY_JOB_ACTION_TYPE })
+      expect.objectContaining({ actionType: EASY_APPLY_JOB_ACTION_TYPE }),
     );
   });
 
@@ -209,8 +225,8 @@ describe("LinkedInJobsService prepare actions", () => {
     expect(() =>
       service.prepareEasyApply({
         jobId: "123",
-        email: "not-an-email"
-      })
+        email: "not-an-email",
+      }),
     ).toThrow("email must look like a valid email address.");
 
     expect(() =>
@@ -218,11 +234,13 @@ describe("LinkedInJobsService prepare actions", () => {
         jobId: "123",
         answers: {
           unsupported: {
-            nested: true
-          }
-        }
-      })
-    ).toThrow("answers.unsupported must be a string, boolean, number, or string array.");
+            nested: true,
+          },
+        },
+      }),
+    ).toThrow(
+      "answers.unsupported must be a string, boolean, number, or string array.",
+    );
   });
 });
 
@@ -239,7 +257,7 @@ describe("LinkedInJobsService exports", () => {
       posted_at: "1 day ago",
       job_url: "https://www.linkedin.com/jobs/view/123/",
       salary_range: "$100k - $150k",
-      employment_type: "Full-time"
+      employment_type: "Full-time",
     };
     const posting: LinkedInJobPosting = {
       job_id: "456",
@@ -254,21 +272,22 @@ describe("LinkedInJobsService exports", () => {
       job_url: "https://www.linkedin.com/jobs/view/456/",
       applicant_count: "25 applicants",
       seniority_level: "Mid-Senior level",
-      is_remote: false
+      is_remote: false,
     };
     const alert: LinkedInJobAlert = {
       alert_id: "alert-1",
       query: "Staff Engineer",
       location: "Remote",
       frequency: "Daily",
-      search_url: "https://www.linkedin.com/jobs/search/?keywords=staff%20engineer&location=Remote",
-      enabled: true
+      search_url:
+        "https://www.linkedin.com/jobs/search/?keywords=staff%20engineer&location=Remote",
+      enabled: true,
     };
     const searchInput: SearchJobsInput = {
-      query: "engineer"
+      query: "engineer",
     };
     const viewInput: ViewJobInput = {
-      jobId: "789"
+      jobId: "789",
     };
     const runtimeKeys: (keyof LinkedInJobsRuntime)[] = [
       "auth",
@@ -278,7 +297,7 @@ describe("LinkedInJobsService exports", () => {
       "rateLimiter",
       "artifacts",
       "confirmFailureArtifacts",
-      "twoPhaseCommit"
+      "twoPhaseCommit",
     ];
 
     expect(result.job_id).toBe("123");
@@ -287,5 +306,867 @@ describe("LinkedInJobsService exports", () => {
     expect(searchInput.query).toBe("engineer");
     expect(viewInput.jobId).toBe("789");
     expect(runtimeKeys).toHaveLength(8);
+  });
+});
+
+describe("Jobs hardening constants", () => {
+  it("exposes a positive finite JOB_SEARCH_QUERY_MAX_LENGTH", () => {
+    expect(Number.isFinite(JOB_SEARCH_QUERY_MAX_LENGTH)).toBe(true);
+    expect(JOB_SEARCH_QUERY_MAX_LENGTH).toBeGreaterThan(0);
+  });
+
+  it("exposes a positive finite JOB_SEARCH_LIMIT_MAX", () => {
+    expect(Number.isFinite(JOB_SEARCH_LIMIT_MAX)).toBe(true);
+    expect(JOB_SEARCH_LIMIT_MAX).toBeGreaterThan(0);
+  });
+
+  it("exposes a positive finite JOB_ALERTS_LIMIT_MAX", () => {
+    expect(Number.isFinite(JOB_ALERTS_LIMIT_MAX)).toBe(true);
+    expect(JOB_ALERTS_LIMIT_MAX).toBeGreaterThan(0);
+  });
+
+  it("exposes a positive finite EASY_APPLY_COVER_LETTER_MAX_LENGTH", () => {
+    expect(Number.isFinite(EASY_APPLY_COVER_LETTER_MAX_LENGTH)).toBe(true);
+    expect(EASY_APPLY_COVER_LETTER_MAX_LENGTH).toBeGreaterThan(0);
+  });
+
+  it("exposes a positive finite EASY_APPLY_PHONE_MAX_LENGTH", () => {
+    expect(Number.isFinite(EASY_APPLY_PHONE_MAX_LENGTH)).toBe(true);
+    expect(EASY_APPLY_PHONE_MAX_LENGTH).toBeGreaterThan(0);
+  });
+
+  it("exposes a positive finite EASY_APPLY_CITY_MAX_LENGTH", () => {
+    expect(Number.isFinite(EASY_APPLY_CITY_MAX_LENGTH)).toBe(true);
+    expect(EASY_APPLY_CITY_MAX_LENGTH).toBeGreaterThan(0);
+  });
+
+  it("exposes a positive finite EASY_APPLY_EMAIL_MAX_LENGTH", () => {
+    expect(Number.isFinite(EASY_APPLY_EMAIL_MAX_LENGTH)).toBe(true);
+    expect(EASY_APPLY_EMAIL_MAX_LENGTH).toBeGreaterThan(0);
+  });
+});
+
+describe("LinkedInJobsService searchJobs input validation", () => {
+  function createAsyncService() {
+    const prepare = vi.fn((input: { preview: Record<string, unknown> }) => ({
+      preparedActionId: "pa_test",
+      confirmToken: "ct_test",
+      expiresAtMs: 123,
+      preview: input.preview,
+    }));
+    const rateLimiter = {
+      peek: vi.fn(
+        (config: {
+          counterKey: string;
+          windowSizeMs: number;
+          limit: number;
+        }) => ({
+          counterKey: config.counterKey,
+          windowStartMs: 0,
+          windowSizeMs: config.windowSizeMs,
+          count: 0,
+          limit: config.limit,
+          remaining: config.limit,
+          allowed: true,
+        }),
+      ),
+    };
+    const auth = {
+      ensureAuthenticated: vi.fn(async () => undefined),
+    };
+    const profileManager = {
+      runWithContext: vi.fn(
+        async (_opts: unknown, cb: (ctx: unknown) => unknown) => {
+          return cb({
+            pages: () => [],
+            newPage: async () => ({ goto: vi.fn(), waitForTimeout: vi.fn() }),
+          });
+        },
+      ),
+    };
+    const logger = { log: vi.fn() };
+    const artifacts = {
+      resolve: vi.fn((p: string) => `/tmp/${p}`),
+      registerArtifact: vi.fn(),
+    };
+    const confirmFailureArtifacts = { enabled: false, maxTraceBytes: 0 };
+
+    const service = new LinkedInJobsService({
+      twoPhaseCommit: { prepare },
+      rateLimiter,
+      auth,
+      profileManager,
+      logger,
+      artifacts,
+      confirmFailureArtifacts,
+    } as unknown as ConstructorParameters<typeof LinkedInJobsService>[0]);
+
+    return { service, prepare, auth };
+  }
+
+  it("rejects empty query before authentication", async () => {
+    const { service, auth } = createAsyncService();
+
+    await expect(service.searchJobs({ query: "" })).rejects.toThrow(
+      "query is required.",
+    );
+    expect(auth.ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects whitespace-only query before authentication", async () => {
+    const { service, auth } = createAsyncService();
+
+    await expect(service.searchJobs({ query: "   \n\t " })).rejects.toThrow(
+      "query is required.",
+    );
+    expect(auth.ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects query exceeding max length before authentication", async () => {
+    const { service, auth } = createAsyncService();
+
+    await expect(
+      service.searchJobs({
+        query: "x".repeat(JOB_SEARCH_QUERY_MAX_LENGTH + 1),
+      }),
+    ).rejects.toThrow(
+      `query must not exceed ${JOB_SEARCH_QUERY_MAX_LENGTH} characters.`,
+    );
+    expect(auth.ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects overlong query even when location and limit are provided", async () => {
+    const { service, auth } = createAsyncService();
+
+    await expect(
+      service.searchJobs({
+        query: "x".repeat(JOB_SEARCH_QUERY_MAX_LENGTH + 1),
+        location: "Remote",
+        limit: 10,
+      }),
+    ).rejects.toThrow(
+      `query must not exceed ${JOB_SEARCH_QUERY_MAX_LENGTH} characters.`,
+    );
+    expect(auth.ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("rejects overlong trimmed query before authentication", async () => {
+    const { service, auth } = createAsyncService();
+    const overlongTrimmed = `${"x".repeat(JOB_SEARCH_QUERY_MAX_LENGTH + 1)}   `;
+
+    await expect(
+      service.searchJobs({ query: overlongTrimmed }),
+    ).rejects.toThrow(
+      `query must not exceed ${JOB_SEARCH_QUERY_MAX_LENGTH} characters.`,
+    );
+    expect(auth.ensureAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("accepts query at max length and reaches authentication", async () => {
+    const { service, auth } = createAsyncService();
+
+    await expect(
+      service.searchJobs({ query: "x".repeat(JOB_SEARCH_QUERY_MAX_LENGTH) }),
+    ).rejects.toThrow();
+    expect(auth.ensureAuthenticated).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("LinkedInJobsService prepareSaveJob and prepareUnsaveJob validation", () => {
+  function createService() {
+    const prepare = vi.fn((input: { preview: Record<string, unknown> }) => ({
+      preparedActionId: "pa_test",
+      confirmToken: "ct_test",
+      expiresAtMs: 123,
+      preview: input.preview,
+    }));
+    const rateLimiter = {
+      peek: vi.fn(
+        (config: {
+          counterKey: string;
+          windowSizeMs: number;
+          limit: number;
+        }) => ({
+          counterKey: config.counterKey,
+          windowStartMs: 0,
+          windowSizeMs: config.windowSizeMs,
+          count: 0,
+          limit: config.limit,
+          remaining: config.limit,
+          allowed: true,
+        }),
+      ),
+    };
+
+    const service = new LinkedInJobsService({
+      twoPhaseCommit: { prepare },
+      rateLimiter,
+    } as unknown as ConstructorParameters<typeof LinkedInJobsService>[0]);
+
+    return {
+      service,
+      prepare,
+    };
+  }
+
+  it("rejects empty jobId in prepareSaveJob", () => {
+    const { service } = createService();
+
+    expect(() => service.prepareSaveJob({ jobId: "" })).toThrow(
+      "jobId is required.",
+    );
+  });
+
+  it("rejects whitespace-only jobId in prepareSaveJob", () => {
+    const { service } = createService();
+
+    expect(() => service.prepareSaveJob({ jobId: " \n\t " })).toThrow(
+      "jobId is required.",
+    );
+  });
+
+  it("rejects empty jobId in prepareUnsaveJob", () => {
+    const { service } = createService();
+
+    expect(() => service.prepareUnsaveJob({ jobId: "" })).toThrow(
+      "jobId is required.",
+    );
+  });
+
+  it("passes valid jobId with trimming in prepareSaveJob", () => {
+    const { service, prepare } = createService();
+
+    service.prepareSaveJob({ jobId: " 123 " });
+
+    expect(prepare).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionType: SAVE_JOB_ACTION_TYPE,
+        target: expect.objectContaining({
+          job_id: "123",
+          job_url: "https://www.linkedin.com/jobs/view/123/",
+        }),
+      }),
+    );
+  });
+});
+
+describe("LinkedInJobsService prepareCreateJobAlert validation", () => {
+  function createService() {
+    const prepare = vi.fn((input: { preview: Record<string, unknown> }) => ({
+      preparedActionId: "pa_test",
+      confirmToken: "ct_test",
+      expiresAtMs: 123,
+      preview: input.preview,
+    }));
+    const rateLimiter = {
+      peek: vi.fn(
+        (config: {
+          counterKey: string;
+          windowSizeMs: number;
+          limit: number;
+        }) => ({
+          counterKey: config.counterKey,
+          windowStartMs: 0,
+          windowSizeMs: config.windowSizeMs,
+          count: 0,
+          limit: config.limit,
+          remaining: config.limit,
+          allowed: true,
+        }),
+      ),
+    };
+
+    const service = new LinkedInJobsService({
+      twoPhaseCommit: { prepare },
+      rateLimiter,
+    } as unknown as ConstructorParameters<typeof LinkedInJobsService>[0]);
+
+    return {
+      service,
+      prepare,
+    };
+  }
+
+  it("rejects empty query", () => {
+    const { service } = createService();
+
+    expect(() => service.prepareCreateJobAlert({ query: "" })).toThrow(
+      "query is required.",
+    );
+  });
+
+  it("rejects whitespace-only query", () => {
+    const { service } = createService();
+
+    expect(() => service.prepareCreateJobAlert({ query: "\n\t " })).toThrow(
+      "query is required.",
+    );
+  });
+
+  it("rejects query exceeding max length", () => {
+    const { service } = createService();
+
+    expect(() =>
+      service.prepareCreateJobAlert({
+        query: "x".repeat(JOB_SEARCH_QUERY_MAX_LENGTH + 1),
+      }),
+    ).toThrow(
+      `query must not exceed ${JOB_SEARCH_QUERY_MAX_LENGTH} characters.`,
+    );
+  });
+
+  it("accepts valid query with location", () => {
+    const { service, prepare } = createService();
+
+    service.prepareCreateJobAlert({
+      query: " engineer ",
+      location: " Remote ",
+    });
+
+    expect(prepare).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionType: CREATE_JOB_ALERT_ACTION_TYPE,
+        target: expect.objectContaining({
+          query: "engineer",
+          location: "Remote",
+          search_url:
+            "https://www.linkedin.com/jobs/search/?keywords=engineer&location=Remote",
+        }),
+      }),
+    );
+  });
+});
+
+describe("LinkedInJobsService prepareEasyApply validation", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const directory of tempDirs.splice(0)) {
+      rmSync(directory, { force: true, recursive: true });
+    }
+  });
+
+  function createService() {
+    const prepare = vi.fn((input: { preview: Record<string, unknown> }) => ({
+      preparedActionId: "pa_test",
+      confirmToken: "ct_test",
+      expiresAtMs: 123,
+      preview: input.preview,
+    }));
+    const rateLimiter = {
+      peek: vi.fn(
+        (config: {
+          counterKey: string;
+          windowSizeMs: number;
+          limit: number;
+        }) => ({
+          counterKey: config.counterKey,
+          windowStartMs: 0,
+          windowSizeMs: config.windowSizeMs,
+          count: 0,
+          limit: config.limit,
+          remaining: config.limit,
+          allowed: true,
+        }),
+      ),
+    };
+
+    const service = new LinkedInJobsService({
+      twoPhaseCommit: { prepare },
+      rateLimiter,
+    } as unknown as ConstructorParameters<typeof LinkedInJobsService>[0]);
+
+    return {
+      service,
+      prepare,
+    };
+  }
+
+  it("rejects empty jobId", () => {
+    const { service } = createService();
+
+    expect(() => service.prepareEasyApply({ jobId: "" })).toThrow(
+      "jobId is required.",
+    );
+  });
+
+  it("rejects invalid email value without domain separator", () => {
+    const { service } = createService();
+
+    expect(() =>
+      service.prepareEasyApply({ jobId: "123", email: "foo" }),
+    ).toThrow("email must look like a valid email address.");
+  });
+
+  it("rejects invalid email value with missing local-part", () => {
+    const { service } = createService();
+
+    expect(() =>
+      service.prepareEasyApply({ jobId: "123", email: "@bar" }),
+    ).toThrow("email must look like a valid email address.");
+  });
+
+  it("rejects invalid email value with missing domain", () => {
+    const { service } = createService();
+
+    expect(() =>
+      service.prepareEasyApply({ jobId: "123", email: "a@" }),
+    ).toThrow("email must look like a valid email address.");
+  });
+
+  it("rejects email exceeding max length", () => {
+    const { service } = createService();
+    const tooLongEmail = `${"a".repeat(EASY_APPLY_EMAIL_MAX_LENGTH)}@x.com`;
+
+    expect(() =>
+      service.prepareEasyApply({ jobId: "123", email: tooLongEmail }),
+    ).toThrow(
+      `email must not exceed ${EASY_APPLY_EMAIL_MAX_LENGTH} characters.`,
+    );
+  });
+
+  it("accepts valid email", () => {
+    const { service, prepare } = createService();
+
+    service.prepareEasyApply({
+      jobId: "123",
+      email: "candidate@example.com",
+    });
+
+    expect(prepare).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionType: EASY_APPLY_JOB_ACTION_TYPE,
+        payload: expect.objectContaining({
+          email: "candidate@example.com",
+        }),
+      }),
+    );
+  });
+
+  it("rejects non-existent resume path", () => {
+    const { service } = createService();
+    const missingPath = path.join(tmpdir(), `nonexistent-${Date.now()}.pdf`);
+
+    expect(() =>
+      service.prepareEasyApply({ jobId: "123", resumePath: missingPath }),
+    ).toThrow("resumePath does not exist:");
+  });
+
+  it("rejects resume path pointing to directory", () => {
+    const { service } = createService();
+    const directory = mkdtempSync(path.join(tmpdir(), "linkedin-jobs-dir-"));
+    tempDirs.push(directory);
+
+    expect(() =>
+      service.prepareEasyApply({ jobId: "123", resumePath: directory }),
+    ).toThrow("resumePath must point to a file:");
+  });
+
+  it("rejects phone exceeding max length", () => {
+    const { service } = createService();
+
+    expect(() =>
+      service.prepareEasyApply({
+        jobId: "123",
+        phoneNumber: "1".repeat(EASY_APPLY_PHONE_MAX_LENGTH + 1),
+      }),
+    ).toThrow(
+      `phoneNumber must not exceed ${EASY_APPLY_PHONE_MAX_LENGTH} characters.`,
+    );
+  });
+
+  it("rejects city exceeding max length", () => {
+    const { service } = createService();
+
+    expect(() =>
+      service.prepareEasyApply({
+        jobId: "123",
+        city: "x".repeat(EASY_APPLY_CITY_MAX_LENGTH + 1),
+      }),
+    ).toThrow(`city must not exceed ${EASY_APPLY_CITY_MAX_LENGTH} characters.`);
+  });
+
+  it("rejects cover letter exceeding max length", () => {
+    const { service } = createService();
+
+    expect(() =>
+      service.prepareEasyApply({
+        jobId: "123",
+        coverLetter: "x".repeat(EASY_APPLY_COVER_LETTER_MAX_LENGTH + 1),
+      }),
+    ).toThrow(
+      `coverLetter must not exceed ${EASY_APPLY_COVER_LETTER_MAX_LENGTH} characters.`,
+    );
+  });
+
+  it("rejects Infinity numeric answers", () => {
+    const { service } = createService();
+
+    expect(() =>
+      service.prepareEasyApply({
+        jobId: "123",
+        answers: {
+          "Years of experience": Number.POSITIVE_INFINITY,
+        },
+      }),
+    ).toThrow("answers.Years of experience must be a finite number.");
+  });
+
+  it("rejects empty string array answers", () => {
+    const { service } = createService();
+
+    expect(() =>
+      service.prepareEasyApply({
+        jobId: "123",
+        answers: {
+          technologies: ["", " "],
+        },
+      }),
+    ).toThrow("answers.technologies must be a non-empty array of strings.");
+  });
+
+  it("rejects empty answer key name", () => {
+    const { service } = createService();
+
+    expect(() =>
+      service.prepareEasyApply({
+        jobId: "123",
+        answers: {
+          "": "value",
+        },
+      }),
+    ).toThrow("answers contains an empty field name.");
+  });
+});
+
+describe("job action executors rate-limit rejection", () => {
+  function createJobsConfirmRuntime() {
+    const rateLimiter = createBlockedRateLimiterStub();
+    const page = {
+      screenshot: vi.fn(async () => undefined),
+      url: vi.fn(() => "https://www.linkedin.com/jobs/view/123/"),
+    };
+    const context = {
+      pages: vi.fn(() => [page]),
+      newPage: vi.fn(async () => page),
+      tracing: {
+        start: vi.fn(async () => undefined),
+        stop: vi.fn(async (options?: { path?: string }) => {
+          if (options?.path) {
+            writeFileSync(options.path, "trace");
+          }
+          return undefined;
+        }),
+      },
+    };
+    const runtime = {
+      auth: { ensureAuthenticated: vi.fn(async () => undefined) },
+      cdpUrl: undefined,
+      profileManager: {
+        runWithContext: vi.fn(
+          async (
+            _options: unknown,
+            callback: (ctx: typeof context) => unknown,
+          ) => callback(context),
+        ),
+      },
+      rateLimiter,
+      logger: { log: vi.fn() },
+      artifacts: {
+        resolve: vi.fn((relativePath: string) => `/tmp/${relativePath}`),
+        registerArtifact: vi.fn(),
+      },
+      confirmFailureArtifacts: { enabled: false, maxTraceBytes: 0 },
+    };
+    return { page, rateLimiter, runtime };
+  }
+
+  it("rejects save confirm execution when rate limited", async () => {
+    const executors = createJobActionExecutors();
+    const { runtime } = createJobsConfirmRuntime();
+
+    await expect(
+      executors[SAVE_JOB_ACTION_TYPE]!.execute({
+        runtime,
+        action: {
+          id: "act-save",
+          target: {
+            profile_name: "default",
+            job_id: "123",
+            job_url: "https://www.linkedin.com/jobs/view/123/",
+          },
+          payload: {},
+        },
+      } as never),
+    ).rejects.toMatchObject({
+      code: "RATE_LIMITED",
+      details: {
+        rate_limit: {
+          counter_key: "linkedin.jobs.save",
+        },
+      },
+    });
+  });
+
+  it("rejects unsave confirm execution when rate limited", async () => {
+    const executors = createJobActionExecutors();
+    const { runtime } = createJobsConfirmRuntime();
+
+    await expect(
+      executors[UNSAVE_JOB_ACTION_TYPE]!.execute({
+        runtime,
+        action: {
+          id: "act-unsave",
+          target: {
+            profile_name: "default",
+            job_id: "123",
+            job_url: "https://www.linkedin.com/jobs/view/123/",
+          },
+          payload: {},
+        },
+      } as never),
+    ).rejects.toMatchObject({
+      code: "RATE_LIMITED",
+      details: {
+        rate_limit: {
+          counter_key: "linkedin.jobs.unsave",
+        },
+      },
+    });
+  });
+
+  it("rejects create alert confirm execution when rate limited", async () => {
+    const executors = createJobActionExecutors();
+    const { runtime } = createJobsConfirmRuntime();
+
+    await expect(
+      executors[CREATE_JOB_ALERT_ACTION_TYPE]!.execute({
+        runtime,
+        action: {
+          id: "act-alert-create",
+          target: {
+            profile_name: "default",
+            query: "engineer",
+            search_url:
+              "https://www.linkedin.com/jobs/search/?keywords=engineer",
+            location: "",
+          },
+          payload: {},
+        },
+      } as never),
+    ).rejects.toMatchObject({
+      code: "RATE_LIMITED",
+      details: {
+        rate_limit: {
+          counter_key: "linkedin.jobs.alerts.create",
+        },
+      },
+    });
+  });
+
+  it("rejects remove alert confirm execution when rate limited", async () => {
+    const executors = createJobActionExecutors();
+    const { runtime } = createJobsConfirmRuntime();
+
+    await expect(
+      executors[REMOVE_JOB_ALERT_ACTION_TYPE]!.execute({
+        runtime,
+        action: {
+          id: "act-alert-remove",
+          target: {
+            profile_name: "default",
+            query: "engineer",
+            search_url:
+              "https://www.linkedin.com/jobs/search/?keywords=engineer",
+            location: "",
+          },
+          payload: {},
+        },
+      } as never),
+    ).rejects.toMatchObject({
+      code: "RATE_LIMITED",
+      details: {
+        rate_limit: {
+          counter_key: "linkedin.jobs.alerts.remove",
+        },
+      },
+    });
+  });
+
+  it("rejects easy apply confirm execution when rate limited", async () => {
+    const executors = createJobActionExecutors();
+    const { runtime } = createJobsConfirmRuntime();
+
+    await expect(
+      executors[EASY_APPLY_JOB_ACTION_TYPE]!.execute({
+        runtime,
+        action: {
+          id: "act-ea",
+          target: {
+            profile_name: "default",
+            job_id: "123",
+            job_url: "https://www.linkedin.com/jobs/view/123/",
+          },
+          payload: {},
+        },
+      } as never),
+    ).rejects.toMatchObject({
+      code: "RATE_LIMITED",
+      details: {
+        rate_limit: {
+          counter_key: "linkedin.jobs.easy_apply",
+        },
+      },
+    });
+  });
+});
+
+describe("job URL builders edge cases", () => {
+  it("encodes special characters in search query", () => {
+    expect(buildJobSearchUrl("R&D engineer & manager")).toBe(
+      "https://www.linkedin.com/jobs/search/?keywords=R%26D%20engineer%20%26%20manager",
+    );
+  });
+
+  it("omits location when location is whitespace-only", () => {
+    expect(buildJobSearchUrl("developer", "  \n\t ")).toBe(
+      "https://www.linkedin.com/jobs/search/?keywords=developer",
+    );
+  });
+
+  it("builds job view URL for numeric string ids", () => {
+    expect(buildJobViewUrl("000123")).toBe(
+      "https://www.linkedin.com/jobs/view/000123/",
+    );
+  });
+
+  it("encodes URL-unsafe characters in job view ids", () => {
+    expect(buildJobViewUrl("abc/123?#[]")).toBe(
+      "https://www.linkedin.com/jobs/view/abc%2F123%3F%23%5B%5D/",
+    );
+  });
+
+  it("returns stable LinkedIn job alerts URL constant", () => {
+    expect(buildJobAlertsUrl()).toBe(LINKEDIN_JOB_ALERTS_URL);
+    expect(LINKEDIN_JOB_ALERTS_URL).toBe(
+      "https://www.linkedin.com/jobs/job-alerts/",
+    );
+  });
+});
+
+describe("LinkedInJobsService prepareRemoveJobAlert resolution", () => {
+  function createService() {
+    const prepare = vi.fn((input: { preview: Record<string, unknown> }) => ({
+      preparedActionId: "pa_test",
+      confirmToken: "ct_test",
+      expiresAtMs: 123,
+      preview: input.preview,
+    }));
+    const rateLimiter = {
+      peek: vi.fn(
+        (config: {
+          counterKey: string;
+          windowSizeMs: number;
+          limit: number;
+        }) => ({
+          counterKey: config.counterKey,
+          windowStartMs: 0,
+          windowSizeMs: config.windowSizeMs,
+          count: 0,
+          limit: config.limit,
+          remaining: config.limit,
+          allowed: true,
+        }),
+      ),
+    };
+
+    const auth = {
+      ensureAuthenticated: vi.fn(async () => undefined),
+    };
+    const profileManager = {
+      runWithContext: vi.fn(
+        async (_opts: unknown, cb: (ctx: unknown) => unknown) => cb({}),
+      ),
+    };
+
+    const service = new LinkedInJobsService({
+      twoPhaseCommit: { prepare },
+      rateLimiter,
+      auth,
+      profileManager,
+      logger: { log: vi.fn() },
+      artifacts: {
+        resolve: vi.fn((p: string) => `/tmp/${p}`),
+        registerArtifact: vi.fn(),
+      },
+      confirmFailureArtifacts: { enabled: false, maxTraceBytes: 0 },
+    } as unknown as ConstructorParameters<typeof LinkedInJobsService>[0]);
+
+    return {
+      service,
+      prepare,
+    };
+  }
+
+  it("resolves by searchUrl when provided", async () => {
+    const { service, prepare } = createService();
+
+    await service.prepareRemoveJobAlert({
+      searchUrl:
+        "https://www.linkedin.com/jobs/search/?keywords=backend%20engineer&location=Remote",
+    });
+
+    expect(prepare).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionType: REMOVE_JOB_ALERT_ACTION_TYPE,
+        target: expect.objectContaining({
+          query: "backend engineer",
+          location: "Remote",
+          search_url:
+            "https://www.linkedin.com/jobs/search/?keywords=backend%20engineer&location=Remote",
+        }),
+      }),
+    );
+  });
+
+  it("resolves by query when no alertId or searchUrl", async () => {
+    const { service, prepare } = createService();
+
+    await service.prepareRemoveJobAlert({
+      query: "platform engineer",
+      location: "Copenhagen",
+    });
+
+    expect(prepare).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionType: REMOVE_JOB_ALERT_ACTION_TYPE,
+        target: expect.objectContaining({
+          query: "platform engineer",
+          location: "Copenhagen",
+          search_url:
+            "https://www.linkedin.com/jobs/search/?keywords=platform%20engineer&location=Copenhagen",
+        }),
+      }),
+    );
+  });
+
+  it("rejects when no identifier is provided", async () => {
+    const { service } = createService();
+
+    await expect(service.prepareRemoveJobAlert({})).rejects.toThrow(
+      "Provide alertId, searchUrl, or query to remove a job alert.",
+    );
+  });
+
+  it("rejects when query exceeds max length", async () => {
+    const { service } = createService();
+
+    await expect(
+      service.prepareRemoveJobAlert({
+        query: "x".repeat(JOB_SEARCH_QUERY_MAX_LENGTH + 1),
+      }),
+    ).rejects.toThrow(
+      `query must not exceed ${JOB_SEARCH_QUERY_MAX_LENGTH} characters.`,
+    );
   });
 });

--- a/packages/core/src/linkedinJobs.ts
+++ b/packages/core/src/linkedinJobs.ts
@@ -15,7 +15,7 @@ import {
   createConfirmRateLimitMessage,
   formatRateLimitState,
 } from "./rateLimiter.js";
-import type { RateLimiter, RateLimiterState } from "./rateLimiter.js";
+import type { RateLimiter } from "./rateLimiter.js";
 import type {
   ActionExecutor,
   ActionExecutorInput,
@@ -183,6 +183,14 @@ const EASY_APPLY_RATE_LIMIT_CONFIG = {
   limit: 6,
 } as const;
 
+export const JOB_SEARCH_QUERY_MAX_LENGTH = 400;
+export const JOB_SEARCH_LIMIT_MAX = 100;
+export const JOB_ALERTS_LIMIT_MAX = 100;
+export const EASY_APPLY_COVER_LETTER_MAX_LENGTH = 4000;
+export const EASY_APPLY_PHONE_MAX_LENGTH = 30;
+export const EASY_APPLY_CITY_MAX_LENGTH = 200;
+export const EASY_APPLY_EMAIL_MAX_LENGTH = 254;
+
 const JOB_ALERTS_URL = "https://www.linkedin.com/jobs/job-alerts/";
 export const LINKEDIN_JOB_ALERTS_URL = JOB_ALERTS_URL;
 const EASY_APPLY_DIALOG_SELECTOR =
@@ -190,42 +198,6 @@ const EASY_APPLY_DIALOG_SELECTOR =
 const EASY_APPLY_FIELD_ATTR = "data-linkedin-assistant-easy-apply-field";
 const EASY_APPLY_GROUP_ATTR = "data-linkedin-assistant-easy-apply-group";
 const EASY_APPLY_OPTION_ATTR = "data-linkedin-assistant-easy-apply-option";
-
-interface JobSearchSnapshot {
-  job_id: string;
-  title: string;
-  company: string;
-  location: string;
-  posted_at: string;
-  job_url: string;
-  salary_range: string;
-  employment_type: string;
-}
-
-interface JobDetailSnapshot {
-  job_id: string;
-  title: string;
-  company: string;
-  company_url: string;
-  location: string;
-  posted_at: string;
-  description: string;
-  salary_range: string;
-  employment_type: string;
-  job_url: string;
-  applicant_count: string;
-  seniority_level: string;
-  is_remote: boolean;
-}
-
-interface JobAlertSnapshot {
-  alert_id: string;
-  query: string;
-  location: string;
-  frequency: string;
-  search_url: string;
-  enabled: boolean;
-}
 
 type EasyApplyFieldKind =
   | "text"
@@ -278,20 +250,16 @@ function normalizeLabelKey(value: string): string {
     .trim();
 }
 
-function readJobsLimit(value: number | undefined): number {
+function readLimit(
+  value: number | undefined,
+  defaultLimit: number,
+  maxLimit: number,
+): number {
   if (typeof value !== "number" || !Number.isFinite(value)) {
-    return 10;
+    return defaultLimit;
   }
 
-  return Math.max(1, Math.floor(value));
-}
-
-function readJobAlertsLimit(value: number | undefined): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return 20;
-  }
-
-  return Math.max(1, Math.floor(value));
+  return Math.max(1, Math.min(Math.floor(value), maxLimit));
 }
 
 function getProfileName(target: Record<string, unknown>): string {
@@ -591,9 +559,41 @@ function validateEasyApplyInput(
   }
 
   const phoneNumber = normalizeText(input.phoneNumber);
+
+  if (phoneNumber && phoneNumber.length > EASY_APPLY_PHONE_MAX_LENGTH) {
+    throw new LinkedInBuddyError(
+      "ACTION_PRECONDITION_FAILED",
+      `phoneNumber must not exceed ${EASY_APPLY_PHONE_MAX_LENGTH} characters.`,
+    );
+  }
+
   const city = normalizeText(input.city);
+
+  if (city && city.length > EASY_APPLY_CITY_MAX_LENGTH) {
+    throw new LinkedInBuddyError(
+      "ACTION_PRECONDITION_FAILED",
+      `city must not exceed ${EASY_APPLY_CITY_MAX_LENGTH} characters.`,
+    );
+  }
+
   const coverLetter = normalizeText(input.coverLetter);
+
+  if (coverLetter && coverLetter.length > EASY_APPLY_COVER_LETTER_MAX_LENGTH) {
+    throw new LinkedInBuddyError(
+      "ACTION_PRECONDITION_FAILED",
+      `coverLetter must not exceed ${EASY_APPLY_COVER_LETTER_MAX_LENGTH} characters.`,
+    );
+  }
+
   const email = validateEmail(input.email);
+
+  if (email && email.length > EASY_APPLY_EMAIL_MAX_LENGTH) {
+    throw new LinkedInBuddyError(
+      "ACTION_PRECONDITION_FAILED",
+      `email must not exceed ${EASY_APPLY_EMAIL_MAX_LENGTH} characters.`,
+    );
+  }
+
   const resumePath = validateResumePath(input.resumePath);
 
   return {
@@ -856,7 +856,7 @@ async function extractJobSearchResults(
         ),
       ).slice(0, maxJobs);
 
-      const results: JobSearchSnapshot[] = [];
+      const results: LinkedInJobSearchResult[] = [];
       for (const card of cards) {
         const jobUrl = pickHref(card, [
           "a[href*='/jobs/view/']",
@@ -1041,7 +1041,7 @@ async function extractJobDetail(
 
     const jobUrl = globalThis.window.location.href;
 
-    const result: JobDetailSnapshot = {
+    const result: LinkedInJobPosting = {
       job_id: passedJobId,
       title,
       company,
@@ -1149,7 +1149,7 @@ async function extractJobAlerts(
         ),
       ).filter((element) => isVisible(element));
 
-      const results: JobAlertSnapshot[] = [];
+      const results: LinkedInJobAlert[] = [];
       const seen = new Set<string>();
       for (const card of cards) {
         const text = normalize(card.textContent);
@@ -2785,9 +2785,7 @@ export class LinkedInJobsService {
     }
 
     const jobUrl = buildJobViewUrl(jobId);
-    const rateLimitState: RateLimiterState = this.runtime.rateLimiter.peek(
-      input.rateLimitConfig,
-    );
+    const rateLimitState = this.runtime.rateLimiter.peek(input.rateLimitConfig);
     const target = {
       profile_name: profileName,
       job_id: jobId,
@@ -2815,12 +2813,19 @@ export class LinkedInJobsService {
     const profileName = input.profileName ?? "default";
     const query = normalizeText(input.query);
     const location = normalizeText(input.location);
-    const limit = readJobsLimit(input.limit);
+    const limit = readLimit(input.limit, 10, JOB_SEARCH_LIMIT_MAX);
 
     if (!query) {
       throw new LinkedInBuddyError(
         "ACTION_PRECONDITION_FAILED",
         "query is required.",
+      );
+    }
+
+    if (query.length > JOB_SEARCH_QUERY_MAX_LENGTH) {
+      throw new LinkedInBuddyError(
+        "ACTION_PRECONDITION_FAILED",
+        `query must not exceed ${JOB_SEARCH_QUERY_MAX_LENGTH} characters.`,
       );
     }
 
@@ -2950,7 +2955,7 @@ export class LinkedInJobsService {
     input: ListJobAlertsInput = {},
   ): Promise<ListJobAlertsOutput> {
     const profileName = input.profileName ?? "default";
-    const limit = readJobAlertsLimit(input.limit);
+    const limit = readLimit(input.limit, 20, JOB_ALERTS_LIMIT_MAX);
 
     await this.runtime.auth.ensureAuthenticated({
       profileName,
@@ -3008,8 +3013,15 @@ export class LinkedInJobsService {
       );
     }
 
+    if (query.length > JOB_SEARCH_QUERY_MAX_LENGTH) {
+      throw new LinkedInBuddyError(
+        "ACTION_PRECONDITION_FAILED",
+        `query must not exceed ${JOB_SEARCH_QUERY_MAX_LENGTH} characters.`,
+      );
+    }
+
     const searchUrl = buildJobSearchUrl(query, location || undefined);
-    const rateLimitState: RateLimiterState = this.runtime.rateLimiter.peek(
+    const rateLimitState = this.runtime.rateLimiter.peek(
       CREATE_JOB_ALERT_RATE_LIMIT_CONFIG,
     );
     const target = {
@@ -3050,6 +3062,13 @@ export class LinkedInJobsService {
     let searchUrl = providedSearch.normalizedUrl;
     let alertId = providedAlertId;
 
+    if (query.length > JOB_SEARCH_QUERY_MAX_LENGTH) {
+      throw new LinkedInBuddyError(
+        "ACTION_PRECONDITION_FAILED",
+        `query must not exceed ${JOB_SEARCH_QUERY_MAX_LENGTH} characters.`,
+      );
+    }
+
     if (!searchUrl && query) {
       searchUrl = buildJobSearchUrl(query, location || undefined);
     }
@@ -3089,7 +3108,7 @@ export class LinkedInJobsService {
     const resolvedAlertId =
       alertId ||
       buildJobAlertIdentifier(searchUrl, resolvedQuery, resolvedLocation);
-    const rateLimitState: RateLimiterState = this.runtime.rateLimiter.peek(
+    const rateLimitState = this.runtime.rateLimiter.peek(
       REMOVE_JOB_ALERT_RATE_LIMIT_CONFIG,
     );
     const target = {
@@ -3124,7 +3143,7 @@ export class LinkedInJobsService {
     preview: Record<string, unknown>;
   } {
     const validatedInput = validateEasyApplyInput(input);
-    const rateLimitState: RateLimiterState = this.runtime.rateLimiter.peek(
+    const rateLimitState = this.runtime.rateLimiter.peek(
       EASY_APPLY_RATE_LIMIT_CONFIG,
     );
 


### PR DESCRIPTION
## Summary

Quality pass for Jobs (#238) — rebased on current main after PR #375 was closed by the external-PR workflow. Reapplied quality improvements adapted to main's updated codebase (which now includes the rate-limiting quality pass).

## Changes

### Phase 3 — Simplify + Refactor
- Removed 3 duplicate internal snapshot interfaces (`JobSearchSnapshot`, `JobDetailSnapshot`, `JobAlertSnapshot`) — uses exported types directly
- Unified `readJobsLimit` / `readJobAlertsLimit` into a single parameterized `readLimit(value, defaultLimit, maxLimit)`
- Removed unused `RateLimiterState` import

### Phase 5 — Harden
- Added 7 max-length constants: `JOB_SEARCH_QUERY_MAX_LENGTH`, `JOB_SEARCH_LIMIT_MAX`, `JOB_ALERTS_LIMIT_MAX`, `EASY_APPLY_COVER_LETTER_MAX_LENGTH`, `EASY_APPLY_PHONE_MAX_LENGTH`, `EASY_APPLY_CITY_MAX_LENGTH`, `EASY_APPLY_EMAIL_MAX_LENGTH`
- Capped `readLimit` with max bound (previously unbounded)
- Added query length validation in `searchJobs`, `prepareCreateJobAlert`, `prepareRemoveJobAlert`
- Added field length validation for phone, city, cover letter, email in Easy Apply

### Phase 4 — Test
- Expanded jobs tests from 9 → 58 (1224 total passing)

### Phase 8 — Docs
- Created `docs/jobs.md`: CLI commands, MCP tools, TypeScript API, rate limits, input validation
- Added entry to README docs map

### Notes
- Phase 6 (UX/MCP descriptions): Main's rate-limiting quality pass already improved MCP patterns with `readBoundedString`, `readValidatedUrl`, `buildRecoveryHint` — no additional MCP changes needed
- Phase 7 (Verify): Skipped — requires live authenticated session

## Quality Gates
- Lint: ✅ (1 pre-existing issue in `sessionAuth.test.ts`)
- Tests: ✅ 1224 passing (108 test files)
- Typecheck: ✅ (2 pre-existing issues in `stealth.ts`)

Closes #354
