### PR TITLE
fix #426: wait for 'Add to profile' dialog content before returning

### DIFF
--- a/packages/core/src/linkedinProfile.ts
+++ b/packages/core/src/linkedinProfile.ts
@@ -4144,6 +4144,50 @@ async function openIntroEditSurface(
   );
 }
 
+// Threshold ≥ 2: the dialog shell always has at least a dismiss button, so
+// we need 2+ interactive elements to confirm section entries have loaded.
+const ADD_SECTION_DIALOG_MIN_INTERACTIVE_ELEMENTS = 2;
+
+// LinkedIn fetches section list asynchronously — shell (title + spinner)
+// appears well before buttons render, so we allow up to 15s for content.
+const ADD_SECTION_DIALOG_CONTENT_TIMEOUT_MS = 15_000;
+const ADD_SECTION_DIALOG_POLL_INTERVAL_MS = 250;
+
+async function waitForAddSectionDialogContent(
+  dialog: Locator,
+  timeoutMs: number = ADD_SECTION_DIALOG_CONTENT_TIMEOUT_MS
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  const interactiveSelector = "button, a, [role='button'], li";
+
+  while (Date.now() < deadline) {
+    const elements = dialog.locator(interactiveSelector);
+    let visibleCount = 0;
+
+    const total = await elements.count().catch(() => 0);
+    for (let i = 0; i < total && visibleCount < ADD_SECTION_DIALOG_MIN_INTERACTIVE_ELEMENTS; i += 1) {
+      if (await elements.nth(i).isVisible().catch(() => false)) {
+        visibleCount += 1;
+      }
+    }
+
+    if (visibleCount >= ADD_SECTION_DIALOG_MIN_INTERACTIVE_ELEMENTS) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, ADD_SECTION_DIALOG_POLL_INTERVAL_MS);
+    });
+  }
+
+  throw new LinkedInBuddyError(
+    "TIMEOUT",
+    `The "Add to profile" dialog opened but its content never loaded ` +
+      `(waited ${timeoutMs}ms). This can happen when LinkedIn loads the ` +
+      `section list asynchronously and the request is slow or blocked.`
+  );
+}
+
 async function openGlobalAddSectionDialog(
   page: Page,
   selectorLocale: LinkedInSelectorLocale
@@ -4175,7 +4219,9 @@ async function openGlobalAddSectionDialog(
     );
   }
 
-  return clickLocatorAndWaitForDialog(page, resolved.locator);
+  const dialog = await clickLocatorAndWaitForDialog(page, resolved.locator);
+  await waitForAddSectionDialogContent(dialog);
+  return dialog;
 }
 
 async function openSectionCreateDialog(


### PR DESCRIPTION
## Summary

Fixes #426 — The "Add to profile" dialog opens but its content (section buttons like "Add about", "Add education") never loads, causing all section-create operations to fail with `TARGET_NOT_FOUND`.

## Root Cause

`openGlobalAddSectionDialog()` returned the dialog locator as soon as the dialog **shell** (title + loading spinner) became visible. However, LinkedIn fetches the section list asynchronously — the actual buttons/links render after a network round-trip. Callers that immediately searched for section entries found an empty dialog.

## Changes

- **New `waitForAddSectionDialogContent()`** — polls the dialog for interactive elements (buttons, links, list items) using a deadline-based loop (250ms intervals, 15s timeout). Requires ≥2 visible interactive elements before returning (the dialog shell always has at least a dismiss button, so 2+ confirms real content loaded).
- **Updated `openGlobalAddSectionDialog()`** — now calls `waitForAddSectionDialogContent()` after the dialog shell appears, ensuring all callers receive a dialog with loaded content.
- **Clear TIMEOUT error** — if content never loads within 15s, throws a `LinkedInBuddyError("TIMEOUT", ...)` with an explanatory message instead of silently returning an empty dialog.

## Affected Callers (all benefit automatically)

- `openSectionCreateDialog()` — section creation (about, experience, education, etc.)
- `openFeaturedAddDialog()` — featured section add flow
- `openSkillsAddDialog()` — skills add flow

## Test Results

- **Lint**: ✅ Clean (`eslint linkedinProfile.ts`)
- **Unit tests**: ✅ 1452/1452 passed (118 test files)
- **Type check**: ✅ Zero errors in changed file (pre-existing errors in cli/mcp packages unrelated to this change)

Closes #426
