### PR TITLE
fix #614: fix 5 bugs in profile banner/photo implementation

### DIFF
--- a/packages/core/src/__tests__/e2e/profile.e2e.test.ts
+++ b/packages/core/src/__tests__/e2e/profile.e2e.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { deflateSync } from "node:zlib";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   expectPreparedAction,
@@ -11,6 +12,49 @@ import { setupE2ESuite, skipIfE2EUnavailable } from "./setup.js";
 // Minimal valid 1x1 transparent PNG (67 bytes)
 const MINIMAL_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQABNl7BcQAAAABJRU5ErkJggg==";
+
+/** Create a minimal valid PNG buffer with the given dimensions (1-bit grayscale, all white). */
+function createMinimalPngBuffer(width: number, height: number): Buffer {
+  const signature = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+  function crc32(buf: Buffer): number {
+    let crc = 0xffffffff;
+    for (let i = 0; i < buf.length; i++) {
+      crc ^= buf[i]!;
+      for (let j = 0; j < 8; j++) {
+        crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+      }
+    }
+    return (crc ^ 0xffffffff) >>> 0;
+  }
+
+  function chunk(type: string, data: Buffer): Buffer {
+    const len = Buffer.alloc(4);
+    len.writeUInt32BE(data.length, 0);
+    const tag = Buffer.from(type, "ascii");
+    const body = Buffer.concat([tag, data]);
+    const crcBuf = Buffer.alloc(4);
+    crcBuf.writeUInt32BE(crc32(body), 0);
+    return Buffer.concat([len, body, crcBuf]);
+  }
+
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 1; // bit depth
+  ihdr[9] = 0; // color type: grayscale
+
+  const rowBytes = Math.ceil(width / 8);
+  const raw = Buffer.alloc((1 + rowBytes) * height, 0xff);
+  for (let y = 0; y < height; y++) raw[y * (1 + rowBytes)] = 0; // filter = None
+
+  return Buffer.concat([
+    signature,
+    chunk("IHDR", ihdr),
+    chunk("IDAT", deflateSync(raw)),
+    chunk("IEND", Buffer.alloc(0))
+  ]);
+}
 
 // Featured item ID prefix used by the profile module
 const FEATURED_ITEM_ID_PREFIX = "pfi_";
