### PR TITLE
feat: expose prepare-upload-photo and prepare-upload-banner in CLI (#590)

### DIFF
--- a/packages/cli/src/bin/linkedin.ts
+++ b/packages/cli/src/bin/linkedin.ts
@@ -7282,6 +7282,79 @@ async function runProfilePrepareUpdatePublicProfile(
   }
 }
 
+async function runProfilePrepareUploadPhoto(
+  input: {
+    profileName: string;
+    filePath: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.profile.prepare_upload_photo.start", {
+      profileName: input.profileName,
+      filePath: input.filePath,
+    });
+
+    const prepared = await runtime.profile.prepareUploadPhoto({
+      profileName: input.profileName,
+      filePath: input.filePath,
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
+    });
+
+    runtime.logger.log("info", "cli.profile.prepare_upload_photo.done", {
+      profileName: input.profileName,
+      preparedActionId: prepared.preparedActionId,
+    });
+
+    printPrepareResult({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      ...prepared,
+    });
+  } finally {
+    runtime.close();
+  }
+}
+
+async function runProfilePrepareUploadBanner(
+  input: {
+    profileName: string;
+    filePath: string;
+    operatorNote?: string;
+  },
+  cdpUrl?: string,
+): Promise<void> {
+  const runtime = createRuntime(cdpUrl);
+
+  try {
+    runtime.logger.log("info", "cli.profile.prepare_upload_banner.start", {
+      profileName: input.profileName,
+      filePath: input.filePath,
+    });
+
+    const prepared = await runtime.profile.prepareUploadBanner({
+      profileName: input.profileName,
+      filePath: input.filePath,
+      ...(input.operatorNote ? { operatorNote: input.operatorNote } : {}),
+    });
+
+    runtime.logger.log("info", "cli.profile.prepare_upload_banner.done", {
+      profileName: input.profileName,
+      preparedActionId: prepared.preparedActionId,
+    });
+
+    printPrepareResult({
+      run_id: runtime.runId,
+      profile_name: input.profileName,
+      ...prepared,
+    });
+  } finally {
+    runtime.close();
+  }
+}
 function summarizeProfileSeedUnsupportedFields(
   unsupportedFields: readonly ProfileSeedUnsupportedField[],
 ): string {
@@ -13245,6 +13318,62 @@ export function createCliProgram(): Command {
           {
             profileName: options.profile,
             vanityName,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
+    );
+
+  profileCommand
+    .command("prepare-upload-photo")
+    .description("Prepare to upload a LinkedIn profile photo (two-phase)")
+    .requiredOption("--file <path>", "Path to the local image file")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .option(
+      "--operator-note <note>",
+      "Optional note attached to the prepared action",
+    )
+    .action(
+      async (options: {
+        file: string;
+        operatorNote?: string;
+        profile: string;
+      }) => {
+        await runProfilePrepareUploadPhoto(
+          {
+            profileName: options.profile,
+            filePath: options.file,
+            ...(options.operatorNote
+              ? { operatorNote: options.operatorNote }
+              : {}),
+          },
+          readCdpUrl(),
+        );
+      },
+    );
+
+  profileCommand
+    .command("prepare-upload-banner")
+    .description("Prepare to upload a LinkedIn profile banner (two-phase)")
+    .requiredOption("--file <path>", "Path to the local image file")
+    .option("-p, --profile <profile>", "Profile name", "default")
+    .option(
+      "--operator-note <note>",
+      "Optional note attached to the prepared action",
+    )
+    .action(
+      async (options: {
+        file: string;
+        operatorNote?: string;
+        profile: string;
+      }) => {
+        await runProfilePrepareUploadBanner(
+          {
+            profileName: options.profile,
+            filePath: options.file,
             ...(options.operatorNote
               ? { operatorNote: options.operatorNote }
               : {}),

--- a/packages/cli/test/profileCli.test.ts
+++ b/packages/cli/test/profileCli.test.ts
@@ -10,6 +10,8 @@ const profileCliMocks = vi.hoisted(() => ({
   loggerLog: vi.fn(),
   prepareUpdatePublicProfile: vi.fn(),
   prepareUpdateSettings: vi.fn(),
+  prepareUploadBanner: vi.fn(),
+  prepareUploadPhoto: vi.fn(),
   prepareRemoveSectionItem: vi.fn(),
   prepareUpdateIntro: vi.fn(),
   prepareUpsertSectionItem: vi.fn(),
@@ -51,6 +53,8 @@ describe("CLI profile commands", () => {
         prepareUpdatePublicProfile: profileCliMocks.prepareUpdatePublicProfile,
         prepareUpdateSettings: profileCliMocks.prepareUpdateSettings,
         prepareUpdateIntro: profileCliMocks.prepareUpdateIntro,
+        prepareUploadBanner: profileCliMocks.prepareUploadBanner,
+        prepareUploadPhoto: profileCliMocks.prepareUploadPhoto,
         prepareUpsertSectionItem: profileCliMocks.prepareUpsertSectionItem,
         prepareRemoveSectionItem: profileCliMocks.prepareRemoveSectionItem
       },
@@ -107,6 +111,18 @@ describe("CLI profile commands", () => {
       confirmToken: "ct_public_profile",
       expiresAtMs: 1,
       preview: { summary: "Update public profile" }
+    });
+    profileCliMocks.prepareUploadPhoto.mockResolvedValue({
+      preparedActionId: "pa_upload_photo",
+      confirmToken: "ct_upload_photo",
+      expiresAtMs: 1,
+      preview: { summary: "Upload LinkedIn profile photo" }
+    });
+    profileCliMocks.prepareUploadBanner.mockResolvedValue({
+      preparedActionId: "pa_upload_banner",
+      confirmToken: "ct_upload_banner",
+      expiresAtMs: 1,
+      preview: { summary: "Upload LinkedIn profile banner" }
     });
     profileCliMocks.prepareUpsertSectionItem.mockReturnValue({
       preparedActionId: "pa_about",
@@ -237,6 +253,56 @@ describe("CLI profile commands", () => {
     expect(profileCliMocks.prepareUpdatePublicProfile).toHaveBeenCalledWith({
       profileName: "smoke",
       vanityName: "avery-cole-example"
+    });
+  });
+
+  it("prepares a profile photo upload", async () => {
+    await runCli([
+      "node",
+      "linkedin",
+      "profile",
+      "prepare-upload-photo",
+      "--profile",
+      "smoke",
+      "--file",
+      "photo.jpg"
+    ]);
+
+    const output = JSON.parse(stdoutChunks.join("\n")) as {
+      confirmToken: string;
+      preview: { summary: string };
+    };
+
+    expect(output.confirmToken).toBe("ct_upload_photo");
+    expect(output.preview.summary).toBe("Upload LinkedIn profile photo");
+    expect(profileCliMocks.prepareUploadPhoto).toHaveBeenCalledWith({
+      profileName: "smoke",
+      filePath: "photo.jpg"
+    });
+  });
+
+  it("prepares a profile banner upload", async () => {
+    await runCli([
+      "node",
+      "linkedin",
+      "profile",
+      "prepare-upload-banner",
+      "--profile",
+      "smoke",
+      "--file",
+      "banner.jpg"
+    ]);
+
+    const output = JSON.parse(stdoutChunks.join("\n")) as {
+      confirmToken: string;
+      preview: { summary: string };
+    };
+
+    expect(output.confirmToken).toBe("ct_upload_banner");
+    expect(output.preview.summary).toBe("Upload LinkedIn profile banner");
+    expect(profileCliMocks.prepareUploadBanner).toHaveBeenCalledWith({
+      profileName: "smoke",
+      filePath: "banner.jpg"
     });
   });
 
@@ -385,6 +451,8 @@ describe("CLI profile apply-spec --continue-on-error", () => {
         prepareUpdatePublicProfile: profileCliMocks.prepareUpdatePublicProfile,
         prepareUpdateSettings: profileCliMocks.prepareUpdateSettings,
         prepareUpdateIntro: profileCliMocks.prepareUpdateIntro,
+        prepareUploadBanner: profileCliMocks.prepareUploadBanner,
+        prepareUploadPhoto: profileCliMocks.prepareUploadPhoto,
         prepareUpsertSectionItem: profileCliMocks.prepareUpsertSectionItem,
         prepareRemoveSectionItem: profileCliMocks.prepareRemoveSectionItem
       },
@@ -443,6 +511,18 @@ describe("CLI profile apply-spec --continue-on-error", () => {
       confirmToken: "ct_public_profile",
       expiresAtMs: 1,
       preview: { summary: "Update public profile" }
+    });
+    profileCliMocks.prepareUploadPhoto.mockResolvedValue({
+      preparedActionId: "pa_upload_photo",
+      confirmToken: "ct_upload_photo",
+      expiresAtMs: 1,
+      preview: { summary: "Upload LinkedIn profile photo" }
+    });
+    profileCliMocks.prepareUploadBanner.mockResolvedValue({
+      preparedActionId: "pa_upload_banner",
+      confirmToken: "ct_upload_banner",
+      expiresAtMs: 1,
+      preview: { summary: "Upload LinkedIn profile banner" }
     });
     profileCliMocks.prepareUpsertSectionItem.mockReturnValue({
       preparedActionId: "pa_about",


### PR DESCRIPTION
## Summary
Exposes `prepare-upload-photo` and `prepare-upload-banner` as standalone commands under the `linkedin profile` namespace.

This allows users to upload their own existing images from their local machine via the CLI without needing an OpenAI key, as they bypass the `generate-profile-images` asset generation pipeline.

## Changes
- Add `runProfilePrepareUploadPhoto` and `runProfilePrepareUploadBanner` implementations in `packages/cli/src/bin/linkedin.ts`.
- Register `.command("prepare-upload-photo")` and `.command("prepare-upload-banner")` under `profileCommand`.
- Add unit tests for both CLI commands in `packages/cli/test/profileCli.test.ts`.

Closes #590
