### PR TITLE
fix #427: prevent text duplication from aria-hidden double spans

### DIFF
--- a/packages/core/src/linkedinFeed.ts
+++ b/packages/core/src/linkedinFeed.ts
@@ -633,7 +633,14 @@ async function extractFeedPosts(
 
       const pickText = (selectors: string[], root: ParentNode): string => {
         for (const selector of selectors) {
-          const text = normalize(root.querySelector(selector)?.textContent);
+          const el = root.querySelector(selector);
+          if (!el) {
+            continue;
+          }
+          // Prefer aria-hidden span to avoid double-read from paired
+          // visible / screen-reader spans that LinkedIn renders.
+          const ariaHidden = el.querySelector("span[aria-hidden='true']");
+          const text = normalize((ariaHidden ?? el).textContent);
           if (text) {
             return text;
           }

--- a/packages/core/src/linkedinJobs.ts
+++ b/packages/core/src/linkedinJobs.ts
@@ -762,7 +762,12 @@ async function extractJobSearchResults(
 
       const pickText = (root: ParentNode, selectors: string[]): string => {
         for (const selector of selectors) {
-          const text = normalize(root.querySelector(selector)?.textContent);
+          const el = root.querySelector(selector);
+          if (!el) {
+            continue;
+          }
+          const ariaHidden = el.querySelector("span[aria-hidden='true']");
+          const text = normalize((ariaHidden ?? el).textContent);
           if (text) {
             return text;
           }
@@ -920,7 +925,12 @@ async function extractJobDetail(
 
     const pickText = (root: ParentNode, selectors: string[]): string => {
       for (const selector of selectors) {
-        const text = normalize(root.querySelector(selector)?.textContent);
+        const el = root.querySelector(selector);
+        if (!el) {
+          continue;
+        }
+        const ariaHidden = el.querySelector("span[aria-hidden='true']");
+        const text = normalize((ariaHidden ?? el).textContent);
         if (text) {
           return text;
         }
@@ -1122,7 +1132,12 @@ async function extractJobAlerts(
 
       const pickText = (root: ParentNode, selectors: string[]): string => {
         for (const selector of selectors) {
-          const text = normalize(root.querySelector(selector)?.textContent);
+          const el = root.querySelector(selector);
+          if (!el) {
+            continue;
+          }
+          const ariaHidden = el.querySelector("span[aria-hidden='true']");
+          const text = normalize((ariaHidden ?? el).textContent);
           if (text) {
             return text;
           }

--- a/packages/core/src/linkedinNotifications.ts
+++ b/packages/core/src/linkedinNotifications.ts
@@ -520,7 +520,12 @@ async function extractNotificationSnapshots(
 
       const pickText = (root: ParentNode, selectors: string[]): string => {
         for (const selector of selectors) {
-          const text = normalize(root.querySelector(selector)?.textContent);
+          const el = root.querySelector(selector);
+          if (!el) {
+            continue;
+          }
+          const ariaHidden = el.querySelector("span[aria-hidden='true']");
+          const text = normalize((ariaHidden ?? el).textContent);
           if (text) {
             return text;
           }

--- a/packages/core/src/linkedinProfile.ts
+++ b/packages/core/src/linkedinProfile.ts
@@ -2050,7 +2050,12 @@ async function extractProfileData(
       root: ParentNode = globalThis.document
     ): string => {
       for (const selector of selectors) {
-        const text = normalize(root.querySelector(selector)?.textContent);
+        const el = root.querySelector(selector);
+        if (!el) {
+          continue;
+        }
+        const ariaHidden = el.querySelector("span[aria-hidden='true']");
+        const text = normalize((ariaHidden ?? el).textContent);
         if (text) {
           return text;
         }


### PR DESCRIPTION
## Summary

Fixes text duplication caused by LinkedIn's paired `aria-hidden` / visually-hidden span pattern. When `pickText()` read `.textContent` from a parent element containing both spans, the text was concatenated (e.g. `"Personal Assistant to Director at SignikantPersonal Assistant to Director at Signikant"`).

## Changes

- Modified all `pickText()` helpers inside `page.evaluate()` blocks to check for a child `span[aria-hidden='true']` first and use its text, falling back to `.textContent` when no such span exists.

### Files changed

| File | `pickText` instances fixed |
|------|---------------------------|
| `packages/core/src/linkedinFeed.ts` | `extractFeedPosts()` |
| `packages/core/src/linkedinJobs.ts` | `extractJobSearchResults()`, `extractJobDetail()`, `extractJobAlerts()` |
| `packages/core/src/linkedinProfile.ts` | profile extraction |
| `packages/core/src/linkedinNotifications.ts` | notification extraction |

## How it works

LinkedIn renders visible text in two sibling spans:
```html
<span class="update-components-actor__name">
  <span aria-hidden="true">John Doe</span>        <!-- visual text -->
  <span class="visually-hidden">John Doe</span>    <!-- screen reader -->
</span>
```

Before: `el.textContent` → `"John DoeJohn Doe"`
After: `el.querySelector("span[aria-hidden='true']").textContent` → `"John Doe"` (falls back to `el.textContent` when no aria-hidden span exists)

## Quality gates

- ✅ LSP diagnostics: Clean on all 4 changed files
- ✅ Lint: Pass
- ✅ Unit tests: 1452/1452 pass
- ✅ Build: Pre-existing errors only (identical to main)

Closes #427
