### PR TITLE
feat: comprehensive QoL improvements for first-time platform usage (#537)

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -406,6 +406,43 @@ function printPrepareResult(value: Record<string, unknown>): void {
   printJson(value);
 }
 
+async function maybeAutoExecute(
+  runtime: ReturnType<typeof createRuntime>,
+  prepared: {
+    preparedActionId: string;
+    confirmToken: string;
+    expiresAtMs: number;
+    preview: Record<string, unknown>;
+  },
+  options: { execute: boolean; profileName: string },
+): Promise<void> {
+  if (!options.execute) {
+    printPrepareResult({
+      run_id: runtime.runId,
+      profile_name: options.profileName,
+      ...prepared,
+    });
+    return;
+  }
+
+  const result = await runtime.twoPhaseCommit.confirmByToken({
+    confirmToken: prepared.confirmToken,
+  });
+
+  const summary =
+    typeof prepared.preview.summary === "string"
+      ? prepared.preview.summary
+      : `Action ${result.actionType}`;
+  writeCliNotice(`Executed: ${summary}`);
+
+  printJson({
+    run_id: runtime.runId,
+    profile_name: options.profileName,
+    auto_executed: true,
+    ...result,
+  });
+}
+
 function formatSearchResults(result: SearchResult): string {
   const lines: string[] = [];
   lines.push(`Search: "${result.query}" (${result.category}) — ${result.count} result(s)`);
@@ -5620,6 +5657,7 @@ async function runPrepareReply(
     profileName: string;
     thread: string;
     text: string;
+    execute: boolean;
   },
   cdpUrl?: string,
 ): Promise<void> {
@@ -5642,10 +5680,9 @@ async function runPrepareReply(
       preparedActionId: prepared.preparedActionId,
     });
 
-    printPrepareResult({
-      run_id: runtime.runId,
-      profile_name: input.profileName,
-      ...prepared,
+    await maybeAutoExecute(runtime, prepared, {
+      execute: input.execute,
+      profileName: input.profileName,
     });
   } finally {
     runtime.close();
@@ -5696,6 +5733,7 @@ async function runPrepareNewThread(
     profileName: string;
     recipients: string[];
     text: string;
+    execute: boolean;
   },
   cdpUrl?: string,
 ): Promise<void> {
@@ -5719,10 +5757,9 @@ async function runPrepareNewThread(
       recipientCount: input.recipients.length,
     });
 
-    printPrepareResult({
-      run_id: runtime.runId,
-      profile_name: input.profileName,
-      ...prepared,
+    await maybeAutoExecute(runtime, prepared, {
+      execute: input.execute,
+      profileName: input.profileName,
     });
   } finally {
     runtime.close();
@@ -6016,6 +6053,7 @@ async function runConnectionsInvite(
     profileName: string;
     targetProfile: string;
     note?: string;
+    execute: boolean;
   },
   cdpUrl?: string,
 ): Promise<void> {
@@ -6038,10 +6076,9 @@ async function runConnectionsInvite(
       preparedActionId: prepared.preparedActionId,
     });
 
-    printPrepareResult({
-      run_id: runtime.runId,
-      profile_name: input.profileName,
-      ...prepared,
+    await maybeAutoExecute(runtime, prepared, {
+      execute: input.execute,
+      profileName: input.profileName,
     });
   } finally {
     runtime.close();
@@ -6052,6 +6089,7 @@ async function runConnectionsAccept(
   input: {
     profileName: string;
     targetProfile: string;
+    execute: boolean;
   },
   cdpUrl?: string,
 ): Promise<void> {
@@ -6073,10 +6111,9 @@ async function runConnectionsAccept(
       preparedActionId: prepared.preparedActionId,
     });
 
-    printPrepareResult({
-      run_id: runtime.runId,
-      profile_name: input.profileName,
-      ...prepared,
+    await maybeAutoExecute(runtime, prepared, {
+      execute: input.execute,
+      profileName: input.profileName,
     });
   } finally {
     runtime.close();
@@ -6087,6 +6124,7 @@ async function runConnectionsWithdraw(
   input: {
     profileName: string;
     targetProfile: string;
+    execute: boolean;
   },
   cdpUrl?: string,
 ): Promise<void> {
@@ -6108,10 +6146,9 @@ async function runConnectionsWithdraw(
       preparedActionId: prepared.preparedActionId,
     });
 
-    printPrepareResult({
-      run_id: runtime.runId,
-      profile_name: input.profileName,
-      ...prepared,
+    await maybeAutoExecute(runtime, prepared, {
+      execute: input.execute,
+      profileName: input.profileName,
     });
   } finally {
     runtime.close();
@@ -6391,6 +6428,7 @@ async function runFeedList(
     profileName: string;
     limit: number;
     mine: boolean;
+    scrollAttempts: number;
   },
   cdpUrl?: string,
 ): Promise<void> {
@@ -6401,12 +6439,14 @@ async function runFeedList(
       profileName: input.profileName,
       limit: input.limit,
       mine: input.mine,
+      scrollAttempts: input.scrollAttempts,
     });
 
     const posts = await runtime.feed.viewFeed({
       profileName: input.profileName,
       limit: input.limit,
       mine: input.mine,
+      scrollAttempts: input.scrollAttempts,
     });
 
     runtime.logger.log("info", "cli.feed.list.done", {
@@ -6414,6 +6454,13 @@ async function runFeedList(
       count: posts.length,
       mine: input.mine,
     });
+
+    if (posts.length === 0) {
+      writeCliNotice(
+        "No feed posts found. For accounts with few connections, " +
+          "try increasing --scroll-attempts or follow more companies and people to populate your feed.",
+      );
+    }
 
     printJson({
       run_id: runtime.runId,
@@ -6468,6 +6515,7 @@ async function runFeedLike(
     postUrl: string;
     reaction?: string;
     operatorNote?: string;
+    execute: boolean;
   },
   cdpUrl?: string,
 ): Promise<void> {
@@ -6494,10 +6542,9 @@ async function runFeedLike(
       reaction,
     });
 
-    printPrepareResult({
-      run_id: runtime.runId,
-      profile_name: input.profileName,
-      ...prepared,
+    await maybeAutoExecute(runtime, prepared, {
+      execute: input.execute,
+      profileName: input.profileName,
     });
   } finally {
     runtime.close();
@@ -6510,6 +6557,7 @@ async function runFeedComment(
     postUrl: string;
     text: string;
     operatorNote?: string;
+    execute: boolean;
   },
   cdpUrl?: string,
 ): Promise<void> {
@@ -6533,10 +6581,9 @@ async function runFeedComment(
       preparedActionId: prepared.preparedActionId,
     });
 
-    printPrepareResult({
-      run_id: runtime.runId,
-      profile_name: input.profileName,
-      ...prepared,
+    await maybeAutoExecute(runtime, prepared, {
+      execute: input.execute,
+      profileName: input.profileName,
     });
   } finally {
     runtime.close();
@@ -6736,6 +6783,7 @@ async function runPostPrepare(
     text: string;
     visibility?: string;
     operatorNote?: string;
+    execute: boolean;
   },
   cdpUrl?: string,
 ): Promise<void> {
@@ -6764,10 +6812,9 @@ async function runPostPrepare(
       visibility,
     });
 
-    printPrepareResult({
-      run_id: runtime.runId,
-      profile_name: input.profileName,
-      ...prepared,
+    await maybeAutoExecute(runtime, prepared, {
+      execute: input.execute,
+      profileName: input.profileName,
     });
   } finally {
     runtime.close();
@@ -11345,17 +11392,20 @@ export function createCliProgram(): Command {
     )
     .requiredOption("--text <text>", "First message text")
     .option("-p, --profile <profile>", "Profile name", "default")
+    .option("-x, --execute", "Immediately execute the action (skip separate confirm step)", false)
     .action(
       async (options: {
         profile: string;
         recipient: string[];
         text: string;
+        execute: boolean;
       }) => {
         await runPrepareNewThread(
           {
             profileName: options.profile,
             recipients: options.recipient,
             text: options.text,
+            execute: options.execute,
           },
           readCdpUrl(),
         );
@@ -11368,13 +11418,15 @@ export function createCliProgram(): Command {
     .requiredOption("--thread <thread>", "Thread id or LinkedIn thread URL")
     .requiredOption("--text <text>", "Message text")
     .option("-p, --profile <profile>", "Profile name", "default")
+    .option("-x, --execute", "Immediately execute the action (skip separate confirm step)", false)
     .action(
-      async (options: { profile: string; thread: string; text: string }) => {
+      async (options: { profile: string; thread: string; text: string; execute: boolean }) => {
         await runPrepareReply(
           {
             profileName: options.profile,
             thread: options.thread,
             text: options.text,
+            execute: options.execute,
           },
           readCdpUrl(),
         );
@@ -11551,13 +11603,15 @@ export function createCliProgram(): Command {
     .argument("<target>", "Vanity name or profile URL")
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("-n, --note <note>", "Optional invitation note")
+    .option("-x, --execute", "Immediately execute the action (skip separate confirm step)", false)
     .action(
-      async (target: string, options: { profile: string; note?: string }) => {
+      async (target: string, options: { profile: string; note?: string; execute: boolean }) => {
         await runConnectionsInvite(
           {
             profileName: options.profile,
             targetProfile: target,
             ...(options.note ? { note: options.note } : {}),
+            execute: options.execute,
           },
           readCdpUrl(),
         );
@@ -11569,11 +11623,13 @@ export function createCliProgram(): Command {
     .description("Prepare to accept a connection invitation (two-phase)")
     .argument("<target>", "Vanity name or profile URL of the sender")
     .option("-p, --profile <profile>", "Profile name", "default")
-    .action(async (target: string, options: { profile: string }) => {
+    .option("-x, --execute", "Immediately execute the action (skip separate confirm step)", false)
+    .action(async (target: string, options: { profile: string; execute: boolean }) => {
       await runConnectionsAccept(
         {
           profileName: options.profile,
           targetProfile: target,
+          execute: options.execute,
         },
         readCdpUrl(),
       );
@@ -11584,11 +11640,13 @@ export function createCliProgram(): Command {
     .description("Prepare to withdraw a sent invitation (two-phase)")
     .argument("<target>", "Vanity name or profile URL")
     .option("-p, --profile <profile>", "Profile name", "default")
-    .action(async (target: string, options: { profile: string }) => {
+    .option("-x, --execute", "Immediately execute the action (skip separate confirm step)", false)
+    .action(async (target: string, options: { profile: string; execute: boolean }) => {
       await runConnectionsWithdraw(
         {
           profileName: options.profile,
           targetProfile: target,
+          execute: options.execute,
         },
         readCdpUrl(),
       );
@@ -11764,13 +11822,27 @@ export function createCliProgram(): Command {
       "-m, --mine",
       "Show only your own posts (navigates to your activity page)",
     )
+    .option(
+      "--scroll-attempts <n>",
+      "Number of scroll attempts for loading feed content (increase for sparse feeds)",
+      "6",
+    )
     .action(
-      async (options: { profile: string; limit: string; mine?: true }) => {
+      async (options: {
+        profile: string;
+        limit: string;
+        mine?: true;
+        scrollAttempts: string;
+      }) => {
         await runFeedList(
           {
             profileName: options.profile,
             limit: coercePositiveInt(options.limit, "limit"),
             mine: options.mine === true,
+            scrollAttempts: coercePositiveInt(
+              options.scrollAttempts,
+              "scroll-attempts",
+            ),
           },
           readCdpUrl(),
         );
@@ -11804,10 +11876,11 @@ export function createCliProgram(): Command {
       "like",
     )
     .option("-o, --operator-note <note>", "Optional operator note")
+    .option("-x, --execute", "Immediately execute the action (skip separate confirm step)", false)
     .action(
       async (
         post: string,
-        options: { profile: string; reaction: string; operatorNote?: string },
+        options: { profile: string; reaction: string; operatorNote?: string; execute: boolean },
       ) => {
         await runFeedLike(
           {
@@ -11817,6 +11890,7 @@ export function createCliProgram(): Command {
             ...(options.operatorNote
               ? { operatorNote: options.operatorNote }
               : {}),
+            execute: options.execute,
           },
           readCdpUrl(),
         );
@@ -11830,10 +11904,11 @@ export function createCliProgram(): Command {
     .requiredOption("--text <text>", "Comment text")
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("-o, --operator-note <note>", "Optional operator note")
+    .option("-x, --execute", "Immediately execute the action (skip separate confirm step)", false)
     .action(
       async (
         post: string,
-        options: { profile: string; text: string; operatorNote?: string },
+        options: { profile: string; text: string; operatorNote?: string; execute: boolean },
       ) => {
         await runFeedComment(
           {
@@ -11843,6 +11918,7 @@ export function createCliProgram(): Command {
             ...(options.operatorNote
               ? { operatorNote: options.operatorNote }
               : {}),
+            execute: options.execute,
           },
           readCdpUrl(),
         );
@@ -12174,12 +12250,14 @@ export function createCliProgram(): Command {
     )
     .option("-p, --profile <profile>", "Profile name", "default")
     .option("-o, --operator-note <note>", "Optional operator note")
+    .option("-x, --execute", "Immediately execute the action (skip separate confirm step)", false)
     .action(
       async (options: {
         profile: string;
         text: string;
         visibility: string;
         operatorNote?: string;
+        execute: boolean;
       }) => {
         await runPostPrepare(
           {
@@ -12189,6 +12267,7 @@ export function createCliProgram(): Command {
             ...(options.operatorNote
               ? { operatorNote: options.operatorNote }
               : {}),
+            execute: options.execute,
           },
           readCdpUrl(),
         );

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,14 @@ export * from "./linkedinAnalytics.js";
 export * from "./linkedinMembers.js";
 export * from "./linkedinPage.js";
 export * from "./linkedinProfile.js";
+export type {
+  LinkedInCertification,
+  LinkedInHonorAward,
+  LinkedInLanguage,
+  LinkedInProfile,
+  LinkedInProject,
+  LinkedInVolunteerExperience
+} from "./linkedinProfile.js";
 export * from "./linkedinPrivacySettings.js";
 export * from "./linkedinJobs.js";
 export * from "./linkedinNotifications.js";

--- a/packages/core/src/linkedinFeed.ts
+++ b/packages/core/src/linkedinFeed.ts
@@ -65,6 +65,12 @@ export interface ViewFeedInput {
   profileName?: string;
   limit?: number;
   mine?: boolean;
+  /**
+   * Number of scroll attempts when loading feed posts.
+   * Higher values help with sparse feeds on new accounts.
+   * @default 6
+   */
+  scrollAttempts?: number;
 }
 
 export interface ViewPostInput {
@@ -1020,10 +1026,11 @@ async function extractFeedPosts(
 async function loadFeedPosts(
   page: Page,
   limit: number,
+  scrollAttempts: number = 6,
 ): Promise<LinkedInFeedPost[]> {
   let posts = await extractFeedPosts(page, limit);
 
-  for (let i = 0; i < 6 && posts.length < limit; i++) {
+  for (let i = 0; i < scrollAttempts && posts.length < limit; i++) {
     await scrollLinkedInPageToBottom(page);
     await page.waitForTimeout(800);
     posts = await extractFeedPosts(page, limit);
@@ -3653,7 +3660,8 @@ export class LinkedInFeedService {
           await page.goto(targetUrl, { waitUntil: "domcontentloaded" });
           await waitForFeedSurface(page);
           await waitForNetworkIdleBestEffort(page, 8_000);
-          const posts = await loadFeedPosts(page, limit);
+          const scrollAttempts = input.scrollAttempts ?? 6;
+          const posts = await loadFeedPosts(page, limit, scrollAttempts);
           return posts.slice(0, limit);
         },
       );

--- a/packages/core/src/linkedinProfile.ts
+++ b/packages/core/src/linkedinProfile.ts
@@ -64,6 +64,38 @@ export interface LinkedInEducation {
   dates: string;
 }
 
+export interface LinkedInCertification {
+  name: string;
+  issuing_organization: string;
+  issue_date: string;
+  credential_id: string;
+}
+
+export interface LinkedInLanguage {
+  name: string;
+  proficiency: string;
+}
+
+export interface LinkedInProject {
+  name: string;
+  description: string;
+  dates: string;
+}
+
+export interface LinkedInVolunteerExperience {
+  role: string;
+  organization: string;
+  duration: string;
+  description: string;
+}
+
+export interface LinkedInHonorAward {
+  title: string;
+  issuer: string;
+  date: string;
+  description: string;
+}
+
 export interface LinkedInProfile {
   profile_url: string;
   vanity_name: string | null;
@@ -74,6 +106,11 @@ export interface LinkedInProfile {
   connection_degree: string;
   experience: LinkedInExperience[];
   education: LinkedInEducation[];
+  certifications: LinkedInCertification[];
+  languages: LinkedInLanguage[];
+  projects: LinkedInProject[];
+  volunteer_experience: LinkedInVolunteerExperience[];
+  honors_awards: LinkedInHonorAward[];
 }
 
 export interface ViewProfileInput {
@@ -2107,7 +2144,12 @@ async function extractProfileData(
       about: "",
       connection_degree: "",
       experience: [],
-      education: []
+      education: [],
+      certifications: [],
+      languages: [],
+      projects: [],
+      volunteer_experience: [],
+      honors_awards: []
     };
 
     const pickText = (
@@ -2455,6 +2497,153 @@ async function extractProfileData(
         })
         .filter((item) => item.school || item.degree || item.field_of_study || item.dates);
 
+      const certificationsSection = findSectionRoot(
+        "certifications",
+        sectionLabels.certifications
+      );
+      const certifications = collectSectionItems(certificationsSection)
+        .map((item) => {
+          const name = pickText(
+            [".t-bold span[aria-hidden='true']", ".t-bold", "[data-field='name']"],
+            item
+          );
+          const issuingOrganization = pickText(
+            [".t-normal span[aria-hidden='true']", ".t-normal", "[data-field='issuer']"],
+            item
+          );
+          const issueDate = pickText(
+            [
+              ".pvs-entity__caption-wrapper span[aria-hidden='true']",
+              ".pvs-entity__caption-wrapper",
+              "[data-field='date']"
+            ],
+            item
+          );
+          const credentialId = pickText(
+            [
+              ".pvs-entity__extra-details span[aria-hidden='true']",
+              "[data-field='credential_id']"
+            ],
+            item
+          );
+          return {
+            name,
+            issuing_organization: issuingOrganization,
+            issue_date: issueDate,
+            credential_id: credentialId
+          };
+        })
+        .filter((item) => item.name || item.issuing_organization);
+
+      const languagesSection = findSectionRoot("languages", sectionLabels.languages);
+      const languages = collectSectionItems(languagesSection)
+        .map((item) => {
+          const name = pickText([".t-bold span[aria-hidden='true']", ".t-bold"], item);
+          const proficiency = pickText(
+            [".t-normal span[aria-hidden='true']", ".t-normal"],
+            item
+          );
+          return {
+            name,
+            proficiency
+          };
+        })
+        .filter((item) => item.name || item.proficiency);
+
+      const projectsSection = findSectionRoot("projects", sectionLabels.projects);
+      const projects = collectSectionItems(projectsSection)
+        .map((item) => {
+          const name = pickText([".t-bold span[aria-hidden='true']", ".t-bold"], item);
+          const description = pickText(
+            [
+              ".inline-show-more-text span[aria-hidden='true']",
+              ".inline-show-more-text"
+            ],
+            item
+          );
+          const dates = pickText(
+            [
+              ".pvs-entity__caption-wrapper span[aria-hidden='true']",
+              ".pvs-entity__caption-wrapper"
+            ],
+            item
+          );
+          return {
+            name,
+            description,
+            dates
+          };
+        })
+        .filter((item) => item.name || item.description || item.dates);
+
+      const volunteerExperienceSection = findSectionRoot(
+        "volunteering_experience",
+        sectionLabels.volunteer_experience
+      );
+      const volunteer_experience = collectSectionItems(volunteerExperienceSection)
+        .map((item) => {
+          const role = pickText([".t-bold span[aria-hidden='true']", ".t-bold"], item);
+          const organization = pickText(
+            [".t-normal span[aria-hidden='true']", ".t-normal"],
+            item
+          );
+          const duration = pickText(
+            [
+              ".pvs-entity__caption-wrapper span[aria-hidden='true']",
+              ".pvs-entity__caption-wrapper"
+            ],
+            item
+          );
+          const description = pickText(
+            [
+              ".inline-show-more-text span[aria-hidden='true']",
+              ".inline-show-more-text"
+            ],
+            item
+          );
+          return {
+            role,
+            organization,
+            duration,
+            description
+          };
+        })
+        .filter((item) => item.role || item.organization || item.duration || item.description);
+
+      const honorsAwardsSection = findSectionRoot(
+        "honors_and_awards",
+        sectionLabels.honors_awards
+      );
+      const honors_awards = collectSectionItems(honorsAwardsSection)
+        .map((item) => {
+          const title = pickText([".t-bold span[aria-hidden='true']", ".t-bold"], item);
+          const issuer = pickText(
+            [".t-normal span[aria-hidden='true']", ".t-normal"],
+            item
+          );
+          const date = pickText(
+            [
+              ".pvs-entity__caption-wrapper span[aria-hidden='true']",
+              ".pvs-entity__caption-wrapper"
+            ],
+            item
+          );
+          const description = pickText(
+            [
+              ".inline-show-more-text span[aria-hidden='true']",
+              ".inline-show-more-text"
+            ],
+            item
+          );
+          return {
+            title,
+            issuer,
+            date,
+            description
+          };
+        })
+        .filter((item) => item.title || item.issuer || item.date || item.description);
+
       return {
         profile_url: globalThis.window.location.href,
         vanity_name: vanityName,
@@ -2464,7 +2653,12 @@ async function extractProfileData(
         about,
         connection_degree: connectionDegree,
         experience,
-        education
+        education,
+        certifications,
+        languages,
+        projects,
+        volunteer_experience,
+        honors_awards
       };
     } catch {
       return emptyProfile;
@@ -2472,7 +2666,15 @@ async function extractProfileData(
   }, {
     about: getLinkedInSelectorPhrases("about", selectorLocale),
     experience: getLinkedInSelectorPhrases("experience", selectorLocale),
-    education: getLinkedInSelectorPhrases("education", selectorLocale)
+    education: getLinkedInSelectorPhrases("education", selectorLocale),
+    certifications: getLinkedInSelectorPhrases("certifications", selectorLocale),
+    languages: getLinkedInSelectorPhrases("languages", selectorLocale),
+    projects: getLinkedInSelectorPhrases("projects", selectorLocale),
+    volunteer_experience: getLinkedInSelectorPhrases(
+      "volunteer_experience",
+      selectorLocale
+    ),
+    honors_awards: getLinkedInSelectorPhrases("honors_awards", selectorLocale)
   });
 
   return {
@@ -2505,6 +2707,33 @@ async function extractProfileData(
       degree: normalizeText(item.degree),
       field_of_study: normalizeText(item.field_of_study),
       dates: normalizeText(item.dates)
+    })),
+    certifications: extracted.certifications.map((item) => ({
+      name: normalizeText(item.name),
+      issuing_organization: normalizeText(item.issuing_organization),
+      issue_date: normalizeText(item.issue_date),
+      credential_id: normalizeText(item.credential_id)
+    })),
+    languages: extracted.languages.map((item) => ({
+      name: normalizeText(item.name),
+      proficiency: normalizeText(item.proficiency)
+    })),
+    projects: extracted.projects.map((item) => ({
+      name: normalizeText(item.name),
+      description: normalizeText(item.description),
+      dates: normalizeText(item.dates)
+    })),
+    volunteer_experience: extracted.volunteer_experience.map((item) => ({
+      role: normalizeText(item.role),
+      organization: normalizeText(item.organization),
+      duration: normalizeText(item.duration),
+      description: normalizeText(item.description)
+    })),
+    honors_awards: extracted.honors_awards.map((item) => ({
+      title: normalizeText(item.title),
+      issuer: normalizeText(item.issuer),
+      date: normalizeText(item.date),
+      description: normalizeText(item.description)
     }))
   };
 }

--- a/packages/core/src/privacy.ts
+++ b/packages/core/src/privacy.ts
@@ -101,6 +101,39 @@ const LIKELY_NAME_FALSE_POSITIVES: ReadonlySet<string> = new Set([
   "Riyadh", "Seoul", "Shanghai", "Singapore", "Stockholm",
   "Taipei", "Tokyo", "Toronto", "Vancouver", "Vienna",
   "Warsaw", "Zurich",
+
+  // Contractions (common at sentence starts, never person names)
+  "I've", "I'm", "I'll", "I'd",
+  "We've", "We're", "We'll", "We'd",
+  "They've", "They'll", "They'd",
+  "You've", "You'll", "You'd",
+  "He'd", "He'll",
+  "She'd", "She'll",
+  "It's", "It'll",
+  "That's", "That'll",
+  "What's", "Who's", "Where's", "When's", "How's",
+  "There's", "Here's", "Let's",
+  "Don't", "Can't", "Won't", "Isn't", "Aren't",
+  "Wasn't", "Weren't", "Doesn't", "Didn't",
+  "Haven't", "Hasn't", "Hadn't",
+  "Couldn't", "Wouldn't", "Shouldn't", "Mightn't",
+
+  // Compound words and indefinite pronouns (sentence starts)
+  "Something", "Everything", "Nothing", "Anything",
+  "Someone", "Everyone", "Anyone", "Somebody", "Everybody",
+  "Anybody", "Somewhere", "Everywhere", "Anywhere",
+  "Sometimes", "Another", "Whatever", "Whenever", "Wherever",
+  "Whoever", "Ourselves", "Themselves", "Yourself", "Myself",
+
+  // Common sentence-start words in professional writing
+  "Because", "Although", "Whether", "Whereas", "Moreover",
+  "Furthermore", "Regardless", "Alternatively", "Additionally",
+  "Consequently", "Specifically", "Essentially", "Unfortunately",
+  "Fortunately", "Apparently", "Obviously", "Certainly",
+  "Absolutely", "Definitely", "Ultimately", "Previously",
+  "Currently", "Recently", "Typically", "Generally",
+  "Particularly", "Especially", "Importantly", "Interestingly",
+  "Surprisingly", "Significantly", "Increasingly", "Successfully",
 ]);
 
 const LINKEDIN_PROFILE_URL_PATTERN =

--- a/packages/core/src/profileManager.ts
+++ b/packages/core/src/profileManager.ts
@@ -222,6 +222,21 @@ export class ProfileManager {
             error.message.includes("ECONNREFUSED"));
 
         if (!isDisconnect || attempt >= maxRetries) {
+          if (isDisconnect) {
+            throw new LinkedInBuddyError(
+              "NETWORK_ERROR",
+              `Browser connection lost after ${maxRetries + 1} attempt(s). ` +
+                "The browser may have been closed or crashed. " +
+                'Run "linkedin keepalive start" to maintain a persistent session, ' +
+                'or restart the browser and try again.',
+              {
+                attempted_retries: maxRetries,
+                last_error_message:
+                  error instanceof Error ? error.message : String(error),
+              },
+              { cause: error instanceof Error ? error : undefined },
+            );
+          }
           throw error;
         }
 

--- a/packages/core/src/selectorLocale.ts
+++ b/packages/core/src/selectorLocale.ts
@@ -125,8 +125,10 @@ export type LinkedInSelectorPhraseKey =
   | "discard"
   | "dismiss"
   | "done"
+  | "certifications"
   | "education"
   | "experience"
+  | "honors_awards"
   | "follow"
   | "following"
   | "funny"
@@ -145,10 +147,12 @@ export type LinkedInSelectorPhraseKey =
   | "more_actions"
   | "notifications"
   | "open_to"
+  | "languages"
   | "pending"
   | "post"
   | "post_comment"
   | "post_settings"
+  | "projects"
   | "react"
   | "reaction"
   | "remove"
@@ -167,6 +171,7 @@ export type LinkedInSelectorPhraseKey =
   | "unsave"
   | "unfollow"
   | "visibility"
+  | "volunteer_experience"
   | "what_do_you_want_to_talk_about"
   | "who_can_see_your_post"
   | "withdraw"
@@ -195,8 +200,10 @@ const ENGLISH_SELECTOR_PHRASES: SelectorPhraseDictionary = {
   discard: ["Discard"],
   dismiss: ["Dismiss"],
   done: ["Done"],
+  certifications: ["Licenses & certifications", "Certifications"],
   education: ["Education"],
   experience: ["Experience"],
+  honors_awards: ["Honors & awards", "Honors and awards"],
   follow: ["Follow"],
   following: ["Following"],
   funny: ["Funny"],
@@ -215,10 +222,12 @@ const ENGLISH_SELECTOR_PHRASES: SelectorPhraseDictionary = {
   more_actions: ["More actions"],
   notifications: ["Notifications"],
   open_to: ["Open to"],
+  languages: ["Languages"],
   pending: ["Pending"],
   post: ["Post"],
   post_comment: ["Post comment"],
   post_settings: ["Post settings"],
+  projects: ["Projects"],
   react: ["React"],
   reaction: ["Reaction", "Reactions"],
   remove: ["Remove"],
@@ -237,6 +246,7 @@ const ENGLISH_SELECTOR_PHRASES: SelectorPhraseDictionary = {
   unsave: ["Unsave"],
   unfollow: ["Unfollow"],
   visibility: ["Visibility"],
+  volunteer_experience: ["Volunteer experience", "Volunteering"],
   what_do_you_want_to_talk_about: ["What do you want to talk about?"],
   who_can_see_your_post: ["Who can see your post?"],
   withdraw: ["Withdraw"],
@@ -259,8 +269,10 @@ const DANISH_SELECTOR_PHRASE_OVERRIDES: SelectorPhraseOverrides = {
   discard: ["Kassér", "Fjern"],
   dismiss: ["Luk"],
   done: ["Færdig", "Udført"],
+  certifications: ["Licenser og certificeringer", "Certificeringer"],
   education: ["Uddannelse"],
   experience: ["Erfaring"],
+  honors_awards: ["Hædersbevisninger og priser"],
   follow: ["Følg"],
   following: ["Følger"],
   funny: ["Sjov"],
@@ -279,10 +291,12 @@ const DANISH_SELECTOR_PHRASE_OVERRIDES: SelectorPhraseOverrides = {
   more_actions: ["Flere handlinger", "Mere"],
   notifications: ["Notifikationer", "Meddelelser"],
   open_to: ["Åben for", "Åben over for"],
+  languages: ["Sprog"],
   pending: ["Afventer"],
   post: ["Slå op", "Opslag"],
   post_comment: ["Slå kommentar op", "Send kommentar"],
   post_settings: ["Opslagsindstillinger", "Indstillinger for opslag"],
+  projects: ["Projekter"],
   react: ["Reager"],
   reaction: ["Reaktion", "Reaktioner"],
   remove: ["Fjern"],
@@ -297,6 +311,7 @@ const DANISH_SELECTOR_PHRASE_OVERRIDES: SelectorPhraseOverrides = {
   time_ago: ["siden"],
   unfollow: ["Følg ikke længere", "Stop med at følge"],
   visibility: ["Synlighed"],
+  volunteer_experience: ["Frivilligt arbejde"],
   what_do_you_want_to_talk_about: [
     "Hvad vil du tale om?",
     "Hvad vil du skrive om?"


### PR DESCRIPTION
## Summary

Comprehensive QoL improvements addressing usability findings from first-time profile setup and platform exploration (issue #537). Implements 5 of 8 suggestions — 2 were already resolved and 1 deferred as low-priority polish.

## Changes

### Item 3: Feed list sparse-account resilience
- Added `--scroll-attempts <n>` option to `feed list` CLI command (default: 6)
- `ViewFeedInput.scrollAttempts` threaded through `loadFeedPosts()` for configurable scroll iterations
- Helpful notice when 0 posts found suggesting users increase scroll attempts or follow more accounts

### Item 4: Profile view extracts all sections
- Extended `LinkedInProfile` interface with 5 new section types: `certifications`, `languages`, `projects`, `volunteer_experience`, `honors_awards`
- Added `LinkedInCertification`, `LinkedInLanguage`, `LinkedInProject`, `LinkedInVolunteerExperience`, `LinkedInHonorAward` interfaces
- Extended `extractProfileData()` with section extraction using existing `findSectionRoot()` + `collectSectionItems()` pattern
- Added selector phrase keys for all 5 sections in both English and Danish locales
- All new types exported from `@linkedin-buddy/core`

### Item 5: CLI `--execute` flag for two-phase commit
- Added `maybeAutoExecute()` shared helper function
- Added `-x, --execute` flag to 8 key prepare commands: inbox prepare-reply, inbox prepare-new-thread, connections invite/accept/withdraw, feed like/comment, post prepare
- When `--execute` is set, prepare + confirm happens in one step, outputting the execution result with `auto_executed: true`

### Item 6: Browser context stale-error wrapping
- Stale browser context errors (after retry exhaustion) now throw `LinkedInBuddyError` with code `NETWORK_ERROR` instead of raw Playwright errors
- Error message includes recovery guidance: suggests running `linkedin keepalive start`
- Includes `attempted_retries` and `last_error_message` in error details

### Item 7: Privacy redaction false-positive guard
- Added 80+ entries to `LIKELY_NAME_FALSE_POSITIVES` covering:
  - Contractions: I've, I'm, We're, They'll, Don't, Can't, etc.
  - Compound words: Something, Everything, Anyone, Wherever, etc.
  - Common sentence starters: Because, Although, Unfortunately, etc.
- Fixes false positives like "Something I've" being redacted as a person name

### Already implemented (no changes needed)
- Item 1: "Already pending" detection — pre-flight checks exist in `executeSendInvitation` and `executeFollowCompanyPage`
- Item 2: `--continue-on-error` flag already exists in `profile apply-spec`

### Deferred
- Item 8: Batch operation reporting — existing patterns in apply-spec and validation runners are sufficient

## Test Results
- 1575 tests pass across 120 test files
- Core package compiles clean
- ESLint passes on all changed files
- Pre-existing type errors in CLI/MCP packages are unrelated to these changes

Closes #537
