### PR TITLE
fix #529: prevent duplicate author_headline in feed post view

### DIFF
--- a/packages/core/src/__tests__/shared.test.ts
+++ b/packages/core/src/__tests__/shared.test.ts
@@ -216,7 +216,26 @@ describe("shared", () => {
     });
   });
 
-  describe("dedupeRepeatedText — issue #480 regression cases", () => {
+  describe("dedupeRepeatedText — issue #529 regression: headline with pipe", () => {
+    it("deduplicates exact-half headline containing pipe separator", () => {
+      expect(dedupeRepeatedText(
+        "executive assistant to the director at signikant | making ai workflows human-friendlyexecutive assistant to the director at signikant | making ai workflows human-friendly"
+      )).toBe("executive assistant to the director at signikant | making ai workflows human-friendly");
+    });
+
+    it("deduplicates headline halves with mixed casing", () => {
+      expect(dedupeRepeatedText(
+        "Executive Assistant to the Director at Signikant | Making AI workflows human-friendlyexecutive assistant to the director at signikant | making ai workflows human-friendly"
+      )).toBe("Executive Assistant to the Director at Signikant | Making AI workflows human-friendly");
+    });
+
+    it("deduplicates prefix pattern with mixed casing", () => {
+      expect(dedupeRepeatedText("Developer developer with verification"))
+        .toBe("developer with verification");
+    });
+  });
+
+    describe("dedupeRepeatedText — issue #480 regression cases", () => {
     it("deduplicates author headline", () => {
       expect(dedupeRepeatedText(
         "Personal Assistant to Director at SignikantPersonal Assistant to Director at Signikant"

--- a/packages/core/src/linkedinFeed.ts
+++ b/packages/core/src/linkedinFeed.ts
@@ -581,6 +581,14 @@ async function extractFeedPosts(
       const normalize = (value: string | null | undefined): string =>
         (value ?? "").replace(/\s+/g, " ").trim();
 
+      // Prefer the aria-hidden span inside an element to avoid reading
+      // both the visible and screen-reader text that LinkedIn renders
+      // as sibling spans (which would double the value).
+      const readElementText = (el: Element): string => {
+        const ariaHidden = el.querySelector("span[aria-hidden='true']");
+        return normalize((ariaHidden ?? el).textContent);
+      };
+
       const toAbsoluteUrl = (href: string | null | undefined): string => {
         const value = normalize(href);
         if (!value) {
@@ -735,7 +743,7 @@ async function extractFeedPosts(
             }
 
             if (!authorName) {
-              const potentialName = normalize(link.textContent);
+              const potentialName = readElementText(link);
               if (potentialName) {
                 authorName = potentialName;
               }
@@ -748,7 +756,7 @@ async function extractFeedPosts(
 
             const siblingDivs = Array.from(parent.querySelectorAll("div"));
             for (const div of siblingDivs) {
-              const text = normalize(div.textContent);
+              const text = readElementText(div);
               if (!text || text === authorName) {
                 continue;
               }
@@ -776,7 +784,7 @@ async function extractFeedPosts(
 
           if (!authorHeadline || !postedAt) {
             const allDivText = Array.from(card.querySelectorAll("div")).map((div) =>
-              normalize(div.textContent),
+              readElementText(div),
             );
             for (const text of allDivText) {
               if (!text || text === authorName || text === authorHeadline) {

--- a/packages/core/src/shared.ts
+++ b/packages/core/src/shared.ts
@@ -79,7 +79,7 @@ export function dedupeRepeatedText(value: string | null | undefined): string {
     const mid = text.length / 2;
     const first = normalizeText(text.slice(0, mid));
     const second = normalizeText(text.slice(mid));
-    if (first && first === second) {
+    if (first && first.toLowerCase() === second.toLowerCase()) {
       return first;
     }
   }
@@ -89,7 +89,7 @@ export function dedupeRepeatedText(value: string | null | undefined): string {
   for (let i = 1; i * 2 <= words.length; i += 1) {
     const prefix = words.slice(0, i).join(" ");
     const next = words.slice(i, i * 2).join(" ");
-    if (prefix === next) {
+    if (prefix.toLowerCase() === next.toLowerCase()) {
       return normalizeText(words.slice(i).join(" "));
     }
   }


### PR DESCRIPTION
## Summary

Fixes the duplicate `author_headline` text in `linkedin feed view` output where the headline appeared twice, concatenated without separator.

**Root cause:** The SDUI feed extraction code used raw `div.textContent` / `link.textContent` to extract author metadata. LinkedIn renders paired visible + screen-reader `<span>` elements inside these containers, so `textContent` concatenated both copies.

## Changes

- **`packages/core/src/linkedinFeed.ts`**: Added `readElementText()` helper inside the browser-side extraction that prefers `span[aria-hidden='true']` text (matching the existing `pickText()` pattern). Applied it to all three SDUI extraction sites: `authorName`, `authorHeadline` (sibling divs loop), and the fallback `allDivText` map.
- **`packages/core/src/shared.ts`**: Made `dedupeRepeatedText()` comparisons case-insensitive as a safety net for edge cases where the two span copies differ in casing.
- **`packages/core/src/__tests__/shared.test.ts`**: Added regression tests for the exact text from issue #529 plus mixed-casing scenarios.

## Test results

- Core typecheck: clean
- Lint: clean  
- Full test suite: 120 files, 1562 tests passed (including 3 new regression tests)

Closes #529
