### PR TITLE
fix: prevent search events category from over-extracting fields

### DIFF
--- a/packages/core/src/__tests__/e2e/events.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/events.e2e.test.ts
@@ -29,7 +29,9 @@ describe("Events E2E", () => {
     const first = result.results[0]!;
     expect(first.event_id.length).toBeGreaterThan(0);
     expect(first.title.length).toBeGreaterThan(0);
+    expect(first.title.length).toBeLessThan(200);
     expect(typeof first.date_time).toBe("string");
+    expect(first.date_time.length).toBeLessThan(100);
     expect(typeof first.location).toBe("string");
     expect(typeof first.organizer).toBe("string");
     expect(typeof first.attendee_count).toBe("string");

--- a/packages/core/src/__tests__/e2e/search.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/search.e2e.test.ts
@@ -129,6 +129,8 @@ describe("Search E2E", () => {
     expect(first).toBeDefined();
     if (first) {
       expect(first.title.length).toBeGreaterThan(0);
+      expect(first.title.length).toBeLessThan(200);
+      expect(first.date.length).toBeLessThan(100);
     }
   });
 

--- a/packages/core/src/linkedinEvents.ts
+++ b/packages/core/src/linkedinEvents.ts
@@ -344,7 +344,7 @@ async function extractEventSearchResults(
     return uniqueLinks.slice(0, maxEvents).map((link) => {
       const card = link.closest("li") ?? link.closest("div[data-view-tracking-scope]") ?? link.closest("div.search-result__wrapper") ?? link.parentElement;
       
-      const rawText = normalize((card as HTMLElement)?.innerText ?? link.innerText ?? "");
+      const rawText = (card as HTMLElement)?.innerText ?? link.innerText ?? "";
       const lines = rawText
         .split("\n")
         .map((line) => normalize(line))

--- a/packages/core/src/linkedinSearch.ts
+++ b/packages/core/src/linkedinSearch.ts
@@ -2295,7 +2295,7 @@ export class LinkedInSearchService {
 
             return Array.from(globalThis.document.querySelectorAll("main li, div.search-results-container ul > li, ul.reusable-search__entity-result-list > li"))
               .map((card) => {
-                const lines = normalize((card as HTMLElement).innerText)
+                const lines = ((card as HTMLElement).innerText || "")
                   .split("\n")
                   .map((line) => normalize(line))
                   .filter(Boolean);


### PR DESCRIPTION
## Summary
Fixes #596 by preventing over-extraction of `title` and `date_time` in events search.

## Changes
- In both `linkedinEvents.ts` and `linkedinSearch.ts`, the code previously called `normalize((card as HTMLElement).innerText)` *before* splitting by newlines. Since `normalize` replaces all whitespace (including newlines) with spaces, the split yielded an array of length 1, mapping the entire card text to `lines[0]`.
- Updated the logic to split by newlines *before* normalizing each line.
- Added E2E assertions in `events.e2e.test.ts` and `search.e2e.test.ts` to ensure `title` and `date_time` are not massively long strings.

Closes #596
