### PR TITLE
feat #506: add --continue-on-error flag to profile apply-spec and seed activity

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -7391,6 +7391,27 @@ function createActivitySeedOperatorNote(
   return `activity seed: ${path.basename(resolvedSpecPath)} / ${sectionLabel}`;
 }
 
+function isFatalSeedError(error: LinkedInBuddyError): boolean {
+  return (
+    error.code === "AUTH_REQUIRED" ||
+    error.code === "CAPTCHA_OR_CHALLENGE"
+  );
+}
+
+function summarizeActionFailure(
+  summary: string,
+  error: LinkedInBuddyError,
+): Record<string, unknown> {
+  return {
+    summary,
+    action_type: null,
+    prepared_action_id: null,
+    status: "failed",
+    error_code: error.code,
+    error_message: error.message,
+  };
+}
+
 function summarizeConfirmedAction(confirmed: {
   actionType: string;
   preparedActionId: string;
@@ -7438,6 +7459,7 @@ async function runProfileApplySpec(
     allowPartial: boolean;
     delayMs: number;
     yes: boolean;
+    continueOnError: boolean;
     outputPath?: string;
   },
   cdpUrl?: string,
@@ -7508,22 +7530,39 @@ async function runProfileApplySpec(
       }
     }
 
+    let failedActionCount = 0;
     const actionResults: Array<Record<string, unknown>> = [];
     for (let index = 0; index < plan.actions.length; index += 1) {
       const action = plan.actions[index]!;
-      const prepared = prepareProfileSeedAction(runtime, action);
-      const confirmed = await runtime.twoPhaseCommit.confirmByToken({
-        confirmToken: prepared.confirmToken,
-      });
+      try {
+        const prepared = prepareProfileSeedAction(runtime, action);
+        const confirmed = await runtime.twoPhaseCommit.confirmByToken({
+          confirmToken: prepared.confirmToken,
+        });
 
-      actionResults.push({
-        summary: action.summary,
-        action_type: confirmed.actionType,
-        prepared_action_id: confirmed.preparedActionId,
-        status: confirmed.status,
-        result: confirmed.result,
-        artifacts: confirmed.artifacts,
-      });
+        actionResults.push({
+          summary: action.summary,
+          action_type: confirmed.actionType,
+          prepared_action_id: confirmed.preparedActionId,
+          status: confirmed.status,
+          result: confirmed.result,
+          artifacts: confirmed.artifacts,
+        });
+      } catch (rawError) {
+        const error = asLinkedInBuddyError(rawError);
+        if (!input.continueOnError || isFatalSeedError(error)) {
+          throw error;
+        }
+
+        runtime.logger.log("warn", "cli.profile.apply_spec.action_failed", {
+          actionIndex: index,
+          summary: action.summary,
+          errorCode: error.code,
+          errorMessage: error.message,
+        });
+        actionResults.push(summarizeActionFailure(action.summary, error));
+        failedActionCount += 1;
+      }
 
       if (index < plan.actions.length - 1 && input.delayMs > 0) {
         await sleep(sampleSeedDelay(input.delayMs));
@@ -7535,15 +7574,19 @@ async function runProfileApplySpec(
       target: "me",
     });
 
+    const succeededActionCount = actionResults.length - failedActionCount;
     const report: Record<string, unknown> = {
       run_id: runtime.runId,
       profile_name: input.profileName,
       spec_path: resolvedSpecPath,
       replace: input.replace,
       allow_partial: input.allowPartial,
+      continue_on_error: input.continueOnError,
       delay_ms: input.delayMs,
       planned_action_count: plan.actions.length,
       executed_action_count: actionResults.length,
+      succeeded_action_count: succeededActionCount,
+      failed_action_count: failedActionCount,
       unsupported_fields: plan.unsupportedFields,
       actions: actionResults,
       profile: finalProfile,
@@ -7552,12 +7595,21 @@ async function runProfileApplySpec(
     if (input.outputPath) {
       report.output_path = await writeOutputJsonFile(input.outputPath, report);
     }
+    if (failedActionCount > 0) {
+      writeCliWarning(
+        `${succeededActionCount}/${actionResults.length} edits succeeded, ${failedActionCount} failed.`,
+      );
+      process.exitCode = 1;
+    }
+
 
     runtime.logger.log("info", "cli.profile.apply_spec.done", {
       profileName: input.profileName,
       specPath: resolvedSpecPath,
       plannedActionCount: plan.actions.length,
       executedActionCount: actionResults.length,
+      succeededActionCount,
+      failedActionCount,
       unsupportedFieldCount: plan.unsupportedFields.length,
     });
 
@@ -7604,6 +7656,7 @@ async function runSeedActivity(
     specPath: string;
     delayMs: number;
     yes: boolean;
+    continueOnError: boolean;
     outputPath?: string;
   },
   cdpUrl?: string,
@@ -7676,6 +7729,8 @@ async function runSeedActivity(
         : {}),
     };
 
+    let failedActionCount = 0;
+
     const connectionsSection: Record<string, unknown> = {
       accepted_pending: [] as Record<string, unknown>[],
       invites: [] as Record<string, unknown>[],
@@ -7694,25 +7749,42 @@ async function runSeedActivity(
       connectionsSection.pending_received = pendingReceived;
 
       for (const [index, invitation] of pendingToAccept.entries()) {
-        const prepared = runtime.connections.prepareAcceptInvitation({
-          profileName: input.profileName,
-          targetProfile: invitation.profile_url,
-          operatorNote: createActivitySeedOperatorNote(
-            resolvedSpecPath,
-            `accept pending ${index + 1}`,
-            undefined,
-          ),
-        });
-        const confirmed = await runtime.twoPhaseCommit.confirmByToken({
-          confirmToken: prepared.confirmToken,
-        });
-        (connectionsSection.accepted_pending as Record<string, unknown>[]).push(
-          {
-            target_profile: invitation.profile_url,
-            full_name: invitation.full_name,
-            ...summarizeConfirmedAction(confirmed),
-          },
-        );
+        try {
+          const prepared = runtime.connections.prepareAcceptInvitation({
+            profileName: input.profileName,
+            targetProfile: invitation.profile_url,
+            operatorNote: createActivitySeedOperatorNote(
+              resolvedSpecPath,
+              `accept pending ${index + 1}`,
+              undefined,
+            ),
+          });
+          const confirmed = await runtime.twoPhaseCommit.confirmByToken({
+            confirmToken: prepared.confirmToken,
+          });
+          (connectionsSection.accepted_pending as Record<string, unknown>[]).push(
+            {
+              target_profile: invitation.profile_url,
+              full_name: invitation.full_name,
+              ...summarizeConfirmedAction(confirmed),
+            },
+          );
+        } catch (rawError) {
+          const error = asLinkedInBuddyError(rawError);
+          if (!input.continueOnError || isFatalSeedError(error)) {
+            throw error;
+          }
+          runtime.logger.log("warn", "cli.seed.activity.action_failed", {
+            section: "connections.accept_pending",
+            actionIndex: index,
+            errorCode: error.code,
+            errorMessage: error.message,
+          });
+          (connectionsSection.accepted_pending as Record<string, unknown>[]).push(
+            summarizeActionFailure(`accept pending ${index + 1}`, error),
+          );
+          failedActionCount += 1;
+        }
         await maybeSleepSeedDelay(input.delayMs);
       }
     }
@@ -7769,24 +7841,41 @@ async function runSeedActivity(
           continue;
         }
 
-        const prepared = runtime.connections.prepareSendInvitation({
-          profileName: input.profileName,
-          targetProfile: invite.targetProfile,
-          ...(invite.note ? { note: invite.note } : {}),
-          operatorNote: createActivitySeedOperatorNote(
-            resolvedSpecPath,
-            `invite ${index + 1}`,
-            invite.operatorNote,
-          ),
-        });
-        const confirmed = await runtime.twoPhaseCommit.confirmByToken({
-          confirmToken: prepared.confirmToken,
-        });
-        (connectionsSection.invites as Record<string, unknown>[]).push({
-          target_profile: invite.targetProfile,
-          ...(invite.note ? { note: invite.note } : {}),
-          ...summarizeConfirmedAction(confirmed),
-        });
+        try {
+          const prepared = runtime.connections.prepareSendInvitation({
+            profileName: input.profileName,
+            targetProfile: invite.targetProfile,
+            ...(invite.note ? { note: invite.note } : {}),
+            operatorNote: createActivitySeedOperatorNote(
+              resolvedSpecPath,
+              `invite ${index + 1}`,
+              invite.operatorNote,
+            ),
+          });
+          const confirmed = await runtime.twoPhaseCommit.confirmByToken({
+            confirmToken: prepared.confirmToken,
+          });
+          (connectionsSection.invites as Record<string, unknown>[]).push({
+            target_profile: invite.targetProfile,
+            ...(invite.note ? { note: invite.note } : {}),
+            ...summarizeConfirmedAction(confirmed),
+          });
+        } catch (rawError) {
+          const error = asLinkedInBuddyError(rawError);
+          if (!input.continueOnError || isFatalSeedError(error)) {
+            throw error;
+          }
+          runtime.logger.log("warn", "cli.seed.activity.action_failed", {
+            section: "connections.invites",
+            actionIndex: index,
+            errorCode: error.code,
+            errorMessage: error.message,
+          });
+          (connectionsSection.invites as Record<string, unknown>[]).push(
+            summarizeActionFailure(`invite ${index + 1}`, error),
+          );
+          failedActionCount += 1;
+        }
         pendingTargets.add(normalizedTarget);
         await maybeSleepSeedDelay(input.delayMs);
       }
@@ -7808,42 +7897,59 @@ async function runSeedActivity(
         post.operatorNote,
       );
 
-      const prepared = mediaPath
-        ? await runtime.posts.prepareCreateMedia({
-            profileName: input.profileName,
-            text: post.text,
-            mediaPaths: [mediaPath],
-            visibility,
-            operatorNote,
-          })
-        : await runtime.posts.prepareCreate({
-            profileName: input.profileName,
-            text: post.text,
-            visibility,
-            operatorNote,
-          });
-      const confirmed = await runtime.twoPhaseCommit.confirmByToken({
-        confirmToken: prepared.confirmToken,
-      });
-      const publishedPostUrl =
-        typeof confirmed.result.published_post_url === "string" &&
-        confirmed.result.published_post_url.trim().length > 0
-          ? confirmed.result.published_post_url.trim()
+      try {
+        const prepared = mediaPath
+          ? await runtime.posts.prepareCreateMedia({
+              profileName: input.profileName,
+              text: post.text,
+              mediaPaths: [mediaPath],
+              visibility,
+              operatorNote,
+            })
+          : await runtime.posts.prepareCreate({
+              profileName: input.profileName,
+              text: post.text,
+              visibility,
+              operatorNote,
+            });
+        const confirmed = await runtime.twoPhaseCommit.confirmByToken({
+          confirmToken: prepared.confirmToken,
+        });
+        const publishedPostUrl =
+          typeof confirmed.result.published_post_url === "string" &&
+          confirmed.result.published_post_url.trim().length > 0
+            ? confirmed.result.published_post_url.trim()
+            : undefined;
+        const verification = publishedPostUrl
+          ? await runtime.feed.viewPost({
+              profileName: input.profileName,
+              postUrl: publishedPostUrl,
+            })
           : undefined;
-      const verification = publishedPostUrl
-        ? await runtime.feed.viewPost({
-            profileName: input.profileName,
-            postUrl: publishedPostUrl,
-          })
-        : undefined;
 
-      postsSection.push({
-        text: post.text,
-        visibility,
-        ...(mediaPath ? { media_path: mediaPath } : {}),
-        ...summarizeConfirmedAction(confirmed),
-        ...(verification ? { verification } : {}),
-      });
+        postsSection.push({
+          text: post.text,
+          visibility,
+          ...(mediaPath ? { media_path: mediaPath } : {}),
+          ...summarizeConfirmedAction(confirmed),
+          ...(verification ? { verification } : {}),
+        });
+      } catch (rawError) {
+        const error = asLinkedInBuddyError(rawError);
+        if (!input.continueOnError || isFatalSeedError(error)) {
+          throw error;
+        }
+        runtime.logger.log("warn", "cli.seed.activity.action_failed", {
+          section: "posts",
+          actionIndex: index,
+          errorCode: error.code,
+          errorMessage: error.message,
+        });
+        postsSection.push(
+          summarizeActionFailure(`post ${index + 1}`, error),
+        );
+        failedActionCount += 1;
+      }
       await maybeSleepSeedDelay(input.delayMs);
     }
     report.posts = postsSection;
@@ -7867,46 +7973,80 @@ async function runSeedActivity(
     }
 
     for (const [index, like] of spec.feed.likes.entries()) {
-      const prepared = runtime.feed.prepareLikePost({
-        profileName: input.profileName,
-        postUrl: like.postUrl,
-        ...(like.reaction ? { reaction: like.reaction } : {}),
-        operatorNote: createActivitySeedOperatorNote(
-          resolvedSpecPath,
-          `feed like ${index + 1}`,
-          like.operatorNote,
-        ),
-      });
-      const confirmed = await runtime.twoPhaseCommit.confirmByToken({
-        confirmToken: prepared.confirmToken,
-      });
-      (feedSection.liked as Record<string, unknown>[]).push({
-        post_url: like.postUrl,
-        ...(like.reaction ? { reaction: like.reaction } : {}),
-        ...summarizeConfirmedAction(confirmed),
-      });
+      try {
+        const prepared = runtime.feed.prepareLikePost({
+          profileName: input.profileName,
+          postUrl: like.postUrl,
+          ...(like.reaction ? { reaction: like.reaction } : {}),
+          operatorNote: createActivitySeedOperatorNote(
+            resolvedSpecPath,
+            `feed like ${index + 1}`,
+            like.operatorNote,
+          ),
+        });
+        const confirmed = await runtime.twoPhaseCommit.confirmByToken({
+          confirmToken: prepared.confirmToken,
+        });
+        (feedSection.liked as Record<string, unknown>[]).push({
+          post_url: like.postUrl,
+          ...(like.reaction ? { reaction: like.reaction } : {}),
+          ...summarizeConfirmedAction(confirmed),
+        });
+      } catch (rawError) {
+        const error = asLinkedInBuddyError(rawError);
+        if (!input.continueOnError || isFatalSeedError(error)) {
+          throw error;
+        }
+        runtime.logger.log("warn", "cli.seed.activity.action_failed", {
+          section: "feed.likes",
+          actionIndex: index,
+          errorCode: error.code,
+          errorMessage: error.message,
+        });
+        (feedSection.liked as Record<string, unknown>[]).push(
+          summarizeActionFailure(`feed like ${index + 1}`, error),
+        );
+        failedActionCount += 1;
+      }
       await maybeSleepSeedDelay(input.delayMs);
     }
 
     for (const [index, comment] of spec.feed.comments.entries()) {
-      const prepared = runtime.feed.prepareCommentOnPost({
-        profileName: input.profileName,
-        postUrl: comment.postUrl,
-        text: comment.text,
-        operatorNote: createActivitySeedOperatorNote(
-          resolvedSpecPath,
-          `feed comment ${index + 1}`,
-          comment.operatorNote,
-        ),
-      });
-      const confirmed = await runtime.twoPhaseCommit.confirmByToken({
-        confirmToken: prepared.confirmToken,
-      });
-      (feedSection.commented as Record<string, unknown>[]).push({
-        post_url: comment.postUrl,
-        text: comment.text,
-        ...summarizeConfirmedAction(confirmed),
-      });
+      try {
+        const prepared = runtime.feed.prepareCommentOnPost({
+          profileName: input.profileName,
+          postUrl: comment.postUrl,
+          text: comment.text,
+          operatorNote: createActivitySeedOperatorNote(
+            resolvedSpecPath,
+            `feed comment ${index + 1}`,
+            comment.operatorNote,
+          ),
+        });
+        const confirmed = await runtime.twoPhaseCommit.confirmByToken({
+          confirmToken: prepared.confirmToken,
+        });
+        (feedSection.commented as Record<string, unknown>[]).push({
+          post_url: comment.postUrl,
+          text: comment.text,
+          ...summarizeConfirmedAction(confirmed),
+        });
+      } catch (rawError) {
+        const error = asLinkedInBuddyError(rawError);
+        if (!input.continueOnError || isFatalSeedError(error)) {
+          throw error;
+        }
+        runtime.logger.log("warn", "cli.seed.activity.action_failed", {
+          section: "feed.comments",
+          actionIndex: index,
+          errorCode: error.code,
+          errorMessage: error.message,
+        });
+        (feedSection.commented as Record<string, unknown>[]).push(
+          summarizeActionFailure(`feed comment ${index + 1}`, error),
+        );
+        failedActionCount += 1;
+      }
       await maybeSleepSeedDelay(input.delayMs);
     }
 
@@ -7935,70 +8075,104 @@ async function runSeedActivity(
     }
 
     for (const [index, thread] of spec.messaging.newThreads.entries()) {
-      const prepared = await runtime.inbox.prepareNewThread({
-        profileName: input.profileName,
-        recipients: thread.recipients,
-        text: thread.text,
-        operatorNote: createActivitySeedOperatorNote(
-          resolvedSpecPath,
-          `new thread ${index + 1}`,
-          thread.operatorNote,
-        ),
-      });
-      const confirmed = await runtime.twoPhaseCommit.confirmByToken({
-        confirmToken: prepared.confirmToken,
-      });
-      const threadUrl =
-        typeof confirmed.result.thread_url === "string" &&
-        confirmed.result.thread_url.trim().length > 0
-          ? confirmed.result.thread_url.trim()
+      try {
+        const prepared = await runtime.inbox.prepareNewThread({
+          profileName: input.profileName,
+          recipients: thread.recipients,
+          text: thread.text,
+          operatorNote: createActivitySeedOperatorNote(
+            resolvedSpecPath,
+            `new thread ${index + 1}`,
+            thread.operatorNote,
+          ),
+        });
+        const confirmed = await runtime.twoPhaseCommit.confirmByToken({
+          confirmToken: prepared.confirmToken,
+        });
+        const threadUrl =
+          typeof confirmed.result.thread_url === "string" &&
+          confirmed.result.thread_url.trim().length > 0
+            ? confirmed.result.thread_url.trim()
+            : undefined;
+        const verification = threadUrl
+          ? await runtime.inbox.getThread({
+              profileName: input.profileName,
+              thread: threadUrl,
+              limit: 10,
+            })
           : undefined;
-      const verification = threadUrl
-        ? await runtime.inbox.getThread({
-            profileName: input.profileName,
-            thread: threadUrl,
-            limit: 10,
-          })
-        : undefined;
-      (messagingSection.new_threads as Record<string, unknown>[]).push({
-        recipients: thread.recipients,
-        text: thread.text,
-        ...summarizeConfirmedAction(confirmed),
-        ...(verification ? { verification } : {}),
-      });
+        (messagingSection.new_threads as Record<string, unknown>[]).push({
+          recipients: thread.recipients,
+          text: thread.text,
+          ...summarizeConfirmedAction(confirmed),
+          ...(verification ? { verification } : {}),
+        });
+      } catch (rawError) {
+        const error = asLinkedInBuddyError(rawError);
+        if (!input.continueOnError || isFatalSeedError(error)) {
+          throw error;
+        }
+        runtime.logger.log("warn", "cli.seed.activity.action_failed", {
+          section: "messaging.new_threads",
+          actionIndex: index,
+          errorCode: error.code,
+          errorMessage: error.message,
+        });
+        (messagingSection.new_threads as Record<string, unknown>[]).push(
+          summarizeActionFailure(`new thread ${index + 1}`, error),
+        );
+        failedActionCount += 1;
+      }
       await maybeSleepSeedDelay(input.delayMs);
     }
 
     for (const [index, reply] of spec.messaging.replies.entries()) {
-      const prepared = await runtime.inbox.prepareReply({
-        profileName: input.profileName,
-        thread: reply.thread,
-        text: reply.text,
-        operatorNote: createActivitySeedOperatorNote(
-          resolvedSpecPath,
-          `reply ${index + 1}`,
-          reply.operatorNote,
-        ),
-      });
-      const confirmed = await runtime.twoPhaseCommit.confirmByToken({
-        confirmToken: prepared.confirmToken,
-      });
-      const threadUrl =
-        typeof confirmed.result.thread_url === "string" &&
-        confirmed.result.thread_url.trim().length > 0
-          ? confirmed.result.thread_url.trim()
-          : reply.thread;
-      const verification = await runtime.inbox.getThread({
-        profileName: input.profileName,
-        thread: threadUrl,
-        limit: 10,
-      });
-      (messagingSection.replies as Record<string, unknown>[]).push({
-        thread: reply.thread,
-        text: reply.text,
-        ...summarizeConfirmedAction(confirmed),
-        verification,
-      });
+      try {
+        const prepared = await runtime.inbox.prepareReply({
+          profileName: input.profileName,
+          thread: reply.thread,
+          text: reply.text,
+          operatorNote: createActivitySeedOperatorNote(
+            resolvedSpecPath,
+            `reply ${index + 1}`,
+            reply.operatorNote,
+          ),
+        });
+        const confirmed = await runtime.twoPhaseCommit.confirmByToken({
+          confirmToken: prepared.confirmToken,
+        });
+        const threadUrl =
+          typeof confirmed.result.thread_url === "string" &&
+          confirmed.result.thread_url.trim().length > 0
+            ? confirmed.result.thread_url.trim()
+            : reply.thread;
+        const verification = await runtime.inbox.getThread({
+          profileName: input.profileName,
+          thread: threadUrl,
+          limit: 10,
+        });
+        (messagingSection.replies as Record<string, unknown>[]).push({
+          thread: reply.thread,
+          text: reply.text,
+          ...summarizeConfirmedAction(confirmed),
+          verification,
+        });
+      } catch (rawError) {
+        const error = asLinkedInBuddyError(rawError);
+        if (!input.continueOnError || isFatalSeedError(error)) {
+          throw error;
+        }
+        runtime.logger.log("warn", "cli.seed.activity.action_failed", {
+          section: "messaging.replies",
+          actionIndex: index,
+          errorCode: error.code,
+          errorMessage: error.message,
+        });
+        (messagingSection.replies as Record<string, unknown>[]).push(
+          summarizeActionFailure(`reply ${index + 1}`, error),
+        );
+        failedActionCount += 1;
+      }
       await maybeSleepSeedDelay(input.delayMs);
     }
 
@@ -8012,6 +8186,21 @@ async function runSeedActivity(
           : {}),
       });
     }
