### PR TITLE
fix: enable blank issue template (#417)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Security vulnerability
     url: https://github.com/sigvardt/linkedin-buddy/security/advisories/new


### PR DESCRIPTION
## Summary

Enables the "blank issue" option in the GitHub issue template chooser by setting `blank_issues_enabled: true` in `.github/ISSUE_TEMPLATE/config.yml`.

Previously, users were forced to pick from the predefined templates (bug report, feature request, question) and could not open a free-form blank issue. This was reported in the screenshot attached to #417.

## Changes

- `.github/ISSUE_TEMPLATE/config.yml`: `blank_issues_enabled: false` → `true`

Closes #417
