### PR TITLE
docs #525: LinkedIn platform exploration session and 12 bug reports

### DIFF
--- a/docs/exploration-session-2026-03-15.md
+++ b/docs/exploration-session-2026-03-15.md
@@ -1,0 +1,75 @@
+# LinkedIn Platform Exploration Session — March 15, 2026
+
+## Session Overview
+
+Full exploration of LinkedIn Buddy capabilities using the Joi Ascend test profile.
+Goal: Fill out profile, engage with platform features, and document tool issues.
+
+## Profile State
+
+| Field | Status | Value |
+|-------|--------|-------|
+| Name | ✅ Set | Joi Ascend |
+| Headline | ✅ Set | Executive Assistant to the Director at Signikant \| Making AI workflows human-friendly |
+| Location | ✅ Set | Copenhagen, Capital Region of Denmark, Denmark |
+| Vanity URL | ✅ Updated | linkedin.com/in/joi-ascend |
+| Industry | ✅ Set | Technology, Information and Internet |
+| About | ❌ Blocked | LinkedIn UI changed — see #526 |
+| Experience | ❌ Blocked | LinkedIn UI changed — see #526 |
+| Education | ❌ Blocked | LinkedIn UI changed — see #526 |
+| Certifications | ❌ Blocked | LinkedIn UI changed — see #526 |
+| Languages | ❌ Blocked | LinkedIn UI changed — see #526 |
+| Projects | ❌ Blocked | LinkedIn UI changed — see #526 |
+| Volunteer | ❌ Blocked | LinkedIn UI changed — see #526 |
+| Honors | ❌ Blocked | LinkedIn UI changed — see #526 |
+
+## Platform Activity
+
+| Feature | Status | Details |
+|---------|--------|---------|
+| Post creation | ✅ Works (rate limited 1/day) | 2 posts exist from previous session |
+| Feed reactions | ✅ Works | Liked own AI tools post |
+| Feed comments | ❌ Browser context closed | Attempted self-comment |
+| Company follow | ✅ Works (partial) | Followed OpenAI; Anthropic already followed; Microsoft blocked by modal |
+| Job search | ✅ Works (parsing issues) | Found 5 results but duplicates, missing fields |
+| Job save | ✅ Works | Saved Executive Assistant posting |
+| Job alerts | ❌ Selector changed | Alert toggle not found |
+| Profile view | ✅ Works | Viewed own + Simon Miller |
+| Inbox list | ✅ Works | LinkedIn Team welcome message visible |
+| Messaging | ❌ Selector changed | Message button not found |
+| Connections | ❌ Selector changed | Connect button not found |
+| Notifications | ✅ List works, ❌ actions broken | IDs not stable |
+| Search | ❌ Returns empty | All categories (people, posts, companies) |
+| Newsletter | ❌ Editor changed | Article editor selectors broken |
+
+## Issues Filed
+
+| # | Type | Title |
+|---|------|-------|
+| #526 | Bug | Profile section edit dialogs broken — LinkedIn changed from modal to dropdown/page-based editing |
+| #527 | Bug | Profile intro editor hangs/times out — edit page route may have changed |
+| #528 | Bug | Search returns 0 results for all categories |
+| #529 | Bug | Feed post view shows duplicate author_headline text |
+| #530 | Bug | Connection invitation fails — Connect button not found |
+| #531 | Bug | Company follow blocked by page viewing settings modal |
+| #532 | Bug | Newsletter and article editor selectors broken |
+| #533 | Bug | Job search results have duplicate entries and missing fields |
+| #534 | Bug | Job alert creation fails — alert toggle not found |
+| #535 | Bug | Inbox messaging fails — Message button not found |
+| #536 | Bug | Notification mark-read fails — IDs not stable |
+| #537 | Enhancement | Comprehensive usability QoL findings |
+
+## Key Insight
+
+LinkedIn has made significant UI changes that break ~70% of write operations. The core
+two-phase commit infrastructure works perfectly. The failures are consistently at the
+Playwright selector level where LinkedIn changed:
+
+1. **Modal dialogs → dropdowns/page routes** (profile editing)
+2. **Button positions** (Connect moved to More menu, Message button structure)
+3. **Page structure** (article editor, job alert toggle, search results)
+
+## Prepared Profile Spec
+
+A complete profile spec JSON is saved at `docs/joi-ascend-profile-spec.json` and ready
+to apply once #526 and #527 are resolved.

