### PR TITLE
fix: use partial match for post visibility option selectors (#591)

### DIFF
--- a/packages/core/src/linkedinPosts.ts
+++ b/packages/core/src/linkedinPosts.ts
@@ -1983,12 +1983,12 @@ function createVisibilityOptionCandidates(
   const labelRegex = buildLinkedInSelectorPhraseRegex(
     visibilityPhraseKey,
     selectorLocale,
-    { exact: true },
+    { exact: false },
   );
   const labelRegexHint = formatLinkedInSelectorRegexHint(
     visibilityPhraseKey,
     selectorLocale,
-    { exact: true },
+    { exact: false },
   );
 
   return [


### PR DESCRIPTION
## Summary
Resolves #591.

LinkedIn recently updated their "Anyone" post visibility option label to include additional descriptive text (e.g., "Anyone on or off LinkedIn") inside the radio button / label element. The previous `{ exact: true }` exact-match regex caused automation to fail to find this option.

## Changes
- Removed `{ exact: true }` from `buildLinkedInSelectorPhraseRegex` and `formatLinkedInSelectorRegexHint` in `createVisibilityOptionCandidates`.
- The automation will now match any visibility option containing the "Anyone" text (or localized equivalents) instead of requiring an exact, character-perfect match.

Closes #591
