### PR TITLE
fix: prevent search category from over-extracting name field (#592)

### DIFF
--- a/packages/core/src/linkedinSearch.ts
+++ b/packages/core/src/linkedinSearch.ts
@@ -436,13 +436,13 @@ export class LinkedInSearchService {
             };
 
             const splitLines = (value: string): string[] =>
-              normalize(value)
+              (value ?? "")
                 .split("\n")
                 .map((line) => normalize(line))
                 .filter(Boolean);
 
             const getCardLines = (card: Element): string[] => {
-              const raw = normalize((card as HTMLElement).innerText || card.textContent || "");
+              const raw = (card as HTMLElement).innerText || card.textContent || "";
               if (!raw) {
                 return [];
               }
@@ -508,12 +508,30 @@ export class LinkedInSearchService {
               link: HTMLAnchorElement | null
             ): Record<string, string> => {
               const lines = getCardLines(card);
-              const nameFromSpan = normalize(
-                (
-                  link?.querySelector("span[dir='ltr'] span[aria-hidden='true']") ??
-                  link?.querySelector("span[aria-hidden='true']")
-                )?.textContent
-              );
+              let nameFromSpan = pickText(card, [
+                ".entity-result__title-text a[href*='/in/'] span[dir='ltr'] span[aria-hidden='true']",
+                ".entity-result__title-text a[href*='/in/'] span[aria-hidden='true']",
+                ".entity-result__title-text span[dir='ltr'] span[aria-hidden='true']",
+                "a[data-field='entity_result_universal_name'] span[dir='ltr'] span[aria-hidden='true']",
+                "a[data-field='entity_result_universal_name'] span[aria-hidden='true']",
+                ".app-aware-link span[dir='ltr'] span[aria-hidden='true']"
+              ]);
+
+              if (!nameFromSpan) {
+                nameFromSpan = normalize(
+                  (
+                    link?.querySelector("span[dir='ltr'] span[aria-hidden='true']") ??
+                    link?.querySelector("span[aria-hidden='true']")
+                  )?.textContent
+                );
+              }
+
+              if (nameFromSpan && (nameFromSpan.includes(" View ") || nameFromSpan.length > 80)) {
+                nameFromSpan = lines[0] || "";
+                if (nameFromSpan.includes(" View ")) {
+                  nameFromSpan = nameFromSpan.split(" View ")[0] ?? "";
+                }
+              }
               const profileUrl = toAbsoluteHref(
                 normalize(link?.getAttribute("href")) || normalize(link?.href)
               );
@@ -819,13 +837,13 @@ export class LinkedInSearchService {
               return "";
             };
             const splitLines = (value: string): string[] =>
-              normalize(value)
+              (value ?? "")
                 .split("\n")
                 .map((line) => normalize(line))
                 .filter(Boolean);
 
             const getCardLines = (card: Element): string[] => {
-              const raw = normalize((card as HTMLElement).innerText || card.textContent || "");
+              const raw = (card as HTMLElement).innerText || card.textContent || "";
               if (!raw) {
                 return [];
               }
@@ -884,12 +902,19 @@ export class LinkedInSearchService {
                 "";
               const subtitleParts = subtitleRaw.split("•").map((part) => normalize(part));
               const logoElement = card.querySelector("img") as HTMLImageElement | null;
-              const nameFromSpan = normalize(
+              let nameFromSpan = normalize(
                 (
                   link?.querySelector("span[dir='ltr'] span[aria-hidden='true']") ??
                   link?.querySelector("span[aria-hidden='true']")
                 )?.textContent
               );
+
+              if (nameFromSpan && (nameFromSpan.includes(" View ") || nameFromSpan.length > 80)) {
+                nameFromSpan = lines[0] || "";
+                if (nameFromSpan.includes(" View ")) {
+                  nameFromSpan = nameFromSpan.split(" View ")[0] ?? "";
+                }
+              }
 
               return {
                 name: nameFromSpan || lines[0] || "",
@@ -1173,13 +1198,13 @@ export class LinkedInSearchService {
               return "";
             };
             const splitLines = (value: string): string[] =>
-              normalize(value)
+              (value ?? "")
                 .split("\n")
                 .map((line) => normalize(line))
                 .filter(Boolean);
 
             const getCardLines = (card: Element): string[] => {
-              const raw = normalize((card as HTMLElement).innerText || card.textContent || "");
+              const raw = (card as HTMLElement).innerText || card.textContent || "";
               if (!raw) {
                 return [];
               }
@@ -1743,12 +1768,19 @@ export class LinkedInSearchService {
                 }
 
                 const paragraphs = Array.from(card.querySelectorAll("p"));
-                const nameFromSpan = normalize(
+                let nameFromSpan = normalize(
                   (
                     link.querySelector("span[dir='ltr'] span[aria-hidden='true']") ??
                     link.querySelector("span[aria-hidden='true']")
                   )?.textContent
                 );
+
+                if (nameFromSpan && (nameFromSpan.includes(" View ") || nameFromSpan.length > 80)) {
+                  nameFromSpan = normalize((paragraphs[0]?.innerText ?? "").split("\n")[0]);
+                  if (nameFromSpan.includes(" View ")) {
+                    nameFromSpan = nameFromSpan.split(" View ")[0] ?? "";
+                  }
+                }
                 const memberParagraph = paragraphs.find((paragraph) =>
                   /member/i.test(normalize((paragraph as HTMLElement).innerText))
                 );


### PR DESCRIPTION
## Summary
Fixes bug where `linkedin search "founder" --category people` over-extracts the `name` field.

## Root Cause
1. `splitLines()` and `getCardLines()` were mistakenly calling `normalize()` on the raw text *before* splitting by `\n`. Since `normalize` replaces all `\s+` (including newlines) with spaces, `lines` was always an array of length 1 containing the entire card's text.
2. In newer AI and modern cards, the entire card is wrapped in a link. The selector `link?.querySelector("span[aria-hidden='true']")` grabbed an outer span that contained the visual text of the entire card.
3. Due to (1), the fallback to `lines[0]` returned the entire card's text anyway.

## Changes
- Fixed `splitLines()` and `getCardLines()` to split by `\n` first, and *then* normalize each line independently.
- Added specific selectors for names in `searchPeople` (like `.entity-result__title-text`).
- Added a fallback safety check: if `name` contains `" View "` or is `> 80` characters, it correctly uses `lines[0]`.
- Applied similar checks for over-extraction in `searchCompanies` and `searchGroups`.

Closes #592
