### PR TITLE
feat: `feed list` --mine flag for own-posts filtering (#412)

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -6109,6 +6109,7 @@ async function runFeedList(
   input: {
     profileName: string;
     limit: number;
+    mine: boolean;
   },
   cdpUrl?: string,
 ): Promise<void> {
@@ -6118,22 +6119,26 @@ async function runFeedList(
     runtime.logger.log("info", "cli.feed.list.start", {
       profileName: input.profileName,
       limit: input.limit,
+      mine: input.mine,
     });
 
     const posts = await runtime.feed.viewFeed({
       profileName: input.profileName,
       limit: input.limit,
+      mine: input.mine,
     });
 
     runtime.logger.log("info", "cli.feed.list.done", {
       profileName: input.profileName,
       count: posts.length,
+      mine: input.mine,
     });
 
     printJson({
       run_id: runtime.runId,
       profile_name: input.profileName,
       count: posts.length,
+      mine: input.mine,
       posts,
     });
   } finally {
@@ -10835,15 +10840,22 @@ export function createCliProgram(): Command {
     .description("List posts from your LinkedIn feed")
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("-l, --limit <limit>", "Max posts to return", "10")
-    .action(async (options: { profile: string; limit: string }) => {
-      await runFeedList(
-        {
-          profileName: options.profile,
-          limit: coercePositiveInt(options.limit, "limit"),
-        },
-        readCdpUrl(),
-      );
-    });
+    .option(
+      "-m, --mine",
+      "Show only your own posts (navigates to your activity page)",
+    )
+    .action(
+      async (options: { profile: string; limit: string; mine?: true }) => {
+        await runFeedList(
+          {
+            profileName: options.profile,
+            limit: coercePositiveInt(options.limit, "limit"),
+            mine: options.mine === true,
+          },
+          readCdpUrl(),
+        );
+      },
+    );
 
   feedCommand
     .command("view")

--- a/packages/core/src/__tests__/linkedinFeed.test.ts
+++ b/packages/core/src/__tests__/linkedinFeed.test.ts
@@ -11,7 +11,8 @@ import {
   SHARE_POST_ACTION_TYPE,
   UNSAVE_POST_ACTION_TYPE,
   createFeedActionExecutors,
-  normalizeLinkedInFeedReaction
+  normalizeLinkedInFeedReaction,
+  type ViewFeedInput
 } from "../linkedinFeed.js";
 
 describe("Feed action type constants", () => {
@@ -211,5 +212,35 @@ describe("reaction mapping", () => {
     expect(() => normalizeLinkedInFeedReaction("rocket")).toThrow(
       "reaction must be one of"
     );
+  });
+});
+
+describe("ViewFeedInput.mine", () => {
+  it("accepts mine flag in input", () => {
+    const input: ViewFeedInput = { mine: true, limit: 5 };
+    expect(input.mine).toBe(true);
+  });
+
+  it("defaults mine to undefined when omitted", () => {
+    const input: ViewFeedInput = { limit: 10 };
+    expect(input.mine).toBeUndefined();
+  });
+
+  it("accepts mine=false explicitly", () => {
+    const input: ViewFeedInput = { mine: false };
+    expect(input.mine).toBe(false);
+  });
+
+  it("accepts full input with mine, profile, and limit", () => {
+    const input: ViewFeedInput = {
+      profileName: "test-profile",
+      limit: 20,
+      mine: true,
+    };
+    expect(input).toEqual({
+      profileName: "test-profile",
+      limit: 20,
+      mine: true,
+    });
   });
 });

--- a/packages/core/src/linkedinFeed.ts
+++ b/packages/core/src/linkedinFeed.ts
@@ -60,6 +60,7 @@ export interface LinkedInFeedPost {
 export interface ViewFeedInput {
   profileName?: string;
   limit?: number;
+  mine?: boolean;
 }
 
 export interface ViewPostInput {
@@ -131,6 +132,8 @@ export interface LinkedInFeedRuntime extends LinkedInFeedExecutorRuntime {
 }
 
 const LINKEDIN_FEED_URL = "https://www.linkedin.com/feed/";
+const LINKEDIN_MY_ACTIVITY_URL =
+  "https://www.linkedin.com/in/me/recent-activity/all/";
 export const LIKE_POST_ACTION_TYPE = "feed.like_post";
 export const COMMENT_ON_POST_ACTION_TYPE = "feed.comment_on_post";
 export const REPOST_POST_ACTION_TYPE = "feed.repost_post";
@@ -3411,6 +3414,8 @@ export class LinkedInFeedService {
   async viewFeed(input: ViewFeedInput = {}): Promise<LinkedInFeedPost[]> {
     const profileName = input.profileName ?? "default";
     const limit = readFeedLimit(input.limit);
+    const mine = input.mine === true;
+    const targetUrl = mine ? LINKEDIN_MY_ACTIVITY_URL : LINKEDIN_FEED_URL;
 
     await this.runtime.auth.ensureAuthenticated({
       profileName,
@@ -3426,7 +3431,7 @@ export class LinkedInFeedService {
         },
         async (context) => {
           const page = await getOrCreatePage(context);
-          await page.goto(LINKEDIN_FEED_URL, { waitUntil: "domcontentloaded" });
+          await page.goto(targetUrl, { waitUntil: "domcontentloaded" });
           await waitForFeedSurface(page);
           const posts = await loadFeedPosts(page, limit);
           return posts.slice(0, limit);
@@ -3439,7 +3444,9 @@ export class LinkedInFeedService {
       throw asLinkedInBuddyError(
         error,
         "UNKNOWN",
-        "Failed to view LinkedIn feed.",
+        mine
+          ? "Failed to view your LinkedIn activity."
+          : "Failed to view LinkedIn feed.",
       );
     }
   }

--- a/packages/mcp/src/bin/linkedin-mcp.ts
+++ b/packages/mcp/src/bin/linkedin-mcp.ts
@@ -3124,26 +3124,31 @@ async function handleFeedList(args: ToolArgs): Promise<ToolResult> {
   try {
     const profileName = readString(args, "profileName", "default");
     const limit = readPositiveNumber(args, "limit", 10);
+    const mine = readBoolean(args, "mine", false);
 
     runtime.logger.log("info", "mcp.feed.list.start", {
       profileName,
       limit,
+      mine,
     });
 
     const posts = await runtime.feed.viewFeed({
       profileName,
       limit,
+      mine,
     });
 
     runtime.logger.log("info", "mcp.feed.list.done", {
       profileName,
       count: posts.length,
+      mine,
     });
 
     return toToolResult({
       run_id: runtime.runId,
       profile_name: profileName,
       count: posts.length,
+      mine,
       posts,
     });
   } finally {
@@ -5785,7 +5790,7 @@ export const LINKEDIN_MCP_TOOL_DEFINITIONS: LinkedInMcpToolDefinition[] = [
   {
     name: LINKEDIN_FEED_LIST_TOOL,
     description: withSelectorAuditHint(
-      "List posts from your LinkedIn feed with author, text, and engagement counts.",
+      "List posts from your LinkedIn feed with author, text, and engagement counts. Set mine=true to show only your own posts (navigates to your activity page instead of the algorithmic feed).",
     ),
     inputSchema: {
       type: "object",
@@ -5800,6 +5805,11 @@ export const LINKEDIN_MCP_TOOL_DEFINITIONS: LinkedInMcpToolDefinition[] = [
           type: "number",
           description:
             "Maximum number of feed posts to return. Defaults to 10.",
+        },
+        mine: {
+          type: "boolean",
+          description:
+            "When true, list only your own posts by navigating to your activity page instead of the algorithmic feed. Useful for post-publish verification. Defaults to false.",
         },
       }),
     },


### PR DESCRIPTION
## Summary

Add `--mine` flag to `feed list` command that navigates to the authenticated user's activity page (`/in/me/recent-activity/all/`) instead of the algorithmic feed. This enables reliable post-publish verification — the algorithmic feed may not include the user's own recent posts, especially for new/low-activity accounts.

## Changes

- **Core** (`linkedinFeed.ts`): Add `mine?: boolean` to `ViewFeedInput` interface; when set, `viewFeed()` navigates to the user's activity page instead of `/feed/`
- **CLI** (`linkedin.ts`): Add `-m, --mine` flag to `feed list` command; pass through to `viewFeed()`
- **MCP** (`linkedin-mcp.ts`): Add `mine` boolean parameter to `linkedin.feed.list` tool handler and schema
- **Tests** (`linkedinFeed.test.ts`): Add unit tests verifying `ViewFeedInput.mine` type acceptance

## Usage

```bash
# CLI
linkedin feed list --mine [--limit 10]

# MCP
{ "tool": "linkedin.feed.list", "args": { "mine": true, "limit": 10 } }

# TypeScript API
runtime.feed.viewFeed({ mine: true, limit: 10 })
```

## QA

- Typecheck: clean (`tsc -b --force`)
- Lint: clean (`eslint .`)
- Tests: 1435/1435 pass (116 test files)
- Build: clean
- Manual: verified `--mine` flag appears in `feed list --help`

Closes #412
