### PR TITLE
fix #595: update group and event name locators

### DIFF
--- a/packages/core/src/linkedinEvents.ts
+++ b/packages/core/src/linkedinEvents.ts
@@ -651,8 +651,9 @@ export class CreateEventActionExecutor
             waitUntil: "domcontentloaded",
           });
 
-          await page.locator("input[name='eventName']").waitFor({ state: "visible", timeout: 10000 });
-          await page.locator("input[name='eventName']").fill(data.name);
+          const nameLocator = page.locator("input[name='eventName']").or(page.getByLabel(/Event name/i)).or(page.getByRole("textbox", { name: /Event name/i })).first();
+          await nameLocator.waitFor({ state: "visible", timeout: 10000 });
+          await nameLocator.fill(data.name);
 
           // We'd fill out the rest here, but for brevity we'll just skip
           // Date pickers are complex and the UI is very dynamic.

--- a/packages/core/src/linkedinGroups.ts
+++ b/packages/core/src/linkedinGroups.ts
@@ -884,8 +884,9 @@ export class CreateGroupActionExecutor
             waitUntil: "domcontentloaded",
           });
           
-          await page.locator("input[name='groupName']").waitFor({ state: "visible", timeout: 10000 });
-          await page.locator("input[name='groupName']").fill(data.name);
+          const nameLocator = page.locator("input[name='groupName']").or(page.getByLabel(/Group name/i)).or(page.getByRole("textbox", { name: /Group name/i })).first();
+          await nameLocator.waitFor({ state: "visible", timeout: 10000 });
+          await nameLocator.fill(data.name);
           
           if (data.description) {
             await page.locator("textarea[name='groupDescription']").fill(data.description);


### PR DESCRIPTION
## Summary
Fixes a bug where `groups prepare-create` and `events prepare-create` operations fail during confirmation because LinkedIn has updated their DOM, rendering the strict `input[name='eventName']` and `input[name='groupName']` CSS selectors invalid.

## Changes
- Updated locator in `CreateEventActionExecutor` (`packages/core/src/linkedinEvents.ts`) to use a more resilient combination: `page.locator().or(page.getByLabel()).or(page.getByRole())`.
- Updated locator in `CreateGroupActionExecutor` (`packages/core/src/linkedinGroups.ts`) to use the same resilient combination strategy.

Closes #595
