### PR TITLE
fix #500: update outdated LinkedIn feed surface selectors

### DIFF
--- a/packages/cli/test/liveValidationCli.integration.test.ts
+++ b/packages/cli/test/liveValidationCli.integration.test.ts
@@ -899,7 +899,7 @@ describe("linkedin live validation CLI integration", () => {
         expect.arrayContaining([
           expect.objectContaining({
             matched_candidate_key: "feed-data-urn",
-            matched_candidate_rank: 1,
+            matched_candidate_rank: 3,
             selector_key: "feed_surface",
             status: "pass"
           }),

--- a/packages/core/src/__tests__/linkedinPosts.test.ts
+++ b/packages/core/src/__tests__/linkedinPosts.test.ts
@@ -540,7 +540,7 @@ describe("verifyPublishedPost", () => {
     const page = createMockPublishedPostPage(
       {
         [feedUrl]: {
-          visibleSelectors: ["main[role='main']"]
+          visibleSelectors: ["main"]
         }
       },
       feedUrl
@@ -556,10 +556,10 @@ describe("verifyPublishedPost", () => {
     const page = createMockPublishedPostPage(
       {
         [feedUrl]: {
-          visibleSelectors: ["main[role='main']"]
+          visibleSelectors: ["main"]
         },
         [activityUrl]: {
-          visibleSelectors: ["main[role='main']"],
+          visibleSelectors: ["main"],
           hasSnippet: true,
           publishedPostUrl
         }

--- a/packages/core/src/linkedinFeed.ts
+++ b/packages/core/src/linkedinFeed.ts
@@ -1920,12 +1920,12 @@ async function findVisiblePostBySnippet(
 ): Promise<Locator | null> {
   const postCandidates = [
     page
-      .locator("article, .feed-shared-update-v2, .occludable-update")
+      .locator("article, [data-urn], .feed-shared-update-v2, .occludable-update")
       .filter({ hasText: snippet }),
     page
       .getByText(snippet)
       .locator(
-        "xpath=ancestor-or-self::*[self::article or contains(@class, 'feed-shared-update-v2') or contains(@class, 'occludable-update')]",
+        "xpath=ancestor-or-self::*[self::article or @data-urn or contains(@class, 'feed-shared-update-v2') or contains(@class, 'occludable-update')]",
       ),
   ];
 

--- a/packages/core/src/linkedinPosts.ts
+++ b/packages/core/src/linkedinPosts.ts
@@ -71,17 +71,18 @@ export const LINKEDIN_POST_POLL_MAX_OPTIONS = 4;
 export const LINKEDIN_POST_POLL_DURATION_DAYS = [1, 3, 7, 14] as const;
 export const LINKEDIN_POST_FEED_SURFACE_SELECTORS = [
   "[data-testid='mainFeed']",
-  "main[role='main']",
+  "[data-testid='mainFeed'] [role='listitem']",
+  "[data-component-type='LazyColumn']",
   "[data-urn]",
   ".feed-shared-update-v2",
   ".occludable-update",
-  ".share-box-feed-entry",
   "main",
 ] as const;
 export const LINKEDIN_POST_ACTIVITY_SURFACE_SELECTORS = [
-  "main[role='main']",
+  "[data-testid='mainFeed']",
   "[data-urn]",
   "article",
+  "[data-component-type='LazyColumn']",
   ".feed-shared-update-v2",
   ".occludable-update",
   "main",
@@ -3152,12 +3153,12 @@ async function findVisiblePostBySnippet(
 ): Promise<Locator | null> {
   const postCandidates = [
     page
-      .locator("article, .feed-shared-update-v2, .occludable-update")
+      .locator("article, [data-urn], .feed-shared-update-v2, .occludable-update")
       .filter({ hasText: snippet }),
     page
       .getByText(snippet)
       .locator(
-        "xpath=ancestor-or-self::*[self::article or contains(@class, 'feed-shared-update-v2') or contains(@class, 'occludable-update')]",
+        "xpath=ancestor-or-self::*[self::article or @data-urn or contains(@class, 'feed-shared-update-v2') or contains(@class, 'occludable-update')]",
       ),
   ];
 

--- a/packages/core/src/linkedinSearch.ts
+++ b/packages/core/src/linkedinSearch.ts
@@ -839,7 +839,7 @@ export class LinkedInSearchService {
           await waitForNetworkIdleBestEffort(page);
           await page
             .locator(
-              "div[data-urn*='activity'], .occludable-update, .feed-shared-update-v2"
+              "div[data-urn*='activity'], article, .occludable-update, .feed-shared-update-v2"
             )
             .first()
             .waitFor({ state: "visible", timeout: 10_000 })
@@ -953,7 +953,7 @@ export class LinkedInSearchService {
 
             const legacyPostContainers = Array.from(
               globalThis.document.querySelectorAll(
-                "div.feed-shared-update-v2[data-urn], .occludable-update[data-urn]"
+                "div.feed-shared-update-v2[data-urn], .occludable-update[data-urn], article[data-urn]"
               )
             ).slice(0, lim);
 

--- a/packages/core/src/liveValidation.ts
+++ b/packages/core/src/liveValidation.ts
@@ -278,9 +278,11 @@ const READ_ONLY_OPERATION_REGISTRY: ReadonlyArray<ReadOnlyOperationDefinition> =
         key: "feed_surface",
         description: "Feed content surface",
         candidates: [
+          { key: "feed-main-testid", selector: "[data-testid='mainFeed']" },
+          { key: "feed-lazy-column", selector: "[data-component-type='LazyColumn']" },
           { key: "feed-update-card", selector: "div.feed-shared-update-v2" },
           { key: "feed-data-urn", selector: "main [data-urn]" },
-          { key: "feed-main", selector: "main[role='main']" }
+          { key: "feed-main", selector: "main" }
         ]
       },
       {


### PR DESCRIPTION
## Summary

Fixes the `post.create` confirm failure caused by outdated LinkedIn feed surface selectors. The `LINKEDIN_POST_FEED_SURFACE_SELECTORS` in `linkedinPosts.ts` used legacy class-based selectors (`.feed-shared-update-v2`, `.occludable-update`, `.share-box-feed-entry`) that no longer match LinkedIn's current DOM, while `linkedinFeed.ts` had already been updated with modern data-attribute selectors.

## Changes

### Core fix — `linkedinPosts.ts`
- **`LINKEDIN_POST_FEED_SURFACE_SELECTORS`**: Replaced `main[role='main']` and `.share-box-feed-entry` with `[data-testid='mainFeed'] [role='listitem']` and `[data-component-type='LazyColumn']` — aligns with the already-working `linkedinFeed.ts` pattern
- **`LINKEDIN_POST_ACTIVITY_SURFACE_SELECTORS`**: Added `[data-testid='mainFeed']` and `[data-component-type='LazyColumn']` as primary selectors, replaced `main[role='main']` with `main` as ultimate fallback
- **`findVisiblePostBySnippet()`**: Added `[data-urn]` to CSS and XPath selectors for post card detection

### Consistency updates
- **`linkedinFeed.ts`**: Updated `findVisiblePostBySnippet()` with matching `[data-urn]` selectors
- **`linkedinSearch.ts`**: Added `article` fallback to post search wait selector; added `article[data-urn]` to legacy post container query
- **`liveValidation.ts`**: Added `feed-main-testid` and `feed-lazy-column` candidates to feed_surface validation; replaced `main[role='main']` with `main`

### Test updates
- Updated mock `visibleSelectors` from `main[role='main']` to `main`
- Updated `matched_candidate_rank` expectation from 1→3 (accounts for 2 new candidates inserted before `feed-data-urn`)

## Verification

- Core package typechecks: clean
- Lint: clean
- All 1513 tests pass (120 test files, 0 regressions)
- Pre-existing build errors in cli/mcp packages are unrelated to this change

Closes #500
