### PR TITLE
fix #503: harden write-operation selectors against LinkedIn DOM drift

### DIFF
--- a/packages/core/src/__tests__/feedPostComposerTriggerSelectors.test.ts
+++ b/packages/core/src/__tests__/feedPostComposerTriggerSelectors.test.ts
@@ -33,10 +33,10 @@ describe("LINKEDIN_FEED_POST_COMPOSER_LINK_SELECTOR", () => {
 });
 
 describe("createFeedPostComposerTriggerCandidates", () => {
-  it("returns the expected three candidates with required fields", () => {
+  it("returns the expected five candidates with required fields", () => {
     const candidates = createFeedPostComposerTriggerCandidates("en");
 
-    expect(candidates).toHaveLength(3);
+    expect(candidates).toHaveLength(5);
 
     for (const candidate of candidates) {
       expect(candidate).toHaveProperty("key");
@@ -70,7 +70,7 @@ describe("createFeedPostComposerTriggerCandidates", () => {
     const englishCandidates = createFeedPostComposerTriggerCandidates("en");
     const danishCandidates = createFeedPostComposerTriggerCandidates("da");
 
-    expect(danishCandidates).toHaveLength(3);
+    expect(danishCandidates).toHaveLength(5);
     expect(danishCandidates[0]?.selectorHint).toContain("Start et opslag");
     expect(danishCandidates[0]?.selectorHint).not.toBe(
       englishCandidates[0]?.selectorHint

--- a/packages/core/src/confirmArtifacts.ts
+++ b/packages/core/src/confirmArtifacts.ts
@@ -6,7 +6,9 @@ import type { ArtifactHelpers } from "./artifacts.js";
 import type { ConfirmFailureArtifactConfig } from "./config.js";
 import { LinkedInBuddyError } from "./errors.js";
 import type { JsonEventLogger } from "./logging.js";
+import type { LinkedInSelectorLocale } from "./selectorLocale.js";
 import type { ActionExecutorResult } from "./twoPhaseCommit.js";
+import { dismissLinkedInOverlaysIfPresent } from "./overlayDismissal.js";
 
 interface TraceArchiveResizeResult {
   originalBytes: number;
@@ -37,6 +39,8 @@ export interface ExecuteConfirmActionWithArtifactsInput<
   metadata?: Record<string, unknown> | undefined;
   errorDetails?: Record<string, unknown> | undefined;
   beforeExecute?: (() => void) | undefined;
+  /** When provided, known LinkedIn overlays are dismissed before execution. */
+  dismissOverlays?: { selectorLocale: LinkedInSelectorLocale; logger?: Pick<JsonEventLogger, "log"> } | undefined;
   mapError: (error: unknown) => LinkedInBuddyError;
   execute: () => Promise<ActionExecutorResult>;
 }
@@ -459,6 +463,15 @@ export async function executeConfirmActionWithArtifacts<
   }
 
   try {
+    // Dismiss any blocking LinkedIn overlays before the write operation.
+    if (input.dismissOverlays) {
+      await dismissLinkedInOverlaysIfPresent(
+        input.page,
+        input.dismissOverlays.selectorLocale,
+        input.dismissOverlays.logger
+      );
+    }
+
     input.beforeExecute?.();
     const result = await input.execute();
     const artifactPaths = [...result.artifacts];

--- a/packages/core/src/feedPostComposerTriggerSelectors.ts
+++ b/packages/core/src/feedPostComposerTriggerSelectors.ts
@@ -56,6 +56,21 @@ export function createFeedPostComposerTriggerCandidates(
         page
           .locator("button, [role='button'], a")
           .filter({ hasText: startPostTextRegex })
+    },
+    {
+      key: "sharebox-preload-any-link",
+      selectorHint: "a[href*='sharebox'], button[data-control-name*='share']",
+      locatorFactory: (page) =>
+        page.locator("a[href*='sharebox'], button[data-control-name*='share']")
+    },
+    {
+      key: "feed-share-trigger-class",
+      selectorHint:
+        ".share-creation-state__trigger, .feed-shared-update-v2__share-trigger",
+      locatorFactory: (page) =>
+        page.locator(
+          ".share-creation-state__trigger, .feed-shared-update-v2__share-trigger"
+        )
     }
   ];
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export * from "./auth/sessionStore.js";
 export * from "./connectionPool.js";
 export * from "./config.js";
 export * from "./confirmArtifacts.js";
+export * from "./overlayDismissal.js";
 export * from "./db/database.js";
 export * from "./draftQualityEval.js";
 export * from "./draftQualityTypes.js";

--- a/packages/core/src/linkedinCompanyPages.ts
+++ b/packages/core/src/linkedinCompanyPages.ts
@@ -331,6 +331,23 @@ function buildCompanyActionButtonCandidates(input: {
       key: `${input.candidateKeyPrefix}-page-aria`,
       selectorHint: ariaSelector,
       locatorFactory: (pageRoot) => pageRoot.locator(ariaSelector)
+    },
+    {
+      key: `${input.candidateKeyPrefix}-data-control`,
+      selectorHint: "button[data-control-name*='follow']",
+      locatorFactory: (pageRoot) =>
+        pageRoot.locator("button[data-control-name*='follow']")
+    },
+    {
+      key: `${input.candidateKeyPrefix}-main-button-text`,
+      selectorHint: "main button hasText follow",
+      locatorFactory: (pageRoot) => {
+        const textRegex = buildLinkedInSelectorPhraseRegex(
+          input.selectorKeys,
+          input.selectorLocale
+        );
+        return pageRoot.locator("main button").filter({ hasText: textRegex });
+      }
     }
   ];
 }
@@ -530,6 +547,10 @@ async function executeFollowCompanyPage(
           target_company: targetCompany,
           company_url: companyUrl
         },
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
+        },
         mapError: (error) =>
           asLinkedInBuddyError(
             error,
@@ -638,6 +659,10 @@ async function executeUnfollowCompanyPage(
         errorDetails: {
           target_company: targetCompany,
           company_url: companyUrl
+        },
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
         },
         mapError: (error) =>
           asLinkedInBuddyError(

--- a/packages/core/src/linkedinConnections.ts
+++ b/packages/core/src/linkedinConnections.ts
@@ -794,6 +794,10 @@ async function executeSendInvitation(
           profile_url: profileUrl,
           note_included: note.length > 0
         },
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
+        },
         beforeExecute: () =>
           consumeRateLimitOrThrow(runtime.rateLimiter, {
             config: getConnectionRateLimitConfig(SEND_INVITATION_ACTION_TYPE),
@@ -966,6 +970,18 @@ async function executeSendInvitation(
           key: "page-connect-aria",
           selectorHint: connectAriaSelector,
           locatorFactory: (targetPage) => targetPage.locator(connectAriaSelector)
+        },
+        {
+          key: "topcard-connect-text-filter",
+          selectorHint: "main button hasText connect",
+          locatorFactory: (targetPage) =>
+            targetPage.locator("main button").filter({ hasText: connectTextRegex })
+        },
+        {
+          key: "page-connect-data-control",
+          selectorHint: "button[data-control-name*='connect']",
+          locatorFactory: (targetPage) =>
+            targetPage.locator("button[data-control-name*='connect']")
         }
       ];
 
@@ -1103,6 +1119,8 @@ async function executeSendInvitation(
           ".artdeco-modal.send-invite, " +
             ".artdeco-modal:has(button[aria-label*='note' i]), " +
             ".artdeco-modal:has(button[aria-label*='Send' i]), " +
+            "[role='dialog']:has(button[aria-label*='Send' i]), " +
+            "[role='dialog']:has(textarea), " +
             "[role='dialog']:not(.vjs-modal-dialog):not(.vjs-hidden)"
         )
         .first();
@@ -1375,6 +1393,12 @@ async function executeSendInvitation(
           selectorHint: "div.send-invite button.artdeco-button--primary",
           locatorFactory: (targetPage) =>
             targetPage.locator("div.send-invite button.artdeco-button--primary")
+        },
+        {
+          key: "send-dialog-primary-button",
+          selectorHint: "dialog button.artdeco-button--primary",
+          locatorFactory: () =>
+            dialogLocator.locator("button.artdeco-button--primary")
         }
       ];
 
@@ -1470,6 +1494,10 @@ async function executeAcceptInvitation(
         },
         errorDetails: {
           target_profile: targetProfile
+        },
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
         },
         beforeExecute: () =>
           consumeRateLimitOrThrow(runtime.rateLimiter, {
@@ -1579,6 +1607,10 @@ async function executeWithdrawInvitation(
         },
         errorDetails: {
           target_profile: targetProfile
+        },
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
         },
         beforeExecute: () =>
           consumeRateLimitOrThrow(runtime.rateLimiter, {
@@ -1709,6 +1741,10 @@ async function executeIgnoreInvitation(
         errorDetails: {
           target_profile: targetProfile
         },
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
+        },
         beforeExecute: () =>
           consumeRateLimitOrThrow(runtime.rateLimiter, {
             config: getConnectionRateLimitConfig(IGNORE_INVITATION_ACTION_TYPE),
@@ -1821,6 +1857,10 @@ async function executeRemoveConnection(
         errorDetails: {
           target_profile: targetProfile,
           profile_url: profileUrl
+        },
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
         },
         beforeExecute: () =>
           consumeRateLimitOrThrow(runtime.rateLimiter, {
@@ -1962,6 +2002,10 @@ async function executeFollowMember(
           target_profile: targetProfile,
           profile_url: profileUrl
         },
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
+        },
         beforeExecute: () =>
           consumeRateLimitOrThrow(runtime.rateLimiter, {
             config: getConnectionRateLimitConfig(FOLLOW_MEMBER_ACTION_TYPE),
@@ -2085,6 +2129,10 @@ async function executeUnfollowMember(
         errorDetails: {
           target_profile: targetProfile,
           profile_url: profileUrl
+        },
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
         },
         beforeExecute: () =>
           consumeRateLimitOrThrow(runtime.rateLimiter, {

--- a/packages/core/src/linkedinInbox.ts
+++ b/packages/core/src/linkedinInbox.ts
@@ -2182,6 +2182,21 @@ function createMessageComposerSelectors(
       selectorHint: ".msg-form [contenteditable='true']",
       locatorFactory: (targetPage) =>
         targetPage.locator(".msg-form [contenteditable='true']")
+    },
+    {
+      key: "msg-form-texteditor-contenteditable",
+      selectorHint:
+        ".msg-form__message-texteditor [contenteditable='true'], .msg-form__message-texteditor p[role='textbox']",
+      locatorFactory: (targetPage) =>
+        targetPage.locator(
+          ".msg-form__message-texteditor [contenteditable='true'], .msg-form__message-texteditor p[role='textbox']"
+        )
+    },
+    {
+      key: "dialog-contenteditable",
+      selectorHint: "[role='dialog'] [contenteditable='true']",
+      locatorFactory: (targetPage) =>
+        targetPage.locator("[role='dialog'] [contenteditable='true']")
     }
   ];
 }
@@ -2198,6 +2213,11 @@ function createSendButtonSelectors(
     "send",
     runtime.selectorLocale,
     { exact: true }
+  );
+  const sendAriaSelector = buildLinkedInAriaLabelContainsSelector(
+    "button",
+    "send",
+    runtime.selectorLocale
   );
 
   return [
@@ -2216,6 +2236,17 @@ function createSendButtonSelectors(
       key: "msg-form-send-button-fallback",
       selectorHint: ".msg-form__send-button",
       locatorFactory: (targetPage) => targetPage.locator(".msg-form__send-button")
+    },
+    {
+      key: "msg-form-submit",
+      selectorHint: ".msg-form button[type='submit']",
+      locatorFactory: (targetPage) =>
+        targetPage.locator(".msg-form button[type='submit']")
+    },
+    {
+      key: "msg-send-aria-label",
+      selectorHint: sendAriaSelector,
+      locatorFactory: (targetPage) => targetPage.locator(sendAriaSelector)
     }
   ];
 }
@@ -2593,6 +2624,20 @@ async function openProfileMessageComposer(input: {
         selectorHint: `page.getByRole(button, ${messageRegexHint})`,
         locatorFactory: (targetPage) =>
           targetPage.getByRole("button", { name: messageRegex })
+      },
+      {
+        key: "profile-message-data-control",
+        selectorHint: "button[data-control-name*='message']",
+        locatorFactory: (targetPage) =>
+          targetPage.locator("button[data-control-name*='message']")
+      },
+      {
+        key: "profile-message-main-button-text",
+        selectorHint: "main button hasText message",
+        locatorFactory: (targetPage) =>
+          targetPage
+            .locator("main button, .pv-top-card button")
+            .filter({ hasText: messageRegex })
       }
     ],
     "profile_message_button",
@@ -3608,6 +3653,10 @@ class SendMessageActionExecutor
           profileName,
           targetUrl: threadUrl,
           persistTraceOnSuccess: true,
+          dismissOverlays: {
+            selectorLocale: runtime.selectorLocale,
+            logger: runtime.logger
+          },
           metadata: {
             thread_url: threadUrl,
             selector_context: SEND_MESSAGE_ACTION_TYPE
@@ -3709,6 +3758,10 @@ class SendNewThreadActionExecutor
           profileName,
           targetUrl: primaryRecipientUrl,
           persistTraceOnSuccess: true,
+          dismissOverlays: {
+            selectorLocale: runtime.selectorLocale,
+            logger: runtime.logger
+          },
           metadata: {
             primary_recipient_profile_url: primaryRecipientUrl,
             recipient_count: recipients.length,
@@ -3838,6 +3891,10 @@ class AddRecipientsActionExecutor
           profileName,
           targetUrl: threadUrl,
           persistTraceOnSuccess: true,
+          dismissOverlays: {
+            selectorLocale: runtime.selectorLocale,
+            logger: runtime.logger
+          },
           metadata: {
             recipient_count: recipients.length,
             selector_context: ADD_RECIPIENTS_ACTION_TYPE,
@@ -3962,6 +4019,10 @@ class ReactMessageActionExecutor
           profileName,
           targetUrl: threadUrl,
           persistTraceOnSuccess: true,
+          dismissOverlays: {
+            selectorLocale: runtime.selectorLocale,
+            logger: runtime.logger
+          },
           metadata: {
             thread_url: threadUrl,
             requested_reaction: reaction,

--- a/packages/core/src/linkedinPosts.ts
+++ b/packages/core/src/linkedinPosts.ts
@@ -12,6 +12,7 @@ import type { LinkedInAuthService } from "./auth/session.js";
 import { LinkedInBuddyError, asLinkedInBuddyError } from "./errors.js";
 import { scrollLinkedInPageToTop } from "./linkedinPage.js";
 import type { JsonEventLogger } from "./logging.js";
+import { dismissLinkedInOverlaysIfPresent } from "./overlayDismissal.js";
 import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
 import {
@@ -1827,6 +1828,22 @@ function createComposerRootCandidates(
       locatorFactory: (page) =>
         page.locator(".share-box__open, .share-creation-state"),
     },
+    {
+      key: "dialog-with-contenteditable-div",
+      selectorHint: "[role='dialog']:has(div[contenteditable='true'])",
+      locatorFactory: (page) =>
+        page.locator("[role='dialog']").filter({
+          has: page.locator("div[contenteditable='true']"),
+        }),
+    },
+    {
+      key: "dialog-with-ql-editor",
+      selectorHint: "[role='dialog']:has(.ql-editor)",
+      locatorFactory: (page) =>
+        page.locator("[role='dialog']").filter({
+          has: page.locator(".ql-editor"),
+        }),
+    },
   ];
 }
 
@@ -1872,6 +1889,15 @@ function createComposerInputCandidates(
       key: "textarea",
       selectorHint: "textarea",
       locatorFactory: (root) => root.locator("textarea"),
+    },
+    {
+      key: "contenteditable-paragraph",
+      selectorHint:
+        "p[contenteditable='true'], div[contenteditable='true'][role='textbox']",
+      locatorFactory: (root) =>
+        root.locator(
+          "p[contenteditable='true'], div[contenteditable='true'][role='textbox']",
+        ),
     },
   ];
 }
@@ -2049,6 +2075,24 @@ function createPublishButtonCandidates(
       key: "submit-button",
       selectorHint: "button[type='submit']",
       locatorFactory: (root) => root.locator("button[type='submit']"),
+    },
+    {
+      key: "publish-footer-primary",
+      selectorHint:
+        "footer button.artdeco-button--primary, .share-box-footer button.artdeco-button--primary",
+      locatorFactory: (root) =>
+        root.locator(
+          "footer button.artdeco-button--primary, .share-box-footer button.artdeco-button--primary",
+        ),
+    },
+    {
+      key: "publish-primary-action-class",
+      selectorHint:
+        ".share-actions__primary-action, button.share-actions__primary-action",
+      locatorFactory: (root) =>
+        root.locator(
+          ".share-actions__primary-action, button.share-actions__primary-action",
+        ),
     },
   ];
 }
@@ -2508,9 +2552,11 @@ async function openPostComposer(
   page: Page,
   selectorLocale: LinkedInSelectorLocale,
   artifactPaths: string[],
+  logger?: Pick<JsonEventLogger, "log">,
 ): Promise<{ composerRoot: Locator; triggerKey: string; rootKey: string }> {
   await page.goto(LINKEDIN_FEED_URL, { waitUntil: "domcontentloaded" });
   await waitForNetworkIdleBestEffort(page);
+  await dismissLinkedInOverlaysIfPresent(page, selectorLocale, logger);
   const triggerCandidates =
     createFeedPostComposerTriggerCandidates(selectorLocale);
   const visibleTrigger = await findOptionalVisibleLocator(
@@ -4469,6 +4515,7 @@ class CreatePostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRu
             page,
             runtime.selectorLocale,
             artifactPaths,
+            runtime.logger,
           );
           const visibilityKey = await setPostVisibility(
             page,
@@ -4741,6 +4788,7 @@ class CreateMediaPostActionExecutor implements ActionExecutor<LinkedInPostsExecu
             page,
             runtime.selectorLocale,
             artifactPaths,
+            runtime.logger,
           );
           const visibilityKey = await setPostVisibility(
             page,
@@ -5043,6 +5091,7 @@ class CreatePollPostActionExecutor implements ActionExecutor<LinkedInPostsExecut
             page,
             runtime.selectorLocale,
             artifactPaths,
+            runtime.logger,
           );
           const visibilityKey = await setPostVisibility(
             page,
@@ -5321,6 +5370,11 @@ class EditPostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRunt
 
           await page.goto(postUrl, { waitUntil: "domcontentloaded" });
           await waitForNetworkIdleBestEffort(page);
+          await dismissLinkedInOverlaysIfPresent(
+            page,
+            runtime.selectorLocale,
+            runtime.logger,
+          );
 
           const targetPost = await findTargetPostLocator(
             page,
@@ -5581,6 +5635,11 @@ class DeletePostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRu
 
           await page.goto(postUrl, { waitUntil: "domcontentloaded" });
           await waitForNetworkIdleBestEffort(page);
+          await dismissLinkedInOverlaysIfPresent(
+            page,
+            runtime.selectorLocale,
+            runtime.logger,
+          );
 
           const targetPost = await findTargetPostLocator(
             page,

--- a/packages/core/src/linkedinProfile.ts
+++ b/packages/core/src/linkedinProfile.ts
@@ -4860,6 +4860,16 @@ async function findSaveButtonInBroaderScope(
       key: "save-fallback-first-dialog",
       locator: page.locator(PROFILE_DIALOG_ROOT_SELECTOR).first(),
       selectorHint: "first (outermost) dialog root on page"
+    },
+    {
+      key: "save-fallback-form-container",
+      locator: page.locator("form:has(button[type='submit'])").last(),
+      selectorHint: "form:has(button[type='submit']) (last)"
+    },
+    {
+      key: "save-fallback-last-dialog",
+      locator: page.locator("[role='dialog']").last(),
+      selectorHint: "[role='dialog'] (last)"
     }
   ];
 
@@ -4923,7 +4933,15 @@ async function clickSaveInProfileEditorSurface(
             surface.root,
             saveLabels,
             "profile-editor-save"
-          )
+          ),
+          {
+            key: "profile-editor-save-footer-primary",
+            locator: surface.root.locator(
+              ".artdeco-modal__actionbar button.artdeco-button--primary, " +
+              "footer button.artdeco-button--primary"
+            ),
+            selectorHint: ".artdeco-modal__actionbar or footer primary button"
+          }
         ]
       : [
           ...createActionCandidates(
@@ -4935,6 +4953,14 @@ async function clickSaveInProfileEditorSurface(
             key: "profile-editor-save-submit",
             locator: surface.root.locator("button[type='submit']"),
             selectorHint: "button[type='submit']"
+          },
+          {
+            key: "profile-editor-save-dialog-primary",
+            locator: surface.root.locator(
+              "[role='dialog'] button.artdeco-button--primary, " +
+              ".artdeco-modal button.artdeco-button--primary"
+            ).last(),
+            selectorHint: "dialog/modal primary button (last)"
           }
         ];
 
@@ -6820,6 +6846,10 @@ async function executeAddProfileSkill(
         context,
         page,
         actionId,
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
+        },
         actionType: ADD_PROFILE_SKILL_ACTION_TYPE,
         profileName,
         targetUrl: resolveProfileUrl("me"),
@@ -6892,6 +6922,10 @@ async function executeReorderProfileSkills(
         context,
         page,
         actionId,
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
+        },
         actionType: REORDER_PROFILE_SKILLS_ACTION_TYPE,
         profileName,
         targetUrl: resolveProfileUrl("me"),
@@ -6969,6 +7003,10 @@ async function executeEndorseProfileSkill(
         context,
         page,
         actionId,
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
+        },
         actionType: ENDORSE_PROFILE_SKILL_ACTION_TYPE,
         profileName,
         targetUrl: targetProfileUrl,
@@ -7057,6 +7095,10 @@ async function executeRequestProfileRecommendation(
         context,
         page,
         actionId,
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
+        },
         actionType: REQUEST_PROFILE_RECOMMENDATION_ACTION_TYPE,
         profileName,
         targetUrl: targetProfileUrl,
@@ -7154,6 +7196,10 @@ async function executeWriteProfileRecommendation(
         context,
         page,
         actionId,
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
+        },
         actionType: WRITE_PROFILE_RECOMMENDATION_ACTION_TYPE,
         profileName,
         targetUrl: targetProfileUrl,
@@ -7236,6 +7282,10 @@ async function executeUploadProfileMedia(
         context,
         page,
         actionId,
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
+        },
         actionType:
           kind === "photo"
             ? UPLOAD_PROFILE_PHOTO_ACTION_TYPE
@@ -7342,6 +7392,10 @@ async function executeAddFeaturedItem(
         context,
         page,
         actionId,
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
+        },
         actionType: ADD_PROFILE_FEATURED_ACTION_TYPE,
         profileName,
         targetUrl: resolveProfileUrl("me"),
@@ -7447,6 +7501,10 @@ async function executeRemoveFeaturedItem(
         context,
         page,
         actionId,
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
+        },
         actionType: REMOVE_PROFILE_FEATURED_ACTION_TYPE,
         profileName,
         targetUrl: resolveProfileUrl("me"),
@@ -7534,6 +7592,10 @@ async function executeReorderFeaturedItems(
         context,
         page,
         actionId,
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
+        },
         actionType: REORDER_PROFILE_FEATURED_ACTION_TYPE,
         profileName,
         targetUrl: resolveProfileUrl("me"),
@@ -7605,6 +7667,10 @@ async function executeUpdateProfileIntro(
         context,
         page,
         actionId,
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
+        },
         actionType: UPDATE_PROFILE_INTRO_ACTION_TYPE,
         profileName,
         targetUrl: resolveProfileUrl("me"),
@@ -7684,6 +7750,10 @@ async function executeUpdateProfileSettings(
         context,
         page,
         actionId,
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
+        },
         actionType: UPDATE_PROFILE_SETTINGS_ACTION_TYPE,
         profileName,
         targetUrl: resolveProfileUrl("me"),
@@ -7769,6 +7839,10 @@ async function executeUpdateProfilePublicProfile(
         context,
         page,
         actionId,
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
+        },
         actionType: UPDATE_PROFILE_PUBLIC_PROFILE_ACTION_TYPE,
         profileName,
         targetUrl: LINKEDIN_PUBLIC_PROFILE_SETTINGS_URL,
@@ -7869,6 +7943,10 @@ async function executeUpsertProfileSectionItem(
         context,
         page,
         actionId,
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
+        },
         actionType: UPSERT_PROFILE_SECTION_ITEM_ACTION_TYPE,
         profileName,
         targetUrl: resolveProfileUrl("me"),
@@ -7980,6 +8058,10 @@ async function executeRemoveProfileSectionItem(
         context,
         page,
         actionId,
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
+        },
         actionType: REMOVE_PROFILE_SECTION_ITEM_ACTION_TYPE,
         profileName,
         targetUrl: resolveProfileUrl("me"),

--- a/packages/core/src/linkedinSearch.ts
+++ b/packages/core/src/linkedinSearch.ts
@@ -232,7 +232,7 @@ export class LinkedInSearchService {
           await waitForNetworkIdleBestEffort(page);
           await page
             .locator(
-              "main a[href*='/in/'], div[data-view-name='search-entity-result-universal-template'], .reusable-search__result-container"
+              "main a[href*='/in/'], div[data-view-name='search-entity-result-universal-template'], .reusable-search__result-container, li.reusable-search__result-container, [data-view-name='search-entity-result-universal-template'], ul.reusable-search__entity-result-list > li, .search-results-container li"
             )
             .first()
             .waitFor({ state: "visible", timeout: 10_000 })
@@ -366,7 +366,7 @@ export class LinkedInSearchService {
 
             const legacyCards = Array.from(
               globalThis.document.querySelectorAll(
-                "div[data-view-name='search-entity-result-universal-template'], .reusable-search__result-container, li.reusable-search__result-container"
+                "div[data-view-name='search-entity-result-universal-template'], .reusable-search__result-container, li.reusable-search__result-container, [data-view-name='search-entity-result-universal-template'], ul.reusable-search__entity-result-list > li, .search-results-container li"
               )
             ).slice(0, lim);
 
@@ -374,6 +374,8 @@ export class LinkedInSearchService {
               name: pickText(card, [
                 "a[href*='/in/'] span[dir='ltr'] > span[aria-hidden='true']",
                 ".entity-result__title-text a span[aria-hidden='true']",
+                ".entity-result__title-text a span[dir='ltr']",
+                "a[data-field='entity_result_universal_name'] span",
                 ".app-aware-link span[dir='ltr']"
               ]),
               headline:
@@ -466,7 +468,7 @@ export class LinkedInSearchService {
           await waitForNetworkIdleBestEffort(page);
           await page
             .locator(
-              "main a[href*='/company/'], div[data-view-name='search-entity-result-universal-template'], .reusable-search__result-container"
+              "main a[href*='/company/'], div[data-view-name='search-entity-result-universal-template'], .reusable-search__result-container, li.reusable-search__result-container, [data-view-name='search-entity-result-universal-template'], ul.reusable-search__entity-result-list > li, .search-results-container li"
             )
             .first()
             .waitFor({ state: "visible", timeout: 10_000 })
@@ -581,7 +583,7 @@ export class LinkedInSearchService {
 
             const legacyCards = Array.from(
               globalThis.document.querySelectorAll(
-                "div[data-view-name='search-entity-result-universal-template'], .reusable-search__result-container, li.reusable-search__result-container"
+                "div[data-view-name='search-entity-result-universal-template'], .reusable-search__result-container, li.reusable-search__result-container, [data-view-name='search-entity-result-universal-template'], ul.reusable-search__entity-result-list > li, .search-results-container li"
               )
             ).slice(0, lim);
 
@@ -682,7 +684,9 @@ export class LinkedInSearchService {
           });
           await waitForNetworkIdleBestEffort(page);
           await page
-            .locator(".job-card-container, .base-search-card")
+            .locator(
+              ".job-card-container, .base-search-card, .job-card-list__entity-lockup, .jobs-search-results-list__list-item"
+            )
             .first()
             .waitFor({ state: "visible", timeout: 10_000 })
             .catch(() => undefined);
@@ -734,7 +738,7 @@ export class LinkedInSearchService {
 
             const cards = Array.from(
               globalThis.document.querySelectorAll(
-                ".job-card-container, .base-search-card"
+                ".job-card-container, .base-search-card, .job-card-list__entity-lockup, .jobs-search-results-list__list-item"
               )
             ).slice(0, lim);
 

--- a/packages/core/src/overlayDismissal.ts
+++ b/packages/core/src/overlayDismissal.ts
@@ -1,0 +1,224 @@
+import type { Locator, Page } from "playwright-core";
+import type { LinkedInSelectorLocale } from "./selectorLocale.js";
+import {
+  buildLinkedInSelectorPhraseRegex,
+  buildLinkedInAriaLabelContainsSelector
+} from "./selectorLocale.js";
+import type { JsonEventLogger } from "./logging.js";
+
+/**
+ * Result from a single overlay dismissal pass.
+ */
+export interface DismissedOverlayResult {
+  /** Whether any overlay was actually dismissed. */
+  dismissed: boolean;
+  /** Identifier for the type of overlay that was dismissed, or `null`. */
+  overlayType: string | null;
+  /** Selector key that matched, or `null`. */
+  selectorKey: string | null;
+}
+
+type LoggerLike = Pick<JsonEventLogger, "log">;
+
+/**
+ * Known LinkedIn overlay / modal selectors that block interaction with the
+ * underlying page.  The ordering matters — more specific selectors first,
+ * generic fallback last.
+ */
+const BLOCKING_OVERLAY_SELECTORS = [
+  // Org-page "viewing settings" modal
+  '[data-test-modal-id="org-page-viewing-setting-modal"]',
+  // Artdeco modal overlays (top-layer)
+  ".artdeco-modal-overlay--is-top-layer",
+  // Generic artdeco toast / global alerts
+  ".artdeco-global-alert--COOKIE_CONSENT",
+  ".artdeco-global-alert:not(.artdeco-global-alert--COOKIE_CONSENT)",
+  // Inbox mini-composer bubble overlay
+  ".msg-overlay-conversation-bubble",
+  // Generic blocking dialogs (checked LAST — only dismissed when they are
+  // clearly blocking, i.e. [aria-modal='true'] without expected action content)
+  "[aria-modal='true'][role='dialog']"
+] as const;
+
+/**
+ * Check whether a locator is visible on page.  Returns `false` on any error.
+ */
+async function isOverlayLocatorVisible(locator: Locator): Promise<boolean> {
+  try {
+    return await locator.first().isVisible();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Attempts to click a close/dismiss button inside the given overlay locator.
+ * Uses locale-aware selectors for "close" and "dismiss" phrases.
+ *
+ * @returns The key of the matched button, or `null` if no close button found.
+ */
+async function tryClickCloseButton(
+  overlay: Locator,
+  selectorLocale: LinkedInSelectorLocale
+): Promise<string | null> {
+  const closeRegex = buildLinkedInSelectorPhraseRegex(
+    ["dismiss", "close"],
+    selectorLocale
+  );
+  const closeAriaSelector = buildLinkedInAriaLabelContainsSelector(
+    "button",
+    ["dismiss", "close"],
+    selectorLocale
+  );
+
+  const candidates: Array<{ key: string; locator: Locator }> = [
+    {
+      key: "overlay-close-role-button",
+      locator: overlay.getByRole("button", { name: closeRegex })
+    },
+    {
+      key: "overlay-close-aria-button",
+      locator: overlay.locator(closeAriaSelector)
+    },
+    {
+      key: "overlay-close-svg-button",
+      locator: overlay.locator(
+        "button:has(svg[data-test-icon='close-small']), " +
+        "button:has(svg[aria-label*='close' i]), " +
+        "button:has(li-icon[type='close'])"
+      )
+    }
+  ];
+
+  for (const candidate of candidates) {
+    const visible = await isOverlayLocatorVisible(candidate.locator);
+    if (visible) {
+      await candidate.locator.first().click({ timeout: 2_000 }).catch(() => undefined);
+      return candidate.key;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Checks whether a `[role='dialog']` overlay contains content that looks like
+ * an expected write-action surface (form fields, content-editable areas, or
+ * action buttons).  Such dialogs should NOT be dismissed — they are the target
+ * of the upcoming write operation.
+ */
+async function isExpectedActionDialog(dialog: Locator): Promise<boolean> {
+  const actionContentSelectors = [
+    "[contenteditable='true']",
+    "textarea",
+    "form",
+    "input[type='text']",
+    "input[type='email']",
+    "input[type='url']"
+  ];
+
+  for (const selector of actionContentSelectors) {
+    const hasContent = await dialog
+      .locator(selector)
+      .first()
+      .isVisible()
+      .catch(() => false);
+    if (hasContent) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Dismisses common LinkedIn overlay modals that block interaction with the
+ * underlying page.
+ *
+ * The utility runs through a prioritized list of known blocking overlay
+ * selectors.  For each visible overlay it attempts to click its close/dismiss
+ * button.  If no close button is found it falls back to the Escape key.
+ *
+ * Safety: Generic `[role='dialog']` overlays are only dismissed when they
+ * do NOT contain content-editable fields or form inputs — those are assumed to
+ * be the target of the upcoming write operation.
+ *
+ * @returns Information about whether an overlay was dismissed and which
+ * selector matched.
+ */
+export async function dismissLinkedInOverlaysIfPresent(
+  page: Page,
+  selectorLocale: LinkedInSelectorLocale,
+  logger?: LoggerLike
+): Promise<DismissedOverlayResult> {
+  for (const selector of BLOCKING_OVERLAY_SELECTORS) {
+    const overlay = page.locator(selector).first();
+    const visible = await isOverlayLocatorVisible(overlay);
+
+    if (!visible) {
+      continue;
+    }
+
+    // For generic dialog overlays, skip if they contain action content
+    // (forms, textareas, content-editable) — those are expected write surfaces.
+    if (selector === "[aria-modal='true'][role='dialog']") {
+      if (await isExpectedActionDialog(overlay)) {
+        continue;
+      }
+    }
+
+    logger?.log("info", "overlay.dismissal.detected", {
+      selector,
+      page_url: page.url()
+    });
+
+    const buttonKey = await tryClickCloseButton(overlay, selectorLocale);
+
+    if (buttonKey) {
+      // Wait for overlay to disappear after clicking close
+      await overlay
+        .waitFor({ state: "hidden", timeout: 3_000 })
+        .catch(() => undefined);
+
+      logger?.log("info", "overlay.dismissal.closed_via_button", {
+        selector,
+        button_key: buttonKey,
+        page_url: page.url()
+      });
+
+      return {
+        dismissed: true,
+        overlayType: selector,
+        selectorKey: buttonKey
+      };
+    }
+
+    // Fallback: press Escape
+    await page.keyboard.press("Escape").catch(() => undefined);
+    await overlay
+      .waitFor({ state: "hidden", timeout: 2_000 })
+      .catch(() => undefined);
+
+    const stillVisible = await isOverlayLocatorVisible(overlay);
+
+    logger?.log("info", "overlay.dismissal.escape_fallback", {
+      selector,
+      still_visible: stillVisible,
+      page_url: page.url()
+    });
+
+    if (!stillVisible) {
+      return {
+        dismissed: true,
+        overlayType: selector,
+        selectorKey: "escape-fallback"
+      };
+    }
+  }
+
+  return {
+    dismissed: false,
+    overlayType: null,
+    selectorKey: null
+  };
+}

--- a/packages/core/src/selectorAudit.ts
+++ b/packages/core/src/selectorAudit.ts
@@ -420,6 +420,26 @@ function createDefaultSelectorAuditRegistry(
                 hasText: profileSurfaceRegex
               })
           }
+        }),
+        createSelectorAuditSelectorDefinition("profile_edit_trigger", "Profile edit pencil/button", {
+          primary: {
+            key: "edit-intro-pencil-aria",
+            selectorHint: "button[aria-label*='Edit intro' i], button[aria-label*='Edit' i]",
+            locatorFactory: (page) =>
+              page.locator("button[aria-label*='Edit intro' i], button[aria-label*='Edit' i]").first()
+          },
+          secondary: {
+            key: "edit-intro-link",
+            selectorHint: "a[href*='/edit/intro'], a[href*='/overlay/edit/']",
+            locatorFactory: (page) =>
+              page.locator("a[href*='/edit/intro'], a[href*='/overlay/edit/']")
+          },
+          tertiary: {
+            key: "edit-intro-svg-button",
+            selectorHint: "button:has(svg[data-test-icon='pencil'])",
+            locatorFactory: (page) =>
+              page.locator("button:has(svg[data-test-icon='pencil']), button:has(li-icon[type='pencil'])")
+          }
         })
       ]
     },
@@ -427,6 +447,30 @@ function createDefaultSelectorAuditRegistry(
       page: "connections",
       url: LINKEDIN_CONNECTIONS_URL,
       selectors: [
+        createSelectorAuditSelectorDefinition(
+          "connections_action_buttons",
+          "Connection action buttons (Message, Remove)",
+          {
+            primary: {
+              key: "connection-message-button",
+              selectorHint: "button[aria-label*='Message' i], button[aria-label*='message' i]",
+              locatorFactory: (page) =>
+                page.locator("button[aria-label*='Message' i], button[aria-label*='message' i]").first()
+            },
+            secondary: {
+              key: "connection-action-link",
+              selectorHint: "a[href*='/messaging/thread/']",
+              locatorFactory: (page) =>
+                page.locator("a[href*='/messaging/thread/']").first()
+            },
+            tertiary: {
+              key: "connection-card-with-actions",
+              selectorHint: "li:has(button)",
+              locatorFactory: (page) =>
+                page.locator("li.mn-connection-card:has(button), li:has(button[aria-label])").first()
+            }
+          }
+        ),
         createSelectorAuditSelectorDefinition(
           "connections_surface",
           "Connections page surface",


### PR DESCRIPTION
## Summary

Fixes #503 — all write operation confirmations were failing due to LinkedIn frontend DOM restructuring. This PR adds fallback selector candidates across all write surfaces and introduces centralized overlay dismissal to prevent blocking modals from interfering with write flows.

Also closes #498, #499, #500, #501, #502.

## Changes

### New: Centralized overlay dismissal (`overlayDismissal.ts`)
- Dismisses blocking LinkedIn overlays before write operations: org-page modals, artdeco overlays, cookie banners, inbox chat bubbles, generic `aria-modal` dialogs
- Safety check: won't dismiss dialogs containing form fields or `contenteditable` (expected write surfaces)
- Integrated into `confirmArtifacts.ts` via new optional `dismissOverlays` field on `ExecuteConfirmActionWithArtifactsInput`

### Profile write selectors (#498, #499)
- Added save button fallback candidates (footer primary, dialog primary buttons)
- Added broader scope candidates (form container, last dialog)
- Wired `dismissOverlays` into all 14 profile `executeConfirmActionWithArtifacts` calls

### Post composer selectors (#500)
- Added 2 new trigger candidates (sharebox link, share-creation-state class)
- Added composer root, input, and publish button fallback candidates
- Direct overlay dismissal in post creation flows

### Connection + Company selectors (#501, #502)
- Added connect button candidates (`data-control-name`, main text filter)
- Expanded connect dialog selector string
- Added send dialog primary button fallback
- Added follow button candidates for company pages
- Wired `dismissOverlays` into all 9 executor calls across both services

### Inbox + Search selectors
- Added message button, composer, and send button fallback candidates for inbox
- Expanded search result container selectors (universal-template, entity-result-list)
- Added name/title fallback selectors for search results
- Wired `dismissOverlays` into all 4 inbox executor calls

### Selector audit
- Added `profile_edit_trigger` and `connections_action_buttons` audit groups

## Approach

- **Additive only** — no existing selectors removed; new candidates appended to fallback chains
- **en/da locale support** — uses existing `selectorLocale.ts` phrase keys (no new keys needed)
- **Backward compatible** — `dismissOverlays` field is optional; existing callers unaffected

## Quality gates

- ✅ `npx tsc --noEmit` — clean
- ✅ `npm run lint` — clean
- ✅ `npm test` — 1513 tests pass across 120 files
- ✅ `npm run build` — same pre-existing CLI/MCP errors as `main` (not from this PR)

## Files changed (12)

| File | Change |
|------|--------|
| `overlayDismissal.ts` | **NEW** — centralized overlay dismissal utility |
| `confirmArtifacts.ts` | Added `dismissOverlays` field + pre-execution call |
| `index.ts` | Added overlayDismissal export |
| `linkedinProfile.ts` | Save button + scope candidates, 14× dismissOverlays |
| `feedPostComposerTriggerSelectors.ts` | 2 new trigger candidates |
| `linkedinPosts.ts` | Composer/publish candidates + overlay dismissal |
| `linkedinConnections.ts` | Connect/dialog/send candidates, 7× dismissOverlays |
| `linkedinCompanyPages.ts` | Follow button candidates, 2× dismissOverlays |
| `linkedinInbox.ts` | Message/composer/send candidates, 4× dismissOverlays |
| `linkedinSearch.ts` | Expanded result container + name selectors |
| `selectorAudit.ts` | 2 new audit groups |
| `feedPostComposerTriggerSelectors.test.ts` | Updated expected candidate count (3→5) |