@@ -36,11 +80,14 @@ describe("Profile E2E", () => {
   const e2e = setupE2ESuite();
   let tempDir: string;
   let tempPngPath: string;
+  let tempBannerPath: string;
 
   beforeAll(() => {
     tempDir = mkdtempSync(path.join(os.tmpdir(), "profile-e2e-"));
     tempPngPath = path.join(tempDir, "test-photo.png");
     writeFileSync(tempPngPath, Buffer.from(MINIMAL_PNG_BASE64, "base64"));
+    tempBannerPath = path.join(tempDir, "test-banner.png");
+    writeFileSync(tempBannerPath, createMinimalPngBuffer(1584, 396));
   });
 
   afterAll(() => {
@@ -225,7 +272,7 @@ describe("Profile E2E", () => {
     skipIfE2EUnavailable(e2e, context);
     const runtime = e2e.runtime();
     const prepared = await runtime.profile.prepareUploadBanner({
-      filePath: tempPngPath
+      filePath: tempBannerPath
     });
 
     expectPreparedAction(prepared);

--- a/packages/core/src/linkedinProfile.ts
+++ b/packages/core/src/linkedinProfile.ts
@@ -8320,6 +8320,10 @@ async function executeRemoveProfilePhoto(
         context,
         page,
         actionId,
+        dismissOverlays: {
+          selectorLocale: runtime.selectorLocale,
+          logger: runtime.logger
+        },
         actionType: REMOVE_PROFILE_PHOTO_ACTION_TYPE,
         profileName,
         targetUrl: resolveProfileUrl("me"),
@@ -8345,7 +8349,7 @@ async function executeRemoveProfilePhoto(
             "Failed to execute LinkedIn profile photo removal."
           ),
         execute: async () => {
-          await navigateToOwnProfile(page);
+          await navigateToOwnProfile(page, { dismissOverlays: { selectorLocale: runtime.selectorLocale, logger: runtime.logger } });
           const dialog = await openProfilePhotoForDelete(page, runtime.selectorLocale);
           if (dialog) {
             await clickDeleteInDialog(page, dialog, runtime.selectorLocale);
@@ -8399,7 +8403,7 @@ async function executeRemoveProfileMedia(
           selectorLocale: runtime.selectorLocale,
           logger: runtime.logger
         },
-        actionType: REMOVE_PROFILE_BANNER_ACTION_TYPE,
+        actionType: kind === "photo" ? REMOVE_PROFILE_PHOTO_ACTION_TYPE : REMOVE_PROFILE_BANNER_ACTION_TYPE,
         profileName,
         targetUrl: resolveProfileUrl("me"),
         metadata: {
@@ -8412,7 +8416,7 @@ async function executeRemoveProfileMedia(
         },
         beforeExecute: createProfileRateLimitGuard(
           runtime,
-          REMOVE_PROFILE_BANNER_ACTION_TYPE,
+          kind === "photo" ? REMOVE_PROFILE_PHOTO_ACTION_TYPE : REMOVE_PROFILE_BANNER_ACTION_TYPE,
           actionId,
           profileName,
           { media_kind: kind }
@@ -8429,6 +8433,13 @@ async function executeRemoveProfileMedia(
           
           if (dialog) {
             await clickDeleteInDialog(page, dialog, runtime.selectorLocale);
+            await page.waitForTimeout(1000);
+
+            // On LinkedIn, a second confirmation dialog might appear
+            const confirmDialog = await getVisibleDialogOrNull(page);
+            if (confirmDialog) {
+              await clickDeleteInDialog(page, confirmDialog, runtime.selectorLocale);
+            }
           } else {
             throw new LinkedInBuddyError("TARGET_NOT_FOUND", "No media to remove.");
           }
@@ -9915,9 +9926,9 @@ export class LinkedInProfileService {
     });
   }
 
-  async prepareRemoveBanner(
+  prepareRemoveBanner(
     input: PrepareRemoveBannerInput
-  ): Promise<PreparedActionResult> {
+  ): PreparedActionResult {
     const profileName = input.profileName ?? "default";
 
     const target = {
@@ -9968,7 +9979,8 @@ export class LinkedInProfileService {
           );
         }
       }
-    } catch {
+    } catch (error) {
+      if (error instanceof LinkedInBuddyError) throw error;
       // If image-size fails (e.g. unknown format), ignore and let LinkedIn handle it
     }
 


### PR DESCRIPTION
Closes #614

## Summary

Fixes 5 bugs in the profile banner/photo implementation that were shipped in #616 but left issue #614 open.

## Bugs Fixed

### 1. CRITICAL: Dimension validation is dead code (line 9971)
The `try/catch` in `prepareUploadBanner` catches ALL errors including the `LinkedInBuddyError` thrown when dimensions are too small. The dimension check (`≥1584x396`) never actually rejects invalid images.

**Fix:** Re-throw `LinkedInBuddyError` in the catch block — only swallow `imageSizeFromFile` failures.

### 2. Hardcoded action type in `executeRemoveProfileMedia` (lines 8402, 8415)
Always uses `REMOVE_PROFILE_BANNER_ACTION_TYPE` regardless of the `kind` parameter. If called with `kind="photo"`, it would use the wrong action type for rate limiting and logging.

**Fix:** Conditionally select `REMOVE_PROFILE_PHOTO_ACTION_TYPE` or `REMOVE_PROFILE_BANNER_ACTION_TYPE` based on `kind`.

### 3. Missing second confirmation dialog in banner removal
`executeRemoveProfilePhoto` handles a second confirmation dialog that LinkedIn sometimes shows after the initial delete click. `executeRemoveProfileMedia` (used for banner) does not.

**Fix:** Add the same second confirmation dialog pattern after `clickDeleteInDialog`.

### 4. Missing `dismissOverlays` in `executeRemoveProfilePhoto`
`executeRemoveProfileMedia` passes `dismissOverlays` to `executeConfirmActionWithArtifacts` and `navigateToOwnProfile`, but `executeRemoveProfilePhoto` does not, making it inconsistent and potentially fragile.

**Fix:** Add `dismissOverlays` to both calls in `executeRemoveProfilePhoto`.

### 5. Unnecessary `async` on `prepareRemoveBanner`
`prepareRemoveBanner` is marked `async` but contains no `await` — unlike `prepareRemovePhoto` which is correctly sync.

**Fix:** Remove `async`, change return type from `Promise<PreparedActionResult>` to `PreparedActionResult`.

## Quality Gates
- [x] `npm run typecheck` — pass
- [x] `npm run lint` — clean
- [x] `npm test` — 120 files, 1614 tests pass
- [x] `npm run build` — pass