### PR TITLE
fix: return partial success with warnings when post-action verification fails (#409)

### DIFF
--- a/packages/core/src/__tests__/twoPhaseCommitWarnings.test.ts
+++ b/packages/core/src/__tests__/twoPhaseCommitWarnings.test.ts
@@ -1,0 +1,141 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { AssistantDatabase } from "../db/database.js";
+import { ensureConfigPaths, resolveConfigPaths } from "../config.js";
+import {
+  TwoPhaseCommitService,
+  type ActionExecutor,
+  type ActionExecutorResult,
+} from "../twoPhaseCommit.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const tempDir = tempDirs.pop();
+    if (!tempDir) {
+      continue;
+    }
+
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+function createTempDb(): { db: AssistantDatabase; baseDir: string } {
+  const baseDir = mkdtempSync(
+    path.join(tmpdir(), "linkedin-2pc-warnings-"),
+  );
+  tempDirs.push(baseDir);
+  const paths = resolveConfigPaths(baseDir);
+  ensureConfigPaths(paths);
+  const db = new AssistantDatabase(paths.dbPath);
+  return { db, baseDir };
+}
+
+class WarningsExecutor implements ActionExecutor<unknown> {
+  constructor(private readonly warnings: string[]) {}
+
+  execute(): ActionExecutorResult {
+    return {
+      ok: true,
+      result: { done: true },
+      artifacts: ["trace.zip"],
+      warnings: this.warnings,
+    };
+  }
+}
+
+class NoWarningsExecutor implements ActionExecutor<unknown> {
+  execute(): ActionExecutorResult {
+    return {
+      ok: true,
+      result: { done: true },
+      artifacts: [],
+    };
+  }
+}
+
+describe("TwoPhaseCommitService warnings passthrough", () => {
+  it("passes executor warnings through to the confirm result", async () => {
+    const { db } = createTempDb();
+    const service = new TwoPhaseCommitService<unknown>(db, {
+      executors: {
+        "test.warn": new WarningsExecutor([
+          "Post verification failed after publish: timed out",
+          "Post-publish screenshot failed: page closed",
+        ]),
+      },
+      getRuntime: () => ({}),
+    });
+
+    const prepared = service.prepare({
+      actionType: "test.warn",
+      target: { profile_name: "default" },
+      payload: { text: "hello" },
+      preview: { summary: "test" },
+    });
+
+    const result = await service.confirm({
+      confirmToken: prepared.confirmToken,
+    });
+
+    expect(result.status).toBe("executed");
+    expect(result.warnings).toEqual([
+      "Post verification failed after publish: timed out",
+      "Post-publish screenshot failed: page closed",
+    ]);
+    expect(result.result).toEqual({ done: true });
+    expect(result.artifacts).toEqual(["trace.zip"]);
+  });
+
+  it("omits warnings field when executor returns no warnings", async () => {
+    const { db } = createTempDb();
+    const service = new TwoPhaseCommitService<unknown>(db, {
+      executors: {
+        "test.clean": new NoWarningsExecutor(),
+      },
+      getRuntime: () => ({}),
+    });
+
+    const prepared = service.prepare({
+      actionType: "test.clean",
+      target: { profile_name: "default" },
+      payload: { text: "hello" },
+      preview: { summary: "test" },
+    });
+
+    const result = await service.confirm({
+      confirmToken: prepared.confirmToken,
+    });
+
+    expect(result.status).toBe("executed");
+    expect(result.warnings).toBeUndefined();
+    expect(result.result).toEqual({ done: true });
+  });
+
+  it("omits warnings field when executor returns empty warnings array", async () => {
+    const { db } = createTempDb();
+    const service = new TwoPhaseCommitService<unknown>(db, {
+      executors: {
+        "test.empty": new WarningsExecutor([]),
+      },
+      getRuntime: () => ({}),
+    });
+
+    const prepared = service.prepare({
+      actionType: "test.empty",
+      target: { profile_name: "default" },
+      payload: { text: "hello" },
+      preview: { summary: "test" },
+    });
+
+    const result = await service.confirm({
+      confirmToken: prepared.confirmToken,
+    });
+
+    expect(result.status).toBe("executed");
+    expect(result.warnings).toBeUndefined();
+  });
+});

--- a/packages/core/src/linkedinPosts.ts
+++ b/packages/core/src/linkedinPosts.ts
@@ -4501,11 +4501,35 @@ class CreatePostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRu
           );
           await waitForNetworkIdleBestEffort(page, 10_000);
 
