### PR TITLE
fix #476: update connection invitation dialog selectors for LinkedIn UI changes

### DIFF
--- a/packages/core/src/linkedinConnections.ts
+++ b/packages/core/src/linkedinConnections.ts
@@ -902,6 +902,19 @@ async function executeSendInvitation(
         "send",
         runtime.selectorLocale
       );
+      const sendNowRegex = buildLinkedInSelectorPhraseRegex(
+        "send_now",
+        runtime.selectorLocale
+      );
+      const sendNowRegexHint = formatLinkedInSelectorRegexHint(
+        "send_now",
+        runtime.selectorLocale
+      );
+      const sendNowAriaSelector = buildLinkedInAriaLabelContainsSelector(
+        "button",
+        "send_now",
+        runtime.selectorLocale
+      );
       const pendingRegex = buildLinkedInSelectorPhraseRegex(
         ["pending", "withdraw"],
         runtime.selectorLocale
@@ -1085,7 +1098,12 @@ async function executeSendInvitation(
       ];
 
       const dialogLocator = page
-        .locator("[role='dialog']")
+        .locator(
+          ".artdeco-modal.send-invite, " +
+            ".artdeco-modal:has(button[aria-label*='note' i]), " +
+            ".artdeco-modal:has(button[aria-label*='Send' i]), " +
+            "[role='dialog']:not(.vjs-modal-dialog):not(.vjs-hidden)"
+        )
         .first();
       const dialogAppeared = await dialogLocator
         .waitFor({ state: "visible", timeout: 5_000 })
@@ -1153,6 +1171,22 @@ async function executeSendInvitation(
 
       const addNoteCandidates: VisibleLocatorCandidate[] = [
         {
+          key: "add-note-dialog-aria-label",
+          selectorHint: "dialog button[aria-label*='Add a note' i]",
+          locatorFactory: () =>
+            dialogLocator.locator("button[aria-label*='note' i]").filter({
+              hasText: addNoteRegex
+            })
+        },
+        {
+          key: "add-note-dialog-role",
+          selectorHint: `dialog.getByRole(button, ${addNoteRegexHint})`,
+          locatorFactory: () =>
+            dialogLocator.getByRole("button", {
+              name: addNoteRegex
+            })
+        },
+        {
           key: "add-note-dialog-text",
           selectorHint: `dialog button hasText ${addNoteRegexHint}`,
           locatorFactory: () =>
@@ -1177,6 +1211,11 @@ async function executeSendInvitation(
       ];
 
       const noteFieldCandidates: VisibleLocatorCandidate[] = [
+        {
+          key: "note-dialog-textarea-role",
+          selectorHint: "dialog.getByRole(textbox)",
+          locatorFactory: () => dialogLocator.getByRole("textbox")
+        },
         {
           key: "note-dialog-textarea-name",
           selectorHint: "dialog textarea[name='message']",
@@ -1247,6 +1286,23 @@ async function executeSendInvitation(
 
       const sendCandidates: VisibleLocatorCandidate[] = [
         {
+          key: "send-dialog-artdeco-primary",
+          selectorHint: "dialog button.artdeco-button--primary",
+          locatorFactory: () =>
+            dialogLocator.locator("button.artdeco-button--primary")
+        },
+        {
+          key: "send-dialog-send-now-text",
+          selectorHint: `dialog button hasText ${sendNowRegexHint}`,
+          locatorFactory: () =>
+            dialogLocator.locator("button").filter({ hasText: sendNowRegex })
+        },
+        {
+          key: "send-dialog-send-now-aria",
+          selectorHint: `dialog ${sendNowAriaSelector}`,
+          locatorFactory: () => dialogLocator.locator(sendNowAriaSelector)
+        },
+        {
           key: "send-dialog-role",
           selectorHint: `dialog.getByRole(button, ${sendExactRegexHint})`,
           locatorFactory: () =>
@@ -1301,6 +1357,23 @@ async function executeSendInvitation(
           selectorHint: `button hasText ${sendWithoutNoteRegexHint}`,
           locatorFactory: (targetPage) =>
             targetPage.locator("button").filter({ hasText: sendWithoutNoteRegex })
+        },
+        {
+          key: "send-now-text",
+          selectorHint: `button hasText ${sendNowRegexHint}`,
+          locatorFactory: (targetPage) =>
+            targetPage.locator("button").filter({ hasText: sendNowRegex })
+        },
+        {
+          key: "send-now-aria",
+          selectorHint: sendNowAriaSelector,
+          locatorFactory: (targetPage) => targetPage.locator(sendNowAriaSelector)
+        },
+        {
+          key: "send-artdeco-primary",
+          selectorHint: "div.send-invite button.artdeco-button--primary",
+          locatorFactory: (targetPage) =>
+            targetPage.locator("div.send-invite button.artdeco-button--primary")
         }
       ];
 

--- a/packages/core/src/selectorLocale.ts
+++ b/packages/core/src/selectorLocale.ts
@@ -159,6 +159,7 @@ export type LinkedInSelectorPhraseKey =
   | "save"
   | "share"
   | "send"
+  | "send_now"
   | "send_without_note"
   | "start_post"
   | "support"
@@ -228,6 +229,7 @@ const ENGLISH_SELECTOR_PHRASES: SelectorPhraseDictionary = {
   save: ["Save"],
   share: ["Share"],
   send: ["Send"],
+  send_now: ["Send now"],
   send_without_note: ["Send without a note"],
   start_post: ["Start a post"],
   support: ["Support"],
@@ -288,6 +290,7 @@ const DANISH_SELECTOR_PHRASE_OVERRIDES: SelectorPhraseOverrides = {
   resources: ["Ressourcer"],
   respond: ["Svar"],
   save: ["Gem"],
+  send_now: ["Send nu"],
   send_without_note: ["Send uden note", "Send uden en note"],
   start_post: ["Start et opslag", "Start et indlæg"],
   support: ["Støt", "Støtter"],


### PR DESCRIPTION
## Summary

Fixes broken connection invitation selectors that fail with `UI_CHANGED_SELECTOR_FAILED` for both with-note and without-note invitation flows.

## Root Cause

Two compounding failures:

1. **Dialog detection matched video.js player modals**: `page.locator("[role='dialog']").first()` was picking up hidden `vjs-modal-dialog` elements (8 per page) instead of the actual `.artdeco-modal.send-invite` invitation dialog. When embedded videos briefly render, a vjs dialog can become momentarily visible, causing false-positive dialog detection pointing to the wrong element — whose interior naturally has no textarea or Send button.

2. **Missing modern LinkedIn selectors**: LinkedIn's invitation dialog now uses `.artdeco-modal` class, `aria-label`-based buttons ("Add a note", "Send without a note"), `button.artdeco-button--primary` for the Send action, and a new "Send now" variant — none of which were in the selector candidates.

## Changes

### `packages/core/src/selectorLocale.ts`
- Added `send_now` phrase key with English ("Send now") and Danish ("Send nu") locale values

### `packages/core/src/linkedinConnections.ts`
- **Fixed dialog detection**: Replaced `[role='dialog']` with composite selector targeting `.artdeco-modal.send-invite`, `.artdeco-modal` with invitation-related buttons, and `[role='dialog']` excluding `.vjs-modal-dialog` / `.vjs-hidden`
- **Added high-priority send button candidates**: `button.artdeco-button--primary` (confirmed working in active automation repos), "Send now" text/aria variants
- **Added high-priority add-note candidates**: `aria-label`-based and `getByRole` selectors scoped to dialog
- **Added note field candidate**: `getByRole("textbox")` as highest-priority candidate
- **Added page-level fallbacks**: "Send now" text/aria and `div.send-invite button.artdeco-button--primary`

All existing selector candidates are preserved as fallbacks — no removals.

## Verification

- ✅ 14/14 connection tests pass
- ✅ 23/23 selector locale tests pass  
- ✅ 1459/1459 full test suite passes (zero regressions)
- ✅ TypeScript compiles cleanly (`tsc -b packages/core`)
- ✅ ESLint clean on both changed files

## Notes

- **E2E validation against live LinkedIn** requires an authenticated session and should be performed separately. The selectors are based on analysis of 4 captured error artifacts (DOM snapshots, accessibility trees, screenshots) plus confirmed patterns from actively-maintained LinkedIn automation repos.
- No function signatures, interfaces, or existing selector candidates were changed — only additions.

Closes #476