--- a/docs/joi-ascend-profile-spec.json
+++ b/docs/joi-ascend-profile-spec.json
@@ -1,0 +1,116 @@
+{
+  "intro": {
+    "firstName": "Joi",
+    "lastName": "Ascend",
+    "headline": "Executive Assistant to the Director at Signikant | Making AI workflows human-friendly",
+    "location": "Copenhagen, Capital Region of Denmark, Denmark"
+  },
+  "about": "I keep things running smoothly at Signikant, where we build AI-powered tools that actually make people's lives easier. My role sits at the intersection of operations, communication, and technology — making sure our director and team can focus on what they do best.\n\nBefore joining Signikant, I spent a few years in office administration and event coordination across Copenhagen's tech scene. The biggest lesson I learned? The best systems are the ones people actually want to use. I bring that philosophy to everything I do: if a process feels like friction, it probably needs redesigning.\n\nI'm endlessly curious about how AI is reshaping the way we work — not replacing humans, but amplifying what we're already good at. That's what gets me out of bed in the morning (well, that and really good coffee).\n\nAlways happy to connect with fellow operations nerds, AI enthusiasts, or anyone navigating the Copenhagen tech ecosystem. Drop me a message!",
+  "experience": [
+    {
+      "title": "Executive Assistant to the Director",
+      "company": "Signikant",
+      "employmentType": "Full-time",
+      "location": "Copenhagen, Denmark",
+      "startMonth": "March",
+      "startYear": "2025",
+      "description": "Supporting the director in day-to-day operations and strategic planning at an AI tooling company. I coordinate cross-functional communication, manage stakeholder relationships, and streamline internal workflows using the very tools we build.\n\nKey focus areas:\n- Calendar and communications management for the leadership team\n- Internal process optimization using AI-assisted productivity tools\n- Cross-team coordination between engineering, product, and design\n- Documentation and knowledge management"
+    },
+    {
+      "title": "Administrative Coordinator",
+      "company": "Nordic Digital Solutions",
+      "employmentType": "Full-time",
+      "location": "Copenhagen, Denmark",
+      "startMonth": "June",
+      "startYear": "2022",
+      "endMonth": "February",
+      "endYear": "2025",
+      "description": "Coordinated daily office operations for a 30-person digital consultancy specializing in Nordic market entry. Managed everything from client onboarding to quarterly team events.\n\nHighlights:\n- Implemented a new project management system that cut meeting overhead by 25%\n- Managed CRM pipeline and client communications for 40+ active accounts\n- Organized quarterly team retreats and industry networking events\n- Trained 5 new hires on internal tools and processes"
+    },
+    {
+      "title": "Office Assistant",
+      "company": "TechHub Copenhagen",
+      "employmentType": "Part-time",
+      "location": "Copenhagen, Denmark",
+      "startMonth": "September",
+      "startYear": "2020",
+      "endMonth": "May",
+      "endYear": "2022",
+      "description": "Provided front-desk and administrative support at Copenhagen's premier co-working space for tech startups. Assisted with event logistics, member onboarding, and community engagement."
+    }
+  ],
+  "education": [
+    {
+      "school": "Copenhagen Business School",
+      "degree": "Bachelor's degree",
+      "fieldOfStudy": "Business Administration and Management",
+      "startYear": "2018",
+      "endYear": "2022",
+      "description": "Focused on organizational management and digital business transformation. Active member of the CBS Entrepreneurship Club."
+    }
+  ],
+  "certifications": [
+    {
+      "name": "Google Workspace Administrator",
+      "issuingOrganization": "Google",
+      "issueMonth": "September",
+      "issueYear": "2023"
+    },
+    {
+      "name": "Certified Administrative Professional (CAP)",
+      "issuingOrganization": "IAAP - International Association of Administrative Professionals",
+      "issueMonth": "March",
+      "issueYear": "2023"
+    }
+  ],
+  "languages": [
+    {
+      "name": "English",
+      "proficiency": "Native or bilingual proficiency"
+    },
+    {
+      "name": "Danish",
+      "proficiency": "Professional working proficiency"
+    },
+    {
+      "name": "Swedish",
+      "proficiency": "Limited working proficiency"
+    }
+  ],
+  "projects": [
+    {
+      "title": "Internal Knowledge Base Redesign",
+      "description": "Led the restructuring of Signikant's internal documentation from scattered Google Docs into a searchable, AI-indexable knowledge base. Reduced average information lookup time from 8 minutes to under 30 seconds.",
+      "startMonth": "April",
+      "startYear": "2025"
+    },
+    {
+      "title": "New Hire Onboarding Playbook",
+      "description": "Created a comprehensive onboarding playbook at Nordic Digital Solutions that standardized the first-week experience for new team members. Adopted company-wide and maintained through three hiring cycles.",
+      "startMonth": "January",
+      "startYear": "2023",
+      "endMonth": "June",
+      "endYear": "2023"
+    }
+  ],
+  "volunteer_experience": [
+    {
+      "role": "Event Volunteer",
+      "organization": "Copenhagen Tech Week",
+      "description": "Helped organize panels and networking sessions at one of Scandinavia's largest annual technology conferences. Coordinated speaker logistics and attendee registration for 500+ participants.",
+      "startMonth": "September",
+      "startYear": "2023",
+      "endMonth": "September",
+      "endYear": "2024"
+    }
+  ],
+  "honors_awards": [
+    {
+      "title": "Employee of the Quarter",
+      "issuer": "Nordic Digital Solutions",
+      "issueMonth": "December",
+      "issueYear": "2023",
+      "description": "Recognized for outstanding contributions to operational efficiency and team culture."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Comprehensive LinkedIn platform exploration session using the Joi Ascend test profile. Documents all tool capabilities, files 12 GitHub issues for bugs and QoL improvements, and provides a ready-to-apply profile spec.

## What Was Done on LinkedIn

**Successfully executed:**
- Updated vanity URL to `joi-ascend` (from auto-generated)
- Set industry to "Technology, Information and Internet"
- Followed OpenAI company page
- Saved a job posting (Executive Assistant)
- Liked own post (feed reactions work)
- Browsed feed, inbox, notifications, profiles, and jobs

**Blocked by LinkedIn UI changes:**
- Profile sections (about, experience, education, etc.) — dialogs replaced by dropdowns
- Connection invitations, messaging, search, newsletters, job alerts, notification actions

## Issues Filed (12)

| # | Type | Title |
|---|------|-------|
| #526 | Bug | Profile section edit dialogs broken |
| #527 | Bug | Profile intro editor timeout |
| #528 | Bug | Search returns 0 results |
| #529 | Bug | Duplicate headline in feed view |
| #530 | Bug | Connection invite button not found |
| #531 | Bug | Company follow modal overlay |
| #532 | Bug | Newsletter/article editor broken |
| #533 | Bug | Job search parsing issues |
| #534 | Bug | Job alert toggle not found |
| #535 | Bug | Message button not found |
| #536 | Bug | Notification IDs not stable |
| #537 | Enhancement | Comprehensive QoL findings |

## Files Added

- `docs/exploration-session-2026-03-15.md` — Detailed session report with feature-by-feature status
- `docs/joi-ascend-profile-spec.json` — Complete profile spec ready to apply once #526/#527 are resolved

## Key Insight

LinkedIn has made significant UI changes breaking ~70% of write operations. The two-phase commit infrastructure works perfectly — failures are at the Playwright selector level.

Closes #525
