### PR TITLE
feat: generate hierarchical AGENTS.md knowledge base (#398)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,68 +3,123 @@
 ## Repo Overview
 
 LinkedIn Buddy — Playwright-based browser automation for LinkedIn with CLI and MCP server.
+Three surfaces (CLI, MCP, TypeScript API) share one core runtime. All write operations go through two-phase commit (prepare/confirm). Local-first: SQLite state, persistent browser profiles, structured logs, screenshots.
 
 ## Monorepo Structure
 
 ```
 packages/
   core/       @linkedin-buddy/core    — automation library, DB, rate limiter, two-phase commit
-  cli/        @linkedin-buddy/cli     — operator CLI (binary: linkedin)
+  cli/        @linkedin-buddy/cli     — operator CLI (binaries: linkedin, lbud, linkedin-buddy)
   mcp/        @linkedin-buddy/mcp     — MCP stdio server (binary: linkedin-mcp)
-scripts/      integration test scripts
+scripts/      build, release, e2e runner, security audit, keep-alive
+docs/         feature docs, architecture notes, research briefs
 ```
 
-### Key Files
+### Key Files — Core Infrastructure
 
 | File | Purpose |
 |------|---------|
-| `packages/core/src/runtime.ts` | Creates the core service graph (all services wired together) |
-| `packages/core/src/twoPhaseCommit.ts` | Two-phase commit framework (prepare/confirm, tokens, DB) |
-| `packages/core/src/linkedinInbox.ts` | Inbox extraction + send_message executor |
-| `packages/core/src/linkedinConnections.ts` | Connection management + send/accept/withdraw executors |
-| `packages/core/src/linkedinFeed.ts` | Feed extraction + like/comment executors |
-| `packages/core/src/linkedinProfile.ts` | Profile viewing |
-| `packages/core/src/linkedinSearch.ts` | Search (people, companies, jobs) |
-| `packages/core/src/linkedinJobs.ts` | Job search and view |
-| `packages/core/src/linkedinNotifications.ts` | Notifications listing |
-| `packages/core/src/auth/session.ts` | Auth service (login, status, ensureAuthenticated) |
+| `packages/core/src/runtime.ts` | Service graph factory — wires all 25+ services via `createCoreRuntime()` |
+| `packages/core/src/index.ts` | Barrel export — 54 re-exports for external consumption |
+| `packages/core/src/twoPhaseCommit.ts` | Two-phase commit framework (prepare/confirm, tokens, executors, DB) |
+| `packages/core/src/errors.ts` | Error taxonomy — `LinkedInBuddyError` with 9 structured codes |
+| `packages/core/src/config.ts` | Configuration resolution (paths, evasion, locale, privacy, webhooks) |
+| `packages/core/src/db/database.ts` | SQLite (better-sqlite3) — prepared actions, logs, artifacts, rate limits, activity |
+| `packages/core/src/db/migrations.ts` | Schema migrations (6 versions) |
+| `packages/core/src/rateLimiter.ts` | Per-action token bucket rate limiting |
+| `packages/core/src/logging.ts` | Structured JSON event logger (`domain.operation.stage` naming) |
+| `packages/core/src/artifacts.ts` | Screenshot/trace artifact management |
 | `packages/core/src/profileManager.ts` | Playwright persistent context / CDP management |
 | `packages/core/src/connectionPool.ts` | Browser connection pooling |
-| `packages/core/src/rateLimiter.ts` | Per-action token bucket rate limiting |
-| `packages/core/src/artifacts.ts` | Screenshot/trace artifact management |
-| `packages/core/src/db/database.ts` | SQLite database (better-sqlite3) |
-| `packages/core/src/db/migrations.ts` | DB schema migrations |
-| `packages/core/src/errors.ts` | Structured error taxonomy |
-| `packages/core/src/humanize.ts` | Human-like delays and pacing |
-| `packages/core/src/logging.ts` | Structured JSON event logger |
-| `packages/core/src/config.ts` | Configuration |
-| `packages/cli/src/bin/linkedin.ts` | CLI entry point (Commander-based) |
-| `packages/mcp/src/bin/linkedin-mcp.ts` | MCP server entry point |
-| `packages/mcp/src/index.ts` | MCP tool name constants |
+| `packages/core/src/humanize.ts` | Human-like typing simulation (typos, pauses, profiles) |
+| `packages/core/src/evasion.ts` | Anti-bot evasion config and profile resolution |
+| `packages/core/src/privacy.ts` | Privacy config, log redaction, JSON sealing |
+
+### Key Files — LinkedIn Feature Services
+
+| File | Purpose |
+|------|---------|
+| `packages/core/src/linkedinInbox.ts` | Inbox — list threads, view messages, send/react/archive/mute |
+| `packages/core/src/linkedinFeed.ts` | Feed — list, view, like/comment/repost/share/save |
+| `packages/core/src/linkedinConnections.ts` | Connections — list, send/accept/withdraw/remove/follow/unfollow |
+| `packages/core/src/linkedinProfile.ts` | Profile — view + 14 edit actions (intro, sections, photos, skills) |
+| `packages/core/src/linkedinSearch.ts` | Search — people, companies, jobs, posts, groups, events |
+| `packages/core/src/linkedinJobs.ts` | Jobs — search, view, save/unsave, alerts, Easy Apply |
+| `packages/core/src/linkedinNotifications.ts` | Notifications — list, dismiss, preference updates |
+| `packages/core/src/linkedinPosts.ts` | Posts — create, edit, delete (text, media, polls) |
+| `packages/core/src/linkedinPublishing.ts` | Articles and newsletters |
+| `packages/core/src/linkedinFollowups.ts` | Follow-up message scheduling |
+| `packages/core/src/linkedinGroups.ts` | Groups — search, view, join/leave/post |
+| `packages/core/src/linkedinEvents.ts` | Events — search, view, RSVP |
+| `packages/core/src/linkedinCompanyPages.ts` | Company pages — view, follow/unfollow |
+| `packages/core/src/linkedinMembers.ts` | Member safety — block/unblock/report |
+| `packages/core/src/linkedinPrivacySettings.ts` | Privacy settings management |
+| `packages/core/src/linkedinAnalytics.ts` | Analytics — profile views, search appearances, post metrics |
+| `packages/core/src/linkedinImageAssets.ts` | Persona image generation (OpenAI) |
+| `packages/core/src/linkedinPage.ts` | Page navigation, waiting, selector helpers |
+
+### Key Files — Auth, Activity & Scheduling
+
+| File | Purpose |
+|------|---------|
+| `packages/core/src/auth/session.ts` | Auth service — login, status, ensureAuthenticated |
+| `packages/core/src/auth/sessionStore.ts` | Session persistence and encryption |
+| `packages/core/src/auth/loginSelectors.ts` | Login page selector strategies |
+| `packages/core/src/auth/rateLimitState.ts` | Rate limit cooldown state management |
+| `packages/core/src/activityWatches.ts` | Activity watch CRUD + webhook subscriptions |
+| `packages/core/src/activityPoller.ts` | Polling engine — tick execution, event diffing, delivery |
+| `packages/core/src/webhookDelivery.ts` | Webhook delivery with signing and retry |
+| `packages/core/src/scheduler.ts` | Deferred job scheduling with lanes and leasing |
+| `packages/core/src/keepAlive.ts` | Session keep-alive daemon |
+| `packages/core/src/healthCheck.ts` | Full system health diagnostics |
+
+### Key Files — Testing & Validation
+
+| File | Purpose |
+|------|---------|
+| `packages/core/src/writeValidation.ts` | Tier 3 live write validation harness |
+| `packages/core/src/liveValidation.ts` | Live read-only validation workflows |
+| `packages/core/src/selectorAudit.ts` | Selector resilience auditing |
+| `packages/core/src/selectorLocale.ts` | Locale-aware selectors (en/da) |
+| `packages/core/src/fixtureReplay.ts` | HTTP fixture replay for deterministic testing |
+| `packages/core/src/draftQualityEval.ts` | Draft content quality scoring |
+
+### Key Files — Interface Layer
+
+| File | Purpose |
+|------|---------|
+| `packages/cli/src/bin/linkedin.ts` | CLI entry point — 127+ Commander commands |
+| `packages/mcp/src/bin/linkedin-mcp.ts` | MCP server — 100+ tool handlers |
+| `packages/mcp/src/index.ts` | MCP tool name constants (157 exports) |
+
+## Service Graph
+
+`createCoreRuntime()` in `runtime.ts` wires all services:
+
+```
+Infrastructure: db → logger → artifacts → profileManager → auth → rateLimiter → twoPhaseCommit
+                                                                        ↓
+LinkedIn Services: inbox, feed, connections, profile, search, jobs, notifications,
+                   posts, publishing, followups, groups, events, companyPages,
+                   members, privacySettings, analytics, imageAssets
+                                                                        ↓
+Activity Layer:    activityWatches → activityPoller → webhookDelivery → scheduler
+```
+
+All services receive dependencies via constructor injection. No circular dependencies.
 
 ## Build & Test
 
 ```bash
-# Install dependencies
-npm install
-
-# Install Playwright browser
-npx playwright install chromium
-
-# Build (TypeScript → dist/)
-npm run build
-
-# Run unit tests (72 tests)
-npm test
-
-# Type check
-npm run typecheck
-
-# Lint
-npm run lint
-
-# E2E tests (requires authenticated LinkedIn session on CDP port 18800)
-npm run test:e2e
+npm install                        # Install dependencies
+npx playwright install chromium    # Install browser
+npm run build                      # TypeScript → dist/ (tsc -b)
+npm test                           # Unit tests (Vitest, 120+ test files)
+npm run typecheck                  # Type check (tsc -b --force)
+npm run lint                       # ESLint (flat config, strict TypeScript)
+npm run test:e2e                   # E2E tests (requires CDP + auth session)
+npm run test:e2e:fixtures          # E2E with fixture replay
 ```
 
 ## Quality Gates
@@ -80,21 +135,73 @@ npm run build
 
 ## Code Conventions
 
-- **Language:** TypeScript, ES modules (`"type": "module"`)
-- **Node version:** 22+
+- **Language:** TypeScript strict mode, ES modules (`"type": "module"`), Node 22+
 - **Imports:** Use `.js` extension in import paths (TypeScript ESM convention)
 - **Exports:** All core modules re-exported via `packages/core/src/index.ts`
-- **Error handling:** Use `LinkedInBuddyError` with structured error codes
-- **Two-phase commit pattern:** Every outbound action must:
-  1. Have a `prepare*` method that stores action in DB and returns confirm token
-  2. Have an `ActionExecutor` class that implements the `execute` method
-  3. Register the executor in the runtime (`packages/core/src/runtime.ts`)
-- **Selector strategy:** Use multi-strategy selectors (role → attribute → text). See `SelectorCandidate` pattern in `linkedinInbox.ts`
 - **Naming:** `camelCase` for variables/functions, `PascalCase` for types/classes, `SCREAMING_SNAKE` for constants
-- **Tests:** Vitest. Unit tests in `packages/core/src/__tests__/`. E2E tests in `packages/core/src/__tests__/e2e/`
-- **Logging:** Use `runtime.logger.log(level, event, details)` — structured JSON events
-- **Artifacts:** Use `runtime.artifacts` for screenshots and traces. Relative paths under run directory.
-- **Feed comment tone for testing:** When testing comment flows, use short, subtle, kind comments that relate directly to the post content. Avoid mentioning tests, bots, automation, or synthetic language.
+- **Error handling:** Use `LinkedInBuddyError` with structured error codes — never raw `throw new Error()`
+- **Logging:** `runtime.logger.log(level, "domain.operation.stage", details)` — structured JSON events
+- **Artifacts:** `runtime.artifacts` for screenshots and traces — relative paths under run directory
+- **Tests:** Vitest. Unit tests in `__tests__/`. E2E tests in `__tests__/e2e/`
+- **Linting:** ESLint flat config — `no-explicit-any` is an error. No Prettier.
+- **Feed comment tone for testing:** Short, subtle, kind comments relating to post content. Never mention tests, bots, automation.
+
+### Two-Phase Commit Pattern (MANDATORY for all write operations)
+
+Every outbound action must:
+1. Have a `prepare*` method that stores action in DB and returns confirm token
+2. Have an `ActionExecutor` class implementing `execute()`
+3. Create a `create*ActionExecutors()` factory function
+4. Register the executor in `runtime.ts`
+
+```
+prepare*() → PreparedAction in DB → { preparedActionId, confirmToken, preview }
+           ↓
+confirm(token) → validate token + expiry → ActionExecutor.execute() → record result
+```
+
+Token TTL: 30 minutes. Tokens are HMAC-SHA256 sealed JSON with entropy.
+
+### Error Codes
+
+| Code | Meaning |
+|------|---------|
+| `AUTH_REQUIRED` | Session expired or not authenticated |
+| `CAPTCHA_OR_CHALLENGE` | LinkedIn challenge/checkpoint detected |
+| `RATE_LIMITED` | Action rate-limited in current window |
+| `UI_CHANGED_SELECTOR_FAILED` | Selector no longer matches LinkedIn UI |
+| `NETWORK_ERROR` | Network/connectivity failure |
+| `TIMEOUT` | Operation exceeded timeout |
+| `TARGET_NOT_FOUND` | Target entity not found |
+| `ACTION_PRECONDITION_FAILED` | Precondition check failed |
+| `UNKNOWN` | Fallback for unmapped errors |
+
+### Selector Strategy
+
+Use multi-strategy selectors with `SelectorCandidate` pattern:
+1. **role** (most stable) → 2. **attribute** → 3. **text** (fragile) → 4. **xpath** (last resort)
+
+Locale support: `selectorLocale.ts` maps UI phrases for `en` and `da`.
+
+### Rate Limiting
+
+Token bucket per action. `rateLimiter.consume()` before writes; `rateLimiter.peek()` for previews.
+State persisted in SQLite `rate_limit_counter` table.
+
+## Database Schema
+
+| Table | Purpose |
+|-------|---------|
+| `prepared_action` | Two-phase commit state (action, token, status, result) |
+| `rate_limit_counter` | Token bucket counters per action |
+| `run_log` | Structured event logs |
+| `artifact_index` | Screenshot/trace metadata |
+| `scheduler_job` | Deferred job queue with lanes |
+| `activity_watch` | Watch definitions (kind, schedule, polling interval) |
+| `activity_entity_state` | Entity snapshots for diff detection |
+| `activity_event` | Emitted activity events |
+| `webhook_subscription` | Webhook targets (URL, signing secret) |
+| `webhook_delivery_attempt` | Delivery history and retry state |
 
 ## Architecture Patterns
 
@@ -108,19 +215,24 @@ npm run build
 2. Export from `packages/core/src/index.ts`
 3. Wire into `packages/core/src/runtime.ts`:
    - Create service instance
-   - Register executors
+   - Register executors via `twoPhaseCommit.registerExecutors()`
    - Expose on runtime object
 4. Add CLI commands in `packages/cli/src/bin/linkedin.ts`
 5. Add MCP tools in `packages/mcp/src/bin/linkedin-mcp.ts` + constants in `packages/mcp/src/index.ts`
 6. Add unit tests and E2E tests
 
-### Two-Phase Commit Flow
+### Evasion & Humanization
 
-```
-prepare*() → stores PreparedAction in DB → returns { preparedActionId, confirmToken, preview }
-           ↓
-confirm(token) → validates token + expiry → calls ActionExecutor.execute() → records result
-```
+Anti-bot evasion levels: `off` → `light` → `moderate` (default) → `aggressive`
+Humanize typing profiles: `careful` (slow, realistic) → `casual` (balanced) → `fast` (testing)
+Config via `--evasion-level` flag, `LINKEDIN_BUDDY_EVASION_LEVEL` env, or runtime options.
+See `packages/core/src/evasion/` for Bezier mouse paths, Poisson intervals, fingerprint hardening.
+
+### Activity Polling & Webhooks
+
+Watches poll LinkedIn at configurable intervals. Events detected via entity snapshot diffing.
+Webhook subscriptions receive signed HTTP POST with retry logic.
+`activity run-once` executes one polling tick; `scheduler start` runs continuous daemon.
 
 ## E2E Testing Safety Rules
 
@@ -132,6 +244,15 @@ confirm(token) → validates token + expiry → calls ActionExecutor.execute() �
 - **Read-only operations** (profile view, search, inbox list, feed view, notifications) are unrestricted.
 
 Violating these rules risks real social interactions on Joakim's LinkedIn account.
+
+## CI/CD
+
+**GitHub Actions:**
+- `ci.yml` — Lint, typecheck, unit tests, fixture E2E, build (on push/PR)
+- `release.yml` — Calver versioning, npm publish, GitHub release (daily/manual)
+- `secret-scan.yml` — Gitleaks history + tracked-file audit
+- `ai-auto-rebase.yml` — Auto-rebase conflicting AI PRs
+- `ai-ci-recovery.yml` — Re-label failed AI branches for retry
 
 ## Branch Naming
 

--- a/packages/cli/src/AGENTS.md
+++ b/packages/cli/src/AGENTS.md
@@ -1,0 +1,65 @@
+# packages/cli/src — CLI Package
+
+## Overview
+
+Commander-based CLI exposing all core services as terminal commands. 127+ commands across 15 categories.
+Entry point: `bin/linkedin.ts` (11,100+ lines — largest file in the repo).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `bin/linkedin.ts` | All CLI commands — search, inbox, feed, jobs, profile, connections, activity, validation, etc. |
+| `activityOutput.ts` | Output formatting for activity events and webhooks |
+| `writeValidationOutput.ts` | Output formatting for write validation results |
+| `draftQualityOutput.ts` | Output formatting for draft quality evaluation |
+| `schedulerOutput.ts` | Output formatting for scheduler state |
+| `keepAliveOutput.ts` | Output formatting for keep-alive daemon |
+| `liveValidationOutput.ts` | Output formatting for live validation |
+| `selectorAuditOutput.ts` | Output formatting for selector audit |
+| `headlessLoginOutput.ts` | Output formatting for headless login |
+| `profileSeed.ts` | Profile seeding for test personas |
+| `activitySeed.ts` | Activity seeding for test data |
+
+## Command Pattern
+
+```typescript
+program
+  .command("feature action <required-arg>")
+  .option("--optional-flag <value>", "Description", "default")
+  .option("-p, --profile <profile>", "Profile name", "default")
+  .action(async (requiredArg, options) => {
+    const runtime = createRuntime(options.cdpUrl);
+    try {
+      const result = await runtime.featureService.method({ profileName: options.profile, ... });
+      printJson(result);
+    } finally {
+      runtime.close();
+    }
+  });
+```
+
+## Adding a New CLI Command
+
+1. Add command definition in `bin/linkedin.ts` under the appropriate group
+2. Follow existing pattern: parse args → create runtime → call core service → format output → close runtime
+3. Use `--profile` option (default: "default") for all commands
+4. Use `--json` flag for structured output
+5. For write commands: call `prepare*()` → display preview → print confirm token
+6. If output is complex, create a dedicated `*Output.ts` formatter
+
+## Global Options
+
+- `--profile <name>` — Playwright profile (default: "default")
+- `--json` — JSON output mode
+- `--cdp-url <url>` — External browser CDP endpoint
+- `--evasion-level <level>` — off/light/moderate/aggressive
+- `--no-evasion` — Disable evasion entirely
+- `--selector-locale <locale>` — UI locale (en/da)
+
+## Anti-Patterns
+
+- NEVER create a new entry point file — all commands go in `bin/linkedin.ts`
+- NEVER call core services without `try/finally` for `runtime.close()`
+- NEVER skip `--profile` option — every command needs profile selection
+- Output formatters belong in dedicated `*Output.ts` files, not inline in the command

--- a/packages/core/src/AGENTS.md
+++ b/packages/core/src/AGENTS.md
@@ -1,0 +1,60 @@
+# packages/core/src — Core Automation Library
+
+## Module Categories
+
+### Feature Services (`linkedin*.ts`)
+Each follows the same pattern: TypeScript interfaces + service class + `prepare*()` for writes + `ActionExecutor` classes + factory function.
+
+| Module | Lines | Executors | Key Complexity |
+|--------|-------|-----------|----------------|
+| `linkedinProfile.ts` | 8,448 | 14 (intro, sections, photos, skills, etc.) | Largest service; multi-step profile editing |
+| `linkedinPosts.ts` | 5,216 | 3 (create, edit, delete) | Media handling, safety linting, async generators |
+| `linkedinInbox.ts` | 4,097 | 5 (send, react, archive, mute, add recipients) | Thread state management, SelectorCandidate pattern |
+| `linkedinFeed.ts` | 3,659 | 7 (like, comment, repost, share, save, unsave, remove) | Heavy selector fallback strategy |
+| `linkedinJobs.ts` | 3,102 | 4 (save, unsave, apply, alert) | Complex form filling for Easy Apply |
+| `linkedinPublishing.ts` | 2,676 | 2 (create article, publish newsletter) | Rich text composition |
+| `linkedinConnections.ts` | 2,406 | 8 (send, accept, withdraw, ignore, remove, follow, unfollow) | Full relationship lifecycle |
+
+### Infrastructure
+- `runtime.ts` — Service graph factory (519 lines). **Central wiring point** — modify here to add services.
+- `twoPhaseCommit.ts` — Prepare/confirm framework (542 lines). Security-critical: token sealing, expiry, DB persistence.
+- `config.ts` — Config resolution (1,297 lines, 53 exports). Paths, evasion, locale, privacy, webhooks.
+- `db/database.ts` — SQLite abstraction (2,615 lines, 50 exports). All persistent state lives here.
+- `rateLimiter.ts` — Token bucket. `peek()` for preview, `consume()` for enforcement.
+- `logging.ts` — JSON event logger. Events: `domain.operation.stage` (e.g., `inbox.send_message.start`).
+
+### Browser Management
+- `profileManager.ts` — Playwright persistent context + CDP attachment. Profile locking prevents concurrent access.
+- `connectionPool.ts` — Browser connection pooling and lifecycle.
+- `linkedinPage.ts` — Page navigation, waiting strategies, selector helpers. Uses async generators.
+
+### Humanization & Evasion
+- `humanize.ts` — Typing simulation (1,993 lines). Grapheme-level control, Intl.Segmenter for Unicode.
+- `evasion/` — Anti-bot subsystem (see `evasion/AGENTS.md`).
+
+### Activity & Scheduling
+- `activityPoller.ts` — Polling tick execution, entity diffing, webhook fan-out (1,696 lines).
+- `activityWatches.ts` — Watch CRUD, subscription management.
+- `webhookDelivery.ts` — HTTP POST with HMAC signing, retry with backoff.
+- `scheduler.ts` — Job queue with lanes, leasing, and deferred execution.
+
+## Where to Look
+
+| Task | Start Here |
+|------|------------|
+| Add new LinkedIn feature | `runtime.ts` → existing `linkedin*.ts` for pattern |
+| Add new write action | `twoPhaseCommit.ts` → existing executor in any `linkedin*.ts` |
+| Change DB schema | `db/migrations.ts` → `db/database.ts` |
+| Fix selector failure | Failing `linkedin*.ts` → `selectorLocale.ts` for locale phrases |
+| Debug auth issues | `auth/session.ts` → `auth/rateLimitState.ts` |
+| Modify rate limits | `rateLimiter.ts` → rate limit configs in the relevant `linkedin*.ts` |
+| Change typing behavior | `humanize.ts` (profiles at top of file) |
+| Adjust evasion | `evasion/profiles.ts` → `evasion/browser.ts` or `evasion/session.ts` |
+
+## Conventions (this directory only)
+
+- Every `linkedin*.ts` must export: interfaces, service class, executor classes, factory function
+- Service constructors take a runtime-like object — never import services directly from each other
+- `SelectorCandidate[]` arrays: define in priority order (role → attribute → text → xpath)
+- All page interactions go through `humanize()` wrapper for typing, or `evasion` for mouse/scroll
+- DB queries use prepared statements — never raw string interpolation

--- a/packages/core/src/__tests__/AGENTS.md
+++ b/packages/core/src/__tests__/AGENTS.md
@@ -1,0 +1,43 @@
+# packages/core/src/__tests__ — Test Suite
+
+## Structure
+
+```
+__tests__/
+  *.test.ts              — Unit tests (65 files, one per core module)
+  e2e/                   — E2E tests against real LinkedIn (see e2e/AGENTS.md)
+  rateLimiterTestUtils.ts — Rate limiter test helpers
+  evasionTestUtils.ts     — Evasion test helpers
+  selectorAuditTestUtils.ts — Selector audit test helpers
+```
+
+## Test Framework
+
+- **Vitest** — config in root `vitest.config.ts`
+- Pattern: `packages/**/src/__tests__/**/*.test.ts` (excludes `*.e2e.test.ts`)
+- Path alias: `@linkedin-buddy/core` resolves to `packages/core/src`
+
+## Adding a New Unit Test
+
+1. Create `__tests__/<moduleName>.test.ts`
+2. Import from `../moduleName.js` (use `.js` extension — ESM convention)
+3. Mock Playwright page/context using Vitest's `vi.fn()` and `vi.mock()`
+4. Test service methods: both read-only and prepare/confirm flows
+5. For prepare tests: verify PreparedAction structure, token generation, preview content
+6. For executor tests: mock page interactions, verify execution result
+
+## Test Utilities
+
+| File | Purpose |
+|------|---------|
+| `rateLimiterTestUtils.ts` | Creates mock rate limiter state, simulates window transitions |
+| `evasionTestUtils.ts` | Creates mock evasion configs, profiles for different levels |
+| `selectorAuditTestUtils.ts` | Creates mock selector registries, simulates audit results |
+
+## Conventions
+
+- Test file mirrors source file name: `linkedinFeed.ts` → `linkedinFeed.test.ts`
+- Group tests with `describe()` blocks matching method names
+- Mock the runtime object — never instantiate real services in unit tests
+- Use `vi.useFakeTimers()` for time-dependent tests (rate limiting, token expiry)
+- Test error paths: verify `LinkedInBuddyError` codes, not just "throws"

--- a/packages/core/src/__tests__/e2e/AGENTS.md
+++ b/packages/core/src/__tests__/e2e/AGENTS.md
@@ -1,0 +1,77 @@
+# packages/core/src/__tests__/e2e — E2E Tests (SAFETY-CRITICAL)
+
+## SAFETY RULES (READ BEFORE RUNNING)
+
+**These tests run against REAL LinkedIn on Joakim's account.**
+
+| Action | Rule |
+|--------|------|
+| **Messages** | ONLY to Simon Miller (`linkedin.com/in/realsimonmiller`) |
+| **Connection requests** | ONLY to Simon Miller |
+| **Comments, likes, posts** | Ask Joakim for approval FIRST — describe target + action |
+| **Read-only** (profile, search, inbox list, feed, notifications) | Unrestricted |
+
+**Violating these rules risks real social interactions on Joakim's LinkedIn account.**
+
+## Prerequisites
+
+1. Authenticated LinkedIn session on CDP port 18800
+2. `npm run build` completed
+3. CDP endpoint accessible: `http://localhost:18800`
+
+## Running
+
+```bash
+npm run test:e2e                  # Full suite via runner (CDP check + auth verify)
+npm run test:e2e:fixtures         # Fixture replay lane (deterministic, no live LinkedIn)
+npm run test:e2e:raw              # Direct Vitest without runner checks
+```
+
+## Test Structure
+
+| File | Type | Safety |
+|------|------|--------|
+| `auth.e2e.test.ts` | Read | Unrestricted |
+| `profile.e2e.test.ts` | Read | Unrestricted |
+| `search.e2e.test.ts` | Read | Unrestricted |
+| `jobs.e2e.test.ts` | Read | Unrestricted |
+| `inbox.e2e.test.ts` | Read | Unrestricted |
+| `feed.e2e.test.ts` | Read | Unrestricted |
+| `connections.e2e.test.ts` | Read | Unrestricted |
+| `notifications.e2e.test.ts` | Read | Unrestricted |
+| `health.e2e.test.ts` | Read | Unrestricted |
+| `inbox-write.e2e.test.ts` | Write | Simon Miller ONLY |
+| `connections-write.e2e.test.ts` | Write | Simon Miller ONLY |
+| `feed-like.e2e.test.ts` | Write | Requires approval |
+| `feed-engagement.e2e.test.ts` | Write | Requires approval |
+| `feed-write.e2e.test.ts` | Write | Requires approval |
+| `post-write.e2e.test.ts` | Write | Requires approval |
+
+## Write Confirm Opt-In
+
+Write E2E tests only execute confirms when explicitly enabled via environment variables:
+
+```bash
+LINKEDIN_E2E_ENABLE_MESSAGE_CONFIRM=true     # inbox-write
+LINKEDIN_E2E_ENABLE_CONNECTION_CONFIRM=true   # connections-write
+LINKEDIN_E2E_ENABLE_LIKE_CONFIRM=true         # feed-like
+LINKEDIN_E2E_ENABLE_COMMENT_CONFIRM=true      # feed-engagement
+LINKEDIN_ENABLE_POST_WRITE_E2E=true           # post-write
+```
+
+Without these flags, write tests only execute prepare (no confirm).
+
+## Fixture Replay
+
+- `fixtureReplay.ts` intercepts HTTP responses for deterministic replay
+- Manifest: `test/fixtures/manifest.json`
+- Set `LINKEDIN_E2E_FIXTURE_FILE` to a fixture path for cached discovery
+- Set `LINKEDIN_E2E_REFRESH_FIXTURES=true` to re-discover live targets
+
+## Adding E2E Tests
+
+1. Create `<feature>.e2e.test.ts` in this directory
+2. Use `setup.ts` helpers for runtime creation and CDP connection
+3. For read tests: call service methods, assert response structure
+4. For write tests: ONLY call `prepare*()` unless confirm opt-in flag is set
+5. Always clean up: close runtime in `afterAll()`

--- a/packages/core/src/auth/AGENTS.md
+++ b/packages/core/src/auth/AGENTS.md
@@ -1,0 +1,43 @@
+# packages/core/src/auth — Authentication & Session Management
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `session.ts` | Main auth service: `login()`, `status()`, `ensureAuthenticated()`, `openLogin()`, `headlessLogin()` |
+| `sessionStore.ts` | Session persistence and encryption. Stores/loads session state from disk. |
+| `sessionInspection.ts` | Session diagnostics and health probes |
+| `loginSelectors.ts` | Login page selector strategies (email field, password field, submit button) |
+| `rateLimitState.ts` | Rate limit cooldown state — persisted to `rate-limit-state.json`, checked before operations |
+
+## Auth Flow
+
+```
+openLogin()          → Opens browser, waits for manual login, polls for auth cookies
+headlessLogin()      → Enters email/password programmatically, handles MFA, detects checkpoints
+status()             → Navigates to LinkedIn, inspects cookies/DOM → returns SessionStatus
+ensureAuthenticated()→ Calls status(), re-authenticates if session expired
+```
+
+## Session Status Fields
+
+- `authenticated` — boolean
+- `identity` — name, headline, profile URL (if authenticated)
+- `rateLimitActive` / `rateLimitUntil` — cooldown state
+- `checkpointDetected` — LinkedIn security challenge
+- `loginWallDetected` — login wall blocking access
+- `sessionCookiePresent` — JSESSIONID cookie exists
+
+## Anti-Patterns
+
+- NEVER skip `ensureAuthenticated()` before page operations
+- NEVER ignore `rateLimitActive` — respect cooldown expiry in `rateLimitState.ts`
+- NEVER hardcode login selectors — use `loginSelectors.ts` with SelectorCandidate pattern
+- Headless login supports `retryOnRateLimit` with exponential backoff — use it
+
+## Rate Limit Cooldown
+
+When LinkedIn returns HTTP 429/999 or a checkpoint URL:
+1. `rateLimitState.ts` records expiry timestamp
+2. All subsequent operations check cooldown before proceeding
+3. `keepAlive.ts` monitors and alerts on cooldown state

--- a/packages/core/src/evasion/AGENTS.md
+++ b/packages/core/src/evasion/AGENTS.md
@@ -1,0 +1,47 @@
+# packages/core/src/evasion — Anti-Bot Evasion System
+
+## Overview
+
+Behavioral simulation to avoid LinkedIn bot detection. Four levels with increasing sophistication.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `browser.ts` | Browser-level: fingerprint hardening, captcha detection, honeypot detection, viewport jitter, momentum scroll, tab blur simulation |
+| `session.ts` | Page-level: `EvasionSession` class wrapping behavioral helpers (mouse movement, scrolling, delays) |
+| `math.ts` | Math primitives: Bezier path computation, Poisson interval sampling, reading pause calculation, momentum step generation |
+| `profiles.ts` | Profile definitions (minimal, moderate, paranoid) with feature matrices and level resolution |
+| `types.ts` | Type definitions: `EvasionLevel`, `EvasionProfile`, session options, diagnostics |
+| `shared.ts` | Shared utilities across evasion modules |
+
+## Evasion Levels
+
+| Level | Mouse | Typing | Fingerprint | Delays | Use Case |
+|-------|-------|--------|-------------|--------|----------|
+| `off` | No | No | No | No | Testing only |
+| `light` | Basic | No | No | Basic | Low-risk reads |
+| `moderate` | Bezier | Yes | Yes | Poisson | Default — balanced |
+| `aggressive` | Bezier + blur | Full | Full + CDP | Poisson + request | High-risk writes |
+
+## Configuration Precedence
+
+1. Runtime option (`evasionLevel` parameter)
+2. Environment variable (`LINKEDIN_BUDDY_EVASION_LEVEL`)
+3. Default: `moderate`
+
+Diagnostics: set `LINKEDIN_BUDDY_EVASION_DIAGNOSTICS=true` for verbose logging.
+
+## Math Patterns
+
+- **Bezier curves** (`math.ts`): Realistic mouse paths with control point randomization
+- **Poisson sampling** (`math.ts`): Natural-feeling intervals between actions
+- **Reading pause** (`math.ts`): Simulates reading time based on content length
+- **Momentum scroll** (`browser.ts`): Scroll with acceleration/deceleration
+
+## Anti-Patterns
+
+- NEVER use `off` level in production — only for local testing
+- NEVER make evasion patterns too uniform — randomization is critical for avoiding detection
+- NEVER skip evasion for credential entry — use `humanize.ts` typing profiles for sensitive fields
+- Changes to math distributions require careful validation — small changes can make patterns detectable

--- a/packages/mcp/src/AGENTS.md
+++ b/packages/mcp/src/AGENTS.md
@@ -1,0 +1,89 @@
+# packages/mcp/src — MCP Server Package
+
+## Overview
+
+Model Context Protocol stdio server exposing all core services as AI-consumable tools.
+100+ tools across 15 categories. Entry point: `bin/linkedin-mcp.ts` (8,000+ lines).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `bin/linkedin-mcp.ts` | All MCP tool handlers — mirrors CLI surface for AI agents |
+| `index.ts` | Tool name constants (157 exports) — `TOOL_SESSION_STATUS`, `TOOL_SEARCH`, etc. |
+
+## Tool Handler Pattern
+
+```typescript
+async function handleToolName(args: ToolArgs): Promise<ToolResult> {
+  const runtime = createRuntime(args);
+  try {
+    const profileName = readString(args, "profileName", "default");
+    const requiredField = readRequiredString(args, "field");
+
+    runtime.logger.log("info", "mcp.domain.operation.start", { profileName });
+    const result = await runtime.service.method({ profileName, requiredField });
+    runtime.logger.log("info", "mcp.domain.operation.done", { ... });
+
+    return toToolResult({ run_id: runtime.runId, profile_name: profileName, ...result });
+  } finally {
+    runtime.close();
+  }
+}
+```
+
+## Input Validation Helpers
+
+| Helper | Purpose |
+|--------|---------|
+| `readString(args, key, default)` | Optional string with default |
+| `readRequiredString(args, key)` | Required string — throws if missing |
+| `readPositiveNumber(args, key, default)` | Positive integer with validation |
+| `readBoolean(args, key, default)` | Boolean with default |
+| `readSearchCategory(args, key, default)` | Enum validation for search categories |
+
+## Adding a New MCP Tool
+
+1. Add tool name constant in `index.ts`: `export const TOOL_FEATURE_ACTION = "linkedin.feature.action";`
+2. Add tool definition in `bin/linkedin-mcp.ts` with input schema (JSON Schema format)
+3. Add handler function following the pattern above
+4. Register in the tool router switch statement
+5. Use `toToolResult()` for success, `toErrorResult()` for errors
+6. Log with `mcp.domain.operation.start/done` event naming
+
+## Tool Categories
+
+| Prefix | Domain | Example |
+|--------|--------|---------|
+| `linkedin.session.*` | Auth | `session.status`, `session.health` |
+| `linkedin.search` | Search | Universal search |
+| `linkedin.inbox.*` | Messaging | `inbox.list_threads`, `inbox.prepare_reply` |
+| `linkedin.feed.*` | Feed | `feed.list`, `feed.like`, `feed.comment` |
+| `linkedin.profile.*` | Profile | `profile.view`, `profile.prepare_update_intro` |
+| `linkedin.connections.*` | Network | `connections.list`, `connections.invite` |
+| `linkedin.jobs.*` | Jobs | `jobs.search`, `jobs.view` |
+| `linkedin.notifications.*` | Alerts | `notifications.list` |
+| `linkedin.post.*` | Publishing | `post.prepare_create` |
+| `linkedin.activity_*` | Polling | `activity_watch.create`, `activity_poller.run_once` |
+| `linkedin.actions.*` | Confirm | `actions.confirm` |
+
+## MCP Client Configuration
+
+```json
+{
+  "mcpServers": {
+    "linkedin": {
+      "command": "npm",
+      "args": ["exec", "-w", "@linkedin-buddy/mcp", "--", "linkedin-mcp"]
+    }
+  }
+}
+```
+
+## Anti-Patterns
+
+- NEVER skip input validation — always use `readString`/`readRequiredString` helpers
+- NEVER return raw errors — wrap in `toErrorResult()` with `LinkedInBuddyError`
+- NEVER forget `runtime.close()` — always use try/finally
+- Tool names follow `linkedin.<domain>.<action>` convention — never deviate
+- All tools include optional `cdpUrl` and `selectorLocale` parameters


### PR DESCRIPTION
## Summary

Generate hierarchical AGENTS.md knowledge base via deep-init, providing comprehensive AI agent instructions across the monorepo.

## Changes

- **Updated root `AGENTS.md`** (155 → 276 lines): Expanded key files tables covering all 50+ core modules, added service graph diagram, error codes table, database schema overview, CI/CD workflows, evasion & humanization section, activity polling overview
- **Created `packages/core/src/AGENTS.md`** (60 lines): Module categories with complexity metrics, where-to-look task guide, directory-specific conventions
- **Created `packages/core/src/auth/AGENTS.md`** (43 lines): Auth flow diagram, session status fields, rate limit cooldown handling
- **Created `packages/core/src/evasion/AGENTS.md`** (47 lines): Evasion level matrix, module responsibilities, math pattern documentation, configuration precedence
- **Created `packages/core/src/__tests__/AGENTS.md`** (43 lines): Test framework config, adding new tests guide, test utilities reference
- **Created `packages/core/src/__tests__/e2e/AGENTS.md`** (77 lines): Safety-critical E2E rules, write confirm opt-in flags, fixture replay guide, test safety classification table
- **Created `packages/cli/src/AGENTS.md`** (65 lines): Command pattern template, adding new commands guide, global options, output formatter conventions
- **Created `packages/mcp/src/AGENTS.md`** (89 lines): Tool handler pattern template, input validation helpers, tool categories reference, adding new tools guide

## Hierarchy

```
./AGENTS.md                              (root — 276 lines)
├── packages/core/src/AGENTS.md          (core library — 60 lines)
│   ├── packages/core/src/auth/AGENTS.md (auth domain — 43 lines)
│   └── packages/core/src/evasion/AGENTS.md (evasion domain — 47 lines)
├── packages/core/src/__tests__/AGENTS.md (test suite — 43 lines)
│   └── packages/core/src/__tests__/e2e/AGENTS.md (E2E safety — 77 lines)
├── packages/cli/src/AGENTS.md           (CLI package — 65 lines)
└── packages/mcp/src/AGENTS.md           (MCP package — 89 lines)
```

## Quality Gates

- Lint: ✅ Pass
- Tests: ✅ 1373 tests pass (112 files)
- Typecheck/Build: Pre-existing errors (same on main — module resolution requires prior build artifacts)

Closes #398
