### PR TITLE
fix #475: job search duplicate results, garbled titles, empty company, inconsistent dates

### DIFF
--- a/packages/core/src/__tests__/shared.test.ts
+++ b/packages/core/src/__tests__/shared.test.ts
@@ -2,6 +2,7 @@ import type { BrowserContext, Locator, Page } from "playwright-core";
 import { describe, expect, it, vi } from "vitest";
 import {
   buildTextRegex,
+  dedupeRepeatedText,
   dedupePhrases,
   escapeCssAttributeValue,
   escapeRegExp,
@@ -76,6 +77,46 @@ describe("shared", () => {
       expect(dedupePhrases(["  a  ", "a"])).toEqual(["a"]);
       expect(dedupePhrases(["", "  ", "valid"])).toEqual(["valid"]);
       expect(dedupePhrases(["x", "y", "x"])).toEqual(["x", "y"]);
+    });
+  });
+
+  describe("dedupeRepeatedText", () => {
+    it("returns empty string for falsy input", () => {
+      expect(dedupeRepeatedText(null)).toBe("");
+      expect(dedupeRepeatedText(undefined)).toBe("");
+      expect(dedupeRepeatedText("")).toBe("");
+    });
+
+    it("returns short text unchanged", () => {
+      expect(dedupeRepeatedText("Hi")).toBe("Hi");
+      expect(dedupeRepeatedText("abc")).toBe("abc");
+    });
+
+    it("removes exact-half duplication", () => {
+      expect(dedupeRepeatedText("TitleTitle")).toBe("Title");
+      expect(dedupeRepeatedText("Software Engineer (C++) - RemoteSoftware Engineer (C++) - Remote"))
+        .toBe("Software Engineer (C++) - Remote");
+    });
+
+    it("removes exact-half duplication with space separator", () => {
+      expect(dedupeRepeatedText("Title Title")).toBe("Title");
+    });
+
+    it("removes prefix-repeated duplication with trailing text", () => {
+      expect(dedupeRepeatedText("Developer Developer with verification"))
+        .toBe("Developer with verification");
+      expect(dedupeRepeatedText("Frontend-udvikler Frontend-udvikler with verification"))
+        .toBe("Frontend-udvikler with verification");
+    });
+
+    it("preserves text that is not doubled", () => {
+      expect(dedupeRepeatedText("Software Engineer")).toBe("Software Engineer");
+      expect(dedupeRepeatedText("Senior Full Stack Developer")).toBe("Senior Full Stack Developer");
+      expect(dedupeRepeatedText("Google")).toBe("Google");
+    });
+
+    it("normalizes whitespace", () => {
+      expect(dedupeRepeatedText("  Developer   Developer  ")).toBe("Developer");
     });
   });
 

--- a/packages/core/src/linkedinJobs.ts
+++ b/packages/core/src/linkedinJobs.ts
@@ -22,7 +22,7 @@ import type {
   ActionExecutorResult,
   TwoPhaseCommitService,
 } from "./twoPhaseCommit.js";