-          const verification = await verifyPublishedPost(
-            page,
-            text,
-            artifactPaths,
-          );
+          const warnings: string[] = [];
+          let verification: {
+            postUrl: string | null;
+            surface: string;
+          } = { postUrl: null, surface: "unknown" };
+          try {
+            verification = await verifyPublishedPost(
+              page,
+              text,
+              artifactPaths,
+            );
+          } catch (verifyError) {
+            const msg =
+              verifyError instanceof Error
+                ? verifyError.message
+                : String(verifyError);
+            warnings.push(
+              `Post verification failed after publish: ${msg}`,
+            );
+            runtime.logger.log(
+              "warn",
+              "linkedin.post.confirm.verification_failed",
+              {
+                action_id: action.id,
+                profile_name: profileName,
+                message: msg,
+              },
+            );
+          }
 
           let screenshotWarning: string | undefined;
           const postPublishScreenshot = `linkedin/screenshot-post-confirm-after-${Date.now()}.png`;
@@ -4539,6 +4563,12 @@ class CreatePostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRu
             );
           }
 
+          if (screenshotWarning) {
+            warnings.push(
+              `Post-publish screenshot failed: ${screenshotWarning}`,
+            );
+          }
+
           return {
             ok: true,
             result: {
@@ -4551,8 +4581,10 @@ class CreatePostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRu
               ...(screenshotWarning
                 ? { screenshot_warning: screenshotWarning }
                 : {}),
+              ...(warnings.length > 0 ? { warnings } : {}),
             },
             artifacts: artifactPaths,
+            ...(warnings.length > 0 ? { warnings } : {}),
           };
         } catch (error) {
           const failureScreenshot = `linkedin/screenshot-post-confirm-error-${Date.now()}.png`;
@@ -4752,11 +4784,35 @@ class CreateMediaPostActionExecutor implements ActionExecutor<LinkedInPostsExecu
           );
           await waitForNetworkIdleBestEffort(page, 10_000);
 
-          const verification = await verifyPublishedPost(
-            page,
-            text,
-            artifactPaths,
-          );
+          const warnings: string[] = [];
+          let verification: {
+            postUrl: string | null;
+            surface: string;
+          } = { postUrl: null, surface: "unknown" };
+          try {
+            verification = await verifyPublishedPost(
+              page,
+              text,
+              artifactPaths,
+            );
+          } catch (verifyError) {
+            const msg =
+              verifyError instanceof Error
+                ? verifyError.message
+                : String(verifyError);
+            warnings.push(
+              `Post verification failed after publish: ${msg}`,
+            );
+            runtime.logger.log(
+              "warn",
+              "linkedin.post.confirm_media.verification_failed",
+              {
+                action_id: action.id,
+                profile_name: profileName,
+                message: msg,
+              },
+            );
+          }
 
           let screenshotWarning: string | undefined;
           const postPublishScreenshot = `linkedin/screenshot-post-media-confirm-after-${Date.now()}.png`;
@@ -4792,6 +4848,12 @@ class CreateMediaPostActionExecutor implements ActionExecutor<LinkedInPostsExecu
             );
           }
 
+          if (screenshotWarning) {
+            warnings.push(
+              `Post-publish screenshot failed: ${screenshotWarning}`,
+            );
+          }
+
           return {
             ok: true,
             result: {
@@ -4807,8 +4869,10 @@ class CreateMediaPostActionExecutor implements ActionExecutor<LinkedInPostsExecu
               ...(screenshotWarning
                 ? { screenshot_warning: screenshotWarning }
                 : {}),
+              ...(warnings.length > 0 ? { warnings } : {}),
             },
             artifacts: artifactPaths,
+            ...(warnings.length > 0 ? { warnings } : {}),
           };
         } catch (error) {
           const failureScreenshot = `linkedin/screenshot-post-media-confirm-error-${Date.now()}.png`;
@@ -5028,11 +5092,35 @@ class CreatePollPostActionExecutor implements ActionExecutor<LinkedInPostsExecut
           );
           await waitForNetworkIdleBestEffort(page, 10_000);
 
