### PR TITLE
fix: specify h3 and span selectors for groups search extraction (#593)

### DIFF
--- a/packages/core/src/linkedinSearch.ts
+++ b/packages/core/src/linkedinSearch.ts
@@ -1792,8 +1792,28 @@ export class LinkedInSearchService {
                     .split("\n")
                     .map((line) => normalize(line))
                     .filter(Boolean);
+                  let h3Text = pickText(card, [
+                    "h3 span[dir='ltr'] span[aria-hidden='true']",
+                    "h3 span[aria-hidden='true']",
+                    "h3",
+                    ".entity-result__title-text a span[dir='ltr'] span[aria-hidden='true']",
+                    ".entity-result__title-text a span[aria-hidden='true']",
+                    ".entity-result__title-text a"
+                  ]);
+
+                  let memberSpanText = "";
+                  const spans = Array.from(card.querySelectorAll("span"));
+                  for (const s of spans) {
+                    const text = normalize(s.textContent);
+                    if (/member/i.test(text) && text.length < 50) {
+                      memberSpanText = text;
+                      break;
+                    }
+                  }
+
                   return {
                     name:
+                      h3Text ||
                       normalize(
                         (
                           link?.querySelector("span[dir='ltr'] span[aria-hidden='true']") ??
@@ -1801,7 +1821,7 @@ export class LinkedInSearchService {
                         )?.textContent
                       ) || lines[0] || "",
                     group_type: lines[1] || "",
-                    member_count: lines.find((line) => /member/i.test(line)) ?? "",
+                    member_count: memberSpanText || (lines.find((line) => /member/i.test(line)) ?? ""),
                     description: lines[2] || lines[3] || "",
                     group_url: toAbsoluteHref(
                       normalize(link?.getAttribute("href")) || normalize(link?.href)
@@ -1827,25 +1847,44 @@ export class LinkedInSearchService {
               const nameLink = card.querySelector(
                 "a[data-test-app-aware-link]"
               );
-              const name = nameLink
-                ? normalize(nameLink.textContent)
-                : pickText(card, [
-                    "a[href*='/groups/'] span[dir='ltr'] span[aria-hidden='true']",
-                    "a[data-test-app-aware-link] span[dir='ltr'] span[aria-hidden='true']",
-                    "a[data-test-app-aware-link] span[aria-hidden='true']",
-                    "a[href*='/groups/'] span[aria-hidden='true']",
-                    "a[href*='/groups/']"
-                  ]);
+              
+              // We prioritize specific h3 and span elements to avoid extracting the entire card's text
+              // if nameLink wraps the whole card
+              let name = pickText(card, [
+                "h3 span[dir='ltr'] span[aria-hidden='true']",
+                "h3 span[aria-hidden='true']",
+                "h3",
+                ".entity-result__title-text a span[dir='ltr'] span[aria-hidden='true']",
+                ".entity-result__title-text a span[aria-hidden='true']",
+                ".entity-result__title-text a",
+                "a[href*='/groups/'] span[dir='ltr'] span[aria-hidden='true']",
+                "a[data-test-app-aware-link] span[dir='ltr'] span[aria-hidden='true']",
+                "a[data-test-app-aware-link] span[aria-hidden='true']",
+                "a[href*='/groups/'] span[aria-hidden='true']"
+              ]);
+              
+              if (!name && nameLink) {
+                // If we fall back to nameLink.textContent, it might contain the whole card text.
+                // We do a safer extraction if possible
+                name = normalize(nameLink.textContent);
+              }
+
+              let memberCount = pickText(card, [
+                ".entity-result__primary-subtitle span[dir='ltr'] span[aria-hidden='true']",
+                ".entity-result__primary-subtitle span[aria-hidden='true']",
+                ".entity-result__primary-subtitle",
+                "div.t-14.t-black.t-normal span[aria-hidden='true']",
+                "div.t-14.t-black.t-normal"
+              ]);
+              
+              if (!memberCount) {
+                memberCount = pickSiblingText(card, "a[data-test-app-aware-link], a[href*='/groups/']", 0);
+              }
 
               return {
                 name,
                 group_type: "",
-                member_count:
-                  pickSiblingText(card, "a[data-test-app-aware-link], a[href*='/groups/']", 0) ||
-                  pickText(card, [
-                    "div.t-14.t-black.t-normal",
-                    ".entity-result__primary-subtitle"
-                  ]),
+                member_count: memberCount,
                 description: pickText(card, [
                   "p[class*='entity-result__summary']",
                   "[class*='entity-result__summary']",
@@ -1866,10 +1905,27 @@ export class LinkedInSearchService {
                   .map((line) => normalize(line))
                   .filter(Boolean);
                 const link = card.querySelector("a[href*='/groups/']") as HTMLAnchorElement | null;
+                
+                const h3Text = pickText(card, [
+                  "h3 span[dir='ltr'] span[aria-hidden='true']",
+                  "h3 span[aria-hidden='true']",
+                  "h3"
+                ]);
+                
+                let memberSpanText = "";
+                const spans = Array.from(card.querySelectorAll("span"));
+                for (const s of spans) {
+                  const text = normalize(s.textContent);
+                  if (/member/i.test(text) && text.length < 50) {
+                    memberSpanText = text;
+                    break;
+                  }
+                }
+                
                 return {
-                  name: lines[0] ?? "",
+                  name: h3Text || (lines[0] ?? ""),
                   group_type: lines[1] ?? "",
-                  member_count: lines.find((line) => /member/i.test(line)) ?? "",
+                  member_count: memberSpanText || (lines.find((line) => /member/i.test(line)) ?? ""),
                   description: lines[2] ?? "",
                   group_url: toAbsoluteHref(
                     normalize(link?.getAttribute("href")) || normalize(link?.href)


### PR DESCRIPTION
## Summary
Resolves #593 

The scraper for group search was extracting the entire text block of the search result card for the `name` and `member_count` properties. This was because it fell back to `.innerText` on the card or `textContent` on the `app-aware-link` which often wraps the entire group search result card in LinkedIn's modern UI.

This PR fixes this behavior by targeting specific `h3` and `span` selectors that explicitly contain the name and member count before falling back to less precise methods.

## Changes
- Modified `legacyCards` group search extractor to first attempt specific `h3` and `span` selectors for name.
- Modified `legacyCards` group search extractor to attempt specific `span` elements for member count before falling back.
- Updated `extractAiCards` and the general list fallback logic to also prioritize explicit `.querySelectorAll("span")` and `h3` tags.

## Validation
- Ran the existing `groups.e2e.test.ts` to ensure `searchGroups` output remains intact.
- Ran `tsc -b packages/core` successfully to ensure type safety.
- Lint passed cleanly.

Closes #593
