### PR TITLE
feat #448: acid test groups — CLI commands, fixture replay, and E2E tests

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -8256,6 +8256,192 @@ async function runNotificationsPreferencesPrepareUpdate(
   }
 }
 
+async function runGroupsSearch(
+  input: {
+    profileName: string;
+    query: string;
+    limit: number;
+  },
+  cdpUrl?: string,
+): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.groups.search.start", {
+      profileName: input.profileName,
+      query: input.query,
+      limit: input.limit,
+    });
+
+    const result = await runtime.groups.searchGroups({
+      profileName: input.profileName,
+      query: input.query,
+      limit: input.limit,
+    });
+
+    runtime.logger.log("info", "cli.groups.search.done", {
+      profileName: input.profileName,
+      count: result.count,
+    });
+
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      ...result,
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function runGroupsView(
+  input: {
+    profileName: string;
+    group: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.groups.view.start", {
+      profileName: input.profileName,
+      group: input.group,
+    });
+
+    const group = await runtime.groups.viewGroup({
+      profileName: input.profileName,
+      group: input.group,
+    });
+
+    runtime.logger.log("info", "cli.groups.view.done", {
+      profileName: input.profileName,
+      groupId: group.group_id,
+    });
+
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      group,
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function runGroupsPrepareJoin(
+  input: {
+    profileName: string;
+    group: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.groups.prepare_join.start", {
+      profileName: input.profileName,
+      group: input.group,
+    });
+
+    const prepared = runtime.groups.prepareJoinGroup({
+      profileName: input.profileName,
+      group: input.group,
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
+    });
+
+    runtime.logger.log("info", "cli.groups.prepare_join.done", {
+      profileName: input.profileName,
+      preparedActionId: prepared.preparedActionId,
+    });
+
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      ...prepared,
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function runGroupsPrepareLeave(
+  input: {
+    profileName: string;
+    group: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.groups.prepare_leave.start", {
+      profileName: input.profileName,
+      group: input.group,
+    });
+
+    const prepared = runtime.groups.prepareLeaveGroup({
+      profileName: input.profileName,
+      group: input.group,
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
+    });
+
+    runtime.logger.log("info", "cli.groups.prepare_leave.done", {
+      profileName: input.profileName,
+      preparedActionId: prepared.preparedActionId,
+    });
+
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      ...prepared,
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function runGroupsPreparePost(
+  input: {
+    profileName: string;
+    group: string;
+    text: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.groups.prepare_post.start", {
+      profileName: input.profileName,
+      group: input.group,
+    });
+
+    const prepared = runtime.groups.preparePostToGroup({
+      profileName: input.profileName,
+      group: input.group,
+      text: input.text,
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
+    });
+
+    runtime.logger.log("info", "cli.groups.prepare_post.done", {
+      profileName: input.profileName,
+      preparedActionId: prepared.preparedActionId,
+    });
+
+    printJson({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      ...prepared,
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
 async function runJobsSearch(
   input: {
     profileName: string;
@@ -11366,6 +11552,122 @@ export function createCliProgram(): Command {
           {
             profileName: options.profile,
             postUrl: post,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
+    );
+
+  const groupsCommand = program
+    .command("groups")
+    .description(
+      "Search, view, join, leave, and post in LinkedIn groups",
+    );
+
+  groupsCommand
+    .command("search")
+    .description("Search LinkedIn groups by keyword")
+    .requiredOption("-q, --query <query>", "Search keywords for LinkedIn groups")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .option("-l, --limit <limit>", "Maximum number of results", "10")
+    .action(
+      async (options: { profile: string; query: string; limit: string }) => {
+        await runGroupsSearch(
+          {
+            profileName: options.profile,
+            query: options.query,
+            limit: parseInt(options.limit, 10) || 10,
+          },
+          readCdpUrl(),
+        );
+      },
+    );
+
+  groupsCommand
+    .command("view")
+    .description("View details of a LinkedIn group")
+    .argument("<group>", "LinkedIn group URL or numeric group ID")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .action(
+      async (group: string, options: { profile: string }) => {
+        await runGroupsView(
+          {
+            profileName: options.profile,
+            group,
+          },
+          readCdpUrl(),
+        );
+      },
+    );
+
+  groupsCommand
+    .command("join")
+    .description("Prepare to join a LinkedIn group (two-phase)")
+    .argument("<group>", "LinkedIn group URL or numeric group ID")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .option("-o, --operator-note <note>", "Optional operator note")
+    .action(
+      async (
+        group: string,
+        options: { profile: string; operatorNote?: string },
+      ) => {
+        await runGroupsPrepareJoin(
+          {
+            profileName: options.profile,
+            group,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
+    );
+
+  groupsCommand
+    .command("leave")
+    .description("Prepare to leave a LinkedIn group (two-phase)")
+    .argument("<group>", "LinkedIn group URL or numeric group ID")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .option("-o, --operator-note <note>", "Optional operator note")
+    .action(
+      async (
+        group: string,
+        options: { profile: string; operatorNote?: string },
+      ) => {
+        await runGroupsPrepareLeave(
+          {
+            profileName: options.profile,
+            group,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
+    );
+
+  groupsCommand
+    .command("post")
+    .description("Prepare to post in a LinkedIn group (two-phase)")
+    .argument("<group>", "LinkedIn group URL or numeric group ID")
+    .requiredOption("-t, --text <text>", "Post text")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .option("-o, --operator-note <note>", "Optional operator note")
+    .action(
+      async (
+        group: string,
+        options: { profile: string; text: string; operatorNote?: string },
+      ) => {
+        await runGroupsPreparePost(
+          {
+            profileName: options.profile,
+            group,
+            text: options.text,
             ...(options.operatorNote
               ? { operatorNote: options.operatorNote }
               : {}),

--- a/packages/core/src/__tests__/e2e/groups.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/groups.e2e.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from "vitest";
+import { setupE2ESuite, skipIfE2EUnavailable } from "./setup.js";
+import {
+  callMcpTool,
+  MCP_TOOL_NAMES,
+  runCliCommand,
+  getLastJsonObject,
+  expectPreparedAction,
+  expectRateLimitPreview,
+  type PreparedActionResult,
+} from "./helpers.js";
+
+describe("Groups E2E", () => {
+  const e2e = setupE2ESuite();
+
+  it("searchGroups returns results with populated fields", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
+    const runtime = e2e.runtime();
+    const result = await runtime.groups.searchGroups({
+      query: "software engineering",
+      limit: 5,
+    });
+
+    expect(result.count).toBeGreaterThan(0);
+    expect(result.results.length).toBeGreaterThan(0);
+    const first = result.results[0]!;
+    expect(first.name.length).toBeGreaterThan(0);
+    expect(first.group_url).toContain("/groups/");
+    expect(first.group_id.length).toBeGreaterThan(0);
+    expect(typeof first.member_count).toBe("string");
+    expect(typeof first.visibility).toBe("string");
+    expect(typeof first.description).toBe("string");
+    expect(["member", "joinable", "pending", "unknown"]).toContain(
+      first.membership_state,
+    );
+  });
+
+  it("viewGroup returns complete details", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
+    const runtime = e2e.runtime();
+
+    const search = await runtime.groups.searchGroups({
+      query: "software engineering",
+      limit: 1,
+    });
+    expect(search.results.length).toBeGreaterThan(0);
+    const groupId = search.results[0]!.group_id;
+
+    const detail = await runtime.groups.viewGroup({ group: groupId });
+
+    expect(detail.group_id).toBe(groupId);
+    expect(detail.name.length).toBeGreaterThan(0);
+    expect(detail.group_url).toContain("/groups/");
+    expect(typeof detail.visibility).toBe("string");
+    expect(typeof detail.member_count).toBe("string");
+    expect(typeof detail.description).toBe("string");
+    expect(typeof detail.about).toBe("string");
+    expect(["member", "joinable", "pending", "unknown"]).toContain(
+      detail.membership_state,
+    );
+  });
+
+  it("prepareJoinGroup returns valid two-phase token", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
+    const runtime = e2e.runtime();
+    const prepared = runtime.groups.prepareJoinGroup({
+      group: "9806731",
+    });
+
+    expectPreparedAction(prepared as PreparedActionResult);
+    expectRateLimitPreview(
+      prepared.preview,
+      "linkedin.groups.join",
+    );
+    expect(prepared.preview).toHaveProperty("summary");
+    expect(String(prepared.preview.summary)).toContain("9806731");
+  });
+
+  it("prepareLeaveGroup returns valid two-phase token", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
+    const runtime = e2e.runtime();
+    const prepared = runtime.groups.prepareLeaveGroup({
+      group: "https://www.linkedin.com/groups/9806731/",
+    });
+
+    expectPreparedAction(prepared as PreparedActionResult);
+    expectRateLimitPreview(
+      prepared.preview,
+      "linkedin.groups.leave",
+    );
+  });
+
+  it("preparePostToGroup returns valid two-phase token with payload", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
+    const runtime = e2e.runtime();
+    const prepared = runtime.groups.preparePostToGroup({
+      group: "9806731",
+      text: "Test post content",
+    });
+
+    expectPreparedAction(prepared as PreparedActionResult);
+    expectRateLimitPreview(
+      prepared.preview,
+      "linkedin.groups.post",
+    );
+    const preview = prepared.preview as Record<string, unknown>;
+    const payload = preview.payload as Record<string, unknown>;
+    expect(payload.text).toBe("Test post content");
+  });
+
+  it("prepareJoinGroup rejects invalid group reference", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
+    const runtime = e2e.runtime();
+
+    expect(() => runtime.groups.prepareJoinGroup({ group: "not-a-group" }))
+      .toThrow(/group must be a LinkedIn group URL or numeric ID/i);
+  });
+
+  it("preparePostToGroup rejects empty text", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
+    const runtime = e2e.runtime();
+
+    expect(() => runtime.groups.preparePostToGroup({ group: "9806731", text: "" }))
+      .toThrow(/text is required/i);
+  });
+
+  it("MCP groups.search returns results", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
+    const result = await callMcpTool(MCP_TOOL_NAMES.groupsSearch, {
+      query: "software engineering",
+      limit: 5,
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.payload).toHaveProperty("count");
+    expect(Number(result.payload.count)).toBeGreaterThan(0);
+    const results = result.payload.results;
+    expect(Array.isArray(results)).toBe(true);
+    const firstResult = (results as Record<string, unknown>[])[0]!;
+    expect(typeof firstResult.name).toBe("string");
+    expect(typeof firstResult.group_url).toBe("string");
+  });
+
+  it("MCP groups.view returns group details", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
+    const result = await callMcpTool(MCP_TOOL_NAMES.groupsView, {
+      group: "9806731",
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.payload).toHaveProperty("group");
+    const group = result.payload.group as Record<string, unknown>;
+    expect(typeof group.group_id).toBe("string");
+    expect(typeof group.name).toBe("string");
+    expect(typeof group.group_url).toBe("string");
+  });
+
+  it("MCP groups.prepare_join returns two-phase token", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
+    const result = await callMcpTool(MCP_TOOL_NAMES.groupsPrepareJoin, {
+      group: "9806731",
+    });
+
+    expect(result.isError).toBe(false);
+    expect(typeof result.payload.preparedActionId).toBe("string");
+    expect(typeof result.payload.confirmToken).toBe("string");
+    expect(String(result.payload.preparedActionId)).toMatch(/^pa_/);
+    expect(String(result.payload.confirmToken)).toMatch(/^ct_/);
+  });
+
+  it("MCP groups.prepare_leave returns two-phase token", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
+    const result = await callMcpTool(MCP_TOOL_NAMES.groupsPrepareLeave, {
+      group: "9806731",
+    });
+
+    expect(result.isError).toBe(false);
+    expect(typeof result.payload.preparedActionId).toBe("string");
+    expect(typeof result.payload.confirmToken).toBe("string");
+  });
+
+  it("MCP groups.prepare_post returns two-phase token with payload", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
+    const result = await callMcpTool(MCP_TOOL_NAMES.groupsPreparePost, {
+      group: "9806731",
+      text: "Acid test post",
+    });
+
+    expect(result.isError).toBe(false);
+    expect(typeof result.payload.preparedActionId).toBe("string");
+    expect(typeof result.payload.confirmToken).toBe("string");
+  });
+
+  it("CLI groups search returns results", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
+    const result = await runCliCommand(
+      ["groups", "search", "--query", "software engineering", "--limit", "5"],
+      { timeoutMs: 30_000 },
+    );
+
+    expect(result.exitCode).toBe(0);
+    const output = getLastJsonObject(result.stdout);
+    expect(Number(output.count)).toBeGreaterThan(0);
+    expect(Array.isArray(output.results)).toBe(true);
+  });
+
+  it("CLI groups view returns group details", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
+    const result = await runCliCommand(
+      ["groups", "view", "9806731"],
+      { timeoutMs: 30_000 },
+    );
+
+    expect(result.exitCode).toBe(0);
+    const output = getLastJsonObject(result.stdout);
+    expect(output.group).toBeDefined();
+    const group = output.group as Record<string, unknown>;
+    expect(typeof group.name).toBe("string");
+    expect(typeof group.group_id).toBe("string");
+  });
+
+  it("CLI groups join returns prepared action", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
+    const result = await runCliCommand(
+      ["groups", "join", "9806731"],
+      { timeoutMs: 30_000 },
+    );
+
+    expect(result.exitCode).toBe(0);
+    const output = getLastJsonObject(result.stdout);
+    expect(typeof output.preparedActionId).toBe("string");
+    expect(typeof output.confirmToken).toBe("string");
+  });
+
+  it("CLI groups leave returns prepared action", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
+    const result = await runCliCommand(
+      ["groups", "leave", "9806731"],
+      { timeoutMs: 30_000 },
+    );
+
+    expect(result.exitCode).toBe(0);
+    const output = getLastJsonObject(result.stdout);
+    expect(typeof output.preparedActionId).toBe("string");
+    expect(typeof output.confirmToken).toBe("string");
+  });
+
+  it("CLI groups post returns prepared action", async (context) => {
+    skipIfE2EUnavailable(e2e, context);
+    const result = await runCliCommand(
+      ["groups", "post", "9806731", "--text", "Test group post"],
+      { timeoutMs: 30_000 },
+    );
+
+    expect(result.exitCode).toBe(0);
+    const output = getLastJsonObject(result.stdout);
+    expect(typeof output.preparedActionId).toBe("string");
+    expect(typeof output.confirmToken).toBe("string");
+  });
+});

--- a/test/fixtures/ci/assets/replay-state.js
+++ b/test/fixtures/ci/assets/replay-state.js
@@ -712,6 +712,51 @@
     `;
   }
 
+  function renderSearchGroups() {
+    const root = document.querySelector("#replay-root");
+    const GROUP_ID = "9806731";
+    const GROUP_URL = `https://www.linkedin.com/groups/${GROUP_ID}/`;
+    root.innerHTML = `
+      <div class="reusable-search__result-container">
+        <a href="${GROUP_URL}">
+          <span>Software Engineering Community</span>
+          <span>Public group</span>
+          <span>15,432 members</span>
+          <span>A community for software engineers to share knowledge and best practices.</span>
+        </a>
+      </div>
+      <div class="reusable-search__result-container">
+        <a href="https://www.linkedin.com/groups/1234567/">
+          <span>Tech Leaders Network</span>
+          <span>Private listed group</span>
+          <span>8,200 members</span>
+          <span>Join</span>
+          <span>Connect with technology leaders worldwide.</span>
+        </a>
+      </div>
+    `;
+  }
+
+  function renderGroupView() {
+    const root = document.querySelector("#replay-root");
+    const GROUP_ID = "9806731";
+    root.innerHTML = `
+      <main class="scaffold-layout__main">
+        <div class="groups-details-view" data-group-id="${GROUP_ID}">
+          <h1>Software Engineering Community</h1>
+          <span>Public group</span>
+          <span>15,432 members</span>
+          <div>
+            <button class="groups-action-dropdown__trigger">More</button>
+          </div>
+          <h2>About this group</h2>
+          <div>A community for software engineers to share knowledge, discuss best practices, and grow their careers together.</div>
+          <div>Start a post in this group</div>
+        </div>
+      </main>
+    `;
+  }
+
   function renderJobsSearch() {
     const root = document.querySelector("#replay-root");
     root.innerHTML = `
@@ -993,6 +1038,16 @@
 
     if (normalizedPath === "/jobs/job-alerts/") {
       renderJobAlerts();
+      return;
+    }
+
+    if (normalizedPath === "/search/results/groups/") {
+      renderSearchGroups();
+      return;
+    }
+
+    if (normalizedPath.startsWith("/groups/")) {
+      renderGroupView();
       return;
     }
 

--- a/test/fixtures/ci/routes.json
+++ b/test/fixtures/ci/routes.json
@@ -259,6 +259,26 @@
       },
       "bodyPath": "pages/app.html",
       "pageType": "connections"
+    },
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/search/results/groups/?keywords=software%20engineering",
+      "status": 200,
+      "headers": {
+        "content-type": "text/html; charset=utf-8"
+      },
+      "bodyPath": "pages/app.html",
+      "pageType": "search"
+    },
+    {
+      "method": "GET",
+      "url": "https://www.linkedin.com/groups/9806731/",
+      "status": 200,
+      "headers": {
+        "content-type": "text/html; charset=utf-8"
+      },
+      "bodyPath": "pages/app.html",
+      "pageType": "search"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Acid test for the Groups module (`LinkedInGroupsService`). Adds missing CLI commands, fixture replay support, and comprehensive E2E test coverage.

## Changes

- **CLI commands** — Added 5 new `linkedin groups` subcommands: `search`, `view`, `join`, `leave`, `post` with runner functions following the existing pattern
- **Fixture replay** — Added `renderSearchGroups()` and `renderGroupView()` to `replay-state.js` with proper selectors, plus 2 new routes in `routes.json`
- **E2E tests** — Created `groups.e2e.test.ts` with 17 tests covering:
  - Core API: search, view, prepare join/leave/post, error handling (invalid group, empty text)
  - MCP tools: search, view, prepare_join/leave/post
  - CLI: search, view, join, leave, post

## Test Results

| Gate | Status |
|------|--------|
| `npm run typecheck` | ✅ |
| `npm run lint` | ✅ |
| `npm run build` | ✅ |
| `npm test` | ✅ (1452/1452) |
| Groups E2E (fixture replay) | ✅ (17/17) |

## Success Criteria

- [x] Group search returns results with populated fields
- [x] Group view shows complete details
- [x] Join/leave flow works (two-phase prepare returns valid tokens)
- [x] Post to group works (two-phase prepare with text payload)
- [x] Error cases handled gracefully (invalid group ref, empty text)

Closes #448