-          const verification = await verifyPublishedPost(
-            page,
-            verificationText,
-            artifactPaths,
-          );
+          const warnings: string[] = [];
+          let verification: {
+            postUrl: string | null;
+            surface: string;
+          } = { postUrl: null, surface: "unknown" };
+          try {
+            verification = await verifyPublishedPost(
+              page,
+              verificationText,
+              artifactPaths,
+            );
+          } catch (verifyError) {
+            const msg =
+              verifyError instanceof Error
+                ? verifyError.message
+                : String(verifyError);
+            warnings.push(
+              `Post verification failed after publish: ${msg}`,
+            );
+            runtime.logger.log(
+              "warn",
+              "linkedin.post.confirm_poll.verification_failed",
+              {
+                action_id: action.id,
+                profile_name: profileName,
+                message: msg,
+              },
+            );
+          }
 
           let screenshotWarning: string | undefined;
           const postPublishScreenshot = `linkedin/screenshot-post-poll-confirm-after-${Date.now()}.png`;
@@ -5068,6 +5156,12 @@ class CreatePollPostActionExecutor implements ActionExecutor<LinkedInPostsExecut
             );
           }
 
+          if (screenshotWarning) {
+            warnings.push(
+              `Post-publish screenshot failed: ${screenshotWarning}`,
+            );
+          }
+
           return {
             ok: true,
             result: {
@@ -5084,8 +5178,10 @@ class CreatePollPostActionExecutor implements ActionExecutor<LinkedInPostsExecut
               ...(screenshotWarning
                 ? { screenshot_warning: screenshotWarning }
                 : {}),
+              ...(warnings.length > 0 ? { warnings } : {}),
             },
             artifacts: artifactPaths,
+            ...(warnings.length > 0 ? { warnings } : {}),
           };
         } catch (error) {
           const failureScreenshot = `linkedin/screenshot-post-poll-confirm-error-${Date.now()}.png`;
@@ -5274,12 +5370,36 @@ class EditPostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRunt
           );
           await waitForNetworkIdleBestEffort(page, 10_000);
 
-          const verification = await verifyUpdatedPostAtUrl(
-            page,
-            postUrl,
-            text,
-            artifactPaths,
-          );
+          const warnings: string[] = [];
+          let verification: {
+            postUrl: string;
+          } = { postUrl: postUrl };
+          try {
+            verification = await verifyUpdatedPostAtUrl(
+              page,
+              postUrl,
+              text,
+              artifactPaths,
+            );
+          } catch (verifyError) {
+            const msg =
+              verifyError instanceof Error
+                ? verifyError.message
+                : String(verifyError);
+            warnings.push(
+              `Post edit verification failed after save: ${msg}`,
+            );
+            runtime.logger.log(
+              "warn",
+              "linkedin.post.confirm_edit.verification_failed",
+              {
+                action_id: action.id,
+                profile_name: profileName,
+                post_url: postUrl,
+                message: msg,
+              },
+            );
+          }
 
           let screenshotWarning: string | undefined;
           const postSaveScreenshot = `linkedin/screenshot-post-edit-confirm-after-${Date.now()}.png`;
@@ -5308,6 +5428,12 @@ class EditPostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRunt
             );
           }
 
+          if (screenshotWarning) {
+            warnings.push(
+              `Post-save screenshot failed: ${screenshotWarning}`,
+            );
+          }
+
           return {
             ok: true,
             result: {
@@ -5318,8 +5444,10 @@ class EditPostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRunt
               ...(screenshotWarning
                 ? { screenshot_warning: screenshotWarning }
                 : {}),
+              ...(warnings.length > 0 ? { warnings } : {}),
             },
             artifacts: artifactPaths,
+            ...(warnings.length > 0 ? { warnings } : {}),
           };
         } catch (error) {
           const failureScreenshot = `linkedin/screenshot-post-edit-confirm-error-${Date.now()}.png`;
@@ -5478,12 +5606,36 @@ class DeletePostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRu
           }
           await waitForNetworkIdleBestEffort(page, 10_000);
 
-          const verification = await verifyDeletedPostAtUrl(
-            page,
-            postUrl,
-            currentSnippet,
-            artifactPaths,
-          );
+          const warnings: string[] = [];
+          let verification: {
+            postUrl: string;
+          } = { postUrl: postUrl };
+          try {
+            verification = await verifyDeletedPostAtUrl(
+              page,
+              postUrl,
+              currentSnippet,
+              artifactPaths,
+            );
+          } catch (verifyError) {
+            const msg =
+              verifyError instanceof Error
+                ? verifyError.message
+                : String(verifyError);
+            warnings.push(
+              `Post deletion verification failed after delete: ${msg}`,
+            );
+            runtime.logger.log(
+              "warn",
+              "linkedin.post.confirm_delete.verification_failed",
+              {
+                action_id: action.id,
+                profile_name: profileName,
+                post_url: postUrl,
+                message: msg,
+              },
+            );
+          }
 
           let screenshotWarning: string | undefined;
           const postDeleteScreenshot = `linkedin/screenshot-post-delete-confirm-after-${Date.now()}.png`;
