### PR TITLE
fix #509: resolve fullName: null in status/health identity extraction

### DIFF
--- a/packages/core/src/__tests__/healthCheck.test.ts
+++ b/packages/core/src/__tests__/healthCheck.test.ts
@@ -66,13 +66,16 @@ function createMockPage(opts: {
         return opts.getAttribute?.(selector, name, currentUrl) ?? null;
       });
       const first = vi.fn();
+      const filter = vi.fn();
       const mockLocator = {
+        filter,
         first,
         getAttribute,
         isVisible,
         textContent
       } as unknown as Locator;
       first.mockReturnValue(mockLocator);
+      filter.mockReturnValue(mockLocator);
       return mockLocator;
     })
   } as unknown as Page;

--- a/packages/core/src/__tests__/sessionAuth.test.ts
+++ b/packages/core/src/__tests__/sessionAuth.test.ts
@@ -122,9 +122,11 @@ function createMockPage(options: {
         return options.getAttribute?.(selector, name, currentUrl) ?? null;
       });
       const first = vi.fn();
+      const filter = vi.fn();
       const mockLocator = {
         click,
         count,
+        filter,
         first,
         getAttribute,
         isVisible,
@@ -132,6 +134,7 @@ function createMockPage(options: {
         waitFor,
       } as unknown as Locator;
       first.mockReturnValue(mockLocator);
+      filter.mockReturnValue(mockLocator);
       return mockLocator;
     }),
     context: vi.fn(() => ({

--- a/packages/core/src/__tests__/sessionInspection.test.ts
+++ b/packages/core/src/__tests__/sessionInspection.test.ts
@@ -62,13 +62,16 @@ function createMockPage(options: {
         return options.getAttribute?.(selector, name, currentUrl) ?? null;
       });
       const first = vi.fn();
+      const filter = vi.fn();
       const mockLocator = {
+        filter,
         first,
         getAttribute,
         isVisible,
         textContent
       } as unknown as Locator;
       first.mockReturnValue(mockLocator);
+      filter.mockReturnValue(mockLocator);
       return mockLocator;
     }),
     context: vi.fn(

--- a/packages/core/src/auth/sessionInspection.ts
+++ b/packages/core/src/auth/sessionInspection.ts
@@ -35,10 +35,13 @@ const CHECKPOINT_FORM_SELECTOR = "form[action*='checkpoint']";
 const AUTH_NAV_SELECTOR = "nav.global-nav";
 const AUTH_PROFILE_MENU_SELECTOR = "[data-control-name='nav.settings_view_profile']";
 const PROFILE_HEADING_SELECTORS = [
+  "h1.text-heading-xlarge",
+  "h1[class*='text-heading']",
   "main h1",
   ".pv-text-details__left-panel h1",
   "h1"
 ];
+
 const LOGIN_WALL_SELECTOR = [
   "[data-test-id='sign-in-form']",
   ".authwall",
@@ -173,6 +176,7 @@ async function readFirstNonEmptyTextWithTimeout(
     try {
       const rawText = await page
         .locator(selector)
+        .filter({ hasText: /\S/ })
         .first()
         .textContent({ timeout: timeoutMs });
       const normalized = normalizeWhitespace(rawText);
@@ -180,7 +184,7 @@ async function readFirstNonEmptyTextWithTimeout(
         return normalized;
       }
     } catch {
-      // Best effort — element missing or timeout exceeded.
+      // Best effort — element missing, has no text, or timeout exceeded.
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes `fullName: null` in `linkedin status` and `linkedin health` identity output.

## Root Cause

`readFirstNonEmptyTextWithTimeout()` in `sessionInspection.ts` found the `<h1>` in DOM immediately (from SSR) but read its empty text before client-side JS hydrated the name. Meanwhile `profileUrl`/`vanityName` worked because they come from HTML attributes (`<link rel=canonical>`, URL bar), not rendered text.

## Changes

- **Updated selectors** — added `h1.text-heading-xlarge` and `h1[class*='text-heading']` to `PROFILE_HEADING_SELECTORS` (consistent with the working extractors in `linkedinProfile.ts`)
- **Added text-readiness wait** — `.filter({ hasText: /\S/ })` makes Playwright auto-wait for non-whitespace text content within the existing 3s per-selector timeout, instead of returning empty text immediately
- **Updated test mocks** — added `filter` method to Playwright locator mocks in 3 test files

## Test Results

- 120 test files, 1547 tests — all passing
- Lint: clean
- Typecheck: no new errors (pre-existing errors in cli/mcp packages unchanged)

Closes #509
