### PR TITLE
fix #558: add navigateToLinkedIn helper with retry for headless browser at about:blank

### DIFF
--- a/packages/core/src/__tests__/pageLoad.test.ts
+++ b/packages/core/src/__tests__/pageLoad.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import { errors as playwrightErrors } from "playwright-core";
+import { navigateToLinkedIn, waitForNetworkIdleBestEffort } from "../pageLoad.js";
+
+function createMockPage(url = "about:blank") {
+  return {
+    goto: vi.fn().mockResolvedValue(null),
+    url: vi.fn().mockReturnValue(url),
+    waitForLoadState: vi.fn().mockResolvedValue(undefined),
+  } as unknown as import("playwright-core").Page;
+}
+
+describe("pageLoad", () => {
+  describe("navigateToLinkedIn", () => {
+    it("navigates successfully on first attempt", async () => {
+      const page = createMockPage();
+
+      await navigateToLinkedIn(page, "https://www.linkedin.com/feed/");
+
+      expect(page.goto).toHaveBeenCalledOnce();
+      expect(page.goto).toHaveBeenCalledWith("https://www.linkedin.com/feed/", {
+        waitUntil: "domcontentloaded",
+      });
+      expect(page.waitForLoadState).toHaveBeenCalledWith("networkidle", {
+        timeout: 5_000,
+      });
+    });
+
+    it("succeeds on retry after network error", async () => {
+      const page = createMockPage();
+      vi.mocked(page.goto)
+        .mockRejectedValueOnce(new Error("net::ERR_NAME_NOT_RESOLVED"))
+        .mockResolvedValueOnce(null);
+
+      await navigateToLinkedIn(page, "https://www.linkedin.com/feed/", {
+        retryDelayMs: 0,
+      });
+
+      expect(page.goto).toHaveBeenCalledTimes(2);
+      expect(page.waitForLoadState).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries on ECONN errors", async () => {
+      const page = createMockPage();
+      vi.mocked(page.goto)
+        .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+        .mockResolvedValueOnce(null);
+
+      await navigateToLinkedIn(page, "https://www.linkedin.com/feed/", {
+        retryDelayMs: 0,
+      });
+
+      expect(page.goto).toHaveBeenCalledTimes(2);
+      expect(page.waitForLoadState).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws after exhausting retries", async () => {
+      const page = createMockPage();
+      const error = new Error("net::ERR_CONNECTION_RESET");
+      vi.mocked(page.goto).mockRejectedValue(error);
+
+      await expect(
+        navigateToLinkedIn(page, "https://www.linkedin.com/feed/", {
+          retries: 1,
+          retryDelayMs: 0,
+        }),
+      ).rejects.toBe(error);
+
+      expect(page.goto).toHaveBeenCalledTimes(2);
+      expect(page.waitForLoadState).not.toHaveBeenCalled();
+    });
+
+    it("does not retry non-network errors", async () => {
+      const page = createMockPage();
+      const error = new Error("some other error");
+      vi.mocked(page.goto).mockRejectedValue(error);
+
+      await expect(
+        navigateToLinkedIn(page, "https://www.linkedin.com/feed/", {
+          retries: 5,
+          retryDelayMs: 0,
+        }),
+      ).rejects.toBe(error);
+
+      expect(page.goto).toHaveBeenCalledOnce();
+      expect(page.waitForLoadState).not.toHaveBeenCalled();
+    });
+
+    it("respects custom retry options", async () => {
+      const page = createMockPage();
+      const error = new Error("ENOTFOUND");
+      vi.mocked(page.goto).mockRejectedValue(error);
+
+      await expect(
+        navigateToLinkedIn(page, "https://www.linkedin.com/feed/", {
+          retries: 2,
+          retryDelayMs: 0,
+        }),
+      ).rejects.toBe(error);
+
+      expect(page.goto).toHaveBeenCalledTimes(3);
+      expect(page.waitForLoadState).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("waitForNetworkIdleBestEffort", () => {
+    it("returns true on networkidle", async () => {
+      const page = createMockPage();
+
+      await expect(waitForNetworkIdleBestEffort(page)).resolves.toBe(true);
+
+      expect(page.waitForLoadState).toHaveBeenCalledWith("networkidle", {
+        timeout: 5_000,
+      });
+    });
+
+    it("returns false on timeout", async () => {
+      const page = createMockPage();
+      vi.mocked(page.waitForLoadState).mockRejectedValue(
+        new playwrightErrors.TimeoutError("timed out"),
+      );
+
+      await expect(waitForNetworkIdleBestEffort(page)).resolves.toBe(false);
+    });
+
+    it("throws on other errors", async () => {
+      const page = createMockPage();
+      const error = new Error("boom");
+      vi.mocked(page.waitForLoadState).mockRejectedValue(error);
+
+      await expect(waitForNetworkIdleBestEffort(page)).rejects.toBe(error);
+    });
+  });
+});

--- a/packages/core/src/linkedinPosts.ts
+++ b/packages/core/src/linkedinPosts.ts
@@ -13,7 +13,7 @@ import { LinkedInBuddyError, asLinkedInBuddyError } from "./errors.js";
 import { scrollLinkedInPageToTop } from "./linkedinPage.js";
 import type { JsonEventLogger } from "./logging.js";
 import { dismissLinkedInOverlaysIfPresent } from "./overlayDismissal.js";
-import { waitForNetworkIdleBestEffort } from "./pageLoad.js";
+import { navigateToLinkedIn, waitForNetworkIdleBestEffort } from "./pageLoad.js";
 import type { ProfileManager } from "./profileManager.js";
 import {
   consumeRateLimitOrThrow,
@@ -2554,8 +2554,7 @@ async function openPostComposer(
   artifactPaths: string[],
   logger?: Pick<JsonEventLogger, "log">,
 ): Promise<{ composerRoot: Locator; triggerKey: string; rootKey: string }> {
-  await page.goto(LINKEDIN_FEED_URL, { waitUntil: "domcontentloaded" });
-  await waitForNetworkIdleBestEffort(page);
+  await navigateToLinkedIn(page, LINKEDIN_FEED_URL);
   await dismissLinkedInOverlaysIfPresent(page, selectorLocale, logger);
   const triggerCandidates =
     createFeedPostComposerTriggerCandidates(selectorLocale);
@@ -3253,18 +3252,14 @@ async function locatePublishedPostOnSurface(
 ): Promise<Locator | null> {
   if (surface === "feed") {
     if (!page.url().startsWith(LINKEDIN_FEED_URL)) {
-      await page.goto(LINKEDIN_FEED_URL, { waitUntil: "domcontentloaded" });
-      await waitForNetworkIdleBestEffort(page);
+      await navigateToLinkedIn(page, LINKEDIN_FEED_URL);
     }
     await scrollLinkedInPageToTop(page);
     await waitForFeedSurface(page);
     return findVisiblePostBySnippet(page, snippet);
   }
 
-  await page.goto(LINKEDIN_PROFILE_ACTIVITY_URL, {
-    waitUntil: "domcontentloaded",
-  });
-  await waitForNetworkIdleBestEffort(page);
+  await navigateToLinkedIn(page, LINKEDIN_PROFILE_ACTIVITY_URL);
   await scrollLinkedInPageToTop(page);
   await waitForProfileActivitySurface(page);
   return findVisiblePostBySnippet(page, snippet);

--- a/packages/core/src/pageLoad.ts
+++ b/packages/core/src/pageLoad.ts
@@ -14,3 +14,31 @@ export async function waitForNetworkIdleBestEffort(
     throw error;
   }
 }
+
+export async function navigateToLinkedIn(
+  page: Page,
+  url: string,
+  options?: { retries?: number; retryDelayMs?: number },
+): Promise<void> {
+  const retryablePattern = /(net::|ERR_|ECONN|ENOTFOUND|EAI_AGAIN|socket hang up)/i;
+  let retriesRemaining = options?.retries ?? 1;
+  const retryDelayMs = options?.retryDelayMs ?? 1_000;
+
+  while (true) {
+    try {
+      await page.goto(url, { waitUntil: "domcontentloaded" });
+      await waitForNetworkIdleBestEffort(page);
+      return;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const isRetryable = retryablePattern.test(message);
+
+      if (!isRetryable || retriesRemaining <= 0) {
+        throw error;
+      }
+
+      retriesRemaining -= 1;
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #558 — CLI `post prepare` fails with `NETWORK_ERROR` when the headless browser page is at `about:blank`.

## Root Cause

When `prepareCreate()` runs, it calls `ensureAuthenticated()` in a separate browser context (context A), then creates a **new** context (context B) where the page starts at `about:blank`. Inside context B, `openPostComposer()` calls `page.goto(LINKEDIN_FEED_URL)` to navigate from `about:blank` to LinkedIn. If this navigation fails (transient DNS, cold headless network stack, etc.), the error surfaces as `NETWORK_ERROR` with `current_url: "about:blank"` — with no retry attempted.

## Changes

- **`packages/core/src/pageLoad.ts`** — Added `navigateToLinkedIn(page, url, options?)` helper that wraps `page.goto()` + `waitForNetworkIdleBestEffort()` with single-retry on network errors (`net::ERR_*`, `ECONN*`, `ENOTFOUND`, `socket hang up`). Non-network errors pass through immediately without retry.

- **`packages/core/src/linkedinPosts.ts`** — Replaced raw `page.goto()` + `waitForNetworkIdleBestEffort()` with `navigateToLinkedIn()` at 3 call sites:
  - `openPostComposer()` — initial feed navigation (affects `prepareCreate`, `prepareCreateMedia`, `prepareCreatePoll`, and all post executors)
  - `locatePublishedPostOnSurface()` — post verification navigation (feed + profile activity branches)

- **`packages/core/src/__tests__/pageLoad.test.ts`** — 9 new unit tests covering first-attempt success, retry on network errors, retry exhaustion, non-retryable error pass-through, custom retry options, and existing `waitForNetworkIdleBestEffort` behavior.

## Test Results

| Gate | Status |
|------|--------|
| New tests (pageLoad.test.ts) | ✅ 9/9 pass |
| Full test suite | ✅ 121 files, 1605 tests pass |
| Lint | ✅ Clean |
| Typecheck/Build | ⚠️ Pre-existing errors in CLI/MCP (not from this PR) |

Closes #558
