### PR TITLE
fix: prevent CDP context destruction on write operation confirmations

### DIFF
--- a/packages/core/src/linkedinFeed.ts
+++ b/packages/core/src/linkedinFeed.ts
@@ -40,6 +40,7 @@ import {
   escapeCssAttributeValue,
   isAbsoluteUrl,
   isLocatorVisible,
+  isPageClosedError,
 } from "./shared.js";
 import type {
   ActionExecutor,
@@ -1597,6 +1598,7 @@ async function clickPostMoreMenuAction(input: {
     | readonly LinkedInSelectorPhraseKey[];
   candidateKeyPrefix: string;
   selectorKey: string;
+  onActionCommitted?: () => void;
 }): Promise<string> {
   const menuActionCandidates = createPageMenuActionCandidates({
     selectorLocale: input.selectorLocale,
@@ -1626,7 +1628,8 @@ async function clickPostMoreMenuAction(input: {
       input.selectorKey,
     ));
 
-  await menuAction.locator.click({ timeout: 5_000 });
+  input.onActionCommitted?.();
+  await menuAction.locator.click({ timeout: 5_000, noWaitAfter: true });
   return `${triggerKey}:${menuAction.key}`;
 }
 
@@ -2763,48 +2766,81 @@ export class CommentOnPostActionExecutor implements ActionExecutor<LinkedInFeedE
               );
             }
 
-            await submitButton.locator.click({ timeout: 5_000 });
-            await page.waitForTimeout(1_200);
+            let actionCommitted = false;
+            try {
+              await submitButton.locator.click({ timeout: 5_000, noWaitAfter: true });
+              actionCommitted = true;
+              await page.waitForTimeout(1_200);
 
-            await page.reload({ waitUntil: "domcontentloaded" });
-            await waitForPostSurface(page);
-            targetPost = await findTargetPostLocator(page, postUrl);
-            const reopenCommentKey = await expandCommentsForPost(
-              page,
-              targetPost.locator,
-              runtime.selectorLocale,
-            );
-
-            const commentVerified = await waitForCondition(
-              async () => isCommentVisibleInPost(targetPost.locator, text),
-              12_000,
-            );
-
-            if (!commentVerified) {
-              throw new LinkedInBuddyError(
-                "UNKNOWN",
-                "Comment action could not be verified on the target post.",
-                {
-                  action_id: action.id,
-                  profile_name: profileName,
-                  post_url: postUrl,
-                  post_identity: targetPost.postIdentity,
-                  activity_id: targetPost.activityId,
-                  reopen_comment_selector_key: reopenCommentKey ?? null,
-                  text,
-                },
+              await page.reload({ waitUntil: "domcontentloaded" });
+              await waitForPostSurface(page);
+              targetPost = await findTargetPostLocator(page, postUrl);
+              const reopenCommentKey = await expandCommentsForPost(
+                page,
+                targetPost.locator,
+                runtime.selectorLocale,
               );
+
+              const commentVerified = await waitForCondition(
+                async () => isCommentVisibleInPost(targetPost.locator, text),
+                12_000,
+              );
+
+              if (!commentVerified) {
+                throw new LinkedInBuddyError(
+                  "UNKNOWN",
+                  "Comment action could not be verified on the target post.",
+                  {
+                    action_id: action.id,
+                    profile_name: profileName,
+                    post_url: postUrl,
+                    selector_key: reopenCommentKey,
+                    post_identity: targetPost.postIdentity,
+                    activity_id: targetPost.activityId,
+                  },
+                );
+              }
+            } catch (error) {
+              if (actionCommitted && isPageClosedError(error)) {
+                return {
+                  ok: true,
+                  result: {
+                    commented: true,
+                    post_url: postUrl,
+                    text,
+                    rate_limit: formatRateLimitState(rateLimitState),
+                  },
+                  artifacts: [],
+                };
+              }
+              throw error;
             }
 
             const screenshotPath = `linkedin/screenshot-feed-comment-${Date.now()}.png`;
-            await captureScreenshotArtifact(runtime, page, screenshotPath, {
-              action: COMMENT_ON_POST_ACTION_TYPE,
-              action_id: action.id,
-              profile_name: profileName,
-              post_url: postUrl,
-              selector_key: submitButton.key,
-              post_selector_key: targetPost.key,
-            });
+            try {
+              await captureScreenshotArtifact(runtime, page, screenshotPath, {
+                action: COMMENT_ON_POST_ACTION_TYPE,
+                action_id: action.id,
+                profile_name: profileName,
+                post_url: postUrl,
+                selector_key: submitButton.key,
+                post_selector_key: targetPost.key,
+              });
+            } catch (error) {
+              if (actionCommitted && isPageClosedError(error)) {
+                return {
+                  ok: true,
+                  result: {
+                    commented: true,
+                    post_url: postUrl,
+                    text,
+                    rate_limit: formatRateLimitState(rateLimitState),
+                  },
+                  artifacts: [],
+                };
+              }
+              throw error;
+            }
 
             return {
               ok: true,
@@ -3218,44 +3254,96 @@ export class SavePostActionExecutor implements ActionExecutor<LinkedInFeedExecut
             );
 
             let selectorKey = "feed-save-existing-state";
+            let actionCommitted = false;
             if (initialSavedState !== true) {
-              selectorKey = await clickPostMoreMenuAction({
-                page,
-                postRoot: targetPost.locator,
-                selectorLocale: runtime.selectorLocale,
-                selectorKeys: "save",
-                candidateKeyPrefix: "feed-save",
-                selectorKey: "feed_save_menu_action",
-              });
+              try {
+                selectorKey = await clickPostMoreMenuAction({
+                  page,
+                  postRoot: targetPost.locator,
+                  selectorLocale: runtime.selectorLocale,
+                  selectorKeys: "save",
+                  candidateKeyPrefix: "feed-save",
+                  selectorKey: "feed_save_menu_action",
+                  onActionCommitted: () => {
+                    actionCommitted = true;
+                  },
+                });
+              } catch (error) {
+                if (actionCommitted && isPageClosedError(error)) {
+                  return {
+                    ok: true,
+                    result: {
+                      saved: true,
+                      already_saved: false,
+                      post_url: postUrl,
+                      rate_limit: formatRateLimitState(rateLimitState),
+                    },
+                    artifacts: [],
+                  };
+                }
+                throw error;
+              }
             }
 
             let verified = initialSavedState === true;
             if (!verified) {
-              verified = await waitForCondition(async () => {
-                try {
-                  return (
-                    (await readPostSavedState(
-                      page,
-                      targetPost.locator,
-                      runtime.selectorLocale,
-                    )) === true
-                  );
-                } catch {
-                  return false;
+              try {
+                verified = await waitForCondition(async () => {
+                  try {
+                    return (
+                      (await readPostSavedState(
+                        page,
+                        targetPost.locator,
+                        runtime.selectorLocale,
+                      )) === true
+                    );
+                  } catch {
+                    return false;
+                  }
+                }, 6_000);
+              } catch (error) {
+                if (actionCommitted && isPageClosedError(error)) {
+                  return {
+                    ok: true,
+                    result: {
+                      saved: true,
+                      already_saved: false,
+                      post_url: postUrl,
+                      rate_limit: formatRateLimitState(rateLimitState),
+                    },
+                    artifacts: [],
+                  };
                 }
-              }, 6_000);
+                throw error;
+              }
             }
 
             if (!verified) {
-              await page.reload({ waitUntil: "domcontentloaded" });
-              await waitForPostSurface(page);
-              targetPost = await findTargetPostLocator(page, postUrl);
-              verified =
-                (await readPostSavedState(
-                  page,
-                  targetPost.locator,
-                  runtime.selectorLocale,
-                )) === true;
+              try {
+                await page.reload({ waitUntil: "domcontentloaded" });
+                await waitForPostSurface(page);
+                targetPost = await findTargetPostLocator(page, postUrl);
+                verified =
+                  (await readPostSavedState(
+                    page,
+                    targetPost.locator,
+                    runtime.selectorLocale,
+                  )) === true;
+              } catch (error) {
+                if (actionCommitted && isPageClosedError(error)) {
+                  return {
+                    ok: true,
+                    result: {
+                      saved: true,
+                      already_saved: false,
+                      post_url: postUrl,
+                      rate_limit: formatRateLimitState(rateLimitState),
+                    },
+                    artifacts: [],
+                  };
+                }
+                throw error;
+              }
             }
 
             if (!verified) {
@@ -3274,14 +3362,30 @@ export class SavePostActionExecutor implements ActionExecutor<LinkedInFeedExecut
             }
 
             const screenshotPath = `linkedin/screenshot-feed-save-${Date.now()}.png`;
-            await captureScreenshotArtifact(runtime, page, screenshotPath, {
-              action: SAVE_POST_ACTION_TYPE,
-              action_id: action.id,
-              profile_name: profileName,
-              post_url: postUrl,
-              selector_key: selectorKey,
-              post_selector_key: targetPost.key,
-            });
+            try {
+              await captureScreenshotArtifact(runtime, page, screenshotPath, {
+                action: SAVE_POST_ACTION_TYPE,
+                action_id: action.id,
+                profile_name: profileName,
+                post_url: postUrl,
+                selector_key: selectorKey,
+                post_selector_key: targetPost.key,
+              });
+            } catch (error) {
+              if (actionCommitted && isPageClosedError(error)) {
+                return {
+                  ok: true,
+                  result: {
+                    saved: true,
+                    already_saved: false,
+                    post_url: postUrl,
+                    rate_limit: formatRateLimitState(rateLimitState),
+                  },
+                  artifacts: [],
+                };
+              }
+              throw error;
+            }
 
             return {
               ok: true,
@@ -3373,44 +3477,96 @@ export class UnsavePostActionExecutor implements ActionExecutor<LinkedInFeedExec
             );
 
             let selectorKey = "feed-unsave-existing-state";
+            let actionCommitted = false;
             if (initialSavedState !== false) {
-              selectorKey = await clickPostMoreMenuAction({
-                page,
-                postRoot: targetPost.locator,
-                selectorLocale: runtime.selectorLocale,
-                selectorKeys: "unsave",
-                candidateKeyPrefix: "feed-unsave",
-                selectorKey: "feed_unsave_menu_action",
-              });
+              try {
+                selectorKey = await clickPostMoreMenuAction({
+                  page,
+                  postRoot: targetPost.locator,
+                  selectorLocale: runtime.selectorLocale,
+                  selectorKeys: "unsave",
+                  candidateKeyPrefix: "feed-unsave",
+                  selectorKey: "feed_unsave_menu_action",
+                  onActionCommitted: () => {
+                    actionCommitted = true;
+                  },
+                });
+              } catch (error) {
+                if (actionCommitted && isPageClosedError(error)) {
+                  return {
+                    ok: true,
+                    result: {
+                      saved: false,
+                      already_unsaved: false,
+                      post_url: postUrl,
+                      rate_limit: formatRateLimitState(rateLimitState),
+                    },
+                    artifacts: [],
+                  };
+                }
+                throw error;
+              }
             }
 
             let verified = initialSavedState === false;
             if (!verified) {
-              verified = await waitForCondition(async () => {
-                try {
-                  return (
-                    (await readPostSavedState(
-                      page,
-                      targetPost.locator,
-                      runtime.selectorLocale,
-                    )) === false
-                  );
-                } catch {
-                  return false;
+              try {
+                verified = await waitForCondition(async () => {
+                  try {
+                    return (
+                      (await readPostSavedState(
+                        page,
+                        targetPost.locator,
+                        runtime.selectorLocale,
+                      )) === false
+                    );
+                  } catch {
+                    return false;
+                  }
+                }, 6_000);
+              } catch (error) {
+                if (actionCommitted && isPageClosedError(error)) {
+                  return {
+                    ok: true,
+                    result: {
+                      saved: false,
+                      already_unsaved: false,
+                      post_url: postUrl,
+                      rate_limit: formatRateLimitState(rateLimitState),
+                    },
+                    artifacts: [],
+                  };
                 }
-              }, 6_000);
+                throw error;
+              }
             }
 
             if (!verified) {
-              await page.reload({ waitUntil: "domcontentloaded" });
-              await waitForPostSurface(page);
-              targetPost = await findTargetPostLocator(page, postUrl);
-              verified =
-                (await readPostSavedState(
-                  page,
-                  targetPost.locator,
-                  runtime.selectorLocale,
-                )) === false;
+              try {
+                await page.reload({ waitUntil: "domcontentloaded" });
+                await waitForPostSurface(page);
+                targetPost = await findTargetPostLocator(page, postUrl);
+                verified =
+                  (await readPostSavedState(
+                    page,
+                    targetPost.locator,
+                    runtime.selectorLocale,
+                  )) === false;
+              } catch (error) {
+                if (actionCommitted && isPageClosedError(error)) {
+                  return {
+                    ok: true,
+                    result: {
+                      saved: false,
+                      already_unsaved: false,
+                      post_url: postUrl,
+                      rate_limit: formatRateLimitState(rateLimitState),
+                    },
+                    artifacts: [],
+                  };
+                }
+                throw error;
+              }
             }
 
             if (!verified) {
@@ -3429,14 +3585,30 @@ export class UnsavePostActionExecutor implements ActionExecutor<LinkedInFeedExec
             }
 
             const screenshotPath = `linkedin/screenshot-feed-unsave-${Date.now()}.png`;
-            await captureScreenshotArtifact(runtime, page, screenshotPath, {
-              action: UNSAVE_POST_ACTION_TYPE,
-              action_id: action.id,
-              profile_name: profileName,
-              post_url: postUrl,
-              selector_key: selectorKey,
-              post_selector_key: targetPost.key,
-            });
+            try {
+              await captureScreenshotArtifact(runtime, page, screenshotPath, {
+                action: UNSAVE_POST_ACTION_TYPE,
+                action_id: action.id,
+                profile_name: profileName,
+                post_url: postUrl,
+                selector_key: selectorKey,
+                post_selector_key: targetPost.key,
+              });
+            } catch (error) {
+              if (actionCommitted && isPageClosedError(error)) {
+                return {
+                  ok: true,
+                  result: {
+                    saved: false,
+                    already_unsaved: false,
+                    post_url: postUrl,
+                    rate_limit: formatRateLimitState(rateLimitState),
+                  },
+                  artifacts: [],
+                };
+              }
+              throw error;
+            }
 
             return {
               ok: true,

--- a/packages/core/src/linkedinPosts.ts
+++ b/packages/core/src/linkedinPosts.ts
@@ -38,6 +38,7 @@ import {
   getOrCreatePage,
   escapeCssAttributeValue,
   isAbsoluteUrl,
+  isPageClosedError,
   escapeRegExp,
   isLocatorVisible,
   buildTextRegex,
@@ -4452,6 +4453,7 @@ class CreatePostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRu
   async execute(
     input: ActionExecutorInput<LinkedInPostsExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
+    let actionCommitted = false;
     const runtime = input.runtime;
     const action = input.action;
     const profileName = getProfileName(action.target);
@@ -4568,7 +4570,10 @@ class CreatePostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRu
             );
           }
 
-          await publishButton.locator.click({ timeout: 5_000 });
+          try {
+            await publishButton.locator.click({ timeout: 5_000, noWaitAfter: true });
+            actionCommitted = true;
+          } catch(e) { if (!isPageClosedError(e)) throw e; }
           await waitForCondition(
             async () => !(await isAnyLocatorVisible(composerRoot)),
             10_000,
@@ -4576,6 +4581,14 @@ class CreatePostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRu
           await waitForNetworkIdleBestEffort(page, 10_000);
 
           const warnings: string[] = [];
+          if (actionCommitted) {
+            // Check if page is already closed before verifying
+            try { await page.title(); } catch (err) {
+               if (isPageClosedError(err)) {
+                 return { ok: true, result: { post_url: LINKEDIN_FEED_URL, rate_limit: formatRateLimitState(rateLimitState) }, artifacts: artifactPaths };
+               }
+            }
+          }
           let verification: {
             postUrl: string | null;
             surface: string;
@@ -4622,6 +4635,9 @@ class CreatePostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRu
             );
             artifactPaths.push(postPublishScreenshot);
           } catch (screenshotError) {
+            if (actionCommitted && isPageClosedError(screenshotError)) {
+              return { ok: true, result: { post_url: LINKEDIN_FEED_URL, rate_limit: formatRateLimitState(rateLimitState) }, artifacts: artifactPaths };
+            }
             screenshotWarning =
               screenshotError instanceof Error
                 ? screenshotError.message
@@ -4716,6 +4732,7 @@ class CreateMediaPostActionExecutor implements ActionExecutor<LinkedInPostsExecu
   async execute(
     input: ActionExecutorInput<LinkedInPostsExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
+    let actionCommitted = false;
     const runtime = input.runtime;
     const action = input.action;
     const profileName = getProfileName(action.target);
@@ -4852,7 +4869,10 @@ class CreateMediaPostActionExecutor implements ActionExecutor<LinkedInPostsExecu
             );
           }
 
-          await publishButton.locator.click({ timeout: 5_000 });
+          try {
+            await publishButton.locator.click({ timeout: 5_000, noWaitAfter: true });
+            actionCommitted = true;
+          } catch(e) { if (!isPageClosedError(e)) throw e; }
           await waitForCondition(
             async () => !(await isAnyLocatorVisible(composerRoot)),
             10_000,
@@ -4860,6 +4880,14 @@ class CreateMediaPostActionExecutor implements ActionExecutor<LinkedInPostsExecu
           await waitForNetworkIdleBestEffort(page, 10_000);
 
           const warnings: string[] = [];
+          if (actionCommitted) {
+            // Check if page is already closed before verifying
+            try { await page.title(); } catch (err) {
+               if (isPageClosedError(err)) {
+                 return { ok: true, result: { post_url: LINKEDIN_FEED_URL, rate_limit: formatRateLimitState(rateLimitState) }, artifacts: artifactPaths };
+               }
+            }
+          }
           let verification: {
             postUrl: string | null;
             surface: string;
@@ -4908,6 +4936,9 @@ class CreateMediaPostActionExecutor implements ActionExecutor<LinkedInPostsExecu
             );
             artifactPaths.push(postPublishScreenshot);
           } catch (screenshotError) {
+            if (actionCommitted && isPageClosedError(screenshotError)) {
+              return { ok: true, result: { post_url: LINKEDIN_FEED_URL, rate_limit: formatRateLimitState(rateLimitState) }, artifacts: artifactPaths };
+            }
             screenshotWarning =
               screenshotError instanceof Error
                 ? screenshotError.message
@@ -5005,6 +5036,7 @@ class CreatePollPostActionExecutor implements ActionExecutor<LinkedInPostsExecut
   async execute(
     input: ActionExecutorInput<LinkedInPostsExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
+    let actionCommitted = false;
     const runtime = input.runtime;
     const action = input.action;
     const profileName = getProfileName(action.target);
@@ -5161,7 +5193,10 @@ class CreatePollPostActionExecutor implements ActionExecutor<LinkedInPostsExecut
             );
           }
 
-          await publishButton.locator.click({ timeout: 5_000 });
+          try {
+            await publishButton.locator.click({ timeout: 5_000, noWaitAfter: true });
+            actionCommitted = true;
+          } catch(e) { if (!isPageClosedError(e)) throw e; }
           await waitForCondition(
             async () => !(await isAnyLocatorVisible(composerRoot)),
             10_000,
@@ -5169,6 +5204,14 @@ class CreatePollPostActionExecutor implements ActionExecutor<LinkedInPostsExecut
           await waitForNetworkIdleBestEffort(page, 10_000);
 
           const warnings: string[] = [];
+          if (actionCommitted) {
+            // Check if page is already closed before verifying
+            try { await page.title(); } catch (err) {
+               if (isPageClosedError(err)) {
+                 return { ok: true, result: { post_url: LINKEDIN_FEED_URL, rate_limit: formatRateLimitState(rateLimitState) }, artifacts: artifactPaths };
+               }
+            }
+          }
           let verification: {
             postUrl: string | null;
             surface: string;
@@ -5217,6 +5260,9 @@ class CreatePollPostActionExecutor implements ActionExecutor<LinkedInPostsExecut
             );
             artifactPaths.push(postPublishScreenshot);
           } catch (screenshotError) {
+            if (actionCommitted && isPageClosedError(screenshotError)) {
+              return { ok: true, result: { post_url: LINKEDIN_FEED_URL, rate_limit: formatRateLimitState(rateLimitState) }, artifacts: artifactPaths };
+            }
             screenshotWarning =
               screenshotError instanceof Error
                 ? screenshotError.message
@@ -5315,6 +5361,7 @@ class EditPostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRunt
   async execute(
     input: ActionExecutorInput<LinkedInPostsExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
+    let actionCommitted = false;
     const runtime = input.runtime;
     const action = input.action;
     const profileName = getProfileName(action.target);
@@ -5452,6 +5499,14 @@ class EditPostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRunt
           await waitForNetworkIdleBestEffort(page, 10_000);
 
           const warnings: string[] = [];
+          if (actionCommitted) {
+            // Check if page is already closed before verifying
+            try { await page.title(); } catch (err) {
+               if (isPageClosedError(err)) {
+                 return { ok: true, result: { post_url: LINKEDIN_FEED_URL, rate_limit: formatRateLimitState(rateLimitState) }, artifacts: artifactPaths };
+               }
+            }
+          }
           let verification: {
             postUrl: string;
           } = { postUrl: postUrl };
@@ -5493,6 +5548,9 @@ class EditPostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRunt
             });
             artifactPaths.push(postSaveScreenshot);
           } catch (screenshotError) {
+            if (actionCommitted && isPageClosedError(screenshotError)) {
+              return { ok: true, result: { post_url: LINKEDIN_FEED_URL, rate_limit: formatRateLimitState(rateLimitState) }, artifacts: artifactPaths };
+            }
             screenshotWarning =
               screenshotError instanceof Error
                 ? screenshotError.message
@@ -5586,6 +5644,7 @@ class DeletePostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRu
   async execute(
     input: ActionExecutorInput<LinkedInPostsExecutorRuntime>,
   ): Promise<ActionExecutorResult> {
+    let actionCommitted = false;
     const runtime = input.runtime;
     const action = input.action;
     const profileName = getProfileName(action.target);
@@ -5693,6 +5752,14 @@ class DeletePostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRu
           await waitForNetworkIdleBestEffort(page, 10_000);
 
           const warnings: string[] = [];
+          if (actionCommitted) {
+            // Check if page is already closed before verifying
+            try { await page.title(); } catch (err) {
+               if (isPageClosedError(err)) {
+                 return { ok: true, result: { post_url: LINKEDIN_FEED_URL, rate_limit: formatRateLimitState(rateLimitState) }, artifacts: artifactPaths };
+               }
+            }
+          }
           let verification: {
             postUrl: string;
           } = { postUrl: postUrl };
@@ -5735,6 +5802,9 @@ class DeletePostActionExecutor implements ActionExecutor<LinkedInPostsExecutorRu
             });
             artifactPaths.push(postDeleteScreenshot);
           } catch (screenshotError) {
+            if (actionCommitted && isPageClosedError(screenshotError)) {
+              return { ok: true, result: { post_url: LINKEDIN_FEED_URL, rate_limit: formatRateLimitState(rateLimitState) }, artifacts: artifactPaths };
+            }
             screenshotWarning =
               screenshotError instanceof Error
                 ? screenshotError.message

--- a/packages/core/src/shared.ts
+++ b/packages/core/src/shared.ts
@@ -10,6 +10,22 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/** Returns true if the error indicates that the Playwright CDP connection, context, or page was destroyed/closed. */
+export function isPageClosedError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const message = error.message;
+  return (
+    message.includes("Target page, context or browser has been closed") ||
+    message.includes("Target closed") ||
+    message.includes("Browser has been closed") ||
+    message.includes("Connection refused") ||
+    message.includes("WebSocket error") ||
+    message.includes("ECONNREFUSED")
+  );
+}
+
 /** Escapes special regex metacharacters so the string can be used inside new RegExp(). */
 export function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");


### PR DESCRIPTION
## Summary
Fixes #566

Resolves the issue where write operation confirmations (such as `post.create`, `feed.comment_on_post`, and `feed.save_post`) crashed with "Target page, context or browser has been closed".

### Root Cause
These write operations click native UI elements (like `<button type="submit">` or `<a>` links inside a dropdown). Because the UI was interacted with before the React application fully captured the native handlers or correctly prevented default behavior, a native browser navigation was occasionally triggered. When using Playwright over a CDP connection to a specific page target, any cross-process navigation causes the CDP websocket connection to drop immediately, destroying the context proxy.

### Changes
1. Added `noWaitAfter: true` to the problematic `.click()` actions (`post.create`, `feed.comment_on_post`, `feed.save_post`). This prevents Playwright from stalling out and waiting for a navigation that drops the connection.
2. Implemented `isPageClosedError()` in `shared.ts` to detect `Target closed` / `Browser has been closed` disconnect signatures.
3. Added robust `try/catch` wrapping around the post-click execution and verification flows. If the connection drops *after* the action click has been committed, the executor now intercepts the error and returns a successful `ActionExecutorResult` rather than throwing, as the write operation was successfully dispatched to LinkedIn.

