### PR TITLE
feat: add actions list and actions show CLI commands (#411)

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -30,6 +30,7 @@ import {
   AssistantDatabase,
   alignToBusinessHours,
   asLinkedInBuddyError,
+  computeEffectiveStatus,
   exportSessionState,
   hasLinkedInSessionToken,
   importSessionState,
@@ -44,6 +45,7 @@ import {
   FEEDBACK_TYPES,
   formatFeedbackDisplayPath,
   getLinkedInSelectorLocaleConfigWarning,
+  isPreparedActionEffectiveStatus,
   isSearchCategory,
   isInRateLimitCooldown,
   isLinkedInFixtureReplayUrl,
@@ -56,6 +58,7 @@ import {
   LINKEDIN_PRIVACY_SETTING_KEYS,
   LINKEDIN_SELECTOR_LOCALES,
   LINKEDIN_WRITE_VALIDATION_ACTIONS,
+  PREPARED_ACTION_EFFECTIVE_STATUSES,
   SEARCH_CATEGORIES,
   LinkedInBuddyError,
   LinkedInSchedulerService,
@@ -113,6 +116,7 @@ import {
   type LinkedInReadOnlyValidationOperation,
   type LinkedInReplayPageType,
   type LocalDataDeletionFailure,
+  type PreparedActionEffectiveStatus,
   type ReadOnlyValidationReport,
   type SchedulerConfig,
   type SchedulerJobRow,
@@ -346,6 +350,17 @@ function coerceProfileName(value: string, label: string = "profile"): string {
   }
 
   return normalized;
+}
+
+function coerceActionStatus(value: string): PreparedActionEffectiveStatus {
+  if (isPreparedActionEffectiveStatus(value)) {
+    return value;
+  }
+
+  throw new LinkedInBuddyError(
+    "ACTION_PRECONDITION_FAILED",
+    `status must be one of: ${PREPARED_ACTION_EFFECTIVE_STATUSES.join(", ")}.`,
+  );
 }
 
 function printJson(value: unknown): void {
@@ -8565,6 +8580,75 @@ async function runDraftQualityAudit(input: {
   }
 }
 
+async function runActionsList(
+  input: {
+    status?: PreparedActionEffectiveStatus;
+    limit: number;
+  },
+  cdpUrl?: string,
+): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.actions.list.start", {
+      ...(input.status ? { status: input.status } : {}),
+      limit: input.limit,
+    });
+
+    const actions = runtime.twoPhaseCommit.listPreparedActions({
+      ...(input.status ? { status: input.status } : {}),
+      limit: input.limit,
+    });
+
+    runtime.logger.log("info", "cli.actions.list.done", {
+      count: actions.length,
+      ...(input.status ? { status: input.status } : {}),
+      limit: input.limit,
+    });
+
+    printJson({
+      run_id: runtime.runId,
+      count: actions.length,
+      actions,
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function runActionsShow(
+  input: {
+    id: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.actions.show.start", {
+      id: input.id,
+    });
+
+    const action = runtime.twoPhaseCommit.getPreparedAction(input.id);
+    const effectiveStatus = computeEffectiveStatus(action.status, action.expiresAtMs);
+
+    runtime.logger.log("info", "cli.actions.show.done", {
+      id: action.id,
+      effectiveStatus,
+    });
+
+    printJson({
+      run_id: runtime.runId,
+      action: {
+        ...action,
+        effectiveStatus,
+      },
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
 function readTargetProfileName(
   target: Record<string, unknown>,
 ): string | undefined {
@@ -12017,6 +12101,43 @@ export function createCliProgram(): Command {
             profileName: options.profile,
             token: options.token,
             yes: options.yes,
+          },
+          readCdpUrl(),
+        );
+      },
+    );
+
+  actionsCommand
+    .command("list")
+    .description("List prepared actions")
+    .option(
+      "--status <status>",
+      `Filter by effective status: ${PREPARED_ACTION_EFFECTIVE_STATUSES.join(", ")}`,
+    )
+    .option("-l, --limit <limit>", "Max actions to show", "20")
+    .action(
+      async (options: { status?: string; limit: string }) => {
+        await runActionsList(
+          {
+            limit: coercePositiveInt(options.limit, "limit"),
+            ...(options.status
+              ? { status: coerceActionStatus(options.status) }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
+    );
+
+  actionsCommand
+    .command("show")
+    .description("Show details of a prepared action")
+    .requiredOption("--id <id>", "Prepared action ID (pa_...)")
+    .action(
+      async (options: { id: string }) => {
+        await runActionsShow(
+          {
+            id: options.id,
           },
           readCdpUrl(),
         );

--- a/packages/core/src/__tests__/actionsListShow.test.ts
+++ b/packages/core/src/__tests__/actionsListShow.test.ts
@@ -1,0 +1,235 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ensureConfigPaths, resolveConfigPaths } from "../config.js";
+import { AssistantDatabase } from "../db/database.js";
+import {
+  TwoPhaseCommitService,
+  computeEffectiveStatus,
+} from "../twoPhaseCommit.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const tempDir = tempDirs.pop();
+    if (!tempDir) {
+      continue;
+    }
+
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+function createTempDb(): { db: AssistantDatabase; baseDir: string } {
+  const baseDir = mkdtempSync(path.join(tmpdir(), "linkedin-actions-list-"));
+  tempDirs.push(baseDir);
+  const paths = resolveConfigPaths(baseDir);
+  ensureConfigPaths(paths);
+  const db = new AssistantDatabase(paths.dbPath);
+  return { db, baseDir };
+}
+
+describe("computeEffectiveStatus", () => {
+  const now = Date.now();
+
+  it("returns 'confirmed' for executed actions", () => {
+    expect(computeEffectiveStatus("executed", now + 10_000, now)).toBe("confirmed");
+  });
+
+  it("returns 'failed' for failed actions", () => {
+    expect(computeEffectiveStatus("failed", now + 10_000, now)).toBe("failed");
+  });
+
+  it("returns 'prepared' for prepared actions that are not expired", () => {
+    expect(computeEffectiveStatus("prepared", now + 10_000, now)).toBe("prepared");
+  });
+
+  it("returns 'expired' for prepared actions past expiry", () => {
+    expect(computeEffectiveStatus("prepared", now - 1_000, now)).toBe("expired");
+  });
+});
+
+describe("TwoPhaseCommitService.listPreparedActions", () => {
+  it("returns empty list when no actions exist", () => {
+    const { db } = createTempDb();
+    const service = new TwoPhaseCommitService(db);
+    const result = service.listPreparedActions({ limit: 10 });
+    expect(result).toEqual([]);
+  });
+
+  it("lists prepared actions ordered by created_at DESC", () => {
+    const { db } = createTempDb();
+    const service = new TwoPhaseCommitService(db);
+
+    service.prepare({
+      actionType: "test.first",
+      target: { profile_name: "default" },
+      payload: { text: "first" },
+      preview: { summary: "First action" },
+    });
+    service.prepare({
+      actionType: "test.second",
+      target: { profile_name: "default" },
+      payload: { text: "second" },
+      preview: { summary: "Second action" },
+    });
+
+    const result = service.listPreparedActions({ limit: 10 });
+    expect(result).toHaveLength(2);
+    expect(result[0]!.actionType).toBe("test.second");
+    expect(result[1]!.actionType).toBe("test.first");
+  });
+
+  it("respects limit parameter", () => {
+    const { db } = createTempDb();
+    const service = new TwoPhaseCommitService(db);
+
+    for (let i = 0; i < 5; i++) {
+      service.prepare({
+        actionType: `test.action${i}`,
+        target: { profile_name: "default" },
+        payload: { text: `action ${i}` },
+        preview: { summary: `Action ${i}` },
+      });
+    }
+
+    const result = service.listPreparedActions({ limit: 3 });
+    expect(result).toHaveLength(3);
+  });
+
+  it("filters by effective status 'prepared'", () => {
+    const { db } = createTempDb();
+    const service = new TwoPhaseCommitService(db);
+    const nowMs = Date.now();
+
+    service.prepare({
+      actionType: "test.valid",
+      target: { profile_name: "default" },
+      payload: { text: "valid" },
+      preview: { summary: "Valid action" },
+      nowMs,
+    });
+
+    service.prepare({
+      actionType: "test.expired",
+      target: { profile_name: "default" },
+      payload: { text: "expired" },
+      preview: { summary: "Expired action" },
+      expiresInMs: 1,
+      nowMs: nowMs - 10_000,
+    });
+
+    const result = service.listPreparedActions({
+      status: "prepared",
+      limit: 10,
+      nowMs,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]!.actionType).toBe("test.valid");
+    expect(result[0]!.effectiveStatus).toBe("prepared");
+  });
+
+  it("filters by effective status 'expired'", () => {
+    const { db } = createTempDb();
+    const service = new TwoPhaseCommitService(db);
+    const nowMs = Date.now();
+
+    service.prepare({
+      actionType: "test.valid",
+      target: { profile_name: "default" },
+      payload: { text: "valid" },
+      preview: { summary: "Valid action" },
+      nowMs,
+    });
+
+    service.prepare({
+      actionType: "test.expired",
+      target: { profile_name: "default" },
+      payload: { text: "expired" },
+      preview: { summary: "Expired action" },
+      expiresInMs: 1,
+      nowMs: nowMs - 10_000,
+    });
+
+    const result = service.listPreparedActions({
+      status: "expired",
+      limit: 10,
+      nowMs,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]!.actionType).toBe("test.expired");
+    expect(result[0]!.effectiveStatus).toBe("expired");
+  });
+
+  it("filters by effective status 'confirmed'", async () => {
+    const { db } = createTempDb();
+    const service = new TwoPhaseCommitService(db, {
+      executors: {
+        "test.echo": {
+          execute() {
+            return { ok: true, result: { done: true }, artifacts: [] };
+          },
+        },
+      },
+      getRuntime: () => ({}),
+    });
+
+    const prepared = service.prepare({
+      actionType: "test.echo",
+      target: { profile_name: "default" },
+      payload: { text: "hello" },
+      preview: { summary: "Test" },
+    });
+    await service.confirmByToken({ confirmToken: prepared.confirmToken });
+
+    service.prepare({
+      actionType: "test.echo",
+      target: { profile_name: "default" },
+      payload: { text: "pending" },
+      preview: { summary: "Pending" },
+    });
+
+    const result = service.listPreparedActions({ status: "confirmed", limit: 10 });
+    expect(result).toHaveLength(1);
+    expect(result[0]!.effectiveStatus).toBe("confirmed");
+  });
+});
+
+describe("TwoPhaseCommitService.getPreparedAction", () => {
+  it("returns a prepared action by ID", () => {
+    const { db } = createTempDb();
+    const service = new TwoPhaseCommitService(db);
+
+    const prepared = service.prepare({
+      actionType: "test.show",
+      target: { profile_name: "default" },
+      payload: { text: "hello" },
+      preview: { summary: "Show test" },
+    });
+
+    const action = service.getPreparedAction(prepared.preparedActionId);
+    expect(action.id).toBe(prepared.preparedActionId);
+    expect(action.actionType).toBe("test.show");
+    expect(action.status).toBe("prepared");
+    expect(action.preview).toEqual({ summary: "Show test" });
+  });
+
+  it("throws TARGET_NOT_FOUND for missing action", () => {
+    const { db } = createTempDb();
+    const service = new TwoPhaseCommitService(db);
+
+    expect(() => service.getPreparedAction("pa_nonexistent")).toThrow(
+      /Prepared action not found/,
+    );
+  });
+});
+
+describe("AssistantDatabase.listPreparedActions", () => {
+  it("returns empty array when table is empty", () => {
+    const { db } = createTempDb();
+    const result = db.listPreparedActions(10);
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/core/src/db/database.ts
+++ b/packages/core/src/db/database.ts
@@ -842,6 +842,20 @@ LIMIT 1
       .get(confirmTokenHash);
   }
 
+  listPreparedActions(limit: number): PreparedActionRow[] {
+    return this.db
+      .prepare<unknown[], PreparedActionRow>(
+        `
+SELECT
+${PREPARED_ACTION_SELECT_COLUMNS}
+FROM prepared_action
+ORDER BY created_at DESC
+LIMIT ?
+`
+      )
+      .all(limit);
+  }
+
   listRunLogs(runId: string): RunLogRow[] {
     return this.db
       .prepare<unknown[], RunLogRow>(

--- a/packages/core/src/twoPhaseCommit.ts
+++ b/packages/core/src/twoPhaseCommit.ts
@@ -149,6 +149,45 @@ export interface PreparedActionPreview {
   operatorNote: string | null;
 }
 
+export type PreparedActionEffectiveStatus =
+  | "prepared"
+  | "confirmed"
+  | "expired"
+  | "failed";
+
+export const PREPARED_ACTION_EFFECTIVE_STATUSES: readonly PreparedActionEffectiveStatus[] = [
+  "prepared",
+  "confirmed",
+  "expired",
+  "failed"
+] as const;
+
+export function isPreparedActionEffectiveStatus(
+  value: string
+): value is PreparedActionEffectiveStatus {
+  return (PREPARED_ACTION_EFFECTIVE_STATUSES as readonly string[]).includes(value);
+}
+
+export interface ListPreparedActionsInput {
+  status?: PreparedActionEffectiveStatus;
+  limit?: number;
+  nowMs?: number;
+}
+
+export interface PreparedActionSummary {
+  id: string;
+  actionType: string;
+  effectiveStatus: PreparedActionEffectiveStatus;
+  createdAtMs: number;
+  expiresAtMs: number;
+  confirmedAtMs: number | null;
+  executedAtMs: number | null;
+  operatorNote: string | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+  preview: Record<string, unknown>;
+}
+
 export interface TwoPhaseCommitServiceOptions<TRuntime> {
   executors?: ActionExecutorRegistry<TRuntime>;
   getRuntime?: () => TRuntime;
@@ -169,6 +208,23 @@ export function hashJsonPayload(json: string): string {
 
 export function isTokenExpired(expiresAtMs: number, nowMs: number = Date.now()): boolean {
   return nowMs > expiresAtMs;
+}
+
+export function computeEffectiveStatus(
+  dbStatus: string,
+  expiresAtMs: number,
+  nowMs: number = Date.now()
+): PreparedActionEffectiveStatus {
+  if (dbStatus === "executed") {
+    return "confirmed";
+  }
+  if (dbStatus === "failed") {
+    return "failed";
+  }
+  if (isTokenExpired(expiresAtMs, nowMs)) {
+    return "expired";
+  }
+  return "prepared";
 }
 
 function parseJsonObject(
@@ -423,6 +479,51 @@ export class TwoPhaseCommitService<TRuntime = unknown> {
       target: action.target,
       operatorNote: action.operatorNote
     };
+  }
+
+  listPreparedActions(input: ListPreparedActionsInput = {}): PreparedActionSummary[] {
+    const limit = input.limit ?? 20;
+    const nowMs = input.nowMs ?? Date.now();
+    const fetchLimit = input.status ? limit * 5 : limit;
+    const rows = this.db.listPreparedActions(fetchLimit);
+
+    const mapped: PreparedActionSummary[] = [];
+    for (const row of rows) {
+      const effectiveStatus = computeEffectiveStatus(row.status, row.expires_at, nowMs);
+      if (input.status && effectiveStatus !== input.status) {
+        continue;
+      }
+      mapped.push({
+        id: row.id,
+        actionType: row.action_type,
+        effectiveStatus,
+        createdAtMs: row.created_at,
+        expiresAtMs: row.expires_at,
+        confirmedAtMs: row.confirmed_at,
+        executedAtMs: row.executed_at,
+        operatorNote: row.operator_note,
+        errorCode: row.error_code,
+        errorMessage: row.error_message,
+        preview: parseJsonObject("preview_json", row.preview_json, row.id)
+      });
+      if (mapped.length >= limit) {
+        break;
+      }
+    }
+
+    return mapped;
+  }
+
+  getPreparedAction(id: string): PreparedAction {
+    const row = this.db.getPreparedActionById(id);
+    if (!row) {
+      throw new LinkedInBuddyError(
+        "TARGET_NOT_FOUND",
+        `Prepared action not found: ${id}`,
+        { action_id: id }
+      );
+    }
+    return mapPreparedActionRow(row);
   }
 
   async confirm(input: ConfirmByTokenInput): Promise<ConfirmByTokenResult> {


### PR DESCRIPTION
## Summary

Add `linkedin actions list` and `linkedin actions show` CLI commands to inspect prepared actions in the two-phase commit database.

- **`actions list`** — lists prepared actions with optional `--status` filter (prepared, confirmed, expired, failed) and `--limit`
- **`actions show`** — displays full details of a specific prepared action by `--id`

## Changes

### Core: Database (`packages/core/src/db/database.ts`)
- Add `listPreparedActions(limit)` method — queries `prepared_action` table ordered by `created_at DESC`

### Core: Two-Phase Commit Service (`packages/core/src/twoPhaseCommit.ts`)
- Add `PreparedActionEffectiveStatus` type and `PREPARED_ACTION_EFFECTIVE_STATUSES` constant
- Add `computeEffectiveStatus()` — maps DB status to user-facing status:
  - `prepared` → prepared (not expired)
  - `prepared` + expired → `expired`
  - `executed` → `confirmed`
  - `failed` → `failed`
- Add `listPreparedActions()` and `getPreparedAction()` service methods

### CLI (`packages/cli/src/bin/linkedin.ts`)
- Add `runActionsList()` and `runActionsShow()` handler functions
- Wire up `actions list` and `actions show` subcommands with options
- Add `coerceActionStatus()` validation helper

### Tests (`packages/core/src/__tests__/actionsListShow.test.ts`)
- 13 unit tests covering: effective status computation, list ordering, limit, all 4 status filters, show by ID, and error handling

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` ✅ (1431 tests, including 13 new)
- `npm run build` ✅
- Manual QA: tested all commands against real SQLite data with prepared/confirmed/expired/failed actions

Closes #411