+
+    const totalWriteActionsAttempted =
+      (connectionsSection.accepted_pending as unknown[]).length +
+      (connectionsSection.invites as unknown[]).length +
+      (report.posts as unknown[]).length +
+      (feedSection.liked as unknown[]).length +
+      (feedSection.commented as unknown[]).length +
+      (messagingSection.new_threads as unknown[]).length +
+      (messagingSection.replies as unknown[]).length;
+    const succeededActionCount = totalWriteActionsAttempted - failedActionCount;
+
+    report.continue_on_error = input.continueOnError;
+    report.executed_action_count = totalWriteActionsAttempted;
+    report.succeeded_action_count = succeededActionCount;
+    report.failed_action_count = failedActionCount;
 
     report.verification = {
       connections: await runtime.connections.listConnections({
@@ -8032,10 +8221,19 @@ async function runSeedActivity(
       report.output_path = await writeOutputJsonFile(input.outputPath, report);
     }
 
+    if (failedActionCount > 0) {
+      writeCliWarning(
+        `${succeededActionCount}/${totalWriteActionsAttempted} actions succeeded, ${failedActionCount} failed.`,
+      );
+      process.exitCode = 1;
+    }
+
     runtime.logger.log("info", "cli.seed.activity.done", {
       profileName: input.profileName,
       specPath: resolvedSpecPath,
       totalWriteActions: planSummary.totalWriteActions,
+      succeededActionCount,
+      failedActionCount,
       totalReadSteps: planSummary.totalReadSteps,
     });
 
@@ -12728,6 +12926,11 @@ export function createCliProgram(): Command {
       false,
     )
     .option(
+      "--continue-on-error",
+      "Record action failures and continue with remaining edits instead of stopping",
+      false,
+    )
+    .option(
       "--delay-ms <ms>",
       "Base delay between confirmed profile edits",
       "3500",
@@ -12753,6 +12956,7 @@ export function createCliProgram(): Command {
         allowPartial: boolean;
         delayMs: string;
         yes: boolean;
+        continueOnError: boolean;
         output?: string;
       }) => {
         await runProfileApplySpec(
@@ -12763,6 +12967,7 @@ export function createCliProgram(): Command {
             allowPartial: options.allowPartial,
             delayMs: coerceNonNegativeInt(options.delayMs, "delay-ms"),
             yes: options.yes,
+            continueOnError: options.continueOnError,
             ...(options.output ? { outputPath: options.output } : {}),
           },
           readCdpUrl(),
@@ -12851,6 +13056,11 @@ export function createCliProgram(): Command {
       "Base delay between confirmed write actions",
       "4500",
     )
+    .option(
+      "--continue-on-error",
+      "Record action failures and continue with remaining actions instead of stopping",
+      false,
+    )
     .option("-y, --yes", "Skip the interactive confirmation prompt", false)
     .option("--output <path>", "Write the final JSON report to a file")
     .addHelpText(
@@ -12871,6 +13081,7 @@ export function createCliProgram(): Command {
         spec: string;
         delayMs: string;
         yes: boolean;
+        continueOnError: boolean;
         output?: string;
       }) => {
         await runSeedActivity(
@@ -12879,6 +13090,7 @@ export function createCliProgram(): Command {
             specPath: options.spec,
             delayMs: coerceNonNegativeInt(options.delayMs, "delay-ms"),
             yes: options.yes,
+            continueOnError: options.continueOnError,
             ...(options.output ? { outputPath: options.output } : {}),
           },
           readCdpUrl(),

--- a/packages/cli/test/activitySeedCli.test.ts
+++ b/packages/cli/test/activitySeedCli.test.ts
@@ -532,3 +532,232 @@ describe("CLI activity seed workflow", () => {
     expect(stderrChunks.join("")).toContain("No running keepalive daemon was detected");
   });
 });
+
+describe("CLI activity seed --continue-on-error", () => {
+  let tempDir = "";
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let stderrWriteSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutChunks: string[] = [];
+  let stderrChunks: string[] = [];
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-cli-activity-seed-coe-"));
+    process.env.LINKEDIN_BUDDY_HOME = path.join(tempDir, "buddy-home");
+    process.exitCode = undefined;
+    stdoutChunks = [];
+    stderrChunks = [];
+    vi.resetAllMocks();
+
+    activitySeedCliMocks.createCoreRuntime.mockImplementation(() => ({
+      runId: "run-activity-seed-coe",
+      evasion: {
+        level: "moderate",
+        diagnosticsEnabled: false
+      },
+      logger: {
+        log: activitySeedCliMocks.loggerLog
+      },
+      connections: {
+        listPendingInvitations: activitySeedCliMocks.listPendingInvitations,
+        listConnections: activitySeedCliMocks.listConnections,
+        prepareAcceptInvitation: activitySeedCliMocks.prepareAcceptInvitation,
+        prepareSendInvitation: activitySeedCliMocks.prepareSendInvitation
+      },
+      posts: {
+        prepareCreate: activitySeedCliMocks.prepareCreate,
+        prepareCreateMedia: activitySeedCliMocks.prepareCreateMedia
+      },
+      feed: {
+        viewFeed: activitySeedCliMocks.viewFeed,
+        viewPost: activitySeedCliMocks.viewPost,
+        prepareLikePost: activitySeedCliMocks.prepareLikePost,
+        prepareCommentOnPost: activitySeedCliMocks.prepareCommentOnPost
+      },
+      jobs: {
+        searchJobs: activitySeedCliMocks.jobsSearchJobs,
+        viewJob: activitySeedCliMocks.jobsViewJob
+      },
+      inbox: {
+        listThreads: activitySeedCliMocks.listThreads,
+        getThread: activitySeedCliMocks.getThread,
+        prepareNewThread: activitySeedCliMocks.prepareNewThread,
+        prepareReply: activitySeedCliMocks.prepareReply
+      },
+      notifications: {
+        listNotifications: activitySeedCliMocks.listNotifications
+      },
+      twoPhaseCommit: {
+        confirmByToken: activitySeedCliMocks.confirmByToken
+      },
+      close: activitySeedCliMocks.close
+    }));
+
+    activitySeedCliMocks.listPendingInvitations.mockResolvedValue([]);
+    activitySeedCliMocks.listConnections.mockResolvedValue([]);
+    activitySeedCliMocks.viewFeed.mockResolvedValue([]);
+    activitySeedCliMocks.listThreads.mockResolvedValue([]);
+
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation((value?: unknown) => {
+      stdoutChunks.push(String(value ?? ""));
+    });
+    stderrWriteSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((...args: Parameters<typeof process.stderr.write>) => {
+        const [chunk] = args;
+        stderrChunks.push(String(chunk));
+        return true;
+      });
+  });
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore();
+    stderrWriteSpy.mockRestore();
+    delete process.env.LINKEDIN_BUDDY_HOME;
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("continues past a failing action and reports summary", async () => {
+    const { LinkedInBuddyError: LBE } = await import("@linkedin-buddy/core");
+
+    activitySeedCliMocks.prepareCreate
+      .mockResolvedValueOnce({
+        preparedActionId: "pa-post-1",
+        confirmToken: "ct-post-1",
+        expiresAtMs: 1,
+        preview: { summary: "Create post" }
+      })
+      .mockResolvedValueOnce({
+        preparedActionId: "pa-post-2",
+        confirmToken: "ct-post-2",
+        expiresAtMs: 1,
+        preview: { summary: "Create post" }
+      });
+
+    activitySeedCliMocks.prepareLikePost.mockReturnValue({
+      preparedActionId: "pa-like",
+      confirmToken: "ct-like",
+      expiresAtMs: 1,
+      preview: { summary: "Like post" }
+    });
+
+    activitySeedCliMocks.confirmByToken
+      .mockResolvedValueOnce({
+        preparedActionId: "pa-post-1",
+        status: "executed",
+        actionType: "post.create",
+        result: { status: "post_created", published_post_url: "" },
+        artifacts: []
+      })
+      .mockRejectedValueOnce(
+        new LBE("UI_CHANGED_SELECTOR_FAILED", "Post composer not found")
+      )
+      .mockResolvedValueOnce({
+        preparedActionId: "pa-like",
+        status: "executed",
+        actionType: "feed.like_post",
+        result: { status: "post_liked" },
+        artifacts: []
+      });
+
+    activitySeedCliMocks.viewFeed.mockResolvedValue([]);
+
+    const specPath = path.join(tempDir, "activity-spec-coe.json");
+    await writeFile(
+      specPath,
+      JSON.stringify(
+        {
+          posts: [
+            { text: "First post content" },
+            { text: "Second post content" }
+          ],
+          feed: {
+            likes: [{ postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/" }]
+          }
+        },
+        null,
+        2
+      )
+    );
+
+    await runCli([
+      "node",
+      "linkedin",
+      "seed",
+      "activity",
+      "--profile",
+      "smoke",
+      "--spec",
+      specPath,
+      "--continue-on-error",
+      "--yes",
+      "--delay-ms",
+      "0"
+    ]);
+
+    const output = JSON.parse(stdoutChunks.join("\n")) as {
+      continue_on_error: boolean;
+      succeeded_action_count: number;
+      failed_action_count: number;
+      executed_action_count: number;
+      posts: Array<{ status: string; error_code?: string }>;
+      feed: { liked: Array<{ status: string }> };
+      verification: Record<string, unknown>;
+    };
+
+    expect(output.continue_on_error).toBe(true);
+    expect(output.succeeded_action_count).toBe(2);
+    expect(output.failed_action_count).toBe(1);
+    expect(output.executed_action_count).toBe(3);
+    expect(output.posts[0]!.status).toBe("executed");
+    expect(output.posts[1]!.status).toBe("failed");
+    expect(output.posts[1]!.error_code).toBe("UI_CHANGED_SELECTOR_FAILED");
+    expect(output.feed.liked[0]!.status).toBe("executed");
+    expect(stderrChunks.join("")).toContain("2/3 actions succeeded, 1 failed");
+    expect(process.exitCode).toBe(1);
+    expect(output.verification).toBeDefined();
+  });
+
+  it("stops on fatal AUTH_REQUIRED despite --continue-on-error", async () => {
+    const { LinkedInBuddyError: LBE } = await import("@linkedin-buddy/core");
+
+    activitySeedCliMocks.prepareCreate.mockResolvedValue({
+      preparedActionId: "pa-post-1",
+      confirmToken: "ct-post-1",
+      expiresAtMs: 1,
+      preview: { summary: "Create post" }
+    });
+
+    activitySeedCliMocks.confirmByToken.mockRejectedValueOnce(
+      new LBE("AUTH_REQUIRED", "Session expired")
+    );
+
+    const specPath = path.join(tempDir, "activity-spec-fatal.json");
+    await writeFile(
+      specPath,
+      JSON.stringify(
+        {
+          posts: [{ text: "Test post" }]
+        },
+        null,
+        2
+      )
+    );
+
+    await expect(
+      runCli([
+        "node",
+        "linkedin",
+        "seed",
+        "activity",
+        "--profile",
+        "smoke",
+        "--spec",
+        specPath,
+        "--continue-on-error",
+        "--yes",
+        "--delay-ms",
+        "0"
+      ])
+    ).rejects.toThrow("Session expired");
+  });
+});

--- a/packages/cli/test/profileCli.test.ts
+++ b/packages/cli/test/profileCli.test.ts
@@ -360,3 +360,246 @@ describe("CLI profile commands", () => {
     expect(profileCliMocks.confirmByToken).not.toHaveBeenCalled();
   });
 });
+
+describe("CLI profile apply-spec --continue-on-error", () => {
+  let tempDir = "";
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutChunks: string[] = [];
+  let stderrChunks: string[] = [];
+  let stderrWriteSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "linkedin-cli-profile-coe-"));
+    process.env.LINKEDIN_BUDDY_HOME = path.join(tempDir, "buddy-home");
+    process.exitCode = undefined;
+    stdoutChunks = [];
+    stderrChunks = [];
+    vi.resetAllMocks();
+
+    profileCliMocks.createCoreRuntime.mockImplementation(() => ({
+      close: profileCliMocks.close,
+      logger: { log: profileCliMocks.loggerLog },
+      profile: {
+        viewEditableProfile: profileCliMocks.viewEditableProfile,
+        viewProfile: profileCliMocks.viewProfile,
+        prepareUpdatePublicProfile: profileCliMocks.prepareUpdatePublicProfile,
+        prepareUpdateSettings: profileCliMocks.prepareUpdateSettings,
+        prepareUpdateIntro: profileCliMocks.prepareUpdateIntro,
+        prepareUpsertSectionItem: profileCliMocks.prepareUpsertSectionItem,
+        prepareRemoveSectionItem: profileCliMocks.prepareRemoveSectionItem
+      },
+      runId: "run-profile-coe",
+      twoPhaseCommit: {
+        confirmByToken: profileCliMocks.confirmByToken
+      }
+    }));
+
+    profileCliMocks.viewEditableProfile.mockResolvedValue({
+      profile_url: "https://www.linkedin.com/in/me/",
+      intro: {
+        full_name: "Avery Cole",
+        headline: "Software Engineer",
+        location: "Copenhagen, Denmark",
+        supported_fields: ["firstName", "lastName", "headline", "location"]
+      },
+      settings: {
+        industry: "Technology, Information and Internet",
+        supported_fields: ["industry"]
+      },
+      public_profile: {
+        vanity_name: "avery-cole-example",
+        public_profile_url: "https://www.linkedin.com/in/avery-cole-example/",
+        supported_fields: ["vanityName", "publicProfileUrl"]
+      },
+      sections: []
+    });
+
+    profileCliMocks.viewProfile.mockResolvedValue({
+      profile_url: "https://www.linkedin.com/in/avery-cole-example/",
+      vanity_name: "avery-cole-example",
+      full_name: "Avery Cole",
+      headline: "Automation Engineer at Example Labs",
+      location: "Copenhagen, Capital Region of Denmark, Denmark",
+      about: "Building production LLM systems.",
+      connection_degree: "",
+      experience: [],
+      education: []
+    });
+
+    profileCliMocks.prepareUpdateIntro.mockReturnValue({
+      preparedActionId: "pa_intro",
+      confirmToken: "ct_intro",
+      expiresAtMs: 1,
+      preview: { summary: "Update intro" }
+    });
+    profileCliMocks.prepareUpdateSettings.mockReturnValue({
+      preparedActionId: "pa_settings",
+      confirmToken: "ct_settings",
+      expiresAtMs: 1,
+      preview: { summary: "Update settings" }
+    });
+    profileCliMocks.prepareUpdatePublicProfile.mockReturnValue({
+      preparedActionId: "pa_public_profile",
+      confirmToken: "ct_public_profile",
+      expiresAtMs: 1,
+      preview: { summary: "Update public profile" }
+    });
+    profileCliMocks.prepareUpsertSectionItem.mockReturnValue({
+      preparedActionId: "pa_about",
+      confirmToken: "ct_about",
+      expiresAtMs: 1,
+      preview: { summary: "Update about" }
+    });
+
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation((value?: unknown) => {
+      stdoutChunks.push(String(value ?? ""));
+    });
+    stderrWriteSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((...args: Parameters<typeof process.stderr.write>) => {
+        const [chunk] = args;
+        stderrChunks.push(String(chunk));
+        return true;
+      });
+  });
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore();
+    stderrWriteSpy.mockRestore();
+    delete process.env.LINKEDIN_BUDDY_HOME;
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("continues past a failing action and reports summary", async () => {
+    const { LinkedInBuddyError: LBE } = await import("@linkedin-buddy/core");
+
+    profileCliMocks.confirmByToken
+      .mockResolvedValueOnce({
+        preparedActionId: "pa_intro",
+        status: "executed",
+        actionType: "profile.update_intro",
+        result: { status: "profile_intro_updated" },
+        artifacts: []
+      })
+      .mockRejectedValueOnce(
+        new LBE("UI_CHANGED_SELECTOR_FAILED", "Settings selector not found")
+      )
+      .mockResolvedValueOnce({
+        preparedActionId: "pa_public_profile",
+        status: "executed",
+        actionType: "profile.update_public_profile",
+        result: { status: "profile_public_profile_updated" },
+        artifacts: []
+      })
+      .mockResolvedValueOnce({
+        preparedActionId: "pa_about",
+        status: "executed",
+        actionType: "profile.upsert_section_item",
+        result: { status: "profile_section_item_upserted" },
+        artifacts: []
+      });
+
+    const specPath = path.join(tempDir, "profile-spec-coe.json");
+    await writeFile(
+      specPath,
+      JSON.stringify(
+        {
+          intro: {
+            headline: "Automation Engineer at Example Labs",
+            location: "Copenhagen, Capital Region of Denmark, Denmark"
+          },
+          industry: "Software Development",
+          customProfileUrl: "avery-automation",
+          about: "Building production LLM systems."
+        },
+        null,
+        2
+      )
+    );
+
+    await runCli([
+      "node",
+      "linkedin",
+      "profile",
+      "apply-spec",
+      "--profile",
+      "smoke",
+      "--spec",
+      specPath,
+      "--continue-on-error",
+      "--yes",
+      "--delay-ms",
+      "0"
+    ]);
+
+    const output = JSON.parse(stdoutChunks.join("\n")) as {
+      continue_on_error: boolean;
+      planned_action_count: number;
+      executed_action_count: number;
+      succeeded_action_count: number;
+      failed_action_count: number;
+      actions: Array<{ status: string; error_code?: string; summary?: string }>;
+    };
+
+    expect(output.continue_on_error).toBe(true);
+    expect(output.planned_action_count).toBe(4);
+    expect(output.executed_action_count).toBe(4);
+    expect(output.succeeded_action_count).toBe(3);
+    expect(output.failed_action_count).toBe(1);
+    expect(output.actions[1]!.status).toBe("failed");
+    expect(output.actions[1]!.error_code).toBe("UI_CHANGED_SELECTOR_FAILED");
+    expect(output.actions[0]!.status).toBe("executed");
+    expect(output.actions[2]!.status).toBe("executed");
+    expect(output.actions[3]!.status).toBe("executed");
+    expect(stderrChunks.join("")).toContain("3/4 edits succeeded, 1 failed");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("stops on fatal AUTH_REQUIRED despite --continue-on-error", async () => {
+    const { LinkedInBuddyError: LBE } = await import("@linkedin-buddy/core");
+
+    profileCliMocks.confirmByToken
+      .mockResolvedValueOnce({
+        preparedActionId: "pa_intro",
+        status: "executed",
+        actionType: "profile.update_intro",
+        result: { status: "profile_intro_updated" },
+        artifacts: []
+      })
+      .mockRejectedValueOnce(
+        new LBE("AUTH_REQUIRED", "Session expired")
+      );
+
+    const specPath = path.join(tempDir, "profile-spec-fatal.json");
+    await writeFile(
+      specPath,
+      JSON.stringify(
+        {
+          intro: {
+            headline: "Automation Engineer at Example Labs"
+          },
+          industry: "Software Development"
+        },
+        null,
+        2
+      )
+    );
+
+    await expect(
+      runCli([
+        "node",
+        "linkedin",
+        "profile",
+        "apply-spec",
+        "--profile",
+        "smoke",
+        "--spec",
+        specPath,
+        "--continue-on-error",
+        "--yes",
+        "--delay-ms",
+        "0"
+      ])
+    ).rejects.toThrow("Session expired");
+  });
+});


### PR DESCRIPTION
## Summary

Adds `--continue-on-error` flag to `profile apply-spec` and `seed activity` CLI commands so batch operations record failures and continue instead of stopping on the first error.

## Changes

- **Two helper functions**: `isFatalSeedError()` gates `AUTH_REQUIRED`/`CAPTCHA_OR_CHALLENGE` as always-fatal; `summarizeActionFailure()` produces structured failure records with `status: "failed"`, `error_code`, `error_message`
- **`runProfileApplySpec()` handler**: wraps prepare+confirm loop in try-catch, tracks `failedActionCount`, adds `continue_on_error`/`succeeded_action_count`/`failed_action_count` to report, writes stderr summary warning, exits non-zero on failures
- **`runSeedActivity()` handler**: wraps all 7 write loops (accept invitations, send invitations, posts, feed likes, feed comments, new threads, replies) in same try-catch pattern with per-section error tracking
- **CLI command definitions**: both commands gain `--continue-on-error` option with pass-through to handler functions
- **Tests**: 4 new tests across `profileCli.test.ts` and `activitySeedCli.test.ts` covering partial-failure continuation and fatal-error short-circuit

## Behavior

| Scenario | Without flag | With `--continue-on-error` |
|---|---|---|
| Edit fails | Stop immediately, no report | Record failure, continue, report all |
| Fatal error (AUTH_REQUIRED) | Stop immediately | Stop immediately (always fatal) |
| Exit code | 0 (success) or throws | 0 if all succeed, 1 if any failed |
| stderr | - | "17/22 edits succeeded, 5 failed" |

## Test results

```
Test Files: 120 passed (120)
Tests: 1533 passed (1533)
Lint: clean
Build: 28 pre-existing type errors (0 new)
```

Closes #506
