### PR TITLE
fix #502: add pre-flight state detection to connection invite

### DIFF
--- a/packages/core/src/__tests__/linkedinConnections.test.ts
+++ b/packages/core/src/__tests__/linkedinConnections.test.ts
@@ -210,3 +210,143 @@ describe("LinkedInPendingInvitation interface shape", () => {
     expect(invitation.sent_or_received).toBe("sent");
   });
 });
+
+describe("prepareSendInvitation validation", () => {
+  it("rejects empty targetProfile with ACTION_PRECONDITION_FAILED", () => {
+    const rateLimiter = createAllowedRateLimiterStub();
+    const prepare = vi.fn();
+    const service = new LinkedInConnectionsService({
+      rateLimiter,
+      twoPhaseCommit: { prepare }
+    } as unknown as ConstructorParameters<typeof LinkedInConnectionsService>[0]);
+
+    expect(() =>
+      service.prepareSendInvitation({
+        targetProfile: "",
+        note: "Hello"
+      })
+    ).toThrow("targetProfile is required");
+    expect(prepare).not.toHaveBeenCalled();
+  });
+
+  it("rejects whitespace-only targetProfile", () => {
+    const rateLimiter = createAllowedRateLimiterStub();
+    const prepare = vi.fn();
+    const service = new LinkedInConnectionsService({
+      rateLimiter,
+      twoPhaseCommit: { prepare }
+    } as unknown as ConstructorParameters<typeof LinkedInConnectionsService>[0]);
+
+    expect(() =>
+      service.prepareSendInvitation({
+        targetProfile: "   ",
+        note: "Hello"
+      })
+    ).toThrow("targetProfile is required");
+    expect(prepare).not.toHaveBeenCalled();
+  });
+
+  it("includes note in preview outbound", () => {
+    const prepare = vi.fn(
+      (input: { preview: Record<string, unknown> }) => ({
+        preparedActionId: "pa_test",
+        confirmToken: "ct_test",
+        expiresAtMs: 123,
+        preview: input.preview
+      })
+    );
+    const rateLimiter = createAllowedRateLimiterStub();
+    const service = new LinkedInConnectionsService({
+      rateLimiter,
+      twoPhaseCommit: { prepare }
+    } as unknown as ConstructorParameters<typeof LinkedInConnectionsService>[0]);
+
+    const result = service.prepareSendInvitation({
+      targetProfile: "test-user",
+      note: "Let's connect!"
+    });
+
+    expect(result.preview).toMatchObject({
+      outbound: { note: "Let's connect!" }
+    });
+  });
+
+  it("defaults note to empty string when omitted", () => {
+    const prepare = vi.fn(
+      (input: { preview: Record<string, unknown> }) => ({
+        preparedActionId: "pa_test",
+        confirmToken: "ct_test",
+        expiresAtMs: 123,
+        preview: input.preview
+      })
+    );
+    const rateLimiter = createAllowedRateLimiterStub();
+    const service = new LinkedInConnectionsService({
+      rateLimiter,
+      twoPhaseCommit: { prepare }
+    } as unknown as ConstructorParameters<typeof LinkedInConnectionsService>[0]);
+
+    const result = service.prepareSendInvitation({
+      targetProfile: "test-user"
+    });
+
+    expect(result.preview).toMatchObject({
+      outbound: { note: "" }
+    });
+  });
+
+  it("includes correct rate limit counter key in preview", () => {
+    const prepare = vi.fn(
+      (input: { preview: Record<string, unknown> }) => ({
+        preparedActionId: "pa_test",
+        confirmToken: "ct_test",
+        expiresAtMs: 123,
+        preview: input.preview
+      })
+    );
+    const rateLimiter = createAllowedRateLimiterStub();
+    const service = new LinkedInConnectionsService({
+      rateLimiter,
+      twoPhaseCommit: { prepare }
+    } as unknown as ConstructorParameters<typeof LinkedInConnectionsService>[0]);
+
+    const result = service.prepareSendInvitation({
+      targetProfile: "test-user",
+      note: "Hi!"
+    });
+
+    expect(result.preview).toMatchObject({
+      rate_limit: {
+        counter_key: "linkedin.connections.send_invitation"
+      }
+    });
+  });
+
+  it("passes operator note to two-phase commit when provided", () => {
+    const prepare = vi.fn(
+      (input: { preview: Record<string, unknown> }) => ({
+        preparedActionId: "pa_test",
+        confirmToken: "ct_test",
+        expiresAtMs: 123,
+        preview: input.preview
+      })
+    );
+    const rateLimiter = createAllowedRateLimiterStub();
+    const service = new LinkedInConnectionsService({
+      rateLimiter,
+      twoPhaseCommit: { prepare }
+    } as unknown as ConstructorParameters<typeof LinkedInConnectionsService>[0]);
+
+    service.prepareSendInvitation({
+      targetProfile: "test-user",
+      note: "Hi!",
+      operatorNote: "Testing invite flow"
+    });
+
+    expect(prepare).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operatorNote: "Testing invite flow"
+      })
+    );
+  });
+});

