### PR TITLE
feat #555: Joi Ascend LinkedIn platform usage — full profile, posts, engagement

### DIFF
--- a/joi-platform-usage-log.json
+++ b/joi-platform-usage-log.json
@@ -1,0 +1,21 @@
+{
+  "session": "issue-555-platform-usage",
+  "account": "joi-ascend",
+  "date": "2026-03-16",
+  "summary": "Comprehensive LinkedIn platform usage test using linkedin-buddy CLI and Playwright MCP.",
+  "profile_completion": "all_sections_complete",
+  "posts_published": 3,
+  "feed_likes": 2,
+  "connections_sent": 1,
+  "jobs_browsed": true,
+  "newsletter_attempted": true,
+  "newsletter_blocked_reason": "Account requires minimum connections for newsletter creation",
+  "bugs_filed": [556, 558],
+  "discoveries": [
+    "CLI headless browser at about:blank breaks page-dependent operations",
+    "LinkedIn Start a post changed from button to div",
+    "Profile edit form URLs: /in/{username}/edit/forms/{section}/new/",
+    "Headless login blocked by CAPTCHA, visible browser bypasses",
+    "Newsletter requires minimum network size"
+  ]
+}


### PR DESCRIPTION
## Summary

Completes issue #555 — comprehensive LinkedIn platform usage test with the Joi Ascend test account.

### What was done

**Profile (ALL sections filled):**
- Intro, About, 4 Experiences, 2 Educations, 4 Certifications, 3 Languages, 2 Volunteer roles, 2 Honors, 2 Projects

**Platform Features Used:**
- 3 posts published (AI tools, Copenhagen tech scene, EA skills)
- 2 feed posts liked
- 1 connection request sent (Simon Miller — pending)
- Job search browsed (AI operations in Copenhagen, 100+ results)
- Notifications listed via CLI

**Bugs Discovered & Filed:**
- #556 — Profile section editing dialog timeout (LinkedIn UI changed)
- #558 — CLI post prepare NETWORK_ERROR (headless browser at about:blank)

**Key Finding:** Most write operations require Playwright MCP browser (not CLI headless) because the CLI browser session doesn't auto-navigate to LinkedIn after cookie import.

### What's blocked
- Newsletter creation: requires minimum network size (0 connections)
- Messaging: connection to Simon Miller pending acceptance

### Files
- `joi-platform-usage-log.json` — Structured log of all activities performed

Closes #555