@@ -5513,6 +5665,12 @@ class DeletePostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRu
             );
           }
 
+          if (screenshotWarning) {
+            warnings.push(
+              `Post-delete screenshot failed: ${screenshotWarning}`,
+            );
+          }
+
           return {
             ok: true,
             result: {
@@ -5523,8 +5681,10 @@ class DeletePostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRu
               ...(screenshotWarning
                 ? { screenshot_warning: screenshotWarning }
                 : {}),
+              ...(warnings.length > 0 ? { warnings } : {}),
             },
             artifacts: artifactPaths,
+            ...(warnings.length > 0 ? { warnings } : {}),
           };
         } catch (error) {
           const failureScreenshot = `linkedin/screenshot-post-delete-confirm-error-${Date.now()}.png`;

--- a/packages/core/src/twoPhaseCommit.ts
+++ b/packages/core/src/twoPhaseCommit.ts
@@ -86,6 +86,12 @@ export interface ActionExecutorResult {
   ok: true;
   result: Record<string, unknown>;
   artifacts: string[];
+  /**
+   * Non-fatal warnings from post-execution steps (e.g. verification, screenshot).
+   * When present, the core action succeeded but ancillary steps failed.
+   * Callers should treat the action as successful and NOT retry.
+   */
+  warnings?: string[];
 }
 
 export interface ActionExecutorInput<TRuntime> {
@@ -129,6 +135,8 @@ export interface ConfirmByTokenResult {
   actionType: string;
   result: Record<string, unknown>;
   artifacts: string[];
+  /** Non-fatal warnings from post-execution steps. Action succeeded; do not retry. */
+  warnings?: string[];
 }
 
 export interface PreparedActionPreview {
@@ -519,7 +527,10 @@ export class TwoPhaseCommitService<TRuntime = unknown> {
       status: "executed",
       actionType: action.actionType,
       result: executionResult.result,
-      artifacts: executionResult.artifacts
+      artifacts: executionResult.artifacts,
+      ...(executionResult.warnings && executionResult.warnings.length > 0
+        ? { warnings: executionResult.warnings }
+        : {})
     };
   }
 }


### PR DESCRIPTION
## Summary

Fixes the bug where rate limit counters are consumed when `post confirm` crashes after the core action (publish/edit/delete) has already succeeded. Callers now receive a success result with warnings instead of an error, preventing unnecessary retries of actions that already went through.

**Implements Option 2** from the issue: distinguish partial success so callers know the action succeeded even if non-critical steps (verification, screenshots) failed.

## Changes

### Framework (`twoPhaseCommit.ts`)
- Add optional `warnings?: string[]` field to `ActionExecutorResult` and `ConfirmByTokenResult` interfaces
- `confirmByToken()` passes executor warnings through to the caller when present

### Post Executors (`linkedinPosts.ts`) — all 5 action executors
- **CreatePostActionExecutor**: wrap `verifyPublishedPost()` in try/catch → warning
- **CreateMediaPostActionExecutor**: same pattern
- **CreatePollPostActionExecutor**: same pattern
- **EditPostActionExecutor**: wrap `verifyUpdatedPostAtUrl()` → warning
- **DeletePostActionExecutor**: wrap `verifyDeletedPostAtUrl()` → warning
- Consolidate existing `screenshotWarning` into the unified `warnings` array

### Tests (`twoPhaseCommitWarnings.test.ts`)
- Executor warnings flow through `confirmByToken()` result
- Empty/missing warnings omit the field entirely
- 3 new unit tests, all passing

## Before → After

**Before:** Post published → verification fails → executor throws → action marked "failed" → rate limit consumed → next prepare blocked

**After:** Post published → verification fails → warning logged → executor returns `{ ok: true, warnings: [...] }` → action marked "executed" → caller sees success + warnings → no retry needed

## Quality Gates
- ✅ TypeScript: clean
- ✅ ESLint: clean
- ✅ Tests: 1418/1418 passing
- ✅ Build: clean

Closes #409