--- a/packages/core/src/linkedinConnections.ts
+++ b/packages/core/src/linkedinConnections.ts
@@ -940,6 +940,49 @@ async function executeSendInvitation(
 
       const topCardRoot = page.locator("main .pv-top-card, main").first();
 
+      // Pre-flight: detect if invitation is already pending
+      const alreadyPendingCandidates = buildProfileActionButtonCandidates({
+        topCardRoot,
+        selectorLocale: runtime.selectorLocale,
+        selectorKeys: ["pending", "withdraw"],
+        candidateKeyPrefix: "already-pending"
+      });
+      const alreadyPending = await findVisibleLocator(page, alreadyPendingCandidates);
+      if (alreadyPending) {
+        throw new LinkedInBuddyError(
+          "ACTION_PRECONDITION_FAILED",
+          `Connection invitation is already pending for "${targetProfile}". ` +
+            "Withdraw the existing invitation before sending a new one.",
+          {
+            target_profile: targetProfile,
+            url: page.url(),
+            detected_state: "pending",
+            detected_selector_key: alreadyPending.key
+          }
+        );
+      }
+
+      // Pre-flight: detect if already connected (Message button = connected)
+      const alreadyConnectedCandidates = buildProfileActionButtonCandidates({
+        topCardRoot,
+        selectorLocale: runtime.selectorLocale,
+        selectorKeys: "message",
+        candidateKeyPrefix: "already-connected"
+      });
+      const alreadyConnected = await findVisibleLocator(page, alreadyConnectedCandidates);
+      if (alreadyConnected) {
+        throw new LinkedInBuddyError(
+          "ACTION_PRECONDITION_FAILED",
+          `Already connected with "${targetProfile}".`,
+          {
+            target_profile: targetProfile,
+            url: page.url(),
+            detected_state: "connected",
+            detected_selector_key: alreadyConnected.key
+          }
+        );
+      }
+
       const connectCandidates: VisibleLocatorCandidate[] = [
         {
           key: "topcard-connect-role",
@@ -1065,7 +1108,8 @@ async function executeSendInvitation(
 
         throw new LinkedInBuddyError(
           "UI_CHANGED_SELECTOR_FAILED",
-          "Could not find Connect button on profile page.",
+          `Could not find Connect button on profile page for "${targetProfile}". ` +
+            "The profile may have an unexpected layout or the Connect option may be unavailable.",
           {
             target_profile: targetProfile,
             url: page.url(),


### PR DESCRIPTION
## Summary

Fixes #502 — connection invite fails with misleading `UI_CHANGED_SELECTOR_FAILED` when the target profile shows "Pending" or "Message" instead of "Connect".

## Changes

- **Pre-flight pending detection**: Before searching for the Connect button, checks if a "Pending"/"Withdraw" button is visible on the profile topcard. If found, throws `ACTION_PRECONDITION_FAILED` with clear message: "Connection invitation is already pending for {target}. Withdraw the existing invitation before sending a new one."
- **Pre-flight connected detection**: Before searching for the Connect button, checks if a "Message" button is visible (indicates already-connected). If found, throws `ACTION_PRECONDITION_FAILED` with clear message: "Already connected with {target}."
- **Improved error message**: The fallback "Could not find Connect button" error now includes the target profile name and additional context about possible causes.
- **Unit tests**: Added 6 new tests for `prepareSendInvitation` validation (empty/whitespace targetProfile rejection, note in preview, default note, rate limit counter key, operator note passthrough).

## Pattern

Follows the established pattern from `executeFollowMember()` which already detects "already following" state before attempting the follow action. Uses the same `buildProfileActionButtonCandidates()` + `findVisibleLocator()` helpers for multi-strategy selector resilience (role + aria + page fallback).

## Verification

- ✅ Core package typechecks clean (`npx tsc --noEmit --project packages/core/tsconfig.json`)
- ✅ Lint passes on changed files
- ✅ All 1519 tests pass across 120 test files (zero regressions)
- ✅ Core package builds clean
- ⚠️ Pre-existing build errors in `cli/` and `mcp/` packages (unrelated to this change)

Closes #502