-import { normalizeText, getOrCreatePage } from "./shared.js";
+import { dedupeRepeatedText, normalizeText, getOrCreatePage } from "./shared.js";
 
 export interface LinkedInJobSearchResult {
   job_id: string;
@@ -765,6 +765,33 @@ async function extractJobSearchResults(
 
       const origin = globalThis.window.location.origin;
 
+      const dedupeRepeatedText = (text: string): string => {
+        const normalized = normalize(text);
+        if (!normalized) {
+          return "";
+        }
+
+        if (normalized.length % 2 === 0) {
+          const midpoint = normalized.length / 2;
+          const firstHalf = normalize(normalized.slice(0, midpoint));
+          const secondHalf = normalize(normalized.slice(midpoint));
+          if (firstHalf && firstHalf === secondHalf) {
+            return firstHalf;
+          }
+        }
+
+        const words = normalized.split(" ");
+        for (let i = 1; i * 2 <= words.length; i += 1) {
+          const prefix = words.slice(0, i).join(" ");
+          const nextSegment = words.slice(i, i * 2).join(" ");
+          if (prefix === nextSegment) {
+            return normalize(words.slice(i).join(" "));
+          }
+        }
+
+        return normalized;
+      };
+
       const pickText = (root: ParentNode, selectors: string[]): string => {
         for (const selector of selectors) {
           const el = root.querySelector(selector);
@@ -772,7 +799,16 @@ async function extractJobSearchResults(
             continue;
           }
           const ariaHidden = el.querySelector("span[aria-hidden='true']");
-          const text = normalize((ariaHidden ?? el).textContent);
+          const ariaText = normalize(ariaHidden?.textContent);
+          if (ariaText) {
+            return ariaText;
+          }
+          const ltrSpan = el.querySelector("span[dir='ltr']");
+          const ltrText = normalize(ltrSpan?.textContent);
+          if (ltrText) {
+            return ltrText;
+          }
+          const text = dedupeRepeatedText(normalize(el.textContent));
           if (text) {
             return text;
           }
@@ -855,11 +891,17 @@ async function extractJobSearchResults(
         return normalize(match?.[1] ?? "");
       };
 
-      const cards = Array.from(
+      const rawCards = Array.from(
         globalThis.document.querySelectorAll(
           "li[data-occludable-job-id], .job-card-container, .base-search-card, .job-card-list__entity-lockup",
         ),
-      ).slice(0, maxJobs * 2);
+      );
+
+      const cards = rawCards
+        .filter(
+          (card) => !rawCards.some((other) => other !== card && other.contains(card)),
+        )
+        .slice(0, maxJobs * 2);
 
       const pickTimeText = (root: ParentNode): string => {
         const timeEl = root.querySelector("time");
@@ -867,8 +909,24 @@ async function extractJobSearchResults(
           return "";
         }
         const datetime = normalize(timeEl.getAttribute("datetime"));
-        const text = normalize(timeEl.textContent);
-        return text || datetime;
+
+        for (const node of Array.from(timeEl.childNodes)) {
+          if (node.nodeType === 3) {
+            const t = normalize(node.textContent);
+            if (t) {
+              return t;
+            }
+          }
+        }
+
+        if (timeEl.firstElementChild) {
+          const t = normalize(timeEl.firstElementChild.textContent);
+          if (t) {
+            return t;
+          }
+        }
+
+        return datetime || normalize(timeEl.textContent);
       };
 
       const results: LinkedInJobSearchResult[] = [];
@@ -882,11 +940,12 @@ async function extractJobSearchResults(
         ]);
 
         const jobId = extractJobId(jobUrl, card);
-        if (jobId && seen.has(jobId)) {
+        const dedupKey = jobId || jobUrl;
+        if (dedupKey && seen.has(dedupKey)) {
           continue;
         }
-        if (jobId) {
-          seen.add(jobId);
+        if (dedupKey) {
+          seen.add(dedupKey);
         }
 
         results.push({
@@ -900,6 +959,8 @@ async function extractJobSearchResults(
           company: pickText(card, [
             ".artdeco-entity-lockup__subtitle span[dir='ltr']",
             "a[href*='/company/'] span[dir='ltr']",
+            ".job-card-container__primary-description span[dir='ltr']",
+            ".artdeco-entity-lockup__subtitle",
             "a[href*='/company/']",
             ".job-card-container__primary-description",
             ".job-card-container__company-name",
@@ -941,7 +1002,7 @@ async function extractJobSearchResults(
   return snapshots
     .map((snapshot) => ({
       job_id: normalizeText(snapshot.job_id),
-      title: normalizeText(snapshot.title),
+      title: dedupeRepeatedText(snapshot.title),
       company: normalizeText(snapshot.company),
       location: normalizeText(snapshot.location),
       posted_at: normalizeText(snapshot.posted_at),

--- a/packages/core/src/shared.ts
+++ b/packages/core/src/shared.ts
@@ -59,6 +59,44 @@ export function buildTextRegex(labels: readonly string[], exact = false): RegExp
   return new RegExp(exact ? `^(?:${pattern})$` : `(?:${pattern})`, "i");
 }
 
+/**
+ * Detects text that has been doubled due to concatenated visible /
+ * screen-reader spans and returns the clean single copy.
+ *
+ * Examples:
+ *   "TitleTitle"                                      -> "Title"
+ *   "Developer Developer with verification"           -> "Developer with verification"
+ *   "Software Engineer (C++) - RemoteSoftware ..."    -> "Software Engineer (C++) - Remote"
+ */
+export function dedupeRepeatedText(value: string | null | undefined): string {
+  const text = normalizeText(value);
+  if (text.length < 4) {
+    return text;
+  }
+
+  // Case 1: exact halves - "TitleTitle" or "Title Title"
+  if (text.length % 2 === 0) {
+    const mid = text.length / 2;
+    const first = normalizeText(text.slice(0, mid));
+    const second = normalizeText(text.slice(mid));
+    if (first && first === second) {
+      return first;
+    }
+  }
+
+  // Case 2: repeated word prefix - "Developer Developer with verification"
+  const words = text.split(" ");
+  for (let i = 1; i * 2 <= words.length; i += 1) {
+    const prefix = words.slice(0, i).join(" ");
+    const next = words.slice(i, i * 2).join(" ");
+    if (prefix === next) {
+      return normalizeText(words.slice(i).join(" "));
+    }
+  }
+
+  return text;
+}
+
 /** Returns the first open page in a browser context, or creates a new one. */
 export async function getOrCreatePage(context: BrowserContext): Promise<Page> {
   const existing = context.pages()[0];


### PR DESCRIPTION
## Summary

Fixes four data quality bugs in `extractJobSearchResults` that caused job search to return duplicate entries, garbled titles, empty company fields, and inconsistent timestamps.

## Changes

### 1. Title Duplication Fix
- `pickText` now tries `span[aria-hidden='true']` → `span[dir='ltr']` → deduplicated `textContent` fallback
- Added `dedupeRepeatedText()` helper that detects and removes doubled text from concatenated visible/screen-reader span pairs
- Applied as both in-browser extraction fix AND post-processing safety net

### 2. Duplicate Results Fix
- Filter out nested card elements from the compound `querySelectorAll` selector (parent `li[data-occludable-job-id]` + child `.job-card-container` both matched)
- Use `jobUrl` as fallback dedup key when `jobId` cannot be extracted

### 3. Empty Company Field Fix
- Added broader selector fallbacks: `.artdeco-entity-lockup__subtitle` (without requiring `span[dir='ltr']` child), `.job-card-container__primary-description span[dir='ltr']`
- `pickText`'s new `span[dir='ltr']` child probe provides an additional extraction path for all fields

### 4. posted_at Inconsistency Fix
- `pickTimeText` now extracts the first direct text node (nodeType === 3) instead of using `textContent` which concatenated nested filter labels like "Within the past 24 hours"
- Falls back to first child element text, then `datetime` attribute, then full `textContent`

## Testing
- Added 7 unit tests for `dedupeRepeatedText` covering: falsy input, short text, exact-half duplication, space-separated duplication, prefix-repeated duplication with trailing text, non-doubled text preservation, and whitespace normalization
- All 1459 existing tests pass (118 test files)
- Core typecheck clean, lint clean

Closes #475
