### PR TITLE
feat: suggest --yes flag in non-interactive confirm errors (#413)

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -7232,7 +7232,7 @@ async function runProfileApplySpec(
       if (!stdin.isTTY || !stdout.isTTY) {
         throw new LinkedInBuddyError(
           "ACTION_PRECONDITION_FAILED",
-          "Refusing to apply a profile seed spec without --yes in non-interactive mode.",
+          "Refusing to apply a profile seed spec in non-interactive mode. Add --yes to bypass interactive confirmation.",
         );
       }
 
@@ -7386,7 +7386,7 @@ async function runSeedActivity(
       if (!stdin.isTTY || !stdout.isTTY) {
         throw new LinkedInBuddyError(
           "ACTION_PRECONDITION_FAILED",
-          "Refusing to apply an activity seed spec without --yes in non-interactive mode.",
+          "Refusing to apply an activity seed spec in non-interactive mode. Add --yes to bypass interactive confirmation.",
         );
       }
 
@@ -8739,7 +8739,7 @@ async function runConfirmAction(
       if (!stdin.isTTY || !stdout.isTTY) {
         throw new LinkedInBuddyError(
           "ACTION_PRECONDITION_FAILED",
-          "Refusing to confirm action without --yes in non-interactive mode.",
+          "Refusing to confirm action in non-interactive mode. Add --yes to bypass interactive confirmation.",
         );
       }
 

--- a/packages/core/src/__tests__/e2eConfirmContracts.test.ts
+++ b/packages/core/src/__tests__/e2eConfirmContracts.test.ts
@@ -144,7 +144,7 @@ describe("CLI confirm contract hardening", () => {
     expect(result.error).toBeDefined();
     expect(getLastJsonObject(result.stderr)).toMatchObject({
       code: "ACTION_PRECONDITION_FAILED",
-      message: expect.stringContaining("without --yes")
+      message: expect.stringContaining("Add --yes to bypass")
     });
     expect(readPreparedActionStatus(assistantHome, prepared.preparedActionId)).toBe(
       "prepared"


### PR DESCRIPTION
## Summary

Non-interactive error messages now include actionable guidance telling callers to add `--yes` to bypass interactive confirmation, reducing round-trips for agent/automation callers.

## Changes

- **`actions confirm`**: `"Refusing to confirm action in non-interactive mode. Add --yes to bypass interactive confirmation."`
- **`profile apply-spec`**: Same pattern applied to profile seed spec confirmation
- **`seed activity`**: Same pattern applied to activity seed spec confirmation
- **Test update**: `e2eConfirmContracts.test.ts` assertion updated to match new message format

### Before
```
Refusing to confirm action without --yes in non-interactive mode.
```

### After
```
Refusing to confirm action in non-interactive mode. Add --yes to bypass interactive confirmation.
```

## Quality Gates

- ✅ Lint: clean
- ✅ Tests: 118 files, 1452 tests pass
- ✅ Typecheck/Build: pre-existing errors only (same as main)

Closes #413
